### PR TITLE
Extend Factory to find subclasses recursively

### DIFF
--- a/src/orion/core/utils/__init__.py
+++ b/src/orion/core/utils/__init__.py
@@ -91,7 +91,16 @@ class Factory(ABCMeta):
                       entry_point.dist.project_name, entry_point.dist.version)
 
         # Get types visible from base module or package, but internal
-        cls.types = cls.__base__.__subclasses__()
+        def get_all_subclasses(parent):
+            """Get set of subclasses recursively"""
+            subclasses = set()
+            for subclass in parent.__subclasses__():
+                subclasses.add(subclass)
+                subclasses |= get_all_subclasses(subclass)
+
+            return subclasses
+
+        cls.types = list(get_all_subclasses(cls.__base__))
         cls.types = [class_ for class_ in cls.types if class_.__name__ != cls.__name__]
         cls.typenames = list(map(lambda x: x.__name__.lower(), cls.types))
         log.debug("Implementations found: %s", cls.typenames)

--- a/tests/unittests/core/test_utils.py
+++ b/tests/unittests/core/test_utils.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Test base functionalities of :mod:`orion.core.utils`."""
+
+import pytest
+
+from orion.core.utils import Factory
+
+
+def test_factory_subclasses_detection():
+    """Verify that meta-class Factory finds all subclasses"""
+    class Base(object):
+        pass
+
+    class A(Base):
+        pass
+
+    class B(Base):
+        pass
+
+    class AA(A):
+        pass
+
+    class AB(A):
+        pass
+
+    class AAA(AA):
+        pass
+
+    class AA_AB(AA, AB):
+        pass
+
+    class MyFactory(Base, metaclass=Factory):
+        pass
+
+    assert type(MyFactory(of_type="A")) is A
+    assert type(MyFactory(of_type="B")) is B
+    assert type(MyFactory(of_type="AA")) is AA
+    assert type(MyFactory(of_type="AAA")) is AAA
+    assert type(MyFactory(of_type="AA_AB")) is AA_AB
+
+    # Test if there is duplicates
+    assert set(MyFactory.types) == set((A, B, AA, AB, AAA, AA_AB))
+    assert len(MyFactory.types) == len(set(MyFactory.types))
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        MyFactory(of_type="random")
+    assert "Could not find implementation of Base, type = 'random'" in str(exc_info.value)


### PR DESCRIPTION
Why:

If a subclass of OptimizationAlgorithm is extended, the meta-class
Factory will not find it's implementation. Let's say for instance that
we define a global class ScikitOptimizationAlgorithm which integrates
generalities for all different algorithms from scikit-optimize, then all
children of ScikitOptimizationAlgorithm would not be found by the
Factory unless they are specifically registered by entry points.

How:

Call recursively on cls.__subclasses__() and list them all.