### PR TITLE
Drop support for py34 and add py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,36 @@ matrix:
   include:
     - env: TOXENV=flake8
       python: 3.7
+      dist: xenial
+      sudo: true
     - env: TOXENV=pylint
       python: 3.7
+      dist: xenial
+      sudo: true
     - env: TOXENV=doc8
       python: 3.7
+      dist: xenial
+      sudo: true
     - env: TOXENV=packaging
       python: 3.7
+      dist: xenial
+      sudo: true
     - env: TOXENV=docs
       python: 3.7
+      dist: xenial
+      sudo: true
     - env: TOXENV=py35
       python: 3.5
     - env: TOXENV=py36
       python: 3.6
     - env: TOXENV=py37
       python: 3.7
+      dist: xenial
+      sudo: true
     - env: TOXENV=demo_random
       python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,15 @@ matrix:
   fast_finish: true
   include:
     - env: TOXENV=flake8
-      python: 3.7
-      dist: xenial
-      sudo: true
+      python: 3.6
     - env: TOXENV=pylint
-      python: 3.7
-      dist: xenial
-      sudo: true
+      python: 3.6
     - env: TOXENV=doc8
-      python: 3.7
-      dist: xenial
-      sudo: true
+      python: 3.6
     - env: TOXENV=packaging
-      python: 3.7
-      dist: xenial
-      sudo: true
+      python: 3.6
     - env: TOXENV=docs
-      python: 3.7
-      dist: xenial
-      sudo: true
+      python: 3.6
     - env: TOXENV=py35
       python: 3.5
     - env: TOXENV=py36
@@ -35,9 +25,7 @@ matrix:
       dist: xenial
       sudo: true
     - env: TOXENV=demo_random
-      python: 3.7
-      dist: xenial
-      sudo: true
+      python: 3.6
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,23 @@ matrix:
   fast_finish: true
   include:
     - env: TOXENV=flake8
-      python: 3.6
+      python: 3.7
     - env: TOXENV=pylint
-      python: 3.6
+      python: 3.7
     - env: TOXENV=doc8
-      python: 3.6
+      python: 3.7
     - env: TOXENV=packaging
-      python: 3.6
+      python: 3.7
     - env: TOXENV=docs
-      python: 3.6
-    - env: TOXENV=py34
-      python: 3.4
+      python: 3.7
     - env: TOXENV=py35
       python: 3.5
     - env: TOXENV=py36
       python: 3.6
+    - env: TOXENV=py37
+      python: 3.7
     - env: TOXENV=demo_random
-      python: 3.6
+      python: 3.7
 
 install:
   - pip install tox

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -33,7 +33,7 @@ By calling::
    tox
 
 one attempts to call all contexts that matter for our Continuous Integration in
-the same call. Those are *py34*, *py35*, *py36*, *py37* for running tests and
+the same call. Those are *py35*, *py36*, *py37* for running tests and
 checking coverage, *flake8*, *pylint*, *doc8*, *packaging* for linting code,
 documentation and Python packaging-related files, and finally *docs* for
 building the Sphinx documentation.

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ application-import-names = orion, versioneer
 
 [testenv:flake8]
 description = Use flake8 linter to impose standards on the project
-basepython = python3.7
+basepython = python3.6
 skip_install = true
 deps =
     flake8 == 3.5.0
@@ -135,7 +135,7 @@ commands =
 
 [testenv:pylint]
 description = Perform static analysis and output code metrics
-basepython = python3.7
+basepython = python3.6
 skip_install = false
 deps =
     pylint == 1.8.1
@@ -148,7 +148,7 @@ file-encoding = utf-8
 
 [testenv:doc8]
 description = Impose standards on *.rst documentation files
-basepython = python3.7
+basepython = python3.6
 skip_install = true
 deps =
     -rdocs/requirements.txt
@@ -158,7 +158,7 @@ commands =
 
 [testenv:packaging]
 description = Check whether README.rst is reST and missing from MANIFEST.in
-basepython = python3.7
+basepython = python3.6
 deps =
     check-manifest
     readme_renderer
@@ -168,7 +168,7 @@ commands =
 
 [testenv:lint]
 description = Lint code and docs against some standard standards
-basepython = python3.7
+basepython = python3.6
 skip_install = false
 deps =
     {[testenv:flake8]deps}
@@ -185,7 +185,7 @@ commands =
 
 [testenv:docs]
 description = Invoke sphinx to build documentation and API reference
-basepython = python3.7
+basepython = python3.6
 deps =
     -rdocs/requirements.txt
 commands =
@@ -194,7 +194,7 @@ commands =
 
 [testenv:serve-docs]
 description = Host project's documentation and API reference in localhost
-basepython = python3.7
+basepython = python3.6
 skip_install = true
 changedir = docs/build/html
 deps =
@@ -204,7 +204,7 @@ commands =
 ## Release tooling (to be removed in favor of CI with CD)
 
 [testenv:build]
-basepython = python3.7
+basepython = python3.6
 skip_install = true
 deps =
     wheel
@@ -213,7 +213,7 @@ commands =
     python setup.py -q sdist bdist_wheel
 
 [testenv:release]
-basepython = python3.7
+basepython = python3.6
 skip_install = true
 deps =
     {[testenv:build]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,flake8,pylint,doc8,packaging,docs
+envlist = py35,py36,py37,flake8,pylint,doc8,packaging,docs
 minversion = 2.7.0
 
 ## Configure test + coverage process
@@ -123,7 +123,7 @@ application-import-names = orion, versioneer
 
 [testenv:flake8]
 description = Use flake8 linter to impose standards on the project
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 deps =
     flake8 == 3.5.0
@@ -135,7 +135,7 @@ commands =
 
 [testenv:pylint]
 description = Perform static analysis and output code metrics
-basepython = python3.6
+basepython = python3.7
 skip_install = false
 deps =
     pylint == 1.8.1
@@ -148,7 +148,7 @@ file-encoding = utf-8
 
 [testenv:doc8]
 description = Impose standards on *.rst documentation files
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 deps =
     -rdocs/requirements.txt
@@ -158,7 +158,7 @@ commands =
 
 [testenv:packaging]
 description = Check whether README.rst is reST and missing from MANIFEST.in
-basepython = python3.6
+basepython = python3.7
 deps =
     check-manifest
     readme_renderer
@@ -168,7 +168,7 @@ commands =
 
 [testenv:lint]
 description = Lint code and docs against some standard standards
-basepython = python3.6
+basepython = python3.7
 skip_install = false
 deps =
     {[testenv:flake8]deps}
@@ -185,7 +185,7 @@ commands =
 
 [testenv:docs]
 description = Invoke sphinx to build documentation and API reference
-basepython = python3.6
+basepython = python3.7
 deps =
     -rdocs/requirements.txt
 commands =
@@ -194,7 +194,7 @@ commands =
 
 [testenv:serve-docs]
 description = Host project's documentation and API reference in localhost
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 changedir = docs/build/html
 deps =
@@ -204,7 +204,7 @@ commands =
 ## Release tooling (to be removed in favor of CI with CD)
 
 [testenv:build]
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 deps =
     wheel
@@ -213,7 +213,7 @@ commands =
     python setup.py -q sdist bdist_wheel
 
 [testenv:release]
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 deps =
     {[testenv:build]deps}


### PR DESCRIPTION
Why:

Python 3.4 is getting old and now entered "security fixes only mode".

https://www.python.org/dev/peps/pep-0429/#id4
3.4.0 final: March 16, 2014

https://www.python.org/downloads/release/python-349/
> Python 3.4.9
> Release Date: 2018-08-02
>
> Python 3.4.9 was released on August 2nd, 2018.
>
> Python 3.4 has now entered "security fixes only" mode, and as such the
> only changes since Python 3.4.7 are security fixes. Also, Python 3.4.9
> has only been released in source code form; no more official binary
> installers will be produced.

> There are no specific plans for the next release of Python 3.4.
> However, the expectation is that Python 3.4.10 will be released in March
> of 2019, and this will be the final release of Python 3.4.

How:

Python 3.7 is supported as-is. Only modification needed is the version
for CI tests.