### PR TITLE
Fix mongodb count deprecation

### DIFF
--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -229,7 +229,10 @@ class MongoDB(AbstractDB):
 
         """
         dbcollection = self._db[collection_name]
-        return dbcollection.count_documents(filter=query if query else {})
+        if hasattr(dbcollection, 'count_documents'):
+            return dbcollection.count_documents(filter=query if query else {})
+
+        return dbcollection.count(filter=query)
 
     def remove(self, collection_name, query):
         """Delete from a collection document[s] which match the `query`.

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -222,14 +222,14 @@ class MongoDB(AbstractDB):
 
         return dbdoc
 
-    def count(self, collection_name, query={}):
+    def count(self, collection_name, query=None):
         """Count the number of documents in a collection which match the `query`.
 
         .. seealso:: :meth:`AbstractDB.count` for argument documentation.
 
         """
         dbcollection = self._db[collection_name]
-        return dbcollection.count_documents(filter=query)
+        return dbcollection.count_documents(filter=query if query else {})
 
     def remove(self, collection_name, query):
         """Delete from a collection document[s] which match the `query`.

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -222,14 +222,14 @@ class MongoDB(AbstractDB):
 
         return dbdoc
 
-    def count(self, collection_name, query=None):
+    def count(self, collection_name, query={}):
         """Count the number of documents in a collection which match the `query`.
 
         .. seealso:: :meth:`AbstractDB.count` for argument documentation.
 
         """
         dbcollection = self._db[collection_name]
-        return dbcollection.count(filter=query)
+        return dbcollection.count_documents(filter=query)
 
     def remove(self, collection_name, query):
         """Delete from a collection document[s] which match the `query`.

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -267,10 +267,10 @@ class TestWrite(object):
         """Should insert a single new entry in the collection."""
         item = {'exp_name': 'supernaekei',
                 'user': 'tsirif'}
-        count_before = database.experiments.count()
+        count_before = database.experiments.count_documents({})
         # call interface
         assert orion_db.write('experiments', item) is True
-        assert database.experiments.count() == count_before + 1
+        assert database.experiments.count_documents({}) == count_before + 1
         value = database.experiments.find_one({'exp_name': 'supernaekei'})
         assert value == item
 
@@ -280,10 +280,10 @@ class TestWrite(object):
                  'user': 'tsirif'},
                 {'exp_name': 'supernaekei3',
                  'user': 'tsirif'}]
-        count_before = database.experiments.count()
+        count_before = database.experiments.count_documents({})
         # call interface
         assert orion_db.write('experiments', item) is True
-        assert database.experiments.count() == count_before + 2
+        assert database.experiments.count_documents({}) == count_before + 2
         value = database.experiments.find_one({'exp_name': 'supernaekei2'})
         assert value == item[0]
         value = database.experiments.find_one({'exp_name': 'supernaekei3'})
@@ -292,10 +292,10 @@ class TestWrite(object):
     def test_update_many_default(self, database, orion_db):
         """Should match existing entries, and update some of their keys."""
         filt = {'metadata.user': 'tsirif'}
-        count_before = database.experiments.count()
+        count_before = database.experiments.count_documents({})
         # call interface
         assert orion_db.write('experiments', {'pool_size': 16}, filt) is True
-        assert database.experiments.count() == count_before
+        assert database.experiments.count_documents({}) == count_before
         value = list(database.experiments.find({}))
         assert value[0]['pool_size'] == 16
         assert value[1]['pool_size'] == 16
@@ -305,10 +305,10 @@ class TestWrite(object):
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
         filt = {'_id': exp_config[0][1]['_id']}
-        count_before = database.experiments.count()
+        count_before = database.experiments.count_documents({})
         # call interface
         assert orion_db.write('experiments', {'pool_size': 36}, filt) is True
-        assert database.experiments.count() == count_before
+        assert database.experiments.count_documents({}) == count_before
         value = list(database.experiments.find())
         assert value[0]['pool_size'] == 2
         assert value[1]['pool_size'] == 36
@@ -317,10 +317,10 @@ class TestWrite(object):
     def test_upsert_with_id(self, database, orion_db):
         """Query with a non-existent ``_id`` should upsert something."""
         filt = {'_id': 'lalalathisisnew'}
-        count_before = database.experiments.count()
+        count_before = database.experiments.count_documents({})
         # call interface
         assert orion_db.write('experiments', {'pool_size': 66}, filt) is True
-        assert database.experiments.count() == count_before + 1
+        assert database.experiments.count_documents({}) == count_before + 1
         value = list(database.experiments.find(filt))
         assert len(value) == 1
         assert len(value[0]) == 2
@@ -385,21 +385,21 @@ class TestRemove(object):
     def test_remove_many_default(self, exp_config, database, orion_db):
         """Should match existing entries, and delete them all."""
         filt = {'metadata.user': 'tsirif'}
-        count_before = database.experiments.count()
-        count_filt = database.experiments.count(filt)
+        count_before = database.experiments.count_documents({})
+        count_filt = database.experiments.count_documents(filt)
         # call interface
         assert orion_db.remove('experiments', filt) is True
-        assert database.experiments.count() == count_before - count_filt
-        assert database.experiments.count() == 1
+        assert database.experiments.count_documents({}) == count_before - count_filt
+        assert database.experiments.count_documents({}) == 1
         assert list(database.experiments.find()) == [exp_config[0][3]]
 
     def test_remove_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
         filt = {'_id': exp_config[0][0]['_id']}
-        count_before = database.experiments.count()
+        count_before = database.experiments.count_documents({})
         # call interface
         assert orion_db.remove('experiments', filt) is True
-        assert database.experiments.count() == count_before - 1
+        assert database.experiments.count_documents({}) == count_before - 1
         assert list(database.experiments.find()) == exp_config[0][1:]
 
 


### PR DESCRIPTION
Why:

The method count() is now deprecate in pymongo.

How:

Use count_documents() instead.