### PR TITLE
Relax constraint for git repository

### DIFF
--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -254,10 +254,10 @@ def fetch_user_repo(user_script):
     dir_path = os.path.dirname(os.path.abspath(user_script))
     try:
         git_repo = git.Repo(dir_path, search_parent_directories=True)
-    except git.exc.InvalidGitRepositoryError as e:
+    except git.exc.InvalidGitRepositoryError:
         git_repo = None
-        raise RuntimeError('Script {} should be in a git repository.'.format(
-            os.path.abspath(user_script))) from e
+        logging.warning('Script %s is not in a git repository. Code modification '
+                        'won\'t be detected.', os.path.abspath(user_script))
     return git_repo
 
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -583,12 +583,12 @@ class Experiment(object):
         # Just overwrite everything else given
         for section, value in config.items():
             if section not in self.__slots__:
-                log.warning("Found section '%s' in configuration. Experiments "
-                            "do not support this option. Ignoring.", section)
+                log.info("Found section '%s' in configuration. Experiments "
+                         "do not support this option. Ignoring.", section)
                 continue
             if section.startswith('_'):
-                log.warning("Found section '%s' in configuration. "
-                            "Cannot set private attributes. Ignoring.", section)
+                log.info("Found section '%s' in configuration. "
+                         "Cannot set private attributes. Ignoring.", section)
                 continue
 
             # Copy sub configuration to value confusing side-effects

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -3,6 +3,7 @@
 """Example usage and tests for :mod:`orion.core.io.resolve_config`."""
 
 import hashlib
+import logging
 import os
 import shutil
 import socket
@@ -348,14 +349,13 @@ def test_infer_versioning_metadata_on_dirty_repo(repo):
     assert vcs['diff_sha'] == hashlib.sha256(''.encode('utf-8')).hexdigest()
 
 
-def test_fetch_user_repo_on_non_repo():
-    """
-    Test if `fetch_user_repo` raises a warning when user's script
-    is not a git repo
-    """
-    with pytest.raises(RuntimeError) as exc_info:
+def test_fetch_user_repo_on_non_repo(caplog):
+    """Test if `fetch_user_repo` logs a warning when user's script is not a git repo."""
+    with caplog.at_level(logging.WARNING):
         resolve_config.fetch_user_repo('.')
-    assert "Script {} should be in a git repository".format(os.getcwd()) in str(exc_info.value)
+    messages = [rec.message for rec in caplog.records]
+    assert len(messages) == 1
+    assert "Script {} is not in a git repository".format(os.getcwd()) in messages[0]
 
 
 def test_infer_versioning_metadata_on_detached_head(repo):


### PR DESCRIPTION
Why:

We decided that Oríon would crash if the script being executed is not part of a code version control (only support git for now). This was to ensure reproducibility, but this constraint is troublesome for users using a different VCS system or none at all. It's not Oríon's role to enforce a VCS on users. They could at least use Oríon without `git`, they will only loose the automatic code change detection.

How:

Log a warning that code change cannot be detected instead of raising an error.
