### PR TITLE
Raise error if branching in non interactive shell

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -634,8 +634,17 @@ class Experiment(object):
         """
         experiment_brancher = ExperimentBranchBuilder(conflicts, branching_configuration)
 
-        if not experiment_brancher.is_resolved or experiment_brancher.auto_resolution:
+        needs_manual_resolution = (not experiment_brancher.is_resolved or
+                                   experiment_brancher.auto_resolution)
+
+        if needs_manual_resolution:
             branching_prompt = BranchingPrompt(experiment_brancher)
+
+            if not sys.__stdin__.isatty():
+                raise ValueError(
+                    "Configuration is different and generates a branching event:\n{}".format(
+                        branching_prompt.get_status()))
+
             branching_prompt.cmdloop()
 
             if branching_prompt.abort or not experiment_brancher.is_resolved:

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -422,11 +422,11 @@ def test_new_algo_not_resolved(init_full_x):
     """Test that new algo conflict is not automatically resolved"""
     name = "full_x"
     branch = "full_x_new_algo"
-    with pytest.raises(OSError) as exc:
+    with pytest.raises(ValueError) as exc:
         orion.core.cli.main(
             ("init_only -n {name} --branch {branch} --config new_algo_config.yaml "
              "./black_box.py -x~uniform(-10,10)").format(name=name, branch=branch).split(" "))
-    assert "reading from stdin while output is captured" in str(exc.value)
+    assert "Configuration is different and generates a branching event" in str(exc.value)
 
 
 def test_new_cli(init_full_x_new_cli):
@@ -445,11 +445,11 @@ def test_new_cli_not_resolved(init_full_x):
     """Test that new cli conflict is not automatically resolved"""
     name = "full_x"
     branch = "full_x_new_cli"
-    with pytest.raises(OSError) as exc:
+    with pytest.raises(ValueError) as exc:
         orion.core.cli.main(
             ("init_only -n {name} --branch {branch} ./black_box.py "
              "-x~uniform(-10,10) --a-new argument").format(name=name, branch=branch).split(" "))
-    assert "reading from stdin while output is captured" in str(exc.value)
+    assert "Configuration is different and generates a branching event" in str(exc.value)
 
 
 def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):
@@ -459,6 +459,7 @@ def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):
         pass
     from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
     monkeypatch.setattr(BranchingPrompt, "cmdloop", _do_nothing)
+    monkeypatch.setattr('sys.__stdin__.isatty', lambda: True)
 
     name = "full_x_full_y"
     branch = "half_x_no_y_new_w"
@@ -484,9 +485,9 @@ def test_auto_resolution_forces_prompt(init_full_x_full_y, monkeypatch):
          "-y~+uniform(-10,10,default_value=1)").format(name=name).split(" "))
 
     # No conflicts, but forced branching, it forces prompt
-    with pytest.raises(OSError) as exc:
+    with pytest.raises(ValueError) as exc:
         orion.core.cli.main(
             ("init_only -n {name} --branch {branch} --auto-resolution ./black_box.py "
              "-x~uniform(-10,10) "
              "-y~+uniform(-10,10,default_value=1)").format(name=name, branch=branch).split(" "))
-    assert "reading from stdin while output is captured" in str(exc.value)
+    assert "Configuration is different and generates a branching event" in str(exc.value)

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -880,3 +880,17 @@ class TestInitExperimentWithEVC(object):
         assert exp.pool_size == 2
         assert exp.max_trials == 1000
         assert exp.configuration['algorithms'] == {'random': {'seed': None}}
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_experiment_non_interactive_branching(self, create_db_instance, random_dt, exp_config,
+                                                  monkeypatch):
+        """Configure an existing experiment with parent."""
+        monkeypatch.setattr('sys.__stdin__.isatty', lambda: True)
+        exp = Experiment('supernaedo2.1')
+        exp.algorithms = {'dumbalgo': {}}
+        with pytest.raises(OSError):
+            exp.configure(exp.configuration)
+        monkeypatch.undo()
+        with pytest.raises(ValueError) as exc_info:
+            exp.configure(exp.configuration)
+        assert "Configuration is different and generates a branching" in str(exc_info.value)


### PR DESCRIPTION
Why:

The comand prompt raises OSError when the shell is non-interactive, but
for some reason it sometimes infinitely raises the OSError and
reactivate the command prompt.

How:

Raise error before starting the prompt if we detect that we are in a non
interactive shell.