### PR TITLE
Add seeding to algorithm and fix parallel strategies

### DIFF
--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -112,8 +112,19 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
                     param.lower() in OptimizationAlgorithm.typenames:
                 # pylint: disable=too-many-function-args
                 param = OptimizationAlgorithm(param, space)
+            elif varname == 'seed':
+                self.seed_rng(param)
 
             setattr(self, varname, param)
+
+    def seed_rng(self, seed):
+        """Seed the state of the random number generator.
+
+        :param seed: Integer seed for the random number generator.
+
+        .. note:: This methods does nothing if the algorithm is deterministic.
+        """
+        pass
 
     @abstractmethod
     def suggest(self, num=1):

--- a/src/orion/algo/random.py
+++ b/src/orion/algo/random.py
@@ -8,6 +8,7 @@
    :synopsis: Draw and deliver samples from prior defined in problem's domain.
 
 """
+import numpy
 
 from orion.algo.base import BaseAlgorithm
 
@@ -15,11 +16,21 @@ from orion.algo.base import BaseAlgorithm
 class Random(BaseAlgorithm):
     """Implement a algorithm that samples randomly from the problem's space."""
 
-    def __init__(self, space):
-        """Random sampler takes no other hyperparameter that the problem's space
+    def __init__(self, space, seed=None):
+        """Random sampler takes no other hyperparameter than the problem's space
         itself.
+
+        :param space: `orion.algo.space.Space` of optimization.
+        :param seed: Integer seed for the random number generator.
         """
-        super(Random, self).__init__(space)
+        super(Random, self).__init__(space, seed=seed)
+
+    def seed_rng(self, seed):
+        """Seed the state of the random number generator.
+
+        :param seed: Integer seed for the random number generator.
+        """
+        self.rng = numpy.random.RandomState(seed)
 
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters. Randomly draw samples
@@ -30,7 +41,7 @@ class Random(BaseAlgorithm):
         .. note:: New parameters must be compliant with the problem's domain
            `orion.algo.space.Space`.
         """
-        return self.space.sample(num)
+        return self.space.sample(num, seed=self.rng.randint(0, 10000))
 
     def observe(self, points, results):
         """Observe evaluation `results` corresponding to list of `points` in

--- a/src/orion/core/worker/primary_algo.py
+++ b/src/orion/core/worker/primary_algo.py
@@ -41,6 +41,10 @@ class PrimaryAlgo(BaseAlgorithm):
         self.transformed_space = build_required_space(requirements, self.space)
         self.algorithm.space = self.transformed_space
 
+    def seed_rng(self, seed):
+        """Seed the state of the algorithm's random number generator."""
+        self.algorithm.seed_rng(seed)
+
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters.
 

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -63,14 +63,16 @@ class Producer(object):
             log.debug("### Algorithm suggests new points.")
 
             new_points = self.naive_algorithm.suggest(self.pool_size)
+            # Dummy sample to keep the original algorithm's rng state incrementing.
+            self.algorithm.suggest(self.pool_size)
 
             for new_point in new_points:
                 log.debug("#### Convert point to `Trial` object.")
                 new_trial = format_trials.tuple_to_trial(new_point, self.space)
                 try:
                     new_trial.parents = self.naive_trials_history.children
-                    self.experiment.register_trial(new_trial)
                     log.debug("#### Register new trial to database: %s", new_trial)
+                    self.experiment.register_trial(new_trial)
                     sampled_points += 1
                 except DuplicateKeyError:
                     log.debug("#### Duplicate sample. Updating algo to produce new ones.")

--- a/src/orion/core/worker/strategy.py
+++ b/src/orion/core/worker/strategy.py
@@ -52,6 +52,9 @@ class BaseParallelStrategy(object, metaclass=ABCMeta):
            Contains the result of an evaluation; partial information about the
            black-box function at each point in `params`.
         """
+        # NOTE: In future points and results will be converted to trials for coherence with
+        # `Strategy.lie()` as well as for coherence with `Algorithm.observe` which will also be
+        # converted to expect trials instead of lists and dictionaries.
         pass
 
     @abstractmethod
@@ -93,8 +96,8 @@ class MaxParallelStrategy(BaseParallelStrategy):
     def observe(self, points, results):
         """See BaseParallelStrategy.observe"""
         super(MaxParallelStrategy, self).observe(points, results)
-        self.max_result = max(result.value for result in results
-                              if result.type == 'objective')
+        self.max_result = max(result['objective'] for result in results
+                              if result['objective'] is not None)
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
@@ -114,7 +117,8 @@ class MeanParallelStrategy(BaseParallelStrategy):
     def observe(self, points, results):
         """See BaseParallelStrategy.observe"""
         super(MeanParallelStrategy, self).observe(points, results)
-        objective_values = [result.value for result in results if result.type == 'objective']
+        objective_values = [result['objective'] for result in results
+                            if result['objective'] is not None]
         self.mean_result = sum(value for value in objective_values) / float(len(objective_values))
 
     def lie(self, trial):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,8 +54,6 @@ class DumbAlgo(BaseAlgorithm):
         rval = []
         while len(rval) < num:
             value = self.possible_values[min(self._index, len(self.possible_values) - 1)]
-            print(self.possible_values)
-            print(self._index, value)
             self._index += 1
             rval.append(value)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,12 @@ class DumbAlgo(BaseAlgorithm):
 
     def __init__(self, space, value=5,
                  scoring=0, judgement=None,
-                 suspend=False, done=False, **nested_algo):
+                 suspend=False, done=False, seed=None, **nested_algo):
         """Configure returns, allow for variable variables."""
         self._times_called_suspend = 0
         self._times_called_is_done = 0
         self._num = 0
+        self._index = 0
         self._points = []
         self._results = []
         self._score_point = None
@@ -35,7 +36,16 @@ class DumbAlgo(BaseAlgorithm):
                                        scoring=scoring, judgement=judgement,
                                        suspend=suspend,
                                        done=done,
+                                       seed=seed,
                                        **nested_algo)
+
+    def seed(self, seed):
+        """Set the index to seed.
+
+        Setting the seed as an index so that unit-tests can force the algorithm to suggest the same
+        values as if seeded.
+        """
+        self._index = seed if seed is not None else 0
 
     def suggest(self, num=1):
         """Suggest based on `value`."""
@@ -43,11 +53,10 @@ class DumbAlgo(BaseAlgorithm):
 
         rval = []
         while len(rval) < num:
-            if len(self.possible_values) > 1:
-                value = self.possible_values.pop(0)
-            else:
-                value = self.possible_values[0]
-
+            value = self.possible_values[min(self._index, len(self.possible_values) - 1)]
+            print(self.possible_values)
+            print(self._index, value)
+            self._index += 1
             rval.append(value)
 
         self._suggested = rval

--- a/tests/functional/commands/experiment.yaml
+++ b/tests/functional/commands/experiment.yaml
@@ -26,7 +26,8 @@
   pool_size: 2
   max_trials: 1000
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: test_insert_missing_default_value
 
@@ -49,7 +50,8 @@
   pool_size: 2
   max_trials: 1000
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: test_insert_two_hyperparameters
 
@@ -72,4 +74,5 @@
   pool_size: 2
   max_trials: 1000
   algorithms: 
-    random: {}
+    random:
+      seed: null

--- a/tests/functional/demo/strategy_config.yaml
+++ b/tests/functional/demo/strategy_config.yaml
@@ -1,0 +1,9 @@
+name: strategy_demo
+
+producer:
+    strategy: NoParallelStrategy
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -6,6 +6,7 @@ import subprocess
 
 import numpy
 import pytest
+import yaml
 
 import orion.core.cli
 from orion.core.io.database import Database
@@ -32,7 +33,7 @@ def test_demo_with_default_algo_cli_config_only(database, monkeypatch):
     assert exp['name'] == 'default_algo'
     assert exp['pool_size'] == 10
     assert exp['max_trials'] == 30
-    assert exp['algorithms'] == {'random': {}}
+    assert exp['algorithms'] == {'random': {'seed': None}}
     assert 'user' in exp['metadata']
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']
@@ -108,7 +109,7 @@ def test_demo_two_workers(database, monkeypatch):
     assert exp['name'] == 'two_workers_demo'
     assert exp['pool_size'] == 2
     assert exp['max_trials'] == 400
-    assert exp['algorithms'] == {'random': {}}
+    assert exp['algorithms'] == {'random': {'seed': None}}
     assert 'user' in exp['metadata']
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']

--- a/tests/unittests/algo/test_base.py
+++ b/tests/unittests/algo/test_base.py
@@ -34,6 +34,7 @@ def test_configuration(dumbalgo):
     config = algo.configuration
     assert config == {
         'dumbalgo': {
+            'seed': None,
             'value': 1,
             'scoring': 0,
             'judgement': None,
@@ -41,6 +42,7 @@ def test_configuration(dumbalgo):
             'done': False,
             'subone': {
                 'dumbalgo': {
+                    'seed': None,
                     'value': 6,
                     'scoring': 5,
                     'judgement': None,

--- a/tests/unittests/algo/test_random.py
+++ b/tests/unittests/algo/test_random.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example usage and tests for :mod:`orion.algo.random`."""
+import numpy
+import pytest
+
+from orion.algo.random import Random
+from orion.algo.space import Integer, Real, Space
+
+
+@pytest.fixture()
+def space():
+    """Return an optimization space"""
+    space = Space()
+    dim1 = Integer('yolo1', 'uniform', -3, 6)
+    space.register(dim1)
+    dim2 = Real('yolo2', 'norm', 0.9)
+    space.register(dim2)
+
+    return space
+
+
+def test_seeding(space):
+    """Verify that seeding makes sampling deterministic"""
+    random_search = Random(space)
+
+    random_search.seed_rng(1)
+    a = random_search.suggest(1)[0]
+    assert not numpy.allclose(a, random_search.suggest(1)[0])
+
+    random_search.seed_rng(1)
+    assert numpy.allclose(a, random_search.suggest(1)[0])

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -42,6 +42,7 @@
   # user's configuration, but defaults are inferred
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      seed: null
       value: 5
       scoring: 0
       judgement: ~
@@ -72,6 +73,7 @@
   max_trials: 1000
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      seed: null
       value: 5
       scoring: 0
       judgement: ~
@@ -103,6 +105,7 @@
   status: done
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      seed: null
       value: 5
       scoring: 0
       judgement: ~
@@ -133,6 +136,7 @@
   max_trials: 1000
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      seed: null
       value: 5
       scoring: 0
       judgement: ~
@@ -182,7 +186,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.2
 
@@ -224,7 +229,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.3
 
@@ -264,7 +270,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.3.1
 
@@ -310,7 +317,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.3.1.1
 
@@ -349,7 +357,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.3.1.2
 
@@ -388,7 +397,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.3.1.3
 
@@ -427,7 +437,8 @@
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 - name: supernaedo2.2.1
 
@@ -464,7 +475,8 @@
 
   # TODO hack in fixtures since we can't define another valid algorithm as we only have random.
   algorithms:
-    random: {}
+    random:
+      seed: null
 
 ---
 

--- a/tests/unittests/core/io/orion_old_config.yaml
+++ b/tests/unittests/core/io/orion_old_config.yaml
@@ -10,6 +10,7 @@ algorithms:
         scoring: 0
         suspend: False
         value: 5
+        seed: null
 
 database:
   type: 'mongodb'

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -178,7 +178,7 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
-    assert exp.algorithms.configuration == {'random': {}}
+    assert exp.algorithms.configuration == {'random': {'seed': None}}
 
 
 @pytest.mark.usefixtures("version_XYZ", "clean_db", "null_db_instances", "with_user_tsirif",
@@ -234,7 +234,7 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp.pool_size == 1
     assert exp.max_trials == 100
     assert not exp.is_done
-    assert exp.algorithms.configuration == {'random': {}}
+    assert exp.algorithms.configuration == {'random': {'seed': None}}
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -260,6 +260,7 @@ class TestConfigProperty(object):
         exp_config[0][0]['algorithms']['dumbalgo']['scoring'] = 0
         exp_config[0][0]['algorithms']['dumbalgo']['suspend'] = False
         exp_config[0][0]['algorithms']['dumbalgo']['value'] = 5
+        exp_config[0][0]['algorithms']['dumbalgo']['seed'] = None
         exp_config[0][0]['producer']['strategy'] = "NoParallelStrategy"
         assert exp._id == exp_config[0][0].pop('_id')
         assert exp.configuration == exp_config[0][0]
@@ -279,6 +280,7 @@ class TestConfigProperty(object):
         exp_config[0][0]['algorithms']['dumbalgo']['scoring'] = 0
         exp_config[0][0]['algorithms']['dumbalgo']['suspend'] = False
         exp_config[0][0]['algorithms']['dumbalgo']['value'] = 5
+        exp_config[0][0]['algorithms']['dumbalgo']['seed'] = None
         exp_config[0][0]['producer']['strategy'] = "NoParallelStrategy"
         assert exp._id == exp_config[0][0].pop('_id')
         assert exp.configuration == exp_config[0][0]
@@ -305,6 +307,7 @@ class TestConfigProperty(object):
         new_config['algorithms']['dumbalgo']['scoring'] = 0
         new_config['algorithms']['dumbalgo']['suspend'] = False
         new_config['algorithms']['dumbalgo']['value'] = 5
+        new_config['algorithms']['dumbalgo']['seed'] = None
         new_config['refers'] = {'adapter': [], 'parent_id': None, 'root_id': _id}
         assert found_config[0] == new_config
         assert exp.name == new_config['name']
@@ -353,6 +356,7 @@ class TestConfigProperty(object):
         exp_config[0][0]['algorithms']['dumbalgo']['scoring'] = 0
         exp_config[0][0]['algorithms']['dumbalgo']['suspend'] = False
         exp_config[0][0]['algorithms']['dumbalgo']['value'] = 5
+        exp_config[0][0]['algorithms']['dumbalgo']['seed'] = None
         exp_config[0][0]['producer']['strategy'] = "NoParallelStrategy"
         assert exp._id == exp_config[0][0].pop('_id')
         assert exp.configuration == exp_config[0][0]
@@ -484,6 +488,7 @@ class TestConfigProperty(object):
         new_config['algorithms']['dumbalgo']['scoring'] = 0
         new_config['algorithms']['dumbalgo']['suspend'] = False
         new_config['algorithms']['dumbalgo']['value'] = 5
+        new_config['algorithms']['dumbalgo']['seed'] = None
         assert exp._id == new_config.pop('_id')
         assert exp.configuration['algorithms'] == new_config['algorithms']
 
@@ -836,13 +841,13 @@ class TestInitExperimentWithEVC(object):
         assert exp._last_fetched == random_dt
         assert exp.pool_size is None
         assert exp.max_trials is None
-        assert exp.configuration['algorithms'] == {'random': {}}
+        assert exp.configuration['algorithms'] == {'random': {'seed': None}}
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_experiment_with_parent(self, create_db_instance, random_dt, exp_config):
         """Configure an existing experiment with parent."""
         exp = Experiment('supernaedo2.1')
-        exp.algorithms = {'random': {}}
+        exp.algorithms = {'random': {'seed': None}}
         exp.configure(exp.configuration)
         assert exp._init_done is True
         assert exp._db is create_db_instance
@@ -852,4 +857,4 @@ class TestInitExperimentWithEVC(object):
         assert exp.metadata == exp_config[0][4]['metadata']
         assert exp.pool_size == 2
         assert exp.max_trials == 1000
-        assert exp.configuration['algorithms'] == {'random': {}}
+        assert exp.configuration['algorithms'] == {'random': {'seed': None}}

--- a/tests/unittests/core/test_primary_algo.py
+++ b/tests/unittests/core/test_primary_algo.py
@@ -33,6 +33,7 @@ class TestPrimaryAlgoWraps(object):
         assert isinstance(palgo.algorithm, dumbalgo)
         assert palgo.configuration == {
             'dumbalgo': {
+                'seed': None,
                 'value': fixed_suggestion,
                 'scoring': 0,
                 'judgement': None,
@@ -40,6 +41,7 @@ class TestPrimaryAlgoWraps(object):
                 'done': False,
                 'subone': {
                     'dumbalgo': {
+                        'seed': None,
                         'value': 6,
                         'scoring': 5,
                         'judgement': None,

--- a/tests/unittests/core/test_strategy.py
+++ b/tests/unittests/core/test_strategy.py
@@ -14,8 +14,7 @@ from orion.core.worker.trial import Trial
 def observations():
     """10 objective observations"""
     points = [i for i in range(10)]
-    results = [Trial.Result(name='foo', type='objective', value=points[i])
-               for i in range(10)]
+    results = [{'objective': points[i]} for i in range(10)]
 
     return points, results
 
@@ -51,9 +50,7 @@ class TestParallelStrategies:
         strategy.observe(points, results)
         lying_result = strategy.lie(incomplete_trial)
 
-        objective_results = [result for result in results
-                             if result.type == 'objective']
-        max_value = max(result.value for result in objective_results)
+        max_value = max(result['objective'] for result in results)
         assert lying_result.value == max_value
 
     def test_mean_parallel_strategy(self, observations, incomplete_trial):
@@ -64,10 +61,8 @@ class TestParallelStrategies:
         strategy.observe(points, results)
         lying_result = strategy.lie(incomplete_trial)
 
-        objective_results = [result for result in results
-                             if result.type == 'objective']
-        mean_value = (sum(result.value for result in objective_results) /
-                      float(len(objective_results)))
+        mean_value = (sum(result['objective'] for result in results) /
+                      float(len(results)))
         assert lying_result.value == mean_value
 
     def test_no_parallel_strategy(self, observations, incomplete_trial):


### PR DESCRIPTION
# Add seeding to algorithm

### Why:

Some (if not many) algorithms are random and should be _seedable_.

### How:

Add the method `seed_rng()` which may seed the algorithm's interval
random number generator. For flexibility, the implementation of the
seeding mechanism is speficic to each algorithm and there is no standard
`RNG` object made public.

# Fix parallel strategies

### Why:

The methods `Strategy.observe` were expecting results as `Result` type,
but were being passed results as dictionaries.

### How:

Since Algorithm.observe gets results as dictionaries, we keep the same
for `Strategy` for coherence.