### PR TITLE
Make experiment's user customisable

### DIFF
--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -83,6 +83,12 @@ def get_basic_args_group(parser):
         help="experiment's unique name; "
              "(default: None - specified either here or in a config)")
 
+    basic_args_group.add_argument(
+        '-u', '--user',
+        type=str,
+        help="user associated to experiment's unique name; "
+             "(default: $USER - can be overriden either here or in a config)")
+
     basic_args_group.add_argument('-c', '--config', type=argparse.FileType('r'),
                                   metavar='path-to-config', help="user provided "
                                   "orion configuration file")

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -178,6 +178,9 @@ class ExperimentBuilder(object):
         exp_config = resolve_config.merge_configs(
             default_options, env_vars, copy.deepcopy(config_from_db), cmdconfig, cmdargs, metadata)
 
+        if 'user' in exp_config:
+            exp_config['metadata']['user'] = exp_config['user']
+
         # TODO: Find a better solution
         if isinstance(exp_config['algorithms'], dict) and len(exp_config['algorithms']) > 1:
             for key in list(config_from_db['algorithms'].keys()):
@@ -218,7 +221,7 @@ class ExperimentBuilder(object):
                                "Please use either `name` cmd line arg or provide "
                                "one in orion's configuration file.")
 
-        return ExperimentView(local_config["name"])
+        return ExperimentView(local_config["name"], local_config.get('user', None))
 
     def build_from(self, cmdargs):
         """Build a fully configured (and writable) experiment based on full configuration.
@@ -264,7 +267,7 @@ class ExperimentBuilder(object):
         config.pop('database', None)
         config.pop('resources', None)
 
-        experiment = Experiment(config['name'])
+        experiment = Experiment(config['name'], config.get('user', None))
 
         # Finish experiment's configuration and write it to database.
         experiment.configure(config)

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -109,6 +109,7 @@ def fetch_default_options():
 
     # get some defaults
     default_config['name'] = None
+    default_config['user'] = getpass.getuser()
     default_config['max_trials'] = DEF_CMD_MAX_TRIALS[0]
     default_config['worker_trials'] = DEF_CMD_WORKER_TRIALS[0]
     default_config['pool_size'] = DEF_CMD_POOL_SIZE[0]

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -89,7 +89,7 @@ class Experiment(object):
                  '_node', '_last_fetched')
     non_branching_attrs = ('pool_size', 'max_trials')
 
-    def __init__(self, name):
+    def __init__(self, name, user=None):
         """Initialize an Experiment object with primary key (:attr:`name`, :attr:`user`).
 
         Try to find an entry in `Database` with such a key and config this object
@@ -112,7 +112,8 @@ class Experiment(object):
         self.name = name
         self._node = None
         self.refers = {}
-        user = getpass.getuser()
+        if user is None:
+            user = getpass.getuser()
         self.metadata = {'user': user}
         self.pool_size = None
         self.max_trials = None
@@ -691,7 +692,7 @@ class ExperimentView(object):
                         ["fetch_trials", "fetch_trials_tree", "fetch_completed_trials",
                          "connect_to_version_control_tree"])
 
-    def __init__(self, name):
+    def __init__(self, name, user=None):
         """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
 
         Build an experiment from configuration found in `Database` with a key (name, user).
@@ -704,7 +705,7 @@ class ExperimentView(object):
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str
         """
-        self._experiment = Experiment(name)
+        self._experiment = Experiment(name, user)
 
         if self._experiment.id is None:
             raise ValueError("No experiment with given name '%s' for user '%s' inside database, "

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.core.io.experiment_builder`."""
+import getpass
 
 import pytest
 
@@ -154,6 +155,21 @@ def test_build_view_from(config_file, create_db_instance, exp_config, random_dt)
     assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_bouthilx")
+def test_build_view_from_force_user(config_file, create_db_instance, exp_config, random_dt):
+    """Try building experiment view when in db"""
+    # Verify default behavior properly fetches bouthilx
+    assert getpass.getuser() == 'bouthilx'
+    cmdargs = {'name': 'supernaedo2', 'config': config_file}
+    with pytest.raises(ValueError) as exc_info:
+        exp_view = ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaedo2' for user 'bouthilx'" in str(exc_info.value)
+
+    cmdargs['user'] = 'tsirif'
+    exp_view = ExperimentBuilder().build_view_from(cmdargs)
+    assert exp_view.metadata['user'] == 'tsirif'
+
+
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_dt, script_path):
     """Try building experiment when not in db"""
@@ -205,6 +221,15 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config, script_
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_bouthilx")
+def test_build_from_force_user(old_config_file, create_db_instance, exp_config, random_dt):
+    """Try building experiment view when in db"""
+    cmdargs = {'name': 'supernaedo2', 'config': old_config_file}
+    cmdargs['user'] = 'tsirif'
+    exp_view = ExperimentBuilder().build_from(cmdargs)
+    assert exp_view.metadata['user'] == 'tsirif'
 
 
 @pytest.mark.usefixtures("version_XYZ", "clean_db", "null_db_instances", "with_user_tsirif")

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -3,6 +3,7 @@
 """Collection of tests for :mod:`orion.core.worker.experiment`."""
 
 import copy
+import getpass
 import random
 
 import pytest
@@ -508,6 +509,27 @@ class TestConfigProperty(object):
         exp.configure(exp_config[0][2])
 
         assert not exp.is_done
+
+
+@pytest.mark.usefixtures("create_db_instance", "with_user_bouthilx")
+def test_forcing_user(exp_config):
+    """Trying to set by forcing user so that NO differences are found."""
+    assert getpass.getuser() == 'bouthilx'
+    exp = Experiment('supernaedo2')
+    assert exp.metadata['user'] == 'bouthilx'
+    exp = Experiment('supernaedo2', 'tsirif')
+    # Deliver an external configuration to finalize init
+    exp_config[0][0]['max_trials'] = 5000
+    exp.configure(exp_config[0][0])
+    exp_config[0][0]['algorithms']['dumbalgo']['done'] = False
+    exp_config[0][0]['algorithms']['dumbalgo']['judgement'] = None
+    exp_config[0][0]['algorithms']['dumbalgo']['scoring'] = 0
+    exp_config[0][0]['algorithms']['dumbalgo']['suspend'] = False
+    exp_config[0][0]['algorithms']['dumbalgo']['value'] = 5
+    exp_config[0][0]['algorithms']['dumbalgo']['seed'] = None
+    exp_config[0][0]['producer']['strategy'] = "NoParallelStrategy"
+    assert exp._id == exp_config[0][0].pop('_id')
+    assert exp.configuration == exp_config[0][0]
 
 
 class TestReserveTrial(object):


### PR DESCRIPTION
Why:

The user's name is defined based on the OS's username (`getpass.getuser()`), but a same user may run the experiment on different systems using different usernames. There should be a way to override to default `getpass.getuser()` and pass a username to Oríon to support such use-cases. This is also true if different users wants to collaborate and fetch results from a colleague.

How:

Username can be passed in config or as `--user`. The name is then passed to either `Experiment` or `ExperimentView` in the `ExperimentBuilder`.

Note:

Maybe we should remove the username from the experiment altogether in the future.