### PR TITLE
Add port option for db backend

### DIFF
--- a/docs/src/examples/cluster.rst
+++ b/docs/src/examples/cluster.rst
@@ -1,0 +1,134 @@
+**************
+Running on HPC
+**************
+
+This guide is based on the example described in :doc:`/user/pytorch`.
+
+Parallel optimization using arrays
+==================================
+
+For simplicity, we will only use Slurm in the examples, but the same applies for PBS based systems
+with the argument ``-t``.
+
+Oríon synchronises workers transparently based on the experiment name. Thanks to this there is no
+master to setup and we can focus solely on submitting the workers. Also, since all
+synchronisation is done through the database, there is no special setup required to connect workers
+together. A minimal Slurm script to launch 10 workers would thus only require the following 2 lines.
+
+.. code-block:: bash
+
+    #SBATCH --array=1-10
+
+    orion hunt -n parallel-exp ./main.py --lr~'loguniform(1e-5, 1.0)'
+
+All workers are optimizing the experiment ``parallel-exp`` in parallel, each holding a copy of the
+optimization algorithm. Adding Slurm options to execute the mnist example with proper ressources
+gives the following
+
+.. code-block:: bash
+
+    #SBATCH --array=1-10
+    #SBATCH --cpus-per-task=2
+    #SBATCH --output=/path/to/some/log/parallel-exp.%A.%a.out
+    #SBATCH --error=/path/to/some/log/parallel-exp.%A.%a.err
+    #SBATCH --gres=gpu:1
+    #SBATCH --job-name=parallel-exp
+    #SBATCH --mem=10GB
+    #SBATCH --time=2:59:00
+
+    orion hunt -n parallel-exp --worker-trials 1 ./main.py --lr~'loguniform(1e-5, 1.0)'
+
+For now, Oríon does not provide detection of lost trials if a worker gets killed due to a
+timeout. Such trial would be indefinitely marked as ``pending`` in the DB and thus could not be
+executed again unless the state is fixed manually. To avoid this, you can set the timeout large
+enough for a single trial and use the argument ``--worker-trials 1`` to limit worker to
+execute only one trial and then quit. If you have a large amount of tasks to execute but do not want
+to have as many workers, you can limit the number of simultaneous jobs with the
+character ``%`` (ex: ``#SBATCH --array=1-100%10``).
+
+.. code-block:: bash
+
+    #SBATCH --array=1-100%10
+    #SBATCH --cpus-per-task=2
+    #SBATCH --output=/path/to/some/log/parallel-exp.%A.%a.out
+    #SBATCH --error=/path/to/some/log/parallel-exp.%A.%a.err
+    #SBATCH --gres=gpu:1
+    #SBATCH --job-name=parallel-exp
+    #SBATCH --mem=10GB
+    #SBATCH --time=2:59:00
+
+    orion hunt -n parallel-exp --worker-trials 1 ./main.py --lr~'loguniform(1e-5, 1.0)'
+
+
+SSH tunnels
+===========
+
+Some HPC infrastructure does not provide access to internet from the compute nodes. To get access to
+the database from the compute nodes, it is necessary to open ssh tunnels to a gateway (typically
+login nodes). The ssh tunnel will redirect traffic from different address and port, therefore the
+config of the database needs to be modified accordingly. Suppose our config was the following
+without using an ssh tunnel. (``$HOME/.config/orion.core/orion_config.yaml``)
+
+.. code-block:: yaml
+
+      database:
+        type: 'mongodb'
+        name: 'db_name'
+        host: 'mongodb://user:pass@<db address>:27017'
+
+Using port 42883, the config would now be like this
+
+.. code-block:: yaml
+
+      database:
+        type: 'mongodb'
+        name: 'db_name'
+        host: 'mongodb://user:pass@localhost'
+        port: '42883'
+
+Note that the port number was removed from ``host`` because it would have precedence over ``port``.
+Also, the host address is changed to ``localhost``, because the traffic is send to
+``localhost:42883`` and then transferred to ``<db address>:27017`` on the other end of the ssh
+tunnel.
+
+Now, to open the ssh tunnel from the compute node, use this command
+
+.. code-block:: bash
+
+    ssh -o StrictHostKeyChecking=no <gateway address> -L 42883:<db address>:27017 -n -N -f
+
+Where <gateway address> is the hostname of the gateway (login node) that you want to connect to.
+
+This would work for a single job, but it is likely to cause trouble if many jobs end up on the same
+compute node. The first job would open the ssh tunnel, and the following ones would fail because the
+port would no longer be available. They would still all be able to use the ssh tunnel, however when
+the first job would end, the ssh tunnel would close with it and all following jobs would loose
+access to the DB. To get around this problem, we need to randomly choose available ports instead,
+so that two jobs working on the same node use different ports. Here's how
+
+.. code-block:: bash
+
+
+    export ORION_DB_PORT=$(python -c "from socket import socket; s = socket(); s.bind((\"\", 0)); print(s.getsockname()[1])")
+
+    ssh -o StrictHostKeyChecking=no <gateway address> -L $ORION_DB_PORT:<db address>:27017 -n -N -f
+
+These lines can then be added to the script to submit workers in parallel.
+
+.. code-block:: bash
+
+    #SBATCH --array=1-100%10
+    #SBATCH --cpus-per-task=2
+    #SBATCH --output=/path/to/some/log/parallel-exp.%A.%a.out
+    #SBATCH --error=/path/to/some/log/parallel-exp.%A.%a.err
+    #SBATCH --gres=gpu:1
+    #SBATCH --job-name=parallel-exp
+    #SBATCH --mem=10GB
+    #SBATCH --time=2:59:00
+
+    export ORION_DB_PORT=$(python -c "from socket import socket; s = socket(); s.bind((\"\", 0)); print(s.getsockname()[1])")
+
+    ssh -o StrictHostKeyChecking=no <gateway address> -L $ORION_DB_PORT:<db address>:27017 -n -N -f
+
+    orion hunt -n parallel-exp --worker-trials 1 ./main.py --lr~'loguniform(1e-5, 1.0)'
+

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -24,6 +24,7 @@
 
    examples/pytorch_cifar
    examples/pytorch_a2c_ppo
+   examples/cluster
 
 .. toctree::
    :caption: Plugin development's Guide

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -92,6 +92,7 @@ Oríon configuration files.
       export ORION_DB_ADDRESS=mongodb://user:pass@localhost
       export ORION_DB_NAME=orion_test
       export ORION_DB_TYPE=MongoDB
+      export ORION_DB_PORT=27017
 
    2. By creating a section in an Oríon's configuration YAML file, like `this one <https://github.com/epistimio/orion/blob/master/tests/functional/demo/orion_config_random.yaml>`_
       used by our functional tests.

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -83,6 +83,11 @@ class MongoDB(AbstractDB):
         self.options = {'authSource': name}
         self.uri = None
 
+        if port is not None:
+            port = int(port)
+        else:
+            port = pymongo.MongoClient.PORT
+
         super(MongoDB, self).__init__(host, name, port, username, password)
 
     @mongodb_exception_wrapper
@@ -249,7 +254,7 @@ class MongoDB(AbstractDB):
         """Sanitize attributes using MongoDB's 'uri_parser' module."""
         try:
             # Host can be a valid MongoDB URI
-            settings = pymongo.uri_parser.parse_uri(self.host)
+            settings = pymongo.uri_parser.parse_uri(self.host, default_port=self.port)
         except pymongo.errors.InvalidURI:  # host argument was a hostname
             if self.port is None:
                 self.port = pymongo.MongoClient.PORT

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -72,7 +72,8 @@ DEF_CONFIG_FILES_PATHS = [
 ENV_VARS_DB = [
     ('ORION_DB_NAME', 'name', 'orion'),
     ('ORION_DB_TYPE', 'type', 'MongoDB'),
-    ('ORION_DB_ADDRESS', 'host', socket.gethostbyname(socket.gethostname()))
+    ('ORION_DB_ADDRESS', 'host', socket.gethostbyname(socket.gethostname())),
+    ('ORION_DB_PORT', 'port', '27017')
     ]
 
 # TODO: Default resource from environmental (localhost)

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -32,6 +32,7 @@ def test_fetch_default_options():
     assert default_config['database']['host'] == socket.gethostbyname(socket.gethostname())
     assert default_config['database']['name'] == 'orion'
     assert default_config['database']['type'] == 'MongoDB'
+    assert default_config['database']['port'] == '27017'
 
     assert default_config['max_trials'] == float('inf')
     assert default_config['name'] is None

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -91,6 +91,20 @@ class TestConnection(object):
         assert orion_db.password == 'pass'
         assert orion_db.name == 'orion_test'
 
+    def test_overwrite_partial_uri(self, monkeypatch):
+        """Check the case when connecting with partial `uri`."""
+        monkeypatch.setattr(MongoDB, 'initiate_connection', lambda self: None)
+
+        orion_db = MongoDB('mongodb://localhost',
+                           port=1231, name='orion', username='lala',
+                           password='none')
+        orion_db._sanitize_attrs()
+        assert orion_db.host == 'localhost'
+        assert orion_db.port == 1231
+        assert orion_db.username == 'lala'
+        assert orion_db.password == 'none'
+        assert orion_db.name == 'orion'
+
     def test_singleton(self):
         """Test that MongoDB class is a singleton."""
         orion_db = MongoDB(username='user', password='pass', name='orion_test')


### PR DESCRIPTION
Why:

SSH tunnels require a way to set ports dynamically from outside the yaml
config of orion, using env vars for instance.

How:

Add the env var ORION_DB_PORT and add tests to make sure it properly
overwrites the db host value in MongoDB.