### PR TITLE
Handle bad socket.hostname

### DIFF
--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -67,12 +67,17 @@ DEF_CONFIG_FILES_PATHS = [
     os.path.join(orion.core.DIRS.user_config_dir, 'orion_config.yaml')
     ]
 
+try:
+    DEFAULT_HOST = socket.gethostbyname(socket.gethostname())
+except socket.gaierror:
+    DEFAULT_HOST = 'localhost'
+
 # list containing tuples of
 # (environmental variable names, configuration keys, default values)
 ENV_VARS_DB = [
     ('ORION_DB_NAME', 'name', 'orion'),
     ('ORION_DB_TYPE', 'type', 'MongoDB'),
-    ('ORION_DB_ADDRESS', 'host', socket.gethostbyname(socket.gethostname())),
+    ('ORION_DB_ADDRESS', 'host', DEFAULT_HOST),
     ('ORION_DB_PORT', 'port', '27017')
     ]
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -3,6 +3,7 @@
 """Example usage and tests for :mod:`orion.core.io.resolve_config`."""
 
 import hashlib
+import importlib
 import logging
 import os
 import shutil
@@ -37,6 +38,21 @@ def test_fetch_default_options():
     assert default_config['max_trials'] == float('inf')
     assert default_config['name'] is None
     assert default_config['pool_size'] == 1
+
+
+def test_socket_on_osx(monkeypatch):
+    """Verify that default hostname is set properly on OSX"""
+    resolve_config.DEF_CONFIG_FILES_PATHS = []
+    default_config = resolve_config.fetch_default_options()
+    assert default_config['database']['host'] == socket.gethostbyname(socket.gethostname())
+    assert socket.gethostbyname(socket.gethostname()) != 'localhost'
+
+    monkeypatch.setattr(socket, 'gethostname', lambda: 'wrong_name_on_osx')
+    importlib.reload(resolve_config)
+
+    resolve_config.DEF_CONFIG_FILES_PATHS = []
+    default_config = resolve_config.fetch_default_options()
+    assert default_config['database']['host'] == 'localhost'
 
 
 def test_fetch_env_vars():


### PR DESCRIPTION
Why:

On OSX, hostnames cannot be interpreted by `gethostbyname()` (See #165).

How:

If the hostname cannot be interpreted, set to `localhost` by default.