### PR TITLE
Handle bool arg in EVC Conflict

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1218,7 +1218,7 @@ class CommandLineConflict(Conflict):
         nameless_args = {key: arg for key, arg in parser.parser.arguments.items()
                          if key in nameless_keys}
 
-        return " ".join(" ".join([key, arg]) for key, arg in
+        return " ".join(" ".join([key, str(arg)]) for key, arg in
                         sorted(nameless_args.items(), key=lambda a: a[0]))
 
     @classmethod

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -286,6 +286,7 @@ def cli_conflict(old_config, new_config):
     """Generate a commandline conflict"""
     new_config = copy.deepcopy(new_config)
     new_config['metadata']['user_args'].append("--some-new=args")
+    new_config['metadata']['user_args'].append("--bool-arg")
     return conflicts.CommandLineConflict(old_config, new_config)
 
 

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -275,7 +275,8 @@ class TestCommandLineConflict(object):
 
     def test_repr(self, cli_conflict):
         """Verify the representation of conflict for user interface"""
-        assert repr(cli_conflict) == "Old arguments '' != new arguments 'some-new args'"
+        assert (
+            repr(cli_conflict) == "Old arguments '' != new arguments 'bool-arg True some-new args'")
 
 
 class TestScriptConfigConflict(object):


### PR DESCRIPTION
Why:

With the new OrionArgParser, boolean arguments are now passed with
boolean values (always True). Since we expected strings before the
change, we now need to convert the values to string in case it is a
boolean.