### PR TITLE
Handle bad results in trials

### DIFF
--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -148,13 +148,13 @@ class Trial(object):
         allowed_types = ('integer', 'real', 'categorical')
 
     __slots__ = ('experiment', '_id', '_status', 'worker',
-                 'submit_time', 'start_time', 'end_time', 'results', 'params', 'parents')
+                 'submit_time', 'start_time', 'end_time', '_results', 'params', 'parents')
     allowed_stati = ('new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken')
 
     def __init__(self, **kwargs):
         """See attributes of `Trial` for meaning and possible arguments for `kwargs`."""
         for attrname in self.__slots__:
-            if attrname in ('results', 'params', 'parents'):
+            if attrname in ('_results', 'params', 'parents'):
                 setattr(self, attrname, list())
             else:
                 setattr(self, attrname, None)
@@ -201,6 +201,24 @@ class Trial(object):
         return ret
 
     __repr__ = __str__
+
+    @property
+    def results(self):
+        """List of results of the trial"""
+        return self._results
+
+    @results.setter
+    def results(self, results):
+        """Verify results before setting the property"""
+        objective = self._fetch_one_result_of_type('objective', results)
+
+        if objective is None:
+            raise ValueError('No objective found in results: {}'.format(results))
+        if not isinstance(objective.value, (float, int)):
+            raise ValueError(
+                'Results must contain a type `objective` with type float/int: {}'.format(objective))
+
+        self._results = results
 
     @property
     def status(self):
@@ -277,9 +295,11 @@ class Trial(object):
                              "have not been set.")
         return self.params_repr(sep='-').replace('/', '.')
 
-    def _fetch_one_result_of_type(self, result_type):
-        value = [result for result in self.results
-                 if result.type == result_type]
+    def _fetch_one_result_of_type(self, result_type, results=None):
+        if results is None:
+            results = self.results
+
+        value = [result for result in results if result.type == result_type]
 
         if not value:
             return None

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -601,9 +601,7 @@ class TestReserveTrial(object):
 def test_push_completed_trial(hacked_exp, database, random_dt):
     """Successfully push a completed trial into database."""
     trial = hacked_exp.reserve_trial()
-    trial.results = []
-    res = Trial.Result(name='yolo', type='objective', value='3')
-    trial.results.append(res)
+    trial.results = [Trial.Result(name='yolo', type='objective', value=3)]
     hacked_exp.push_completed_trial(trial)
     yo = database.trials.find_one({'_id': trial.id})
     assert len(yo['results']) == len(trial.results)

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -121,6 +121,30 @@ class TestTrial(object):
         assert str(t.params[0]) == "Param(name='/encoding_layer', "\
                                    "type='categorical', value='gru')"
 
+    def test_invalid_result(self, exp_config):
+        """Test that invalid objectives cannot be set"""
+        t = Trial(**exp_config[1][2])
+
+        # Make sure valid ones pass
+        t.results = [Trial.Result(name='asfda', type='constraint', value=None),
+                     Trial.Result(name='asfdb', type='objective', value=1e-5)]
+
+        # No results at all
+        with pytest.raises(ValueError) as exc:
+            t.results = []
+        assert 'No objective found' in str(exc.value)
+
+        # No objectives
+        with pytest.raises(ValueError) as exc:
+            t.results = [Trial.Result(name='asfda', type='constraint', value=None)]
+        assert 'No objective found' in str(exc.value)
+
+        # Bad objective type
+        with pytest.raises(ValueError) as exc:
+            t.results = [Trial.Result(name='asfda', type='constraint', value=None),
+                         Trial.Result(name='asfdb', type='objective', value=None)]
+        assert 'Results must contain' in str(exc.value)
+
     def test_objective_property(self, exp_config):
         """Check property `Trial.objective`."""
         # 1 results in `results` list


### PR DESCRIPTION
Why:

If the user pass bad results (missing objective, None objective, etc),
Oríon will later crash in mysterious ways for the users. We should
detect this early and raise an insightfull error for the user.

How:

Make the result attribute private and test in results.setter if the
provided results are valid.