### PR TITLE
Fix null comparison in EphemeralDB

### DIFF
--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -270,8 +270,8 @@ class EphemeralDocument(object):
 
     operators = {
         "$in": (lambda a, b: a in b),
-        "$gte": (lambda a, b: a >= b),
-        "$gt": (lambda a, b: a > b)
+        "$gte": (lambda a, b: a is not None and a >= b),
+        "$gt": (lambda a, b: a is not None and a > b)
     }
 
     def __init__(self, data):

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -127,6 +127,20 @@ class TestRead(object):
              'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
         assert value == exp_config[1][3:7]
 
+    def test_null_comp(self, exp_config, orion_db):
+        """Fetch value(s) from an entry."""
+        all_values = orion_db.read(
+            'trials',
+            {'experiment': 'supernaedo2',
+             'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
+
+        orion_db._db['trials']._documents[0]._data['end_time'] = None
+        values = orion_db.read(
+            'trials',
+            {'experiment': 'supernaedo2',
+             'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
+        assert len(values) == len(all_values) - 1
+
 
 @pytest.mark.usefixtures("clean_db")
 class TestWrite(object):


### PR DESCRIPTION
Why:

Sometimes a field is None which causes comparisons in queries to crash.
Comparisons with a None field should return False instead of crashing.