### PR TITLE
Add timeout for connection to Database

### DIFF
--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -13,6 +13,7 @@ import logging
 import textwrap
 
 import orion
+from orion.core.io.database import DatabaseError
 from orion.core.utils.exceptions import NoConfigurationError
 
 
@@ -73,6 +74,8 @@ class OrionArgsParser:
             function(args)
         except NoConfigurationError:
             print("Error: No commandline configuration found for new experiment.")
+        except DatabaseError as e:
+            print(e)
 
 
 def get_basic_args_group(parser):

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -42,13 +42,14 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
     DESCENDING = 1
 
     def __init__(self, host='localhost', name=None,
-                 port=None, username=None, password=None):
+                 port=None, username=None, password=None, **kwargs):
         """Init method, see attributes of :class:`AbstractDB`."""
         self.host = host
         self.name = name
         self.port = port
         self.username = username
         self.password = password
+        self.options = kwargs
 
         self._db = None
         self._conn = None

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -78,9 +78,8 @@ class MongoDB(AbstractDB):
     """
 
     def __init__(self, host='localhost', name=None,
-                 port=None, username=None, password=None):
+                 port=None, username=None, password=None, server_timeout=5000):
         """Init method, see attributes of :class:`AbstractDB`."""
-        self.options['authSource'] = name
         self.uri = None
 
         if port is not None:
@@ -89,6 +88,9 @@ class MongoDB(AbstractDB):
             port = pymongo.MongoClient.PORT
 
         super(MongoDB, self).__init__(host, name, port, username, password)
+
+        self.options['serverSelectionTimeoutMS'] = server_timeout
+        self.options['authSource'] = name
 
     @mongodb_exception_wrapper
     def initiate_connection(self):

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -78,7 +78,7 @@ class MongoDB(AbstractDB):
     """
 
     def __init__(self, host='localhost', name=None,
-                 port=None, username=None, password=None, server_timeout=5000):
+                 port=None, username=None, password=None, serverSelectionTimeoutMS=5000):
         """Init method, see attributes of :class:`AbstractDB`."""
         self.uri = None
 
@@ -87,10 +87,9 @@ class MongoDB(AbstractDB):
         else:
             port = pymongo.MongoClient.PORT
 
-        super(MongoDB, self).__init__(host, name, port, username, password)
-
-        self.options['serverSelectionTimeoutMS'] = server_timeout
-        self.options['authSource'] = name
+        super(MongoDB, self).__init__(host, name, port, username, password,
+                                      serverSelectionTimeoutMS=serverSelectionTimeoutMS,
+                                      authSource=name)
 
     @mongodb_exception_wrapper
     def initiate_connection(self):

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -80,7 +80,7 @@ class MongoDB(AbstractDB):
     def __init__(self, host='localhost', name=None,
                  port=None, username=None, password=None):
         """Init method, see attributes of :class:`AbstractDB`."""
-        self.options = {'authSource': name}
+        self.options['authSource'] = name
         self.uri = None
 
         if port is not None:

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -128,7 +128,7 @@ def fetch_default_options():
             default_config[signifier][key] = default_value
 
     if 'serverSelectionTimeoutMS' not in default_config['database']:
-        default_config['database']['serverSelectionTimeoutMS'] = 1000
+        default_config['database']['serverSelectionTimeoutMS'] = 5000
 
     # fetch options from default configuration files
     for configpath in DEF_CONFIG_FILES_PATHS:

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -127,6 +127,9 @@ def fetch_default_options():
         for _, key, default_value in env_vars:
             default_config[signifier][key] = default_value
 
+    if 'serverSelectionTimeoutMS' not in default_config['database']:
+        default_config['database']['serverSelectionTimeoutMS'] = 1000
+
     # fetch options from default configuration files
     for configpath in DEF_CONFIG_FILES_PATHS:
         try:

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -127,9 +127,6 @@ def fetch_default_options():
         for _, key, default_value in env_vars:
             default_config[signifier][key] = default_value
 
-    if 'serverSelectionTimeoutMS' not in default_config['database']:
-        default_config['database']['serverSelectionTimeoutMS'] = 5000
-
     # fetch options from default configuration files
     for configpath in DEF_CONFIG_FILES_PATHS:
         try:

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -117,7 +117,8 @@ class TestConnection(object):
 
     def test_change_server_timeout(self):
         """Test that the server timeout is correctly changed."""
-        orion_db = MongoDB(username='user', password='pass', name='orion_test', server_timeout=6000)
+        orion_db = MongoDB(username='user', password='pass', name='orion_test',
+                           serverSelectionTimeoutMS=6000)
         assert 6000 in str(orion_db)
 
 

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -4,6 +4,7 @@
 
 from datetime import datetime
 import functools
+from timeit import timeit
 
 import pymongo
 from pymongo import MongoClient
@@ -108,7 +109,7 @@ class TestConnection(object):
     def test_singleton(self):
         """Test that MongoDB class is a singleton."""
         orion_db = MongoDB('mongodb://localhost',
-                           port=27017, name='orion', username='lala',
+                           port=27017, name='orion_test', username='user',
                            password='pass')
         # reinit connection does not change anything
         orion_db.initiate_connection()
@@ -117,9 +118,8 @@ class TestConnection(object):
 
     def test_change_server_timeout(self):
         """Test that the server timeout is correctly changed."""
-        orion_db = MongoDB(username='user', password='pass', name='orion_test',
-                           serverSelectionTimeoutMS=6000)
-        assert 6000 in str(orion_db)
+        assert timeit(lambda: MongoDB(username='user', password='pass', name='orion_test',
+                                      serverSelectionTimeoutMS=1000), number=1) <= 2
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -107,11 +107,18 @@ class TestConnection(object):
 
     def test_singleton(self):
         """Test that MongoDB class is a singleton."""
-        orion_db = MongoDB(username='user', password='pass', name='orion_test')
+        orion_db = MongoDB('mongodb://localhost',
+                           port=27017, name='orion', username='lala',
+                           password='pass')
         # reinit connection does not change anything
         orion_db.initiate_connection()
         orion_db.close_connection()
         assert MongoDB() is orion_db
+
+    def test_change_server_timeout(self):
+        """Test that the server timeout is correctly changed."""
+        orion_db = MongoDB(username='user', password='pass', name='orion_test', server_timeout=6000)
+        assert 6000 in str(orion_db)
 
 
 @pytest.mark.usefixtures("clean_db")


### PR DESCRIPTION
Why: we were not failing fast when dealing with a non-existing
database. Now there is a default value for a timeout when connecting.