### PR TITLE
Add state_dict/set_state to algos

### DIFF
--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -17,6 +17,7 @@ from orion.core.utils import Factory
 log = logging.getLogger(__name__)
 
 
+# pylint: disable=too-many-public-methods
 class BaseAlgorithm(object, metaclass=ABCMeta):
     """Base class describing what an algorithm can do.
 
@@ -123,6 +124,18 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
         :param seed: Integer seed for the random number generator.
 
         .. note:: This methods does nothing if the algorithm is deterministic.
+        """
+        pass
+
+    @property
+    def state_dict(self):
+        """Return a state dict that can be used to reset the state of the algorithm."""
+        return {}
+
+    def set_state(self, state_dict):
+        """Reset the state of the algorithm based on the given state_dict
+
+        :param state_dict: Dictionary representing state of an algorithm
         """
         pass
 

--- a/src/orion/algo/random.py
+++ b/src/orion/algo/random.py
@@ -32,6 +32,19 @@ class Random(BaseAlgorithm):
         """
         self.rng = numpy.random.RandomState(seed)
 
+    @property
+    def state_dict(self):
+        """Return a state dict that can be used to reset the state of the algorithm."""
+        return {'rng_state': self.rng.get_state()}
+
+    def set_state(self, state_dict):
+        """Reset the state of the algorithm based on the given state_dict
+
+        :param state_dict: Dictionary representing state of an algorithm
+        """
+        self.seed_rng(0)
+        self.rng.set_state(state_dict['rng_state'])
+
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters. Randomly draw samples
         from the import space and return them.

--- a/src/orion/core/worker/primary_algo.py
+++ b/src/orion/core/worker/primary_algo.py
@@ -13,6 +13,7 @@ from orion.algo.base import BaseAlgorithm
 from orion.core.worker.transformer import build_required_space
 
 
+# pylint: disable=too-many-public-methods
 class PrimaryAlgo(BaseAlgorithm):
     """Perform checks on points and transformations. Wrap the primary algorithm.
 
@@ -44,6 +45,18 @@ class PrimaryAlgo(BaseAlgorithm):
     def seed_rng(self, seed):
         """Seed the state of the algorithm's random number generator."""
         self.algorithm.seed_rng(seed)
+
+    @property
+    def state_dict(self):
+        """Return a state dict that can be used to reset the state of the algorithm."""
+        return self.algorithm.state_dict
+
+    def set_state(self, state_dict):
+        """Reset the state of the algorithm based on the given state_dict
+
+        :param state_dict: Dictionary representing state of an algorithm
+        """
+        self.algorithm.set_state(state_dict)
 
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters.

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -63,8 +63,8 @@ class Producer(object):
             log.debug("### Algorithm suggests new points.")
 
             new_points = self.naive_algorithm.suggest(self.pool_size)
-            # Dummy sample to keep the original algorithm's rng state incrementing.
-            self.algorithm.suggest(self.pool_size)
+            # Sync state of original algo so that state continues evolving.
+            self.algorithm.set_state(self.naive_algorithm.state_dict)
 
             for new_point in new_points:
                 log.debug("#### Convert point to `Trial` object.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,20 @@ class DumbAlgo(BaseAlgorithm):
         """
         self._index = seed if seed is not None else 0
 
+    @property
+    def state_dict(self):
+        """Return a state dict that can be used to reset the state of the algorithm."""
+        return {'index': self._index, 'suggested': self._suggested, 'num': self._num}
+
+    def set_state(self, state_dict):
+        """Reset the state of the algorithm based on the given state_dict
+
+        :param state_dict: Dictionary representing state of an algorithm
+        """
+        self._index = state_dict['index']
+        self._suggested = state_dict['suggested']
+        self._num = state_dict['num']
+
     def suggest(self, num=1):
         """Suggest based on `value`."""
         self._num += num

--- a/tests/unittests/algo/test_random.py
+++ b/tests/unittests/algo/test_random.py
@@ -30,3 +30,16 @@ def test_seeding(space):
 
     random_search.seed_rng(1)
     assert numpy.allclose(a, random_search.suggest(1)[0])
+
+
+def test_set_state(space):
+    """Verify that resetting state makes sampling deterministic"""
+    random_search = Random(space)
+
+    random_search.seed_rng(1)
+    state = random_search.state_dict
+    a = random_search.suggest(1)[0]
+    assert not numpy.allclose(a, random_search.suggest(1)[0])
+
+    random_search.set_state(state)
+    assert numpy.allclose(a, random_search.suggest(1)[0])


### PR DESCRIPTION
Why:

The behavior of original algo and the naive version may be different if
they have different history, leading to state increment that cannot be
synced simply but sampling and discarding from original algo. A better
way of syncing them is to provide methods state_dict/set_state so that
state can be copied over, while still discarding the lies from history.

How:

`state_dict` returns a dictionary containing required information to
reset algo state (ex: RNG state).