### PR TITLE
Add missing Fidelity methods

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -655,13 +655,17 @@ class Fidelity(Dimension):
         self.prior = None
         self._prior_name = 'None'
 
+    def get_prior_string(self):
+        """Build the string corresponding to current prior"""
+        return 'fidelity()'
+
     def validate(self):
         """Do not do anything."""
         raise NotImplementedError
 
     def sample(self, n_samples=1, seed=None):
         """Do not do anything."""
-        pass
+        return ['fidelity']
 
     def interval(self, alpha=1.0):
         """Do not do anything."""
@@ -674,6 +678,18 @@ class Fidelity(Dimension):
     def __repr__(self):
         """Represent the object as a string."""
         return "{0}(name={1})".format(self.__class__.__name__, self.name)
+
+    def __contains__(self, value):
+        """Check if constraints hold for this `point` of `Dimension`.
+
+        .. note ::
+
+            Always True for Fidelity.
+
+        :param point: a parameter corresponding to this `Dimension`.
+        :type point: numeric or array-like
+        """
+        return True
 
 
 class Space(OrderedDict):

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -145,7 +145,7 @@ class Trial(object):
         """
 
         __slots__ = ()
-        allowed_types = ('integer', 'real', 'categorical')
+        allowed_types = ('integer', 'real', 'categorical', 'fidelity')
 
     __slots__ = ('experiment', '_id', '_status', 'worker',
                  'submit_time', 'start_time', 'end_time', '_results', 'params', 'parents')

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -464,7 +464,7 @@ class TestCategorical(object):
 class TestFidelity(object):
     """Test methods of a Fidelity object."""
 
-    def test_simple_instance(self, seed):
+    def test_simple_instance(self):
         """Test Fidelity.__init__."""
         dim = Fidelity('epoch')
 
@@ -472,6 +472,20 @@ class TestFidelity(object):
         assert dim.name == 'epoch'
         assert dim.type == 'fidelity'
         assert dim.shape is None
+
+    def test_sampling(self):
+        """Make sure Fidelity simply returns `fidelity`"""
+        dim = Fidelity('epoch')
+
+        assert dim.sample() == ['fidelity']
+
+    def test_contains(self):
+        """Make sure fidelity.__contains__ always returns True"""
+        dim = Fidelity('epoch')
+
+        assert None in dim
+        assert 0 in dim
+        assert object() in dim
 
     def test_interval(self):
         """Check that error is being raised."""


### PR DESCRIPTION
Why:

The methods `__contains__`, `get_prior_string` and `sample` were not
implemented.