### PR TITLE
[WIP] Implementation of ASHA in orion.algo

### DIFF
--- a/docs/src/code/algo.rst
+++ b/docs/src/code/algo.rst
@@ -14,3 +14,4 @@ TODO
    algo/space
    algo/base
    algo/random
+   algo/asha

--- a/docs/src/code/algo/asha.rst
+++ b/docs/src/code/algo/asha.rst
@@ -1,0 +1,8 @@
+Asynchronous Successive Halving Algorithm
+=========================================
+
+Can't build documentation because of import order.
+Sphinx is loading ``orion.algo.asha`` before ``orion.algo`` and therefore
+there is a cycle between the definition of ``OptimizationAlgorithm`` and
+``ASHA`` as the meta-class ``Factory`` is trying to import ``ASHA``.
+`PR #135 <https://github.com/Epistimio/orion/pull/135/files>`_ should get rid of this problem.

--- a/docs/src/install/plugins.rst
+++ b/docs/src/install/plugins.rst
@@ -18,7 +18,7 @@ Algorithms
 Skopt algorithms
 ----------------
 
-`orion.algo.skopt` provides a wrapper for `Bayesian optimizer`_ using Gaussian process implemented
+``orion.algo.skopt`` provides a wrapper for `Bayesian optimizer`_ using Gaussian process implemented
 in `scikit optimize`_. For more information about algorithms configuration and usage please refer to
 :doc:`/user/algorithms`.
 

--- a/docs/src/user/algorithms.rst
+++ b/docs/src/user/algorithms.rst
@@ -37,7 +37,7 @@ Configuration
 
 .. code-block:: yaml
 
-     algorithms: 
+     algorithms:
         random:
            seed: null
 

--- a/docs/src/user/algorithms.rst
+++ b/docs/src/user/algorithms.rst
@@ -1,15 +1,9 @@
-.. contents:: User's Guide 103: Algorithms
-
-
 ****************
 Setup Algorithms
 ****************
 
 Default algorithm is a random search based on the probability
 distribution given to a search parameter's definition.
-
-In the examples given below actual functional tests will be demonstrated,
-in `demo <https://github.com/epistimio/orion/tree/master/tests/functional/demo>`_.
 
 Selecting and Configuring
 =========================
@@ -26,21 +20,191 @@ In this particular example, the name of the algorithm extension class to be
 imported and instantiated is ``Gradient_Descent``, so the lower-case identifier
 corresponds to it.
 
-Also, notice that we can configure the optimization algorithms that we would
-like to use by tweaking the value of a keyword argument which is expected to
-be accepted at algorithm's initialization.
+All algorithms have default arguments that should work reasonably in general.
+To tune the algorithm for a specific problem, use can set those arguments in the
+yaml file as shown above with ``learning_rate``.
 
-Most algorithms have most of their arguments be optional and keyword. In case
-that an explicit value setup is provided in the configuration file in use, then
-the default values of corresponding missing values will be used; those that have
-been decided by the developers of an algorithm's implementation.
+Included Algorithms
+===================
 
-List of Available Implementations
-=================================
+Random Search
+-------------
 
-TODO
+Random search is the most simple algorithm. It samples from given priors. That's it.
 
-Installing Algorithms as Plugins
-================================
+Configuration
+~~~~~~~~~~~~~
 
-TODO
+.. code-block:: yaml
+
+     algorithms: 
+        random:
+           seed: null
+
+
+``seed``
+
+Seed for the random number generator used to sample new trials. Default is ``None``.
+
+ASHA
+----
+
+`Asynchronous Successive Halving Algorithm`_, the asynchronous version of
+`Hyperband`_, can be roughly interpreted as a sophisticated random search that leverages
+partial information of the trial execution to concentrate resources on the
+most promising ones.
+
+The main idea of the algorithm is the following. Given a fidelity dimension, such as
+the number of epochs to train or the size of the dataset, ASHA samples trials
+with low-fidelity and promotes the most promising ones to the next fidelity level.
+This makes it possible to only execute one trial with full fidelity, leading
+to very optimal resource usage.
+
+The most common way of using ASHA is to reduce number of epochs,
+but the algorithm is generic and can be applied to any multi-fidelity setting.
+That is, you can use training time, specifying the fidelity with ``--epochs~fidelity()``
+(assuming your script takes this argument in commandline), but you could also use other fidelity
+such as dataset size ``--dataset-size~fidelity()`` (assuming your script takes this argument and
+adapt dataset size accordingly). The placeholder ``fidelity()`` is a special prior for
+multi-fidelity algorithms.
+
+
+.. _asynchronous successive halving algorithm: https://arxiv.org/abs/1810.05934
+.. _Hyperband: https://arxiv.org/abs/1603.06560
+
+.. note::
+
+   Current implementation does not support more than one fidelity dimension.
+
+Configuration
+~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+     algorithms:
+        asha:
+           seed: null
+           max_resources: 100
+           grace_period: 1
+           reduction_factor: 4
+           num_brackets: 1
+
+``seed``
+
+Seed for the random number generator used to sample new trials. Default is ``None``.
+
+
+``max_resources``
+
+Maximum amount of resource that will be assigned to trials by ASHA. Only the best
+performing trial will be assigned the maximum amount of resources. Default is 100.
+
+``grace_period``
+
+The minimum number of resource assigned to each trial. Default is 1.
+
+``reduction_factor``
+
+The factor by which ASHA promotes trials. If the reduction factor is 4, it means
+the number of trials from one fidelity level to the next one is roughly divided by 4, and
+each fidelity level has 4 times more resources than the prior one. Default is 4.
+
+``num_brackets``
+
+Using a grace period that is too small may bias ASHA too strongly towards fast
+converging trials that do not lead to best results at convergence (stragglers).
+To overcome this, you can increase the number of brackets, which increases the amount of resources
+required for optimisation but decreases the bias towards stragglers. Default is 1.
+
+
+Algorithm Plugins
+=================
+
+Bayesian Optimizer
+------------------
+
+``orion.algo.skopt`` provides a wrapper for `Bayesian optimizer`_ using Gaussian process implemented
+in `scikit optimize`_.
+
+.. _scikit optimize: https://scikit-optimize.github.io/
+.. _bayesian optimizer: https://scikit-optimize.github.io/#skopt.Optimizer
+
+Installation
+~~~~~~~~~~~~
+
+.. code-block:: sh
+
+   pip install orion.algo.skopt
+
+Configuration
+~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+     algorithms:
+        bayesopt:
+           seed: null
+           strategy: cl_min
+           n_initial_points: 10
+           acq_func: gp_hedge
+           alpha: 1e-10
+           n_restarts_optimizer: 0
+           noise: "gaussian"
+           normalize_y: False
+
+``seed``
+
+
+``strategy``
+
+Method to use to sample multiple points.
+Supported options are `"cl_min"`, `"cl_mean"` or `"cl_max"`.
+Check skopt docs for details.
+
+``n_initial_points``
+
+Number of evaluations of ``func`` with initialization points
+before approximating it with ``base_estimator``. Points provided as
+``x0`` count as initialization points. If len(x0) < n_initial_points
+additional points are sampled at random.
+
+``acq_func``
+
+Function to minimize over the posterior distribution. Can be:
+``["LCB", "EI", "PI", "gp_hedge", "EIps", "PIps"]``. Check skopt
+docs for details.
+
+``alpha``
+
+Value added to the diagonal of the kernel matrix during fitting.
+Larger values correspond to increased noise level in the observations
+and reduce potential numerical issue during fitting. If an array is
+passed, it must have the same number of entries as the data used for
+fitting and is used as datapoint-dependent noise level. Note that this
+is equivalent to adding a WhiteKernel with c=alpha. Allowing to specify
+the noise level directly as a parameter is mainly for convenience and
+for consistency with Ridge.
+
+``n_restarts_optimizer``
+
+The number of restarts of the optimizer for finding the kernel's
+parameters which maximize the log-marginal likelihood. The first run
+of the optimizer is performed from the kernel's initial parameters,
+the remaining ones (if any) from thetas sampled log-uniform randomly
+from the space of allowed theta-values. If greater than 0, all bounds
+must be finite. Note that n_restarts_optimizer == 0 implies that one
+run is performed.
+
+``noise``
+
+If set to "gaussian", then it is assumed that y is a noisy estimate of f(x) where the
+noise is gaussian.
+
+``normalize_y``
+
+Whether the target values y are normalized, i.e., the mean of the
+observed target values become zero. This parameter should be set to
+True if the target values' mean is expected to differ considerable from
+zero. When enabled, the normalization effectively modifies the GP's
+prior based on the data, which contradicts the likelihood principle;
+normalization is thus disabled per default.

--- a/docs/src/user/algorithms.rst
+++ b/docs/src/user/algorithms.rst
@@ -20,8 +20,8 @@ In this particular example, the name of the algorithm extension class to be
 imported and instantiated is ``Gradient_Descent``, so the lower-case identifier
 corresponds to it.
 
-All algorithms have default arguments that should work reasonably in general.
-To tune the algorithm for a specific problem, use can set those arguments in the
+All algorithms have default arguments that should work reasonably well in general.
+To tune the algorithm for a specific problem, you can set those arguments in the
 yaml file as shown above with ``learning_rate``.
 
 Included Algorithms
@@ -60,7 +60,7 @@ with low-fidelity and promotes the most promising ones to the next fidelity leve
 This makes it possible to only execute one trial with full fidelity, leading
 to very optimal resource usage.
 
-The most common way of using ASHA is to reduce number of epochs,
+The most common way of using ASHA is to reduce the number of epochs,
 but the algorithm is generic and can be applied to any multi-fidelity setting.
 That is, you can use training time, specifying the fidelity with ``--epochs~fidelity()``
 (assuming your script takes this argument in commandline), but you could also use other fidelity
@@ -96,12 +96,12 @@ Seed for the random number generator used to sample new trials. Default is ``Non
 
 ``max_resources``
 
-Maximum amount of resource that will be assigned to trials by ASHA. Only the best
+Maximum amount of resources that will be assigned to trials by ASHA. Only the best
 performing trial will be assigned the maximum amount of resources. Default is 100.
 
 ``grace_period``
 
-The minimum number of resource assigned to each trial. Default is 1.
+The minimum number of resources assigned to each trial. Default is 1.
 
 ``reduction_factor``
 
@@ -178,7 +178,7 @@ docs for details.
 
 Value added to the diagonal of the kernel matrix during fitting.
 Larger values correspond to increased noise level in the observations
-and reduce potential numerical issue during fitting. If an array is
+and reduce potential numerical issues during fitting. If an array is
 passed, it must have the same number of entries as the data used for
 fitting and is used as datapoint-dependent noise level. Note that this
 is equivalent to adding a WhiteKernel with c=alpha. Allowing to specify

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup_args = dict(
             ],
         'OptimizationAlgorithm': [
             'random = orion.algo.random:Random',
+            'asha = orion.algo.asha:ASHA',
             ],
         },
     install_requires=['PyYAML', 'pymongo>=3', 'numpy', 'scipy', 'gitpython', 'filelock'],

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -8,6 +8,7 @@
    :synopsis: TODO
 
 """
+import copy
 import hashlib
 
 import numpy
@@ -174,7 +175,8 @@ class _Bracket():
         for rung_id in range(len(self.rungs) - 2, 0, -1):
             objective, candidate = self.get_candidate(rung_id)
             if candidate:
+                candidate = copy.deepcopy(candidate)
                 self.rungs[rung_id + 1][1][self.asha._get_id(candidate)] = (objective, candidate)
-                candidate[self.asha.fidelity_index] = self.rungs[-1][0]
+                candidate[self.asha.fidelity_index] = self.rungs[rung_id + 1][0]
 
                 return candidate

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -101,6 +101,7 @@ class ASHA(BaseAlgorithm):
             candidate = bracket.update_rungs()
 
             if candidate:
+                logger.debug('Promoting')
                 return [candidate]
 
         point = list(self.space.sample(num, seed=self.rng.randint(0, 10000))[0])
@@ -112,6 +113,8 @@ class ASHA(BaseAlgorithm):
 
         point[self.fidelity_index] = self.brackets[idx].rungs[0][0]
         self.trial_info[self.get_id(point)] = self.brackets[idx]
+
+        logger.debug('Sampling for bracket {} {}'.format(idx, self.brackets[idx]))
 
         return [tuple(point)]
 
@@ -246,9 +249,20 @@ class Bracket():
         for rung_id in range(len(self.rungs) - 2, -1, -1):
             candidate = self.get_candidate(rung_id)
             if candidate:
+
+                logger.debug(
+                    'Promoting {point} from rung {past_rung} with fidelity {past_fidelity} to '
+                    'rung {new_rung} with fidelity {new_fidelity}'.format(
+                        point=candidate, past_rung=rung_id,
+                        past_fidelity=candidate[self.asha.fidelity_index],
+                        new_rung=rung_id + 1, new_fidelity=self.rungs[rung_id + 1][0]))
+
                 candidate = list(copy.deepcopy(candidate))
                 candidate[self.asha.fidelity_index] = self.rungs[rung_id + 1][0]
 
                 return tuple(candidate)
 
         return None
+
+    def __repr__(self):
+        return 'Bracket({})'.format([rung[0] for rung in self.rungs])

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -132,10 +132,14 @@ class _Bracket():
         self.reduction_factor = reduction_factor
         max_rungs = int(numpy.log(max_t / min_t) / numpy.log(reduction_factor) - s + 1)
         self.rungs = [(min_t * reduction_factor**(k + s), dict())
-                      for k in reversed(range(max_rungs + 1))]
+                      for k in range(max_rungs + 1)]
 
     def register(self, point, objective):
-        self.rungs[-1][1][self.asha._get_id(point)] = (objective, point)
+        if point[self.asha.fidelity_index] != self.rungs[0][0]:
+            raise AttributeError("Point {} budget different than rung 0.".format(
+                                 self.asha._get_id(point)))
+
+        self.rungs[0][1][self.asha._get_id(point)] = (objective, point)
 
     def get_candidate(self, rung_id):
         budget, rung = self.rungs[rung_id]
@@ -166,7 +170,7 @@ class _Bracket():
             Lookup for promotion in rung l + 1 contains trials of any status.
         """
         # NOTE: There should be base + 1 rungs
-        for rung_id in range(1, len(self.rungs)):
+        for rung_id in range(len(self.rungs) - 1, 0, -1):
             candidate, objective = self.get_candidate(rung_id)
 
             if candidate:

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -159,7 +159,7 @@ class _Bracket():
 
     @property
     def is_done(self):
-        return len(self.rungs[0][1])
+        return len(self.rungs[-1][1])
 
     def update_rungs(self):
         """

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -104,7 +104,13 @@ class ASHA(BaseAlgorithm):
                 logger.debug('Promoting')
                 return [candidate]
 
-        point = list(self.space.sample(num, seed=self.rng.randint(0, 10000))[0])
+        for attempt in range(100):
+            point = list(self.space.sample(num, seed=self.rng.randint(0, 10000))[0])
+            if self.get_id(point) not in self.trial_info:
+                break
+
+        if self.get_id(point) in self.trial_info:
+            raise RuntimeError('Keeps sampling already existing points')
 
         sizes = numpy.array([len(b.rungs) for b in self.brackets])
         probs = numpy.e**(sizes - sizes.max())

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -105,14 +105,14 @@ class ASHA(BaseAlgorithm):
                 return [candidate]
 
         for attempt in range(100):
-            point = list(self.space.sample(num, seed=self.rng.randint(0, 1000000))[0])
+            point = list(self.space.sample(1, seed=tuple(self.rng.randint(0, 1000000, size=3))))
             if self.get_id(point) not in self.trial_info:
                 break
 
         if self.get_id(point) in self.trial_info:
             raise RuntimeError(
-                'ASHA keeps sampling already existing points. '
-                'Please report this to https://github.com/Epistimio/orion/issues')
+                'ASHA keeps sampling already existing points. This should not happen, '
+                'please report this error to https://github.com/Epistimio/orion/issues')
 
         sizes = numpy.array([len(b.rungs) for b in self.brackets])
         probs = numpy.e**(sizes - sizes.max())

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -105,12 +105,14 @@ class ASHA(BaseAlgorithm):
                 return [candidate]
 
         for attempt in range(100):
-            point = list(self.space.sample(num, seed=self.rng.randint(0, 10000))[0])
+            point = list(self.space.sample(num, seed=self.rng.randint(0, 1000000))[0])
             if self.get_id(point) not in self.trial_info:
                 break
 
         if self.get_id(point) in self.trial_info:
-            raise RuntimeError('Keeps sampling already existing points')
+            raise RuntimeError(
+                'ASHA keeps sampling already existing points. '
+                'Please report this to https://github.com/Epistimio/orion/issues')
 
         sizes = numpy.array([len(b.rungs) for b in self.brackets])
         probs = numpy.e**(sizes - sizes.max())
@@ -155,10 +157,10 @@ class ASHA(BaseAlgorithm):
             try:
                 bracket.register(point, result['objective'])
             except IndexError as e:
-                raise RuntimeError('Point registered to wrong bracket. This is likely due '
-                                   'to a corrupted database, where trials of different fidelity '
-                                   'have a wrong timestamps. Please report this to '
-                                   'https://github.com/Epistimio/orion/issues') from e
+                logger.warning('Point registered to wrong bracket. This is likely due '
+                               'to a corrupted database, where trials of different fidelity '
+                               'have a wrong timestamps.')
+                continue
 
             if _id not in self.trial_info:
                 self.trial_info[_id] = bracket

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -80,8 +80,10 @@ class ASHA(BaseAlgorithm):
         self.rng.set_state(state_dict['rng_state'])
 
     def suggest(self, num=1):
-        """Suggest a `num` of new sets of parameters. Randomly draw samples
-        from the import space and return them.
+        """Suggest a `num` of new sets of parameters.
+
+        Promote a trial if possible, otherwise randomly draw samples from the space and
+        randomly assign to a bracket.
 
         :param num: how many sets to be suggested.
 

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -21,7 +21,7 @@ class ASHA(BaseAlgorithm):
     """Implement an algorithm that samples randomly from the problem's space."""
 
     def __init__(self, space, seed=None, max_resources=100, grace_period=1, reduction_factor=4,
-                 brackets=1):
+                 num_brackets=1):
         """Random sampler takes no other hyperparameter than the problem's space
         itself.
 
@@ -30,7 +30,7 @@ class ASHA(BaseAlgorithm):
         """
         super(ASHA, self).__init__(
             space, seed=seed, max_resources=max_resources, grace_period=grace_period,
-            reduction_factor=reduction_factor, brackets=brackets)
+            reduction_factor=reduction_factor, num_brackets=num_brackets)
 
         if reduction_factor < 2:
             raise AttributeError("Reduction factor for ASHA needs to be at least 2.")
@@ -40,7 +40,7 @@ class ASHA(BaseAlgorithm):
         # Tracks state for new trial add
         self.brackets = [
             _Bracket(self, grace_period, max_resources, reduction_factor, s)
-            for s in range(brackets)
+            for s in range(num_brackets)
         ]
 
     def seed_rng(self, seed):

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -171,9 +171,8 @@ class _Bracket():
             Lookup for promotion in rung l + 1 contains trials of any status.
         """
         # NOTE: There should be base + 1 rungs
-        for rung_id in range(len(self.rungs) - 1, 0, -1):
+        for rung_id in range(len(self.rungs) - 2, 0, -1):
             objective, candidate = self.get_candidate(rung_id)
-
             if candidate:
                 self.rungs[rung_id + 1][1][self.asha._get_id(candidate)] = (objective, candidate)
                 candidate[self.asha.fidelity_index] = self.rungs[-1][0]

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -193,7 +193,7 @@ class Bracket():
         rungs = [rung for budget, rung in self.rungs if budget == fidelity]
         if not rungs:
             budgets = [budget for budget, rung in self.rungs]
-            raise IndexError(REGISTRATION_ERROR).format(fidelity, budgets, point)
+            raise IndexError(REGISTRATION_ERROR.format(fidelity=fidelity, budgets=budgets, params=point))
 
         rungs[0][self.asha.get_id(point)] = (objective, point)
 

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -17,6 +17,12 @@ from orion.algo.base import BaseAlgorithm
 from orion.algo.space import Fidelity
 
 
+REGISTRATION_ERROR = """
+Bad fidelity level {fidelity}. Should be in {budgets}.
+Params: {params}
+"""
+
+
 class ASHA(BaseAlgorithm):
     """Asynchronous Successive Halving Algorithm
 
@@ -187,7 +193,7 @@ class Bracket():
         rungs = [rung for budget, rung in self.rungs if budget == fidelity]
         if not rungs:
             budgets = [budget for budget, rung in self.rungs]
-            raise IndexError('Bad fidelity level {}. Should be in {}'.format(fidelity, budgets))
+            raise IndexError(REGISTRATION_ERROR).format(fidelity, budgets, point)
 
         rungs[0][self.asha.get_id(point)] = (objective, point)
 

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -10,11 +10,15 @@
 """
 import copy
 import hashlib
+import logging
 
 import numpy
 
 from orion.algo.base import BaseAlgorithm
 from orion.algo.space import Fidelity
+
+
+logger = logging.getLogger(__name__)
 
 
 REGISTRATION_ERROR = """
@@ -188,6 +192,8 @@ class Bracket():
         max_rungs = int(numpy.log(max_t / min_t) / numpy.log(reduction_factor) - s + 1)
         self.rungs = [(min_t * reduction_factor**(k + s), dict())
                       for k in range(max_rungs)]
+
+        logger.debug('Bracket budgets: {}'.format([rung[0] for rung in self.rungs]))
 
     def register(self, point, objective):
         """Register a point in the corresponding rung"""

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -189,8 +189,8 @@ class Bracket():
 
         self.asha = asha
         self.reduction_factor = reduction_factor
-        max_rungs = int(numpy.log(max_t / min_t) / numpy.log(reduction_factor) - s + 1)
-        self.rungs = [(min_t * reduction_factor**(k + s), dict())
+        max_rungs = int(numpy.ceil(numpy.log(max_t / min_t) / numpy.log(reduction_factor) - s + 1))
+        self.rungs = [(min(min_t * reduction_factor**(k + s), max_t), dict())
                       for k in range(max_rungs)]
 
         logger.debug('Bracket budgets: {}'.format([rung[0] for rung in self.rungs]))

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -18,7 +18,17 @@ from orion.algo.space import Fidelity
 
 
 class ASHA(BaseAlgorithm):
-    """Implement an algorithm that samples randomly from the problem's space."""
+    """Asynchronous Successive Halving Algorithm
+
+        A simple and robust hyperparameter tuning algorithm with solid theoretical underpinnings
+        that exploits parallelism and aggressive early-stopping.
+
+    For more information on the algorithm, see original paper at https://arxiv.org/abs/1810.05934.
+
+    Li, Liam, et al. "Massively parallel hyperparameter tuning."
+    arXiv preprint arXiv:1810.05934 (2018)
+
+    """
 
     def __init__(self, space, seed=None, max_resources=100, grace_period=1, reduction_factor=4,
                  num_brackets=1):

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -105,7 +105,7 @@ class ASHA(BaseAlgorithm):
                 return [candidate]
 
         for attempt in range(100):
-            point = list(self.space.sample(1, seed=tuple(self.rng.randint(0, 1000000, size=3))))
+            point = list(self.space.sample(1, seed=tuple(self.rng.randint(0, 1000000, size=3)))[0])
             if self.get_id(point) not in self.trial_info:
                 break
 
@@ -120,7 +120,6 @@ class ASHA(BaseAlgorithm):
         idx = self.rng.choice(len(self.brackets), p=normalized)
 
         point[self.fidelity_index] = self.brackets[idx].rungs[0][0]
-        self.trial_info[self.get_id(point)] = self.brackets[idx]
 
         logger.debug('Sampling for bracket {} {}'.format(idx, self.brackets[idx]))
 

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -30,24 +30,43 @@ Params: {params}
 class ASHA(BaseAlgorithm):
     """Asynchronous Successive Halving Algorithm
 
-        A simple and robust hyperparameter tuning algorithm with solid theoretical underpinnings
-        that exploits parallelism and aggressive early-stopping.
+    `A simple and robust hyperparameter tuning algorithm with solid theoretical underpinnings
+    that exploits parallelism and aggressive early-stopping.`
 
     For more information on the algorithm, see original paper at https://arxiv.org/abs/1810.05934.
 
     Li, Liam, et al. "Massively parallel hyperparameter tuning."
     arXiv preprint arXiv:1810.05934 (2018)
 
+    Parameters
+    ----------
+    space: bla
+    seed: None, int or sequence of int
+        Seed for the random number generator used to sample new trials.
+        Default: ``None``
+    max_resources: int
+        Maximum amount of resource that will be assigned to trials by ASHA. Only the
+        best performing trial will be assigned the maximum amount of resources.
+        Default: 100
+    grace_period: int
+        The minimum number of resource assigned to each trial.
+        Default: 1
+    reduction_factor: int
+        The factor by which ASHA promotes trials. If the reduction factor is 4,
+        it means the number of trials from one fidelity level to the next one is roughly
+        divided by 4, and each fidelity level has 4 times more resources than the prior one.
+        Default: 4
+    num_brackets: int
+        Using a grace period that is too small may bias ASHA too strongly towards
+        fast converging trials that do not lead to best results at convergence (stagglers). To
+        overcome this, you can increase the number of brackets, which increases the amount of
+        resource required for optimisation but decreases the bias towards stragglers.
+        Default: 1
+
     """
 
     def __init__(self, space, seed=None, max_resources=100, grace_period=1, reduction_factor=4,
                  num_brackets=1):
-        """Random sampler takes no other hyperparameter than the problem's space
-        itself.
-
-        :param space: `orion.algo.space.Space` of optimization.
-        :param seed: Integer seed for the random number generator.
-        """
         super(ASHA, self).__init__(
             space, seed=seed, max_resources=max_resources, grace_period=grace_period,
             reduction_factor=reduction_factor, num_brackets=num_brackets)

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.algo.asha` -- TODO
+======================================================================
+
+.. module:: asha 
+   :platform: Unix
+   :synopsis: TODO
+
+"""
+import numpy
+
+from orion.algo.base import BaseAlgorithm
+
+
+class ASHA(BaseAlgorithm):
+    """Implement a algorithm that samples randomly from the problem's space."""
+
+    def __init__(self, space, seed=None, max_resources=100, grace_period=0, reduction_factor=4,
+                 brackets=1):
+        """Random sampler takes no other hyperparameter than the problem's space
+        itself.
+
+        :param space: `orion.algo.space.Space` of optimization.
+        :param seed: Integer seed for the random number generator.
+        """
+        super(ASHA, self).__init__(
+            space, seed=seed, max_resources=max_resources, grace_period=grace_period,
+            reduction_factor=reduction_factor, brackets=brackets)
+
+        self.trial_info = {}  # Stores Trial -> Bracket
+
+        # Tracks state for new trial add
+        self.brackets = [
+            _Bracket(self, grace_period, max_resources, reduction_factor, s)
+            for s in range(brackets)
+        ]
+
+    def seed_rng(self, seed):
+        """Seed the state of the random number generator.
+
+        :param seed: Integer seed for the random number generator.
+        """
+        self.rng = numpy.random.RandomState(seed)
+
+    def suggest(self, num=1):
+        """Suggest a `num` of new sets of parameters. Randomly draw samples
+        from the import space and return them.
+
+        :param num: how many sets to be suggested.
+
+        .. note:: New parameters must be compliant with the problem's domain
+           `orion.algo.space.Space`.
+        """
+
+        for bracket in self.brackets:
+            candidate = bracket.update_rungs()
+            if candidate:
+                return candidate
+
+        # TODO: Add fidelity here based on `space`
+        point = self.space.sample(num, seed=self.rng.randint(0, 10000))
+
+        sizes = numpy.array([len(b.rungs) for b in self.brackets])
+        probs = numpy.e**(sizes - sizes.max())
+        normalized = probs / probs.sum()
+        idx = numpy.random.choice(len(self.brackets), p=normalized)
+        #  TODO: Hash point (without fidelity) to get a unique trial id
+        self.trial_info[point] = self.brackets[idx]
+        # NOTE: The point is not registered in bracket here, until in `observe()`
+
+        return point
+
+    def observe(self, points, results):
+        """Observe evaluation `results` corresponding to list of `points` in
+        space.
+
+        A simple random sampler though does not take anything into account.
+        """
+
+
+        for point, result in zip(points, results):
+
+            # TODO find which bracket containts the point. If none,
+            #      randomly select one. WARNING, the fidelity may not match the bracket, test for it
+            bracket.register(point, result)
+
+    def is_done(self):
+        return all(bracket.is_done for bracket in self.brackets)
+
+
+class _Bracket():
+    def __init__(self, asha, min_t, max_t, reduction_factor, s):
+        self.asha = asha
+        self.reduction_factor = reduction_factor
+        max_rungs = int(numpy.log(max_t / min_t) / numpy.log(reduction_factor) - s + 1)
+        self.rungs = [(min(min_t * reduction_factor**(k + s), max_t), set())
+                      for k in reversed(range(max_rungs + 1))]
+
+        if self.rungs[0][0] == self.rungs[1][0]:
+            del self.rungs[0]
+
+    def register(self, point, objective):
+        self.rungs[-1][1].add((objective, point))
+
+    def get_candidate(self, rung_id):
+        budget, rung = self.rungs[rung_id]
+        next_rung = self.rungs[rung_id - 1][1]
+
+        k = len(rung) // self.reduction_factor
+        rung = list(sorted(rung))
+        i = 0
+        k = min(k, len(rung))
+        while i < k:
+            objective, point = rung[i]
+            if point not in next_rung:
+                return point, objective
+            i += 1
+
+        return None, None
+
+    @property
+    def is_done(self):
+        return len(self.rungs[0][1])
+
+    def update_rungs(self):
+        """
+
+        Notes
+        -----
+            All trials are part of the rungs, for any state. Only completed trials
+            are eligible for promotion, i.e., only completed trials can be part of top-k.
+            Lookup for promotion in rung l + 1 contains trials of any status.
+        """
+        # NOTE: There should be base + 1 rungs
+        for rung_id in range(1, len(self.rungs)):
+            candidate, objective = self.get_candidate(rung_id)
+
+            if candidate:
+                self.rungs[rung_id - 1][1].add(candidate)
+
+                return candidate

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.algo.asha` -- TODO
-======================================================================
+:mod:`orion.algo.asha` -- Asynchronous Successive Halving Algorithm
+===================================================================
 
 .. module:: asha
    :platform: Unix
-   :synopsis: TODO
+   :synopsis: Asynchronous Successive Halving Algorithm
 
 """
 import copy
@@ -40,16 +40,17 @@ class ASHA(BaseAlgorithm):
 
     Parameters
     ----------
-    space: bla
+    space: `orion.algo.space.Space`
+        Optimisation space with priors for each dimension.
     seed: None, int or sequence of int
         Seed for the random number generator used to sample new trials.
         Default: ``None``
     max_resources: int
-        Maximum amount of resource that will be assigned to trials by ASHA. Only the
+        Maximum amount of resources that will be assigned to trials by ASHA. Only the
         best performing trial will be assigned the maximum amount of resources.
         Default: 100
     grace_period: int
-        The minimum number of resource assigned to each trial.
+        The minimum number of resources assigned to each trial.
         Default: 1
     reduction_factor: int
         The factor by which ASHA promotes trials. If the reduction factor is 4,
@@ -272,7 +273,6 @@ class Bracket():
             Lookup for promotion in rung l + 1 contains trials of any status.
 
         """
-        # NOTE: There should be base + 1 rungs
         for rung_id in range(len(self.rungs) - 2, -1, -1):
             candidate = self.get_candidate(rung_id)
             if candidate:

--- a/src/orion/algo/random.py
+++ b/src/orion/algo/random.py
@@ -54,7 +54,7 @@ class Random(BaseAlgorithm):
         .. note:: New parameters must be compliant with the problem's domain
            `orion.algo.space.Space`.
         """
-        return self.space.sample(num, seed=self.rng.randint(0, 10000))
+        return self.space.sample(num, seed=tuple(self.rng.randint(0, 1000000, size=3)))
 
     def observe(self, points, results):
         """Observe evaluation `results` corresponding to list of `points` in

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -36,8 +36,15 @@ from collections import OrderedDict
 import numbers
 
 import numpy
-from scipy._lib._util import check_random_state
 from scipy.stats import distributions
+
+
+def check_random_state(seed):
+    """Return numpy global rng or RandomState if seed is specified"""
+    if seed is None:
+        return numpy.random.mtrand._rand  # pylint:disable=protected-access
+
+    return numpy.random.RandomState(seed)
 
 
 # helper class to be able to print [1, ..., 4] instead of [1, '...', 4]
@@ -46,7 +53,7 @@ class _Ellipsis:  # pylint:disable=too-few-public-methods
         return '...'
 
 
-class Dimension(object):
+class Dimension:
     """Base class for search space dimensions.
 
     Attributes

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -42,7 +42,7 @@ from scipy.stats import distributions
 def check_random_state(seed):
     """Return numpy global rng or RandomState if seed is specified"""
     if seed is None:
-        return numpy.random.mtrand._rand  # pylint:disable=protected-access
+        return numpy.random.mtrand._rand  # pylint:disable=protected-access,c-extension-no-member
 
     return numpy.random.RandomState(seed)
 

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -41,10 +41,18 @@ from scipy.stats import distributions
 
 def check_random_state(seed):
     """Return numpy global rng or RandomState if seed is specified"""
-    if seed is None:
-        return numpy.random.mtrand._rand  # pylint:disable=protected-access,c-extension-no-member
+    if seed is None or seed is numpy.random:
+        rng = numpy.random.mtrand._rand  # pylint:disable=protected-access,c-extension-no-member
+    elif isinstance(seed, numpy.random.RandomState):
+        rng = seed
+    else:
+        try:
+            rng = numpy.random.RandomState(seed)
+        except Exception as e:
+            raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
+                             ' instance' % seed) from e
 
-    return numpy.random.RandomState(seed)
+    return rng
 
 
 # helper class to be able to print [1, ..., 4] instead of [1, '...', 4]

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -147,7 +147,10 @@ class Experiment(object):
                               unique=True)
         self._db.ensure_index('experiments', 'metadata.datetime')
 
-        self._db.ensure_index('trials', 'experiment')
+        self._db.ensure_index('trials',
+                              [('experiment', Database.ASCENDING),
+                               ('index', Database.ASCENDING)],
+                              unique=True)
         self._db.ensure_index('trials', 'status')
         self._db.ensure_index('trials', 'results')
         self._db.ensure_index('trials', 'start_time')

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -147,10 +147,7 @@ class Experiment(object):
                               unique=True)
         self._db.ensure_index('experiments', 'metadata.datetime')
 
-        self._db.ensure_index('trials',
-                              [('experiment', Database.ASCENDING),
-                               ('index', Database.ASCENDING)],
-                              unique=True)
+        self._db.ensure_index('trials', 'experiment')
         self._db.ensure_index('trials', 'status')
         self._db.ensure_index('trials', 'results')
         self._db.ensure_index('trials', 'start_time')

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -330,37 +330,22 @@ class Experiment(object):
         self._db.write('trials', trial.to_dict())
 
     def fetch_completed_trials(self):
-        """Fetch recent completed trials that this `Experiment` instance has not
-        yet seen.
+        """Fetch completed trials of this `Experiment` instance.
 
         Trials are sorted based on `Trial.submit_time`
-
-        .. note::
-
-            It will return only those with `Trial.end_time` after `_last_fetched`, for performance
-            reasons.
 
         :return: list of completed `Trial` objects
         """
         query = dict(
             status='completed',
-            end_time={'$gte': self._last_fetched - datetime.timedelta(minutes=1)}
             )
-        completed_trials = self.fetch_trials_tree(query)
 
-        if completed_trials:
-            self._last_fetched = max(trial.end_time for trial in completed_trials)
-
-        new_completed_trials = [trial for trial in completed_trials
-                                if trial.id not in self._completed_buffer]
-
-        if new_completed_trials:
-            self._completed_buffer |= set(trial.id for trial in new_completed_trials)
-
-        return new_completed_trials
+        return self.fetch_trials_tree(query)
 
     def fetch_noncompleted_trials(self):
         """Fetch non-completed trials of this `Experiment` instance.
+
+        Trials are sorted based on `Trial.submit_time`
 
         .. note::
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -333,17 +333,34 @@ class Experiment(object):
         self._db.write('trials', trial.to_dict())
 
     def fetch_completed_trials(self):
-        """Fetch completed trials of this `Experiment` instance.
+        """Fetch recent completed trials that this `Experiment` instance has not yet seen.
 
         Trials are sorted based on `Trial.submit_time`
+
+        .. note::
+
+            It will return only those with `Trial.end_time` after `_last_fetched`, for performance
+            reasons.
 
         :return: list of completed `Trial` objects
         """
         query = dict(
             status='completed',
+            end_time={'$gte': self._last_fetched - datetime.timedelta(minutes=1)}
             )
 
-        return self.fetch_trials_tree(query)
+        completed_trials = self.fetch_trials_tree(query)
+
+        if completed_trials:
+            self._last_fetched = max(trial.end_time for trial in completed_trials)
+
+        new_completed_trials = [trial for trial in completed_trials
+                                if trial.id not in self._completed_buffer]
+
+        if new_completed_trials:
+            self._completed_buffer |= set(trial.id for trial in new_completed_trials)
+
+        return new_completed_trials
 
     def fetch_noncompleted_trials(self):
         """Fetch non-completed trials of this `Experiment` instance.

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -138,7 +138,6 @@ class Experiment(object):
             self._id = config['_id']
 
         self._last_fetched = self.metadata.get("datetime", datetime.datetime.utcnow())
-        self._completed_buffer = set()
 
     def _setup_db(self):
         self._db.ensure_index('experiments',
@@ -343,7 +342,7 @@ class Experiment(object):
         """
         query = dict(
             status='completed',
-            end_time={'$gte': self._last_fetched - datetime.timedelta(minutes=1)}
+            end_time={'$gt': self._last_fetched}
             )
 
         completed_trials = self.fetch_trials_tree(query)
@@ -351,13 +350,7 @@ class Experiment(object):
         if completed_trials:
             self._last_fetched = max(trial.end_time for trial in completed_trials)
 
-        new_completed_trials = [trial for trial in completed_trials
-                                if trial.id not in self._completed_buffer]
-
-        if new_completed_trials:
-            self._completed_buffer |= set(trial.id for trial in new_completed_trials)
-
-        return new_completed_trials
+        return completed_trials
 
     def fetch_noncompleted_trials(self):
         """Fetch non-completed trials of this `Experiment` instance.

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -97,7 +97,7 @@ class Producer(object):
 
     def _update_algorithm(self):
         """Pull newest completed trials to update local model."""
-        log.debug("### Fetch trials to observe:")
+        log.debug("### Fetch completed trials to observe:")
         completed_trials = self.experiment.fetch_completed_trials()
 
         new_completed_trials = [trial for trial in completed_trials

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -72,6 +72,7 @@ class Producer(object):
                 new_trial = format_trials.tuple_to_trial(new_point, self.space)
                 try:
                     new_trial.parents = self.naive_trials_history.children
+                    new_trial.index = len(self.naive_trials_history.full)
                     log.debug("#### Register new trial to database: %s", new_trial)
                     self.experiment.register_trial(new_trial)
                     sampled_points += 1

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -45,7 +45,6 @@ class Producer(object):
         self.naive_algorithm = None
         # TODO: Move trials_history into PrimaryAlgo during the refactoring of Algorithm with
         #       Strategist and Scheduler.
-        self._completed_buffer = set()
         self.trials_history = TrialsHistory()
         self.naive_trials_history = None
 
@@ -100,19 +99,16 @@ class Producer(object):
         log.debug("### Fetch completed trials to observe:")
         completed_trials = self.experiment.fetch_completed_trials()
 
-        new_completed_trials = [trial for trial in completed_trials
-                                if trial.id not in self.trials_history]
+        log.debug("### %s", completed_trials)
 
-        log.debug("### %s", new_completed_trials)
-
-        if new_completed_trials:
+        if completed_trials:
             log.debug("### Convert them to list of points and their results.")
             points = list(map(lambda trial: format_trials.trial_to_tuple(trial, self.space),
-                              new_completed_trials))
-            results = list(map(format_trials.get_trial_results, new_completed_trials))
+                              completed_trials))
+            results = list(map(format_trials.get_trial_results, completed_trials))
 
             log.debug("### Observe them.")
-            self.trials_history.update(new_completed_trials)
+            self.trials_history.update(completed_trials)
             self.algorithm.observe(points, results)
             self.strategy.observe(points, results)
 

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -71,7 +71,6 @@ class Producer(object):
                 new_trial = format_trials.tuple_to_trial(new_point, self.space)
                 try:
                     new_trial.parents = self.naive_trials_history.children
-                    new_trial.index = len(self.naive_trials_history.full)
                     log.debug("#### Register new trial to database: %s", new_trial)
                     self.experiment.register_trial(new_trial)
                     sampled_points += 1

--- a/src/orion/core/worker/strategy.py
+++ b/src/orion/core/worker/strategy.py
@@ -129,6 +129,25 @@ class MeanParallelStrategy(BaseParallelStrategy):
         return Trial.Result(name='lie', type='lie', value=self.mean_result)
 
 
+class StubParallelStrategy(BaseParallelStrategy):
+    """Parallel strategy that returns static objective value for incompleted trials."""
+
+    def __init__(self, stub_value=None):
+        """Initialize the stub value"""
+        self.stub_value = stub_value
+
+    def observe(self, points, results):
+        """See BaseParallelStrategy.observe"""
+        pass
+
+    def lie(self, trial):
+        """See BaseParallelStrategy.lie"""
+        if get_objective(trial):
+            raise RuntimeError("Trial {} is completed but should not be.".format(trial.id))
+
+        return Trial.Result(name='lie', type='lie', value=self.stub_value)
+
+
 # pylint: disable=too-few-public-methods,abstract-method
 class Strategy(BaseParallelStrategy, metaclass=Factory):
     """Class used to build a parallel strategy given name and params

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -147,7 +147,7 @@ class Trial(object):
         __slots__ = ()
         allowed_types = ('integer', 'real', 'categorical', 'fidelity')
 
-    __slots__ = ('experiment', '_id', '_status', 'worker',
+    __slots__ = ('experiment', 'index', '_id', '_status', 'worker',
                  'submit_time', 'start_time', 'end_time', '_results', 'params', 'parents')
     allowed_stati = ('new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken')
 

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -147,7 +147,7 @@ class Trial(object):
         __slots__ = ()
         allowed_types = ('integer', 'real', 'categorical', 'fidelity')
 
-    __slots__ = ('experiment', 'index', '_id', '_status', 'worker',
+    __slots__ = ('experiment', '_id', '_status', 'worker',
                  'submit_time', 'start_time', 'end_time', '_results', 'params', 'parents')
     allowed_stati = ('new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken')
 

--- a/src/orion/core/worker/trials_history.py
+++ b/src/orion/core/worker/trials_history.py
@@ -17,11 +17,15 @@ class TrialsHistory:
     def __init__(self):
         """Create empty trials history"""
         self.children = []
+        self.full = set()
+
+    def __contains__(self, trial_id):
+        return trial_id in self.full
 
     def update(self, trials):
         """Update the list of children trials
 
-        This history only keeps children. Current children that are now ancestors of
+        The children history only keeps children. Current children that are now ancestors of
         the new nodes are discarded from the history. This is because we can rebuild the entire
         history from the current children, therefore we only need to keep those.
         """
@@ -29,5 +33,7 @@ class TrialsHistory:
         for trial in trials:
             descendents -= set(trial.parents)
             descendents.add(trial.id)
+
+        self.full |= descendents
 
         self.children = list(sorted(descendents))

--- a/src/orion/core/worker/trials_history.py
+++ b/src/orion/core/worker/trials_history.py
@@ -17,10 +17,6 @@ class TrialsHistory:
     def __init__(self):
         """Create empty trials history"""
         self.children = []
-        self.full = set()
-
-    def __contains__(self, trial_id):
-        return trial_id in self.full
 
     def update(self, trials):
         """Update the list of children trials
@@ -33,7 +29,5 @@ class TrialsHistory:
         for trial in trials:
             descendents -= set(trial.parents)
             descendents.add(trial.id)
-
-        self.full |= descendents
 
         self.children = list(sorted(descendents))

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -72,6 +72,7 @@ def test_demo(database, monkeypatch):
     trials = list(database.trials.find({'experiment': exp_id}))
     assert len(trials) <= 15
     assert trials[-1]['status'] == 'completed'
+    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
     for result in trials[-1]['results']:
         assert result['type'] != 'constraint'
         if result['type'] == 'objective':
@@ -174,6 +175,7 @@ def test_workon(database):
 
     trials = list(database.trials.find({'experiment': exp_id}))
     assert len(trials) <= 15
+    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
     assert trials[-1]['status'] == 'completed'
     for result in trials[-1]['results']:
         assert result['type'] != 'constraint'

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -2,23 +2,61 @@
 # -*- coding: utf-8 -*-
 """Tests for :mod:`orion.algo.asha`."""
 
+import hashlib
+import numpy as np
 import pytest
 
-from orion.algo.asha import _Bracket
+from orion.algo.asha import ASHA, _Bracket
+from orion.algo.space import Real, Fidelity, Space
+
+
+@pytest.fixture
+def space():
+    space = Space()
+    space.register(Real('lr', 'uniform', 0, 1))
+    space.register(Fidelity('epoch'))
+    return space
 
 
 @pytest.fixture
 def b_config():
+    """Return a configuration for a bracket."""
     return {'n': 9, 'r': 1, 'R': 9, 'eta': 3}
+
+
+@pytest.fixture
+def asha(b_config, space):
+    """Return an instance of ASHA."""
+    return ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                reduction_factor=b_config['eta'])
+
+
+@pytest.fixture
+def bracket(b_config):
+    """Return a `_Bracket` instance configured with `b_config`."""
+    return _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+
+
+@pytest.fixture
+def rung_0():
+    """Create fake points and objectives for rung 0."""
+    points = np.linspace(0, 1, 9)
+    return (1, {hashlib.md5(str([point]).encode('utf-8')).hexdigest():
+            (point, [point, 1]) for point in points})
+
+
+@pytest.fixture
+def rung_1(rung_0):
+    """Create fake points and objectives for rung 1."""
+    return (3, {hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value for value in
+                sorted(rung_0[1].values())})
 
 
 class TestBracket():
     """Tests for the `_Bracket` class."""
 
-    def test_rungs_creation(self, b_config):
+    def test_rungs_creation(self, bracket):
         """Test the creation of rungs for bracket 0."""
-        bracket = _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
-
         assert len(bracket.rungs) == 3
         assert bracket.rungs[0][0] == 1
         assert bracket.rungs[1][0] == 3
@@ -41,3 +79,48 @@ class TestBracket():
             _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
         assert 'smaller' in str(ex)
+
+    def test_candidate_promotion(self, asha, bracket, rung_0):
+        """Test that correct point is promoted."""
+        bracket.asha = asha
+        bracket.rungs[0] = rung_0
+
+        objective, point = bracket.get_candidate(0)
+
+        assert objective == 0.0
+        assert point == [0.0, 1]
+
+    def test_promotion_with_rung_1_hit(self, asha, bracket, rung_0):
+        """Test that get_candidate gives us the next best thing if point is already in rung 1."""
+        point = [0.0, 1]
+        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        bracket.asha = asha
+        bracket.rungs[0] = rung_0
+        bracket.rungs[1][1][point_hash] = (0.0, point)
+
+        objective, point = bracket.get_candidate(0)
+
+        assert objective == 0.125
+        assert point == [0.125, 1]
+
+    def test_no_promotion_when_rung_full(self, asha, bracket, rung_0, rung_1):
+        """Test that get_candidate returns `None` if rung 1 is full."""
+        bracket.asha = asha
+        bracket.rungs[0] = rung_0
+        bracket.rungs[1] = rung_1
+
+        objective, point = bracket.get_candidate(0)
+
+        assert objective is None
+        assert point is None
+
+    def test_no_promotion_if_not_enough_points(self, asha, bracket):
+        """Test the get_candidate return None if there is not enough points ready."""
+        bracket.asha = asha
+        bracket.rungs[0] = (1, {hashlib.md5(str([0.0]).encode('utf-8')).hexdigest():
+                                (0.0, [0.0, 1])})
+
+        objective, point = bracket.get_candidate(0)
+
+        assert objective is None
+        assert point is None

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -49,7 +49,7 @@ def rung_0():
 def rung_1(rung_0):
     """Create fake points and objectives for rung 1."""
     return (3, {hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value for value in
-                sorted(rung_0[1].values())})
+            map(lambda v: (v[0], [v[0], 3]), sorted(rung_0[1].values()))})
 
 
 class TestBracket():
@@ -124,3 +124,12 @@ class TestBracket():
 
         assert objective is None
         assert point is None
+
+    def test_is_done(self, bracket, rung_0):
+        """Test that the `is_done` property works."""
+        assert not bracket.is_done
+
+        # Actual value of the point is not important here
+        bracket.rungs[2] = (9, {'1': [0.0, 1]})
+
+        assert bracket.is_done

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -3,11 +3,12 @@
 """Tests for :mod:`orion.algo.asha`."""
 
 import hashlib
+
 import numpy as np
 import pytest
 
-from orion.algo.asha import ASHA, _Bracket
-from orion.algo.space import Real, Fidelity, Space
+from orion.algo.asha import ASHA, Bracket
+from orion.algo.space import Fidelity, Real, Space
 
 
 @pytest.fixture
@@ -34,8 +35,8 @@ def asha(b_config, space):
 
 @pytest.fixture
 def bracket(b_config):
-    """Return a `_Bracket` instance configured with `b_config`."""
-    return _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+    """Return a `Bracket` instance configured with `b_config`."""
+    return Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
 
 @pytest.fixture
@@ -43,18 +44,25 @@ def rung_0():
     """Create fake points and objectives for rung 0."""
     points = np.linspace(0, 1, 9)
     return (1, {hashlib.md5(str([point]).encode('utf-8')).hexdigest():
-            (point, [point, 1]) for point in points})
+            (point, (point, 1)) for point in points})
 
 
 @pytest.fixture
 def rung_1(rung_0):
     """Create fake points and objectives for rung 1."""
     return (3, {hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value for value in
-            map(lambda v: (v[0], [v[0], 3]), sorted(rung_0[1].values()))})
+            map(lambda v: (v[0], (v[0], 3)), sorted(rung_0[1].values()))})
+
+
+@pytest.fixture
+def rung_2(rung_1):
+    """Create fake points and objectives for rung 1."""
+    return (9, {hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value for value in
+            map(lambda v: (v[0], (v[0], 9)), sorted(rung_1[1].values()))})
 
 
 class TestBracket():
-    """Tests for the `_Bracket` class."""
+    """Tests for the `Bracket` class."""
 
     def test_rungs_creation(self, bracket):
         """Test the creation of rungs for bracket 0."""
@@ -64,27 +72,27 @@ class TestBracket():
         assert bracket.rungs[2][0] == 9
 
     def test_negative_minimum_resources(self, b_config):
-        """Test to see if `_Bracket` handles negative minimum resources."""
+        """Test to see if `Bracket` handles negative minimum resources."""
         b_config['r'] = -1
 
         with pytest.raises(AttributeError) as ex:
-            _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+            Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
         assert 'positive' in str(ex)
 
     def test_min_resources_greater_than_max(self, b_config):
-        """Test to see if `_Bracket` handles minimum resources too high."""
+        """Test to see if `Bracket` handles minimum resources too high."""
         b_config['r'] = 10
 
         with pytest.raises(AttributeError) as ex:
-            _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+            Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
         assert 'smaller' in str(ex)
 
     def test_register(self, asha, bracket):
         """Check that a point is correctly registered inside a bracket."""
         bracket.asha = asha
-        point = [0.0, 1]
+        point = (0.0, 1)
         point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
 
         bracket.register(point, 0.0)
@@ -97,33 +105,31 @@ class TestBracket():
         """Check that a non-valid point is not registered."""
         bracket.asha = asha
 
-        with pytest.raises(AttributeError) as ex:
-            bracket.register([0.0, 3], 0.0)
+        with pytest.raises(IndexError) as ex:
+            bracket.register((0.0, 55), 0.0)
 
-        assert 'Point' in str(ex)
+        assert 'Bad fidelity level 55' in str(ex)
 
     def test_candidate_promotion(self, asha, bracket, rung_0):
         """Test that correct point is promoted."""
         bracket.asha = asha
         bracket.rungs[0] = rung_0
 
-        objective, point = bracket.get_candidate(0)
+        point = bracket.get_candidate(0)
 
-        assert objective == 0.0
-        assert point == [0.0, 1]
+        assert point == (0.0, 1)
 
     def test_promotion_with_rung_1_hit(self, asha, bracket, rung_0):
         """Test that get_candidate gives us the next best thing if point is already in rung 1."""
-        point = [0.0, 1]
+        point = (0.0, 1)
         point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
         bracket.asha = asha
         bracket.rungs[0] = rung_0
         bracket.rungs[1][1][point_hash] = (0.0, point)
 
-        objective, point = bracket.get_candidate(0)
+        point = bracket.get_candidate(0)
 
-        assert objective == 0.125
-        assert point == [0.125, 1]
+        assert point == (0.125, 1)
 
     def test_no_promotion_when_rung_full(self, asha, bracket, rung_0, rung_1):
         """Test that get_candidate returns `None` if rung 1 is full."""
@@ -131,21 +137,33 @@ class TestBracket():
         bracket.rungs[0] = rung_0
         bracket.rungs[1] = rung_1
 
-        objective, point = bracket.get_candidate(0)
+        point = bracket.get_candidate(0)
 
-        assert objective is None
         assert point is None
-<<<<<<< HEAD
 
     def test_no_promotion_if_not_enough_points(self, asha, bracket):
         """Test the get_candidate return None if there is not enough points ready."""
         bracket.asha = asha
         bracket.rungs[0] = (1, {hashlib.md5(str([0.0]).encode('utf-8')).hexdigest():
-                                (0.0, [0.0, 1])})
+                                (0.0, (0.0, 1))})
 
-        objective, point = bracket.get_candidate(0)
+        point = bracket.get_candidate(0)
 
-        assert objective is None
+        assert point is None
+
+    def test_no_promotion_if_not_completed(self, asha, bracket, rung_0):
+        """Test the get_candidate return None if trials are not completed."""
+        bracket.asha = asha
+        bracket.rungs[0] = rung_0
+        rung = bracket.rungs[0][1]
+
+        point = bracket.get_candidate(0)
+
+        for p_id in rung.keys():
+            rung[p_id] = (None, rung[p_id][1])
+
+        point = bracket.get_candidate(0)
+
         assert point is None
 
     def test_is_done(self, bracket, rung_0):
@@ -153,7 +171,7 @@ class TestBracket():
         assert not bracket.is_done
 
         # Actual value of the point is not important here
-        bracket.rungs[2] = (9, {'1': [0.0, 1]})
+        bracket.rungs[2] = (9, {'1': (0.0, 1)})
 
         assert bracket.is_done
 
@@ -165,8 +183,8 @@ class TestBracket():
 
         candidate = bracket.update_rungs()
 
-        assert point_hash in bracket.rungs[2][1]
-        assert bracket.rungs[1][1][point_hash] == (0.0, [0.0, 3])
+        assert point_hash in bracket.rungs[1][1]
+        assert bracket.rungs[1][1][point_hash] == (0.0, (0.0, 3))
         assert candidate[1] == 9
 
     def test_update_rungs_return_no_candidate(self, asha, bracket, rung_1):
@@ -176,5 +194,180 @@ class TestBracket():
         candidate = bracket.update_rungs()
 
         assert candidate is None
-=======
->>>>>>> b0eb25f... Add test for `get_candidate`
+
+
+class TestASHA():
+    """Tests for the algo ASHA."""
+
+    def test_register(self, asha, bracket, rung_0, rung_1):
+        """Check that a point is registered inside the bracket."""
+        asha.brackets = [bracket]
+        bracket.asha = asha
+        bracket.rungs = [rung_0, rung_1]
+        point = (0.0, 1)
+        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+
+        asha.observe([point], [{'objective': 0.0}])
+
+        assert len(bracket.rungs[0])
+        assert point_hash in bracket.rungs[0][1]
+        assert (0.0, point) == bracket.rungs[0][1][point_hash]
+
+    def test_register_bracket_multi_fidelity(self, space, b_config):
+        """Check that a point is registered inside the same bracket for diff fidelity."""
+        asha = ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                    reduction_factor=b_config['eta'], num_brackets=3)
+
+        value = 50
+        fidelity = 1
+        point = (value, fidelity)
+        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+
+        asha.observe([point], [{'objective': 0.0}])
+
+        bracket = asha.brackets[0]
+
+        assert len(bracket.rungs[0])
+        assert point_hash in bracket.rungs[0][1]
+        assert (0.0, point) == bracket.rungs[0][1][point_hash]
+
+        fidelity = 3
+        point = [value, fidelity]
+        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+
+        asha.observe([point], [{'objective': 0.0}])
+
+        assert len(bracket.rungs[0])
+        assert point_hash in bracket.rungs[1][1]
+        assert (0.0, point) != bracket.rungs[0][1][point_hash]
+        assert (0.0, point) == bracket.rungs[1][1][point_hash]
+
+    def test_register_next_bracket(self, space, b_config):
+        """Check that a point is registered inside the good bracket when higher fidelity."""
+        asha = ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                    reduction_factor=b_config['eta'], num_brackets=3)
+
+        value = 50
+        fidelity = 3
+        point = (value, fidelity)
+        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+
+        asha.observe([point], [{'objective': 0.0}])
+
+        assert sum(len(rung[1]) for rung in asha.brackets[0].rungs) == 0
+        assert sum(len(rung[1]) for rung in asha.brackets[1].rungs) == 1
+        assert sum(len(rung[1]) for rung in asha.brackets[2].rungs) == 0
+        assert point_hash in asha.brackets[1].rungs[0][1]
+        assert (0.0, point) == asha.brackets[1].rungs[0][1][point_hash]
+
+        value = 51
+        fidelity = 9
+        point = (value, fidelity)
+        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+
+        asha.observe([point], [{'objective': 0.0}])
+
+        assert sum(len(rung[1]) for rung in asha.brackets[0].rungs) == 0
+        assert sum(len(rung[1]) for rung in asha.brackets[1].rungs) == 1
+        assert sum(len(rung[1]) for rung in asha.brackets[2].rungs) == 1
+        assert point_hash in asha.brackets[2].rungs[0][1]
+        assert (0.0, point) == asha.brackets[2].rungs[0][1][point_hash]
+
+    def test_register_invalid_fidelity(self, space, b_config):
+        """Check that a point cannot registered if fidelity is invalid."""
+        asha = ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                    reduction_factor=b_config['eta'], num_brackets=3)
+
+        value = 50
+        fidelity = 2
+        point = (value, fidelity)
+
+        with pytest.raises(ValueError) as ex:
+            asha.observe([point], [{'objective': 0.0}])
+
+        assert 'No bracket found for point' in str(ex)
+
+    def test_register_corrupted_db(self, space, b_config):
+        """Check that a point cannot registered if passed in order diff than fidelity."""
+        asha = ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                    reduction_factor=b_config['eta'], num_brackets=3)
+
+        value = 50
+        fidelity = 3
+        point = (value, fidelity)
+
+        asha.observe([point], [{'objective': 0.0}])
+
+        fidelity = 1
+        point = [value, fidelity]
+
+        with pytest.raises(RuntimeError) as ex:
+            asha.observe([point], [{'objective': 0.0}])
+
+        assert 'Point registered to wrong bracket' in str(ex)
+
+    def test_get_id(self, space, b_config):
+        """Test valid id of points"""
+        asha = ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                    reduction_factor=b_config['eta'], num_brackets=3)
+
+        assert asha.get_id([1, 'whatever']) == asha.get_id([1, 'is here'])
+        assert asha.get_id([1, 'whatever']) != asha.get_id([2, 'is here'])
+
+    def test_get_id_multidim(self, b_config):
+        """Test valid id for points with dim of shape > 1"""
+        space = Space()
+        space.register(Fidelity('epoch'))
+        space.register(Real('lr', 'uniform', 0, 1, shape=2))
+
+        asha = ASHA(space, max_resources=b_config['R'], grace_period=b_config['r'],
+                    reduction_factor=b_config['eta'], num_brackets=3)
+
+        assert asha.get_id(['whatever', [1, 1]]) == asha.get_id(['is here', [1, 1]])
+        assert asha.get_id(['whatever', [1, 1]]) != asha.get_id(['is here', [2, 2]])
+
+    def test_suggest_new(self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2):
+        """Test that a new point is sampled."""
+        asha.brackets = [bracket]
+        bracket.asha = asha
+        bracket.rungs[0] = rung_0
+        bracket.rungs[1] = rung_1
+        bracket.rungs[2] = rung_2
+
+        def sample(num=1, seed=None):
+            return [(0.5, 'fidelity')]
+
+        monkeypatch.setattr(asha.space, 'sample', sample)
+
+        points = asha.suggest()
+
+        assert points == [(0.5, 1)]
+
+    def test_suggest_promote(self, asha, bracket, rung_0):
+        """Test that correct point is promoted and returned."""
+        asha.brackets = [bracket]
+        bracket.asha = asha
+        bracket.rungs[0] = rung_0
+
+        points = asha.suggest()
+
+        assert points == [(0.0, 3)]
+
+    def test_seed_rng(self, asha):
+        """Test that algo is seeded properly"""
+        asha.seed_rng(1)
+        a = asha.suggest(1)[0]
+        assert not np.allclose(a, asha.suggest(1)[0])
+
+        asha.seed_rng(1)
+        assert np.allclose(a, asha.suggest(1)[0])
+
+    def test_set_state(self, asha):
+        """Test that state is reset properly"""
+        asha.seed_rng(1)
+        state = asha.state_dict
+        a = asha.suggest(1)[0]
+        assert not np.allclose(a, asha.suggest(1)[0])
+
+        asha.set_state(state)
+        assert np.allclose(a, asha.suggest(1)[0])

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -197,7 +197,6 @@ class TestBracket():
 
     def test_repr(self, bracket, rung_0, rung_1, rung_2):
         """Test the string representation of Bracket"""
-
         bracket.rungs[0] = rung_0
         bracket.rungs[1] = rung_1
         bracket.rungs[2] = rung_2
@@ -379,7 +378,6 @@ class TestASHA():
 
     def test_suggest_inf_duplicates(self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2):
         """Test that sampling inf collisions raises runtime error."""
-
         asha.brackets = [bracket]
         bracket.asha = asha
 

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -12,6 +12,7 @@ from orion.algo.space import Real, Fidelity, Space
 
 @pytest.fixture
 def space():
+    """Create a Space with a real dimension and a fidelity value."""
     space = Space()
     space.register(Real('lr', 'uniform', 0, 1))
     space.register(Fidelity('epoch'))
@@ -133,3 +134,23 @@ class TestBracket():
         bracket.rungs[2] = (9, {'1': [0.0, 1]})
 
         assert bracket.is_done
+
+    def test_update_rungs_return_candidate(self, asha, bracket, rung_1):
+        """Check if a valid modified candidate is returned by update_rungs."""
+        bracket.asha = asha
+        bracket.rungs[1] = rung_1
+        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+
+        candidate = bracket.update_rungs()
+
+        assert point_hash in bracket.rungs[2][1]
+        assert bracket.rungs[1][1][point_hash] == (0.0, [0.0, 9])
+        assert candidate[1] == 9
+
+    def test_update_rungs_return_no_candidate(self, asha, bracket, rung_1):
+        """Check if no candidate is returned by update_rungs."""
+        bracket.asha = asha
+
+        candidate = bracket.update_rungs()
+
+        assert candidate is None

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -135,6 +135,7 @@ class TestBracket():
 
         assert objective is None
         assert point is None
+<<<<<<< HEAD
 
     def test_no_promotion_if_not_enough_points(self, asha, bracket):
         """Test the get_candidate return None if there is not enough points ready."""
@@ -175,3 +176,5 @@ class TestBracket():
         candidate = bracket.update_rungs()
 
         assert candidate is None
+=======
+>>>>>>> b0eb25f... Add test for `get_candidate`

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -20,9 +20,9 @@ class TestBracket():
         bracket = _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
         assert len(bracket.rungs) == 3
-        assert bracket.rungs[0][0] == 9
+        assert bracket.rungs[0][0] == 1
         assert bracket.rungs[1][0] == 3
-        assert bracket.rungs[2][0] == 1
+        assert bracket.rungs[2][0] == 9
 
     def test_negative_minimum_resources(self, b_config):
         """Test to see if `_Bracket` handles negative minimum resources."""
@@ -34,6 +34,7 @@ class TestBracket():
         assert 'positive' in str(ex)
 
     def test_min_resources_greater_than_max(self, b_config):
+        """Test to see if `_Bracket` handles minimum resources too high."""
         b_config['r'] = 10
 
         with pytest.raises(AttributeError) as ex:

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`orion.algo.asha`."""
+
+import pytest
+
+from orion.algo.asha import _Bracket
+
+
+@pytest.fixture
+def b_config():
+    return {'n': 9, 'r': 1, 'R': 9, 'eta': 3}
+
+
+class TestBracket():
+    """Tests for the `_Bracket` class."""
+
+    def test_rungs_creation(self, b_config):
+        """Test the creation of rungs for bracket 0."""
+        bracket = _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+
+        assert len(bracket.rungs) == 3
+        assert bracket.rungs[0][0] == 9
+        assert bracket.rungs[1][0] == 3
+        assert bracket.rungs[2][0] == 1
+
+    def test_negative_minimum_resources(self, b_config):
+        """Test to see if `_Bracket` handles negative minimum resources."""
+        b_config['r'] = -1
+
+        with pytest.raises(AttributeError) as ex:
+            _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+
+        assert 'positive' in str(ex)
+
+    def test_min_resources_greater_than_max(self, b_config):
+        b_config['r'] = 10
+
+        with pytest.raises(AttributeError) as ex:
+            _Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
+
+        assert 'smaller' in str(ex)

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -78,7 +78,7 @@ class TestBracket():
         with pytest.raises(AttributeError) as ex:
             Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
-        assert 'positive' in str(ex)
+        assert 'positive' in str(ex.value)
 
     def test_min_resources_greater_than_max(self, b_config):
         """Test to see if `Bracket` handles minimum resources too high."""
@@ -87,7 +87,7 @@ class TestBracket():
         with pytest.raises(AttributeError) as ex:
             Bracket(None, b_config['r'], b_config['R'], b_config['eta'], 0)
 
-        assert 'smaller' in str(ex)
+        assert 'smaller' in str(ex.value)
 
     def test_register(self, asha, bracket):
         """Check that a point is correctly registered inside a bracket."""
@@ -293,7 +293,7 @@ class TestASHA():
         with pytest.raises(ValueError) as ex:
             asha.observe([point], [{'objective': 0.0}])
 
-        assert 'No bracket found for point' in str(ex)
+        assert 'No bracket found for point' in str(ex.value)
 
     def test_register_corrupted_db(self, caplog, space, b_config):
         """Check that a point cannot registered if passed in order diff than fidelity."""

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -81,6 +81,27 @@ class TestBracket():
 
         assert 'smaller' in str(ex)
 
+    def test_register(self, asha, bracket):
+        """Check that a point is correctly registered inside a bracket."""
+        bracket.asha = asha
+        point = [0.0, 1]
+        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+
+        bracket.register(point, 0.0)
+
+        assert len(bracket.rungs[0])
+        assert point_hash in bracket.rungs[0][1]
+        assert (0.0, point) == bracket.rungs[0][1][point_hash]
+
+    def test_bad_register(self, asha, bracket):
+        """Check that a non-valid point is not registered."""
+        bracket.asha = asha
+
+        with pytest.raises(AttributeError) as ex:
+            bracket.register([0.0, 3], 0.0)
+
+        assert 'Point' in str(ex)
+
     def test_candidate_promotion(self, asha, bracket, rung_0):
         """Test that correct point is promoted."""
         bracket.asha = asha

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -166,7 +166,7 @@ class TestBracket():
         candidate = bracket.update_rungs()
 
         assert point_hash in bracket.rungs[2][1]
-        assert bracket.rungs[1][1][point_hash] == (0.0, [0.0, 9])
+        assert bracket.rungs[1][1][point_hash] == (0.0, [0.0, 3])
         assert candidate[1] == 9
 
     def test_update_rungs_return_no_candidate(self, asha, bracket, rung_1):

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -9,7 +9,40 @@ from numpy.testing import assert_array_equal as assert_eq
 import pytest
 from scipy.stats import distributions as dists
 
-from orion.algo.space import (Categorical, Dimension, Fidelity, Integer, Real, Space)
+from orion.algo.space import (
+    Categorical, check_random_state, Dimension, Fidelity, Integer, Real, Space)
+
+
+class TestCheckRandomState:
+    """Test `orion.algo.space.check_random_state`"""
+
+    def test_rng_null(self):
+        """Test that passing None returns numpy._rand"""
+        assert check_random_state(None) is np.random.mtrand._rand
+
+    def test_rng_random_state(self):
+        """Test that passing RandomState returns itself"""
+        rng = np.random.RandomState(1)
+        assert check_random_state(rng) is rng
+
+    def test_rng_int(self):
+        """Test that passing int returns RandomState"""
+        rng = check_random_state(1)
+        assert isinstance(rng, np.random.RandomState)
+        assert rng is not np.random.mtrand._rand
+
+    def test_rng_tuple(self):
+        """Test that passing int returns RandomState"""
+        rng = check_random_state((1, 12, 123))
+        assert isinstance(rng, np.random.RandomState)
+        assert rng is not np.random.mtrand._rand
+
+    def test_rng_invalid_value(self):
+        """Test that passing int returns RandomState"""
+        with pytest.raises(ValueError) as exc:
+            check_random_state('oh_no_oh_no')
+
+        assert '\'oh_no_oh_no\' cannot be used to seed' in str(exc.value)
 
 
 class TestDimension(object):

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -514,28 +514,6 @@
 - experiment: supernaedo2
 
   status: completed
-  worker: 1251231
-  submit_time: 2017-11-22T23:00:00
-  start_time: ~
-  end_time: 2017-11-22T22:30:00
-  results:
-    - name: ~
-      type: objective  # objective, constraint
-      value: 2
-    - name: naedw_grad
-      type: gradient
-      value: [-0.1, 2]
-  params:
-    - name: /encoding_layer
-      type: categorical
-      value: rnn
-    - name: /decoding_layer
-      type: categorical
-      value: rnn
-  parents: []
-- experiment: supernaedo2
-
-  status: completed
   worker: 23415151
   submit_time: 2017-11-23T00:00:00
   start_time: 150
@@ -558,6 +536,30 @@
       type: categorical
       value: lstm_with_attention
   parents: []
+
+- experiment: supernaedo2
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: rnn
+  parents: []
+
 
 - experiment: supernaedo2
 

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -272,7 +272,7 @@ class TestRead(object):
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][2:7]
+        assert value == [exp_config[1][1]] + exp_config[1][3:7]
 
         value = orion_db.read(
             'trials',

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -128,7 +128,7 @@ class TestRead(object):
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][2:7]
+        assert value == [exp_config[1][1]] + exp_config[1][3:7]
 
         value = orion_db.read(
             'trials',

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -684,7 +684,7 @@ def test_fetch_all_trials(hacked_exp, exp_config, random_dt):
 def test_fetch_completed_trials(hacked_exp, exp_config, random_dt):
     """Fetch a list of the unseen yet completed trials."""
     trials = hacked_exp.fetch_completed_trials()
-    assert hacked_exp._last_fetched == random_dt
+    assert hacked_exp._last_fetched == max(trial.end_time for trial in trials)
     assert len(trials) == 3
     # Trials are sorted based on submit time
     assert trials[0].to_dict() == exp_config[1][0]
@@ -815,7 +815,7 @@ def test_fetch_completed_trials_from_view(hacked_exp, exp_config, random_dt):
     experiment_view._experiment = hacked_exp
 
     trials = experiment_view.fetch_completed_trials()
-    assert experiment_view._experiment._last_fetched == random_dt
+    assert experiment_view._experiment._last_fetched == max(trial.end_time for trial in trials)
     assert len(trials) == 3
     assert trials[0].to_dict() == exp_config[1][0]
     assert trials[1].to_dict() == exp_config[1][2]

--- a/tests/unittests/core/test_pickleddb.py
+++ b/tests/unittests/core/test_pickleddb.py
@@ -115,7 +115,7 @@ class TestRead(object):
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][2:7]
+        assert value == [exp_config[1][1]] + exp_config[1][3:7]
 
         value = orion_db.read(
             'trials',

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -197,6 +197,10 @@ def test_lies_generation(producer, database, random_dt):
     lies = producer._produce_lies()
     assert len(lies) == 4
 
+    trials_non_completed = list(
+        sorted(trials_non_completed,
+               key=lambda trial: trial.get('submit_time', datetime.datetime.utcnow())))
+
     for i in range(4):
         trials_non_completed[i]['_id'] = lies[i].id
         trials_non_completed[i]['status'] = 'completed'

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Collection of tests for :mod:`orion.core.worker.producer`."""
 import copy
+import datetime
 
 import pytest
 
@@ -226,6 +227,10 @@ def test_register_lies(producer, database, random_dt):
 
     lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
     assert len(lying_trials) == 4
+
+    trials_non_completed = list(
+        sorted(trials_non_completed,
+               key=lambda trial: trial.get('submit_time', datetime.datetime.utcnow())))
 
     for i in range(4):
         trials_non_completed[i]['_id'] = lying_trials[i]['_id']

--- a/tests/unittests/core/test_strategy.py
+++ b/tests/unittests/core/test_strategy.py
@@ -3,10 +3,8 @@
 """Collection of tests for :mod:`orion.core.worker.strategies`."""
 import pytest
 
-from orion.core.worker.strategy import (MaxParallelStrategy,
-                                        MeanParallelStrategy,
-                                        NoParallelStrategy,
-                                        Strategy)
+from orion.core.worker.strategy import (
+    MaxParallelStrategy, MeanParallelStrategy, NoParallelStrategy, Strategy, StubParallelStrategy)
 from orion.core.worker.trial import Trial
 
 
@@ -73,3 +71,12 @@ class TestParallelStrategies:
         strategy.observe(points, results)
         lying_result = strategy.lie(incomplete_trial)
         assert lying_result is None
+
+    def test_stub_parallel_strategy(self, observations, incomplete_trial):
+        """Test that NoParallelStrategy lies outputs None"""
+        points, results = observations
+
+        strategy = StubParallelStrategy()
+        strategy.observe(points, results)
+        lying_result = strategy.lie(incomplete_trial)
+        assert lying_result.value is None

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -110,20 +110,20 @@ class TestTrial(object):
 
     def test_str_trial(self, exp_config):
         """Test representation of `Trial`."""
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert str(t) == "Trial(experiment='supernaedo2', status='completed',\n"\
                          "      params=/encoding_layer:gru\n"\
                          "             /decoding_layer:lstm_with_attention)"
 
     def test_str_value(self, exp_config):
         """Test representation of `Trial.Value`."""
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert str(t.params[0]) == "Param(name='/encoding_layer', "\
                                    "type='categorical', value='gru')"
 
     def test_invalid_result(self, exp_config):
         """Test that invalid objectives cannot be set"""
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
 
         # Make sure valid ones pass
         t.results = [Trial.Result(name='asfda', type='constraint', value=None),
@@ -148,58 +148,58 @@ class TestTrial(object):
     def test_objective_property(self, exp_config):
         """Check property `Trial.objective`."""
         # 1 results in `results` list
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert isinstance(t.objective, Trial.Result)
         assert t.objective.name == 'yolo'
         assert t.objective.type == 'objective'
         assert t.objective.value == 10
 
         # 0 results in `results` list
-        tmp = exp_config[1][2]['results'].pop(0)
-        t = Trial(**exp_config[1][2])
+        tmp = exp_config[1][1]['results'].pop(0)
+        t = Trial(**exp_config[1][1])
         assert t.objective is None
-        exp_config[1][2]['results'].append(tmp)
+        exp_config[1][1]['results'].append(tmp)
 
         # >1 results in `results` list
-        exp_config[1][2]['results'].append(dict(name='yolo2',
+        exp_config[1][1]['results'].append(dict(name='yolo2',
                                                 type='objective',
                                                 value=12))
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert isinstance(t.objective, Trial.Result)
         assert t.objective.name == 'yolo'
         assert t.objective.type == 'objective'
         assert t.objective.value == 10
-        tmp = exp_config[1][2]['results'].pop()
+        tmp = exp_config[1][1]['results'].pop()
 
     def test_gradient_property(self, exp_config):
         """Check property `Trial.gradient`."""
         # 1 results in `results` list
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert isinstance(t.gradient, Trial.Result)
         assert t.gradient.name == 'naedw_grad'
         assert t.gradient.type == 'gradient'
         assert t.gradient.value == [5, 3]
 
         # 0 results in `results` list
-        tmp = exp_config[1][2]['results'].pop()
-        t = Trial(**exp_config[1][2])
+        tmp = exp_config[1][1]['results'].pop()
+        t = Trial(**exp_config[1][1])
         assert t.gradient is None
-        exp_config[1][2]['results'].append(tmp)
+        exp_config[1][1]['results'].append(tmp)
 
         # >1 results in `results` list
-        exp_config[1][2]['results'].append(dict(name='yolo2',
+        exp_config[1][1]['results'].append(dict(name='yolo2',
                                                 type='gradient',
                                                 value=[12, 15]))
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert isinstance(t.gradient, Trial.Result)
         assert t.gradient.name == 'naedw_grad'
         assert t.gradient.type == 'gradient'
         assert t.gradient.value == [5, 3]
-        tmp = exp_config[1][2]['results'].pop()
+        tmp = exp_config[1][1]['results'].pop()
 
     def test_params_repr_property(self, exp_config):
         """Check property `Trial.params_repr`."""
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert t.params_repr() == "/encoding_layer:gru,/decoding_layer:lstm_with_attention"
         assert t.params_repr(sep='\n') == "/encoding_layer:gru\n/decoding_layer:lstm_with_attention"
 
@@ -208,7 +208,7 @@ class TestTrial(object):
 
     def test_hash_name_property(self, exp_config):
         """Check property `Trial.hash_name`."""
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert t.hash_name == "af737340845fb882e625d119968fd922"
 
         t = Trial()
@@ -218,7 +218,7 @@ class TestTrial(object):
 
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""
-        t = Trial(**exp_config[1][2])
+        t = Trial(**exp_config[1][1])
         assert t.full_name == ".encoding_layer:gru-.decoding_layer:lstm_with_attention"
 
         t = Trial()

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,8 @@ show-source = True
 doctests = True
 # select = E, F, W, C90, I, D, B, B902
 ignore =
+    # Missing docstring in __init__
+    D107
     # blank-line after doc summaries (annoying for modules' doc)
     D205
     # conflicts with D211: No blank lines allowed before class docstring


### PR DESCRIPTION
### Add implementation of ASHA

### Add documentation of available algorithms

### Return completed trials sorted by submit_time

Seems like the most reasonable default ordering. Algos restarts may
depend on the ordering of the data for consistency (ex: ASHA).

### Add StubParallelStategy

Some algos need to know about uncompleted trials. Passing default values
like None makes it possible to detect those from inside the algorithm.

Note that this is a hack until we support iterative objectives instead
of final objectives.

### Re-implement `check_random_state`

Scipy's version did not support sequences for seeds. We need to support seed space that is very large so we need to support sequences.

### Add D107 to ignored cases

Following numpy docstring guide, ``__init__`` should described in the class
docstring itself and therefore there is no need to document the
constructor method.