### PR TITLE
Add PickledDB to support FileSystem backend

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pyyaml
     - pymongo >=3
     - gitpython
+    - filelock
 
 test:
   import:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup_args = dict(
             'random = orion.algo.random:Random',
             ],
         },
-    install_requires=['PyYAML', 'pymongo>=3', 'numpy', 'scipy', 'gitpython'],
+    install_requires=['PyYAML', 'pymongo>=3', 'numpy', 'scipy', 'gitpython', 'filelock'],
     tests_require=tests_require,
     setup_requires=['setuptools', 'pytest-runner'],
     extras_require=dict(test=tests_require),

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -139,7 +139,16 @@ class EphemeralCollection(object):
 
         keys = tuple(key for (key, order) in keys)
         if unique and keys not in self._indexes:
-            self._indexes[keys] = []
+            self._indexes[keys] = set()
+
+            for document in self._documents:
+                self._validate_index(document, indexes=[keys])
+                self._indexes[keys].add(tuple(document[key] for key in keys))
+
+    def _register_keys(self, document):
+        """Register index values of a new document"""
+        for index, values in self._indexes.items():
+            values.add(tuple(document[key] for key in index))
 
     def find(self, query=None, selection=None):
         """Find documents in the collection and return a value according to the query.
@@ -154,22 +163,20 @@ class EphemeralCollection(object):
 
         return found_documents
 
-    def _validate_index(self, document):
+    def _validate_index(self, document, indexes=None):
         """Validate index values of a document
 
         :raises: :exc:`DuplicateKeyError`: if the document contains unique indexes which are already
         present in the database.
         """
-        for index, values in self._indexes.items():
-            document_values = document.select({key: 1 for key in index})
-            if document_values in values:
+        if indexes is None:
+            indexes = self._indexes.keys()
+
+        for index in indexes:
+            document_values = tuple(document[key] for key in index)
+            if document_values in self._indexes[index]:
                 raise DuplicateKeyError(
                     "Duplicate key error: index={} value={}".format(index, document_values))
-
-    def _register_keys(self, document):
-        """Register index values of a new document"""
-        for index, values in self._indexes.items():
-            values.append(document.select({key: 1 for key in index}))
 
     def _get_new_id(self):
         """Return max id + 1"""
@@ -315,16 +322,22 @@ class EphemeralDocument(object):
 
             _id is set to 1 if not specified. Only _id may be set to 0 if other keys are set to 1.
         """
+        if len(keys) == 1 and keys.get('_id', 0) == 1:
+            return keys
+
         keys_without_id = [key for key in keys if key != '_id']
         n_keys = sum(keys[key] for key in keys_without_id)
         if n_keys != 0 and n_keys != len(keys_without_id):
             raise ValueError(
                 'Cannot mix selection with 1 and 0s except for _id: {}'.format(keys))
 
+        # All given keys are 0 (with possible exception of _id)
         if n_keys == 0:
             new_keys = dict((key, 1) for key in self._data.keys() if key not in keys)
             new_keys['_id'] = keys.get('_id', 1)
             keys = new_keys
+
+        keys.setdefault('_id', 1)
 
         return keys
 
@@ -335,7 +348,8 @@ class EphemeralDocument(object):
         while value=1 means it will.
 
         All specified keys should be 0 or 1. They cannot have different values with the exception
-        of _id which can be specified to 0 while the others are at 1.
+        of _id which can be specified to 0 while the others are at 1. The _id field is always
+        returned unless specified with 0.
 
         Parameters
         ----------

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.io.database.pickleddb` -- Pickled Database
+===========================================================
+
+.. module:: database
+   :platform: Unix
+   :synopsis: Implement permanent version of :class:`orion.core.io.database.EphemeralDB`
+
+"""
+from contextlib import contextmanager
+import os
+import pickle
+
+from filelock import FileLock
+
+import orion.core
+from orion.core.io.database import AbstractDB
+from orion.core.io.database.ephemeraldb import EphemeralDB
+
+
+DEFAULT_HOST = os.path.join(orion.core.DIRS.user_data_dir, 'orion', 'orion_db.pkl')
+
+
+class PickledDB(AbstractDB):
+    """Pickled EphemeralDB to support permanancy and concurrency
+
+    This is a very simple and inefficient implementation of a permanent database on disk for Oríon.
+    The data is loaded from disk for every operation, and every operation is protected with a
+    filelock.
+    """
+
+    # pylint: disable=unused-argument
+    def __init__(self, host=DEFAULT_HOST, *args, **kwargs):
+        """Initialize the DB
+
+        Base folder defined by `host` is created during init.
+
+        :param host: File path to save pickled ephemeraldb.
+                     Default is {user data dir}/orion/orion_db.pkl
+                     ex: $HOME/.local/share/orion/orion_db.pkl
+        :type host: str
+        """
+        super(PickledDB, self).__init__(host)
+
+        if os.path.dirname(host):
+            os.makedirs(os.path.dirname(host), exist_ok=True)
+
+    @property
+    def is_connected(self):
+        """Return true, always."""
+        return True
+
+    def initiate_connection(self):
+        """Do nothing"""
+        pass
+
+    def close_connection(self):
+        """Do nothing"""
+        pass
+
+    def ensure_index(self, collection_name, keys, unique=False):
+        """Create given indexes if they do not already exist in database.
+
+        Indexes are only created if `unique` is True.
+        """
+        with self.locked_database() as database:
+            database.ensure_index(collection_name, keys, unique=unique)
+
+    def write(self, collection_name, data, query=None):
+        """Write new information to a collection. Perform insert or update.
+
+        .. seealso:: :meth:`AbstractDB.write` for argument documentation.
+
+        """
+        with self.locked_database() as database:
+            return database.write(collection_name, data, query=query)
+
+    def read(self, collection_name, query=None, selection=None):
+        """Read a collection and return a value according to the query.
+
+        .. seealso:: :meth:`AbstractDB.read` for argument documentation.
+
+        """
+        with self.locked_database(write=False) as database:
+            return database.read(collection_name, query=query, selection=selection)
+
+    def read_and_write(self, collection_name, query, data, selection=None):
+        """Read a collection's document and update the found document.
+
+        Returns the updated document, or None if nothing found.
+
+        .. seealso:: :meth:`AbstractDB.read_and_write` for
+                     argument documentation.
+
+        """
+        with self.locked_database() as database:
+            return database.read_and_write(collection_name, query=query, data=data,
+                                           selection=selection)
+
+    def count(self, collection_name, query=None):
+        """Count the number of documents in a collection which match the `query`.
+
+        .. seealso:: :meth:`AbstractDB.count` for argument documentation.
+
+        """
+        with self.locked_database(write=False) as database:
+            return database.count(collection_name, query=query)
+
+    def remove(self, collection_name, query):
+        """Delete from a collection document[s] which match the `query`.
+
+        .. seealso:: :meth:`AbstractDB.remove` for argument documentation.
+
+        """
+        with self.locked_database() as database:
+            return database.remove(collection_name, query=query)
+
+    def _get_database(self):
+        """Read fresh DB state from pickled file"""
+        if not os.path.exists(self.host):
+            return EphemeralDB()
+
+        with open(self.host, 'rb') as f:
+            database = pickle.load(f)
+
+        return database
+
+    def _dump_database(self, database):
+        """Write pickled DB on disk"""
+        tmp_file = self.host + '.tmp'
+        with open(tmp_file, 'wb') as f:
+            pickle.dump(database, f)
+
+        os.rename(tmp_file, self.host)
+
+    @contextmanager
+    def locked_database(self, write=True):
+        """Lock database file during wrapped operation call."""
+        lock = FileLock(self.host + '.lock')
+
+        with lock.acquire(timeout=60):
+            database = self._get_database()
+
+            yield database
+
+            if write:
+                self._dump_database(database)

--- a/tests/unittests/core/test_pickleddb.py
+++ b/tests/unittests/core/test_pickleddb.py
@@ -1,47 +1,33 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Collection of tests for :mod:`orion.core.io.database.ephemeraldb`."""
+"""Collection of tests for :mod:`orion.core.io.database.pickleddb`."""
 
 from datetime import datetime
+from multiprocessing import Pool
+import os
 
 import pytest
 
 from orion.core.io.database import Database, DuplicateKeyError
-from orion.core.io.database.ephemeraldb import EphemeralCollection, EphemeralDB, EphemeralDocument
-
-
-@pytest.fixture()
-def document():
-    """Return EphemeralDocument."""
-    return EphemeralDocument({'_id': 1, 'hello': 'there', 'mighty': 'duck'})
-
-
-@pytest.fixture()
-def collection(document):
-    """Return EphemeralCollection."""
-    collection = EphemeralCollection()
-    collection.insert_many([document.to_dict()])
-
-    return collection
+from orion.core.io.database.pickleddb import PickledDB
 
 
 @pytest.fixture()
 def orion_db():
-    """Return EphemeralDB wrapper instance initiated with test opts."""
-    EphemeralDB.instance = None
-    orion_db = EphemeralDB()
-    return orion_db
+    """Return PickledDB wrapper instance initiated with test opts."""
+    PickledDB.instance = None
+    orion_db = PickledDB(host='orion_db.pkl')
+    yield orion_db
 
 
 @pytest.fixture()
-def database(orion_db):
-    """Return the ephemeral database, a defaultdict of ephemeral collections"""
-    return orion_db._db
-
-
-@pytest.fixture()
-def clean_db(database, exp_config):
+def clean_db(orion_db, exp_config):
     """Clean insert example experiment entries to collections."""
+    if os.path.exists(orion_db.host):
+        os.remove(orion_db.host)
+
+    ephemeral_db = orion_db._get_database()
+    database = ephemeral_db._db
     database['experiments'].drop()
     database['experiments'].insert_many(exp_config[0])
     database['trials'].drop()
@@ -50,45 +36,46 @@ def clean_db(database, exp_config):
     database['workers'].insert_many(exp_config[2])
     database['resources'].drop()
     database['resources'].insert_many(exp_config[3])
+    orion_db._dump_database(ephemeral_db)
 
 
 @pytest.mark.usefixtures("clean_db")
 class TestEnsureIndex(object):
-    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.ensure_index`."""
+    """Calls to :meth:`orion.core.io.database.pickleddb.PickledDB.ensure_index`."""
 
     def test_new_index(self, orion_db):
-        """Index should be added to ephemeral database"""
-        assert ("new_field", ) not in orion_db._db['new_collection']._indexes
+        """Index should be added to pickled database"""
+        assert ("new_field", ) not in orion_db._get_database()._db['new_collection']._indexes
 
         orion_db.ensure_index('new_collection', 'new_field', unique=False)
-        assert ("new_field", ) not in orion_db._db['new_collection']._indexes
+        assert ("new_field", ) not in orion_db._get_database()._db['new_collection']._indexes
 
         orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert ("new_field", ) in orion_db._db['new_collection']._indexes
+        assert ("new_field", ) in orion_db._get_database()._db['new_collection']._indexes
 
     def test_existing_index(self, orion_db):
-        """Index should be added to ephemeral database and reattempt should do nothing"""
-        assert ("new_field", ) not in orion_db._db['new_collection']._indexes
+        """Index should be added to pickled database and reattempt should do nothing"""
+        assert ("new_field", ) not in orion_db._get_database()._db['new_collection']._indexes
 
         orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert ("new_field", ) in orion_db._db['new_collection']._indexes
+        assert ("new_field", ) in orion_db._get_database()._db['new_collection']._indexes
 
         # reattempt
         orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert ("new_field", ) in orion_db._db['new_collection']._indexes
+        assert ("new_field", ) in orion_db._get_database()._db['new_collection']._indexes
 
     def test_compound_index(self, orion_db):
         """Tuple of Index should be added as a compound index."""
-        assert ("name", "metadata.user") not in orion_db._db['experiments']._indexes
+        assert ("name", "metadata.user") not in orion_db._get_database()._db['experiments']._indexes
         orion_db.ensure_index('experiments',
                               [('name', Database.ASCENDING),
                                ('metadata.user', Database.ASCENDING)], unique=True)
-        assert ("name", "metadata.user") in orion_db._db['experiments']._indexes
+        assert ("name", "metadata.user") in orion_db._get_database()._db['experiments']._indexes
 
 
 @pytest.mark.usefixtures("clean_db")
 class TestRead(object):
-    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.read`."""
+    """Calls to :meth:`orion.core.io.database.pickleddb.PickledDB.read`."""
 
     def test_read_experiment(self, exp_config, orion_db):
         """Fetch a whole experiment entries."""
@@ -143,7 +130,10 @@ class TestRead(object):
             {'experiment': 'supernaedo2',
              'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
 
-        orion_db._db['trials']._documents[0]._data['end_time'] = None
+        db = orion_db._get_database()
+        db._db['trials']._documents[0]._data['end_time'] = None
+        orion_db._dump_database(db)
+
         values = orion_db.read(
             'trials',
             {'experiment': 'supernaedo2',
@@ -153,40 +143,42 @@ class TestRead(object):
 
 @pytest.mark.usefixtures("clean_db")
 class TestWrite(object):
-    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.write`."""
+    """Calls to :meth:`orion.core.io.database.pickleddb.PickledDB.write`."""
 
-    def test_insert_one(self, database, orion_db):
+    def test_insert_one(self, orion_db):
         """Should insert a single new entry in the collection."""
         item = {'exp_name': 'supernaekei',
                 'user': 'tsirif'}
-        count_before = database['experiments'].count()
+        count_before = orion_db._get_database().count('experiments')
         # call interface
         assert orion_db.write('experiments', item) is True
-        assert database['experiments'].count() == count_before + 1
-        value = database['experiments'].find({'exp_name': 'supernaekei'})[0]
+        assert orion_db._get_database().count('experiments') == count_before + 1
+        value = orion_db._get_database()._db['experiments'].find({'exp_name': 'supernaekei'})[0]
         assert value == item
 
-    def test_insert_many(self, database, orion_db):
+    def test_insert_many(self, orion_db):
         """Should insert two new entry (as a list) in the collection."""
         item = [{'exp_name': 'supernaekei2',
                  'user': 'tsirif'},
                 {'exp_name': 'supernaekei3',
                  'user': 'tsirif'}]
-        count_before = database['experiments'].count()
+        count_before = orion_db._get_database()._db['experiments'].count()
         # call interface
         assert orion_db.write('experiments', item) is True
+        database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before + 2
         value = database['experiments'].find({'exp_name': 'supernaekei2'})[0]
         assert value == item[0]
         value = database['experiments'].find({'exp_name': 'supernaekei3'})[0]
         assert value == item[1]
 
-    def test_update_many_default(self, database, orion_db):
+    def test_update_many_default(self, orion_db):
         """Should match existing entries, and update some of their keys."""
         filt = {'metadata.user': 'tsirif'}
-        count_before = database['experiments'].count()
+        count_before = orion_db._get_database().count('experiments')
         # call interface
         assert orion_db.write('experiments', {'pool_size': 16}, filt) is True
+        database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before
         value = list(database['experiments'].find({}))
         assert value[0]['pool_size'] == 16
@@ -194,24 +186,26 @@ class TestWrite(object):
         assert value[2]['pool_size'] == 16
         assert value[3]['pool_size'] == 2
 
-    def test_update_with_id(self, exp_config, database, orion_db):
+    def test_update_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
         filt = {'_id': exp_config[0][1]['_id']}
-        count_before = database['experiments'].count()
+        count_before = orion_db._get_database().count('experiments')
         # call interface
         assert orion_db.write('experiments', {'pool_size': 36}, filt) is True
+        database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before
         value = list(database['experiments'].find())
         assert value[0]['pool_size'] == 2
         assert value[1]['pool_size'] == 36
         assert value[2]['pool_size'] == 2
 
-    def test_upsert_with_id(self, database, orion_db):
+    def test_upsert_with_id(self, orion_db):
         """Query with a non-existent ``_id`` should upsert something."""
         filt = {'_id': 'lalalathisisnew'}
-        count_before = database['experiments'].count()
+        count_before = orion_db._get_database().count('experiments')
         # call interface
         assert orion_db.write('experiments', {'pool_size': 66}, filt) is True
+        database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before + 1
         value = list(database['experiments'].find(filt))
         assert len(value) == 1
@@ -219,23 +213,12 @@ class TestWrite(object):
         assert value[0]['_id'] == 'lalalathisisnew'
         assert value[0]['pool_size'] == 66
 
-    def test_insert_duplicate(self, database, orion_db):
-        """Verify that duplicates cannot by inserted if index is unique"""
-        orion_db.ensure_index('some_doc', 'unique_field', unique=True)
-        # call interface
-        orion_db.write('some_doc', {'unique_field': 1})
-
-        with pytest.raises(DuplicateKeyError) as exc:
-            orion_db.write('some_doc', {'unique_field': 1})
-
-        assert 'unique_field' in str(exc.value)
-
 
 @pytest.mark.usefixtures("clean_db")
 class TestReadAndWrite(object):
-    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.read_and_write`."""
+    """Calls to :meth:`orion.core.io.database.pickleddb.PickledDB.read_and_write`."""
 
-    def test_read_and_write_one(self, database, orion_db, exp_config):
+    def test_read_and_write_one(self, orion_db, exp_config):
         """Should read and update a single entry in the collection."""
         # Make sure there is only one match
         documents = orion_db.read(
@@ -251,7 +234,7 @@ class TestReadAndWrite(object):
         exp_config[0][3]['pool_size'] = 'lalala'
         assert loaded_config == exp_config[0][3]
 
-    def test_read_and_write_many(self, database, orion_db, exp_config):
+    def test_read_and_write_many(self, orion_db, exp_config):
         """Should update only one entry."""
         # Make sure there is many matches
         documents = orion_db.read('experiments', {'name': 'supernaedo2'})
@@ -271,7 +254,7 @@ class TestReadAndWrite(object):
         assert documents[0]['pool_size'] == 'lalala'
         assert documents[1]['pool_size'] != 'lalala'
 
-    def test_read_and_write_no_match(self, database, orion_db):
+    def test_read_and_write_no_match(self, orion_db):
         """Should return None when there is no match."""
         loaded_config = orion_db.read_and_write(
             'experiments',
@@ -283,33 +266,37 @@ class TestReadAndWrite(object):
 
 @pytest.mark.usefixtures("clean_db")
 class TestRemove(object):
-    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.remove`."""
+    """Calls to :meth:`orion.core.io.database.pickleddb.PickledDB.remove`."""
 
-    def test_remove_many_default(self, exp_config, database, orion_db):
+    def test_remove_many_default(self, exp_config, orion_db):
         """Should match existing entries, and delete them all."""
         filt = {'metadata.user': 'tsirif'}
+        database = orion_db._get_database()._db
         count_before = database['experiments'].count()
         count_filt = database['experiments'].count(filt)
         # call interface
         assert orion_db.remove('experiments', filt) is True
+        database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before - count_filt
         assert database['experiments'].count() == 1
         assert list(database['experiments'].find()) == [exp_config[0][3]]
 
-    def test_remove_with_id(self, exp_config, database, orion_db):
+    def test_remove_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
         filt = {'_id': exp_config[0][0]['_id']}
 
+        database = orion_db._get_database()._db
         count_before = database['experiments'].count()
         # call interface
         assert orion_db.remove('experiments', filt) is True
+        database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before - 1
         assert database['experiments'].find() == exp_config[0][1:]
 
 
 @pytest.mark.usefixtures("clean_db")
 class TestCount(object):
-    """Calls :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.count`."""
+    """Calls :meth:`orion.core.io.database.pickleddb.PickledDB.count`."""
 
     def test_count_default(self, exp_config, orion_db):
         """Call just with collection name."""
@@ -332,57 +319,39 @@ class TestCount(object):
         assert found == 0
 
 
-@pytest.mark.usefixtures("clean_db")
-class TestIndex(object):
-    """Test index for :meth:`orion.core.io.database.ephemeraldb.EphemeralCollection`."""
+def write(field, i):
+    """Write the given value to the pickled db."""
+    PickledDB.instance = None
+    orion_db = PickledDB(host='orion_db.pkl')
+    try:
+        orion_db.write('concurrent', {field: i})
+    except DuplicateKeyError:
+        print('dup')
+        pass
 
-    def test_create_index(self, collection):
-        """Test if new index added property."""
-        collection.create_index('hello')
-        assert collection._indexes == {('_id',): {(1, )}}
-
-        collection.create_index('hello', unique=True)
-        assert collection._indexes == {('_id',): {(1, )}, ('hello', ): {('there', )}}
-
-    def test_track_index(self, collection):
-        """Test if index values are tracked property."""
-        collection.create_index('hello', unique=True)
-        collection.insert_many([{'hello': 'here'}, {'hello': 2}])
-        assert (
-            collection._indexes ==
-            {('_id',): {(1, ), (2, ), (3, )}, ('hello', ): {('there', ), ('here', ), (2, )}})
+    print(field, i)
 
 
 @pytest.mark.usefixtures("clean_db")
-class TestSelect(object):
-    """Calls :meth:`orion.core.io.database.ephemeraldb.EphemeralDocument.select`."""
+class TestConcurreny(object):
+    """Test concurrent operations"""
 
-    def test_select_all(self, document):
-        """Select only one field."""
-        assert document.select({}) == {'_id': 1, 'hello': 'there', 'mighty': 'duck'}
+    def test_concurrent_writes(self, orion_db):
+        """Test that concurrent writes all get written properly"""
+        orion_db.ensure_index('concurrent', 'diff')
 
-    def test_select_id(self, document):
-        """Select only one field."""
-        assert document.select({'_id': 1}) == {'_id': 1}
+        assert orion_db.count('concurrent', {'diff': {'$gt': -1}}) == 0
 
-    def test_select_one(self, document):
-        """Select only one field."""
-        assert document.select({'hello': 1}) == {'_id': 1, 'hello': 'there'}
+        Pool(10).starmap(write, (('diff', i) for i in range(10)))
 
-    def test_select_two(self, document):
-        """Select only two field."""
-        assert (
-            document.select({'hello': 1, 'mighty': 1}) ==
-            {'_id': 1, 'hello': 'there', 'mighty': 'duck'})
+        assert orion_db.count('concurrent', {'diff': {'$gt': -1}}) == 10
 
-    def test_unselect_one(self, document):
-        """Unselect only one field."""
-        assert document.select({'hello': 0}) == {'_id': 1, 'mighty': 'duck'}
+    def test_concurrent_unique_writes(self, orion_db):
+        """Test that concurrent writes cannot duplicate unique fields"""
+        orion_db.ensure_index('concurrent', 'unique', unique=True)
 
-    def test_unselect_two(self, document):
-        """Unselect two field."""
-        assert document.select({'_id': 0, 'hello': 0}) == {'mighty': 'duck'}
+        assert orion_db.count('concurrent', {'unique': 1}) == 0
 
-    def test_mixed_select(self, document):
-        """Select one field and unselect _id."""
-        assert document.select({'_id': 0, 'hello': 1}) == {'hello': 'there'}
+        Pool(10).starmap(write, (('unique', 1) for i in range(10)))
+
+        assert orion_db.count('concurrent', {'unique': 1}) == 1


### PR DESCRIPTION
Why:

MongoDB does not play nicely with ssh tunnels and we are currently
stucked with a cluster where compute nodes does not have access to
internet, leaving us isolated from MongoDB. Using the file-system is not
optimal but it is at least simpler to set-up for the users.

How:

Simply load a pickled version of EphemeralDB and write the updated
version back to the file. All operations are locked using `filelock` to
provide support for parallel workers.