### PR TITLE
Add a roadmap to the documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # General info
 include LICENSE
 include *.rst
+include ROADMAP.md
 exclude RESEARCH.md
 
 # Control and setup helpers

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,11 @@ Start by starring and forking our Github repo!
 
 Thanks for the support!
 
+Roadmap
+========
+
+You can find our roadmap here: `<https://github.com/Epistimio/orion/blob/master/ROADMAP.md>`_
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,9 @@ Features
 Installation
 ============
 
-Install Oríon (beta) by running:
+Install Oríon by running:
 
-``pip install git+https://github.com/epistimio/orion.git@master``
+``pip install orion.core``
 
 For more information read the `full installation docs`_.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,65 @@
+# Roadmap
+Last update July 5th, 2019
+
+## Next releases - Short-Term
+
+### v0.1.4
+
+#### Trial interruption/suspension/resumption
+
+Handle interrupted or lost trials so that they can be automatically resumed by running workers.
+
+#### Command line tools to monitor experiments
+
+See #125 
+
+### v0.1.5
+
+#### Auto-resolution of EVC
+
+Make branching events automatically solved with sane defaults.
+
+## Next releases - Mid-Term
+
+### v0.2: ETA End of summer 2019
+#### Journal Protocol Plugins
+Offering:
+- no need to setup DB, can use one's existing backend
+- Can re-use tools provided by backend for visualizations, etc.
+#### Python API
+
+Traditional `suggest`/`observe` interface
+
+```python
+experiment = orion.client.register(
+    experiment='fct-dummy',
+    x='loguniform(0.1, 1)', verbose=True, message='running trial {trial.hash_name}')
+
+trial = experiment.suggest()
+results = dummy(**trial.arguments)
+experiment.observe(trial, results)
+```
+
+### v0.3
+#### Generic `Optimizer` interface supporting various types of algorithms
+
+Change interface to support trial object instead of curated lists. This is necessary to support algorithms such as PBT.
+
+#### More Optimizers
+- PBT
+- BOHB
+
+## Next releases - Long-Term
+
+#### Simple dashboard specific to monitoring and benchmarking of Black-Box optimization
+- Specific to hyper parameter optimizations
+- Provide status of experiments
+
+#### Conditional Space
+
+The Space class will be refactored on top of [ConfigSpace](https://automl.github.io/ConfigSpace). This will give access to [conditional parameters](https://automl.github.io/ConfigSpace/master/Guide.html#nd-example-categorical-hyperparameters-and-conditions) and [forbidden clauses](https://automl.github.io/ConfigSpace/master/Guide.html#rd-example-forbidden-clauses).
+
+## Other possibilities
+- NAS
+- Multi-Objective Optimization
+- Dynamic Scheduler

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Handle interrupted or lost trials so that they can be automatically resumed by r
 
 #### Command line tools to monitor experiments
 
-See #125 
+See [#125](https://github.com/Epistimio/orion/issues/125)
 
 ### v0.1.5
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup_args['classifiers'] = [
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ] + [('Programming Language :: Python :: %s' % x)
-     for x in '3 3.4 3.5 3.6'.split()]
+     for x in '3 3.5 3.6 3.7'.split()]
 
 if __name__ == '__main__':
     setup(**setup_args)


### PR DESCRIPTION
I added a roadmap in the repo in the form of a markdown file. It is referenced from the README file and thus from the home page of the doc as well.