### PR TITLE
Add CI support for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,44 +3,65 @@ language: python
 
 jobs:
   include:
-    - stage: pretest
-      env: TOXENV=flake8
-      python: 3.6
-    - env: TOXENV=pylint
-      python: 3.6
-    - env: TOXENV=doc8
-      python: 3.6
-    - env: TOXENV=docs
-      python: 3.6
-    - &test
-      stage: test
-      services: mongodb
-      before_script:
-        - sleep 15
-        - mongo orion_test --eval 'db.createUser({user:"user",pwd:"pass",roles:["readWrite"]});'
-      after_success:
-        - tox -e final-coverage
-        - tox -e codecov
-      env: TOXENV=py35
-      python: 3.5
-    - <<: *test
-      env: TOXENV=py36
-      python: 3.6
-    - <<: *test
-      env: TOXENV=py37
-      python: 3.7
-      dist: xenial
-      sudo: true
-    - <<: *test
-      env: TOXENV=demo_random
-      python: 3.6
-    - stage: packaging
-      env: TOXENV=packaging
-      python: 3.6
-    - env: TOXENV=none
-      python: 3.6
-      install: skip
-      script: ./conda/conda_build.sh
+      - stage: pretest
+        env: TOXENV=flake8
+        python: 3.6
+      - env: TOXENV=pylint
+        python: 3.6
+      - env: TOXENV=doc8
+        python: 3.6
+      - env: TOXENV=docs
+        python: 3.6
+      - &test
+        stage: test
+        services: mongodb
+        before_script:
+          - sleep 15
+          - mongo orion_test --eval 'db.createUser({user:"user",pwd:"pass",roles:["readWrite"]});'
+        after_success:
+          - tox -e final-coverage
+          - tox -e codecov
+        env: TOXENV=py35
+        python: 3.5
+      - <<: *test
+        env: TOXENV=py36
+        python: 3.6
+      - <<: *test
+        env: TOXENV=py36, PYTHON=3.6.3
+        python: 3.6
+        os: osx
+        language: generic
+      - <<: *test
+        env: TOXENV=py37
+        python: 3.7
+        dist: xenial
+        sudo: true
+      - <<: *test
+        env: TOXENV=demo_random
+        python: 3.6
+      - stage: packaging
+        env: TOXENV=packaging
+        python: 3.6
+      - env: TOXENV=none
+        python: 3.6
+        install: skip
+        script: ./conda/conda_build.sh
+
+before_install: |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew update
+    brew install readline
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    pyenv install $PYTHON
+    export PYENV_VERSION=$PYTHON
+    export PATH="/Users/travis/.pyenv/shims:${PATH}"
+    pyenv-virtualenv venv
+    source venv/bin/activate
+    python --version
+    brew install mongodb
+    brew services start mongodb
+  fi
 
 install:
   - pip install tox

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import os
 import shutil
 import subprocess
+import tempfile
 
 import numpy
 import pytest
@@ -267,14 +268,15 @@ def test_working_dir_argument_cmdline(database, monkeypatch, tmp_path):
 @pytest.mark.usefixtures("null_db_instances")
 def test_tmpdir_is_deleted(database, monkeypatch, tmp_path):
     """Check that a permanent directory is used instead of tmpdir"""
-    if os.path.exists("/tmp/orion"):
-        shutil.rmtree("/tmp/orion")
+    tmp_path = os.path.join(tempfile.gettempdir(), 'orion')
+    if os.path.exists(tmp_path):
+        shutil.rmtree(tmp_path)
 
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     orion.core.cli.main(["hunt", "-n", "allo", "--max-trials", "2", "--config",
                          "./database_config.yaml", "./black_box.py", "-x~uniform(-50,50)"])
 
-    assert not os.listdir("/tmp/orion")
+    assert not os.listdir(tmp_path)
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -282,17 +284,20 @@ def test_tmpdir_is_deleted(database, monkeypatch, tmp_path):
 def test_working_dir_argument_config(database, monkeypatch):
     """Check that a permanent directory is used instead of tmpdir"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    assert not os.path.exists("/tmp/orion/test")
+    dir_path = os.path.join('orion', 'test')
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
+
     orion.core.cli.main(["hunt", "-n", "allo", "--max-trials", "2",
                          "--config", "./working_dir_config.yaml", "./black_box.py",
                          "-x~uniform(-50,50)"])
 
     exp = list(database.experiments.find({'name': 'allo'}))[0]
-    assert exp['working_dir'] == "/tmp/orion/test"
-    assert os.path.exists("/tmp/orion/test")
-    assert os.listdir("/tmp/orion/test")
+    assert exp['working_dir'] == dir_path
+    assert os.path.exists(dir_path)
+    assert os.listdir(dir_path)
 
-    shutil.rmtree("/tmp/orion/test")
+    shutil.rmtree(dir_path)
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/tests/functional/demo/working_dir_config.yaml
+++ b/tests/functional/demo/working_dir_config.yaml
@@ -1,6 +1,6 @@
 name: allo
 
-working_dir: /tmp/orion/test
+working_dir: orion/test
 
 database:
   type: 'mongodb'


### PR DESCRIPTION
There should not be much differences between linux and OSX so running all our tests on both OS may be overkill. We will limit tests on OSX to `py36` test.