### PR TITLE
Add pydocstyle version to tox-flake8 deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -128,6 +128,7 @@ description = Use flake8 linter to impose standards on the project
 basepython = python3.6
 skip_install = true
 deps =
+    pydocstyle == 3.0.0
     flake8 == 3.5.0
     flake8-import-order == 0.15
     flake8-docstrings == 1.1.0


### PR DESCRIPTION
Why:

The version of pydocstyle is not upper bounded in flake8. The new
version 4.0.0 of pydocstyle is not yet supported by flake8 and won't
ever be by flake8 3.5.0.

How:

Add pydocstyle == 3.0.0 to force lower version number than what is
automatically installed when installing flake8.