### PR TITLE
Add heartbeat to Trial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .spyproject
 .ropeproject
 *.log
+*.pkl
+*.lock
 
 # StarUML documentation
 *.mdj

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -258,8 +258,8 @@ class Experiment(object):
             selected_trial = self.reserve_trial(score_handle=score_handle)
         else:
             selected_trial = Trial(**selected_trial_dict)
+            TrialMonitor(self, selected_trial.id).start()
 
-        TrialMonitor(self, selected_trial.id).start()
         return selected_trial
 
     def push_completed_trial(self, trial):

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -23,6 +23,8 @@ class Trial(object):
     experiment : str
        Unique identifier for the experiment that produced this trial.
        Same as an `Experiment._id`.
+    heartbeat : datetime.datetime
+        Last time trial was identified as being alive.
     status : str
        Indicates how this trial is currently being used. Can take the following
        values:
@@ -147,7 +149,7 @@ class Trial(object):
         __slots__ = ()
         allowed_types = ('integer', 'real', 'categorical', 'fidelity')
 
-    __slots__ = ('experiment', '_id', '_status', 'worker', '_working_dir',
+    __slots__ = ('experiment', '_id', '_status', 'worker', '_working_dir', 'heartbeat',
                  'submit_time', 'start_time', 'end_time', '_results', 'params', 'parents')
     allowed_stati = ('new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken')
 

--- a/src/orion/core/worker/trial_monitor.py
+++ b/src/orion/core/worker/trial_monitor.py
@@ -45,11 +45,9 @@ class TrialMonitor(threading.Thread):
     def _monitor_trial(self):
         query = {'_id': self.trial_id, 'status': 'reserved'}
         trials = self.exp.fetch_trials(query)
-        print(trials)
 
-        if len(trials):
+        if trials:
             update = dict(heartbeat=datetime.datetime.utcnow())
-            print("Changing.")
             Database().write('trials', update, query)
         else:
             self.stopped.set()

--- a/src/orion/core/worker/trial_monitor.py
+++ b/src/orion/core/worker/trial_monitor.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.worker.trial_monitor` -- Monitor trial execution
+=================================================================
+.. module:: trial_monitor
+   :platform: Unix
+   :synopsis: Monitor trials and update their heartbeat
+
+"""
+import datetime
+import threading
+
+from orion.core.io.database import Database
+
+
+class TrialMonitor(threading.Thread):
+    """Monitor a given trial inside a thread, updating its heartbeat
+    at a given interval  of time.
+
+    Parameters
+    ----------
+    exp: Experiment
+        The current Experiment.
+
+    """
+
+    def __init__(self, exp, trial_id, wait_time=60):
+        """Initialize a TrialMonitor."""
+        threading.Thread.__init__(self)
+        self.stopped = threading.Event()
+        self.exp = exp
+        self.trial_id = trial_id
+        self.wait_time = wait_time
+
+    def stop(self):
+        """Stop monitoring."""
+        self.stopped.set()
+        self.join()
+
+    def run(self):
+        """Run the trial monitoring every given interval."""
+        while not self.stopped.wait(self.wait_time):
+            self._monitor_trial()
+
+    def _monitor_trial(self):
+        query = {'_id': self.trial_id, 'status': 'reserved'}
+        trials = self.exp.fetch_trials(query)
+        print(trials)
+
+        if len(trials):
+            update = dict(heartbeat=datetime.datetime.utcnow())
+            print("Changing.")
+            Database().write('trials', update, query)
+        else:
+            self.stopped.set()

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -589,10 +589,11 @@ class TestReserveTrial(object):
         trial = hacked_exp.reserve_trial()
         exp_config[1][3]['status'] = 'reserved'
         exp_config[1][3]['start_time'] = random_dt
+        exp_config[1][3]['heartbeat'] = random_dt
         assert trial.to_dict() == exp_config[1][3]
 
     @pytest.mark.usefixtures("patch_sample2")
-    def test_reserve_success2(self, exp_config, hacked_exp):
+    def test_reserve_success2(self, exp_config, hacked_exp, random_dt):
         """Successfully find new trials in db and reserve one at 'random'.
 
         Version that start_time does not get written, because the selected trial
@@ -600,6 +601,7 @@ class TestReserveTrial(object):
         """
         trial = hacked_exp.reserve_trial()
         exp_config[1][6]['status'] = 'reserved'
+        exp_config[1][6]['heartbeat'] = random_dt
         assert trial.to_dict() == exp_config[1][6]
 
     @pytest.mark.usefixtures("patch_sample_concurrent")
@@ -608,6 +610,7 @@ class TestReserveTrial(object):
         trial = hacked_exp.reserve_trial()
         exp_config[1][4]['status'] = 'reserved'
         exp_config[1][4]['start_time'] = random_dt
+        exp_config[1][4]['heartbeat'] = random_dt
         assert trial.to_dict() == exp_config[1][4]
 
     @pytest.mark.usefixtures("patch_sample_concurrent2")
@@ -626,12 +629,13 @@ class TestReserveTrial(object):
         self.times_called += 1
         return self.times_called
 
-    def test_reserve_with_score(self, hacked_exp, exp_config):
+    def test_reserve_with_score(self, hacked_exp, exp_config, random_dt):
         """Reserve with a score object that can do its job."""
         self.times_called = 0
         hacked_exp.configure(exp_config[0][3])
         trial = hacked_exp.reserve_trial(score_handle=self.fake_handle)
         exp_config[1][6]['status'] = 'reserved'
+        exp_config[1][6]['heartbeat'] = random_dt
         assert trial.to_dict() == exp_config[1][6]
 
 

--- a/tests/unittests/core/worker/test_trial_monitor.py
+++ b/tests/unittests/core/worker/test_trial_monitor.py
@@ -105,7 +105,7 @@ def test_trial_heartbeat_not_updated_inbetween(config):
 
     heartbeat = trials[0].heartbeat
 
-    time.sleep(4)
+    time.sleep(6)
 
     trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
 

--- a/tests/unittests/core/worker/test_trial_monitor.py
+++ b/tests/unittests/core/worker/test_trial_monitor.py
@@ -36,7 +36,7 @@ def test_trial_update_heartbeat(config):
     trial_monitor = TrialMonitor(exp, trial.id, wait_time=1)
 
     trial_monitor.start()
-    time.sleep(1)
+    time.sleep(2)
 
     trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
 
@@ -44,7 +44,7 @@ def test_trial_update_heartbeat(config):
 
     heartbeat = trials[0].heartbeat
 
-    time.sleep(1)
+    time.sleep(2)
 
     trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
 
@@ -67,7 +67,7 @@ def test_trial_heartbeat_not_updated(config):
     trial_monitor = TrialMonitor(exp, trial.id, wait_time=1)
 
     trial_monitor.start()
-    time.sleep(1)
+    time.sleep(2)
 
     trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
 
@@ -76,7 +76,7 @@ def test_trial_heartbeat_not_updated(config):
     data = {'status': 'interrupted'}
     Database().write('trials', data, query=dict(_id=trial.id))
 
-    time.sleep(1)
+    time.sleep(2)
 
     trial_monitor.join()
     assert 1

--- a/tests/unittests/core/worker/test_trial_monitor.py
+++ b/tests/unittests/core/worker/test_trial_monitor.py
@@ -78,6 +78,7 @@ def test_trial_heartbeat_not_updated(config):
 
     time.sleep(2)
 
+    # `join` blocks until all thread have finish executing. So, the test will hang if it fails.
     trial_monitor.join()
     assert 1
 

--- a/tests/unittests/core/worker/test_trial_monitor.py
+++ b/tests/unittests/core/worker/test_trial_monitor.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.worker.consumer`."""
+import datetime
+import time
+
+import pytest
+
+from orion.core.io.database import Database
+from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.format_trials import tuple_to_trial
+from orion.core.worker.trial_monitor import TrialMonitor
+
+
+@pytest.fixture
+def config(exp_config):
+    """Return a configuration."""
+    config = exp_config[0][0]
+    config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
+    config['name'] = 'exp'
+    return config
+
+
+@pytest.mark.usefixtures("create_db_instance")
+def test_trial_update_heartbeat(config):
+    """Test that the heartbeat of a trial has been updated."""
+    exp = ExperimentBuilder().build_from(config)
+    trial = tuple_to_trial((1.0,), exp.space)
+    heartbeat = datetime.datetime.utcnow()
+    trial.heartbeat = heartbeat
+
+    data = {'_id': trial.id, 'status': 'reserved', 'heartbeat': heartbeat, 'experiment': exp.id}
+
+    Database().write('trials', data)
+
+    trial_monitor = TrialMonitor(exp, trial.id, wait_time=1)
+
+    trial_monitor.start()
+    time.sleep(1)
+
+    trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
+
+    assert trial.heartbeat != trials[0].heartbeat
+
+    heartbeat = trials[0].heartbeat
+
+    time.sleep(1)
+
+    trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
+
+    assert heartbeat != trials[0].heartbeat
+    trial_monitor.stop()
+
+
+@pytest.mark.usefixtures("create_db_instance")
+def test_trial_heartbeat_not_updated(config):
+    """Test that the heartbeat of a trial is not updated when trial is not longer reserved."""
+    exp = ExperimentBuilder().build_from(config)
+    trial = tuple_to_trial((1.0,), exp.space)
+    heartbeat = datetime.datetime.utcnow()
+    trial.heartbeat = heartbeat
+
+    data = {'_id': trial.id, 'status': 'reserved', 'heartbeat': heartbeat, 'experiment': exp.id}
+
+    Database().write('trials', data)
+
+    trial_monitor = TrialMonitor(exp, trial.id, wait_time=1)
+
+    trial_monitor.start()
+    time.sleep(1)
+
+    trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
+
+    assert trial.heartbeat != trials[0].heartbeat
+
+    data = {'status': 'interrupted'}
+    Database().write('trials', data, query=dict(_id=trial.id))
+
+    time.sleep(1)
+
+    trial_monitor.join()
+    assert 1
+
+
+@pytest.mark.usefixtures("create_db_instance")
+def test_trial_heartbeat_not_updated_inbetween(config):
+    """Test that the heartbeat of a trial is not updated before wait time."""
+    exp = ExperimentBuilder().build_from(config)
+    trial = tuple_to_trial((1.0,), exp.space)
+    heartbeat = datetime.datetime.utcnow().replace(microsecond=0)
+    trial.heartbeat = heartbeat
+
+    data = {'_id': trial.id, 'status': 'reserved', 'heartbeat': heartbeat, 'experiment': exp.id}
+
+    Database().write('trials', data)
+
+    trial_monitor = TrialMonitor(exp, trial.id, wait_time=5)
+
+    trial_monitor.start()
+    time.sleep(1)
+
+    trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
+    assert trial.heartbeat == trials[0].heartbeat
+
+    heartbeat = trials[0].heartbeat
+
+    time.sleep(4)
+
+    trials = exp.fetch_trials({'_id': trial.id, 'status': 'reserved'})
+
+    assert heartbeat != trials[0].heartbeat
+    trial_monitor.stop()


### PR DESCRIPTION
When a trial is reserved, a heartbeat should be updated every N seconds so that we can detect if the trial is still reserved/running or lost. Currently, the wait time is configurable inside the monitoring thread, but we are waiting for the Configuration overhaul to implement it inside the configuration options.