### PR TITLE
Add $ne and handle non-supported operation in EphemeralDB

### DIFF
--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -283,6 +283,7 @@ class EphemeralDocument(object):
     """
 
     operators = {
+        "$ne": (lambda a, b: a != b),
         "$in": (lambda a, b: a in b),
         "$gte": (lambda a, b: a is not None and a >= b),
         "$gt": (lambda a, b: a is not None and a > b),
@@ -309,8 +310,9 @@ class EphemeralDocument(object):
         return key.split(".")[-1].startswith('$')
 
     def _get_key_operator(self, key):
-        operator = key.split(".")[-1]
-        key = ".".join(key.split(".")[:-1])
+        path = key.split(".")
+        operator = path[-1]
+        key = ".".join(path[:-1])
 
         if operator not in self.operators:
             raise ValueError('Operator \'{}\' is not supported by EphemeralDB'.format(operator))
@@ -322,7 +324,7 @@ class EphemeralDocument(object):
         value based on the operator defined within the key.
 
         Default operator is equal when no operator is defined.
-        Other operators could be $in, $gte, $gt or $lte. They are defined
+        Other operators could be $ne, $in, $gte, $gt or $lte. They are defined
         in the last section of the key. For example: `abc.def.$in` or `abc.def.$gte`.
         """
         if self._is_operator(key):

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -305,19 +305,30 @@ class EphemeralDocument(object):
 
         return True
 
+    def _is_operator(self, key):  # pylint: disable=no-self-use
+        return key.split(".")[-1].startswith('$')
+
+    def _get_key_operator(self, key):
+        operator = key.split(".")[-1]
+        key = ".".join(key.split(".")[:-1])
+
+        if operator not in self.operators:
+            raise ValueError('Operator \'{}\' is not supported by EphemeralDB'.format(operator))
+
+        return key, self.operators[operator]
+
     def match_key(self, key, value):
         """Test if a data corresponding to the given key is in agreement with the given
         value based on the operator defined within the key.
 
         Default operator is equal when no operator is defined.
-        Other operators could be $in, $gte, $gt. They are defined
+        Other operators could be $in, $gte, $gt or $lte. They are defined
         in the last section of the key. For example: `abc.def.$in` or `abc.def.$gte`.
         """
-        if key.split(".")[-1] in self.operators:
-            operator = key.split(".")[-1]
-            key = ".".join(key.split(".")[:-1])
+        if self._is_operator(key):
+            key, operator = self._get_key_operator(key)
 
-            return key in self and self.operators[operator](self[key], value)
+            return key in self and operator(self[key], value)
 
         return key in self and self[key] == value
 

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -424,6 +424,11 @@ class TestMatch:
         assert document.match({'_id': {'$lte': 1}})
         assert not document.match({'_id': {'$lte': 0}})
 
+    def test_match_ne(self, document):
+        """Test $ne operator with document"""
+        assert document.match({'hello': {'$ne': 'here'}})
+        assert not document.match({'hello': {'$ne': 'there'}})
+
     def test_match_bad_operator(self, document):
         """Test invalid operator handling"""
         with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
### Handle non invalid $op for EphemeralDB 
Why:

The operator $ne was not supported by EphemeralDB but the operation was silently failling as a failed comparison (the field `whatever.$ne` could not exist in the document). Any unsupported operation should blatantly fail.


### Add $ne op to EphemeralDB
Why:

The operation is used in `Experiment.fetch_non_completed_trials`.