### PR TITLE
Fix ScriptConfigConflict

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1344,9 +1344,10 @@ class ScriptConfigConflict(Conflict):
         """Get configuration dict of user's script without dimension definitions"""
         space_builder = SpaceBuilder()
         space_builder.build_from(config['metadata']['user_args'])
+
         nameless_config = dict((key, value)
                                for (key, value) in space_builder.parser.config_file_data.items()
-                               if not value.startswith('orion~'))
+                               if not (isinstance(value, str) and value.startswith('orion~')))
 
         return nameless_config
 

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -17,6 +17,7 @@ from orion.core.worker.experiment import Experiment
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 YAML_SAMPLE = os.path.join(TEST_DIR, 'sample_config.yml')
+YAML_DIFF_SAMPLE = os.path.join(TEST_DIR, 'sample_config_diff.yml')
 JSON_SAMPLE = os.path.join(TEST_DIR, 'sample_config.json')
 UNKNOWN_SAMPLE = os.path.join(TEST_DIR, 'sample_config.txt')
 
@@ -27,10 +28,22 @@ def yaml_sample_path():
     return os.path.abspath(YAML_SAMPLE)
 
 
+@pytest.fixture(scope='session')
+def yaml_diff_sample_path():
+    """Return path with a different yaml sample file."""
+    return os.path.abspath(YAML_DIFF_SAMPLE)
+
+
 @pytest.fixture
 def yaml_config(yaml_sample_path):
     """Return a list containing the key and the sample path for a yaml config."""
     return ['--config', yaml_sample_path]
+
+
+@pytest.fixture
+def yaml_diff_config(yaml_diff_sample_path):
+    """Return a list containing the key and the sample path for a different yaml config."""
+    return ['--config', yaml_diff_sample_path]
 
 
 @pytest.fixture(scope='session')

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -322,6 +322,21 @@ class TestScriptConfigConflict(object):
         """Verify the representation of conflict for user interface"""
         assert repr(config_conflict) == "Script's configuration file changed"
 
+    def test_comparison(self, yaml_config, yaml_diff_config):
+        """Test that different configs are detected as conflict."""
+        old_config = {'metadata': {'user_args': yaml_config}}
+        new_config = {'metadata': {'user_args': yaml_diff_config}}
+
+        conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
+        assert len(conflicts) == 1
+
+    def test_comparison_idem(self, yaml_config):
+        """Test that identical configs are not detected as conflict."""
+        old_config = {'metadata': {'user_args': yaml_config}}
+        new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
+
+        assert list(conflict.ScriptConfigConflict.detect(old_config, new_config)) == []
+
 
 @pytest.mark.usefixtures("create_db_instance")
 class TestExperimentNameConflict(object):

--- a/tests/unittests/core/sample_config_diff.yml
+++ b/tests/unittests/core/sample_config_diff.yml
@@ -1,0 +1,16 @@
+yo: 5
+training:
+  lr0: orion~loguniform(0.0001, 0.3)
+  mbs: orion~uniform(32, 256, discrete=True)
+
+# some comments
+
+layers:
+  - width: 128
+    type: relu
+  - width: orion~uniform(32, 128, discrete=True)
+    type: orion~choices('relu', 'sigmoid', 'selu', 'leaky')
+  - width: 16
+    type: orion~choices('relu', 'sigmoid', 'selu', 'leaky')
+
+something-same: orion~choices([1, 2, 3, 4, 5])


### PR DESCRIPTION
Why:

The conflict class was looking for `orion~prior()` templates in the
values of the configuration files, but they can have other types than
strings.