### PR TITLE
Handle `orion list --name` properly

### DIFF
--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -35,9 +35,17 @@ def main(args):
     config = builder.fetch_full_config(args, use_db=False)
     builder.setup_database(config)
 
-    experiments = Database().read("experiments", {})
+    query = {}
 
-    root_experiments = [exp for exp in experiments if exp['refers']['root_id'] == exp['_id']]
+    if args['name']:
+        query['name'] = args['name']
+
+    experiments = Database().read("experiments", query)
+
+    if args['name']:
+        root_experiments = experiments
+    else:
+        root_experiments = [exp for exp in experiments if exp['refers']['root_id'] == exp['_id']]
 
     for root_experiment in root_experiments:
         root = EVCBuilder().build_view_from({'name': root_experiment['name']}).node

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -90,3 +90,43 @@ def test_three_exp(capsys, three_experiments):
 
     assert captured == " test_list_double┐\n                 └test_list_double_child\n \
 test_list_single\n"
+
+
+def test_no_exp_name(three_experiments, monkeypatch, capsys):
+    """Test that nothing is printed when there are no experiments with a given name."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list', '--name', 'I don\'t exist'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == ""
+
+
+def test_exp_name(three_experiments, monkeypatch, capsys):
+    """Test that only the specified experiment is printed."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list', '--name', 'test_list_single'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == " test_list_single\n"
+
+
+def test_exp_name_with_child(three_experiments, monkeypatch, capsys):
+    """Test that only the specified experiment is printed, and with its child."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list', '--name', 'test_list_double'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == " test_list_double┐\n                 └test_list_double_child\n"
+
+
+def test_exp_name_child(three_experiments, monkeypatch, capsys):
+    """Test that only the specified child experiment is printed."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list', '--name', 'test_list_double_child'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == " test_list_double_child\n"

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -6,19 +6,32 @@ import os
 import pytest
 
 import orion.core.cli
+from orion.core.io.database import Database
 
 
 @pytest.fixture
 def no_experiment(database):
-    """Make sure there is no experiment."""
+    """Create and save a singleton for an empty database instance."""
     database.experiments.drop()
+    database.lying_trials.drop()
+    database.trials.drop()
+    database.workers.drop()
+    database.resources.drop()
+
+    try:
+        db = Database(of_type='MongoDB', name='orion_test',
+                      username='user', password='pass')
+    except ValueError:
+        db = Database()
+
+    return db
 
 
 @pytest.fixture
-def one_experiment(monkeypatch, no_experiment):
+def one_experiment(monkeypatch, create_db_instance):
     """Create a single experiment."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['init_only', '-n', 'test_list_single', '-c', './orion_config_random.yaml',
+    orion.core.cli.main(['init_only', '-n', 'test_list_single',
                          './black_box.py', '--x~uniform(0,1)'])
 
 
@@ -26,9 +39,9 @@ def one_experiment(monkeypatch, no_experiment):
 def two_experiments(monkeypatch, no_experiment):
     """Create an experiment and its child."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['init_only', '-n', 'test_list_double', '-c', './orion_config_random.yaml',
+    orion.core.cli.main(['init_only', '-n', 'test_list_double',
                          './black_box.py', '--x~uniform(0,1)'])
-    orion.core.cli.main(['init_only', '-n', 'test_list_double', '-c', './orion_config_random.yaml',
+    orion.core.cli.main(['init_only', '-n', 'test_list_double',
                          '--branch', 'test_list_double_child', './black_box.py',
                          '--x~uniform(0,1)', '--y~+uniform(0,1)'])
 
@@ -37,14 +50,14 @@ def two_experiments(monkeypatch, no_experiment):
 def three_experiments(monkeypatch, two_experiments):
     """Create a single experiment and an experiment and its child."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['init_only', '-n', 'test_list_single', '-c', './orion_config_random.yaml',
+    orion.core.cli.main(['init_only', '-n', 'test_list_single',
                          './black_box.py', '--x~uniform(0,1)'])
 
 
 def test_no_exp(no_experiment, monkeypatch, capsys):
     """Test that nothing is printed when there are no experiments."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list', '--config', './orion_config_random.yaml'])
+    orion.core.cli.main(['list'])
 
     captured = capsys.readouterr().out
 
@@ -53,7 +66,7 @@ def test_no_exp(no_experiment, monkeypatch, capsys):
 
 def test_single_exp(capsys, one_experiment):
     """Test that the name of the experiment is printed when there is one experiment."""
-    orion.core.cli.main(['list', '--config', './orion_config_random.yaml'])
+    orion.core.cli.main(['list'])
 
     captured = capsys.readouterr().out
 
@@ -61,8 +74,8 @@ def test_single_exp(capsys, one_experiment):
 
 
 def test_two_exp(capsys, two_experiments):
-    """Test that nothing is printed when there are no experiments."""
-    orion.core.cli.main(['list', '--config', './orion_config_random.yaml'])
+    """Test that experiment and child are printed."""
+    orion.core.cli.main(['list'])
 
     captured = capsys.readouterr().out
 
@@ -70,8 +83,8 @@ def test_two_exp(capsys, two_experiments):
 
 
 def test_three_exp(capsys, three_experiments):
-    """Test that nothing is printed when there are no experiments."""
-    orion.core.cli.main(['list', '--config', './orion_config_random.yaml'])
+    """Test that experiment, child  and grand-child are printed."""
+    orion.core.cli.main(['list'])
 
     captured = capsys.readouterr().out
 


### PR DESCRIPTION
### Handle --name argument properly 

Why:

The argument --name was currently ignored. It should filter the name of the experiments

### Get rid of config file in `list` tests 

Why:

There is no need for a config file, what we need is to fix the DB instance in the fixture so that this one is used in all tests and not the global config or the current user running the tests.