### PR TITLE
Fix race conditions during algo updates

### DIFF
--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -98,16 +98,21 @@ class Producer(object):
         log.debug("### Fetch completed trials to observe:")
         completed_trials = self.experiment.fetch_completed_trials()
 
-        log.debug("### %s", completed_trials)
+        new_completed_trials = []
+        for trial in completed_trials:
+            if trial not in self.trials_history:
+                new_completed_trials.append(trial)
 
-        if completed_trials:
+        log.debug("### %s", new_completed_trials)
+
+        if new_completed_trials:
             log.debug("### Convert them to list of points and their results.")
             points = list(map(lambda trial: format_trials.trial_to_tuple(trial, self.space),
-                              completed_trials))
-            results = list(map(format_trials.get_trial_results, completed_trials))
+                              new_completed_trials))
+            results = list(map(format_trials.get_trial_results, new_completed_trials))
 
             log.debug("### Observe them.")
-            self.trials_history.update(completed_trials)
+            self.trials_history.update(new_completed_trials)
             self.algorithm.observe(points, results)
             self.strategy.observe(points, results)
 

--- a/src/orion/core/worker/trials_history.py
+++ b/src/orion/core/worker/trials_history.py
@@ -17,6 +17,11 @@ class TrialsHistory:
     def __init__(self):
         """Create empty trials history"""
         self.children = []
+        self.ids = set()
+
+    def __contains__(self, trial):
+        """Return True if the trial is in the observed history"""
+        return trial.id in self.ids
 
     def update(self, trials):
         """Update the list of children trials
@@ -29,5 +34,7 @@ class TrialsHistory:
         for trial in trials:
             descendents -= set(trial.parents)
             descendents.add(trial.id)
+
+        self.ids |= descendents
 
         self.children = list(sorted(descendents))

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -160,7 +160,6 @@ def test_build_view_from(config_file, create_db_instance, exp_config, random_dt)
     assert exp_view.name == exp_config[0][0]['name']
     assert exp_view.configuration['refers'] == exp_config[0][0]['refers']
     assert exp_view.metadata == exp_config[0][0]['metadata']
-    assert exp_view._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp_view.pool_size == exp_config[0][0]['pool_size']
     assert exp_view.max_trials == exp_config[0][0]['max_trials']
     assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
@@ -202,7 +201,6 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp.metadata['user'] == 'tsirif'
     assert exp.metadata['user_script'] == cmdargs['user_args'][0]
     assert exp.metadata['user_args'] == cmdargs['user_args'][1:]
-    assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
     assert exp.algorithms.configuration == {'random': {'seed': None}}
@@ -228,7 +226,6 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config, script_
     assert exp.name == exp_config[0][0]['name']
     assert exp.configuration['refers'] == exp_config[0][0]['refers']
     assert exp.metadata == exp_config[0][0]['metadata']
-    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
@@ -266,7 +263,6 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp.metadata['user'] == 'tsirif'
     assert exp.metadata['user_script'] == cmdargs['user_args'][0]
     assert exp.metadata['user_args'] == cmdargs['user_args'][1:]
-    assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
     assert not exp.is_done
@@ -303,7 +299,6 @@ def test_build_from_config_hit(old_config_file, create_db_instance, exp_config, 
     assert exp.name == exp_config[0][0]['name']
     assert exp.configuration['refers'] == exp_config[0][0]['refers']
     assert exp.metadata == exp_config[0][0]['metadata']
-    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
@@ -332,7 +327,6 @@ def test_build_without_config_hit(old_config_file, create_db_instance, exp_confi
     assert exp.name == exp_config[0][0]['name']
     assert exp.configuration['refers'] == exp_config[0][0]['refers']
     assert exp.metadata == exp_config[0][0]['metadata']
-    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -184,7 +184,6 @@ class TestInitExperiment(object):
         assert exp.name == 'supernaekei'
         assert exp.refers == {}
         assert exp.metadata['user'] == 'tsirif'
-        assert exp._last_fetched == random_dt
         assert len(exp.metadata) == 1
         assert exp.pool_size is None
         assert exp.max_trials is None
@@ -203,7 +202,6 @@ class TestInitExperiment(object):
         assert exp.name == 'supernaedo2'
         assert exp.refers == {}
         assert exp.metadata['user'] == 'bouthilx'
-        assert exp._last_fetched == random_dt
         assert len(exp.metadata) == 1
         assert exp.pool_size is None
         assert exp.max_trials is None
@@ -222,7 +220,6 @@ class TestInitExperiment(object):
         assert exp.name == exp_config[0][0]['name']
         assert exp.refers == exp_config[0][0]['refers']
         assert exp.metadata == exp_config[0][0]['metadata']
-        assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.algorithms == exp_config[0][0]['algorithms']
@@ -802,7 +799,6 @@ def test_fetch_all_trials(hacked_exp, exp_config, random_dt):
 def test_fetch_completed_trials(hacked_exp, exp_config, random_dt):
     """Fetch a list of the unseen yet completed trials."""
     trials = hacked_exp.fetch_completed_trials()
-    assert hacked_exp._last_fetched == max(trial.end_time for trial in trials)
     assert len(trials) == 3
     # Trials are sorted based on submit time
     assert trials[0].to_dict() == exp_config[1][0]
@@ -921,7 +917,6 @@ class TestInitExperimentView(object):
         assert exp.name == exp_config[0][0]['name']
         assert exp.configuration['refers'] == exp_config[0][0]['refers']
         assert exp.metadata == exp_config[0][0]['metadata']
-        assert exp._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
@@ -978,7 +973,6 @@ def test_fetch_completed_trials_from_view(hacked_exp, exp_config, random_dt):
     experiment_view._experiment = hacked_exp
 
     trials = experiment_view.fetch_completed_trials()
-    assert experiment_view._experiment._last_fetched == max(trial.end_time for trial in trials)
     assert len(trials) == 3
     assert trials[0].to_dict() == exp_config[1][0]
     assert trials[1].to_dict() == exp_config[1][2]
@@ -1064,7 +1058,6 @@ class TestInitExperimentWithEVC(object):
         assert exp.configuration['refers'] == exp_config[0][4]['refers']
         exp_config[0][4]['metadata']['datetime'] = random_dt
         assert exp.metadata == exp_config[0][4]['metadata']
-        assert exp._last_fetched == random_dt
         assert exp.pool_size is None
         assert exp.max_trials is None
         assert exp.configuration['algorithms'] == {'random': {'seed': None}}

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -30,6 +30,21 @@ class DumbParallelStrategy:
         return lie
 
 
+def produce_lies(producer):
+    """Wrap production of lies outside of `Producer.update`"""
+    return producer._produce_lies(producer.experiment.fetch_noncompleted_trials())
+
+
+def update_algorithm(producer):
+    """Wrap update of algorithm outside of `Producer.update`"""
+    return producer._update_algorithm(producer.experiment.fetch_completed_trials())
+
+
+def update_naive_algorithm(producer):
+    """Wrap update of naive algorithm outside of `Producer.update`"""
+    return producer._update_naive_algorithm(producer.experiment.fetch_noncompleted_trials())
+
+
 @pytest.fixture()
 def producer(hacked_exp, random_dt, exp_config, categorical_values):
     """Return a setup `Producer`."""
@@ -181,7 +196,7 @@ def test_no_lies_if_all_trials_completed(producer, database, random_dt):
 
     producer.update()
 
-    assert len(producer._produce_lies()) == 0
+    assert len(produce_lies(producer)) == 0
 
 
 def test_lies_generation(producer, database, random_dt):
@@ -195,7 +210,7 @@ def test_lies_generation(producer, database, random_dt):
 
     producer.update()
 
-    lies = producer._produce_lies()
+    lies = produce_lies(producer)
     assert len(lies) == 4
 
     trials_non_completed = list(
@@ -223,7 +238,7 @@ def test_register_lies(producer, database, random_dt):
     assert len(trials_completed) == 3
 
     producer.update()
-    producer._produce_lies()
+    produce_lies(producer)
 
     lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
     assert len(lying_trials) == 4
@@ -257,7 +272,7 @@ def test_register_duplicate_lies(producer, database, random_dt):
     producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru')]
 
     producer.update()
-    assert len(producer._produce_lies()) == 4
+    assert len(produce_lies(producer)) == 4
     lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
     assert len(lying_trials) == 4
 
@@ -270,12 +285,12 @@ def test_register_duplicate_lies(producer, database, random_dt):
 
     producer.update()
 
-    assert len(producer._produce_lies()) == 5
+    assert len(produce_lies(producer)) == 5
     lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
     assert len(lying_trials) == 5
 
     # Make sure trying to generate again does not add more fake trials since they are identical
-    assert len(producer._produce_lies()) == 5
+    assert len(produce_lies(producer)) == 5
     lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
     assert len(lying_trials) == 5
 
@@ -289,14 +304,14 @@ def test_register_duplicate_lies_with_different_results(producer, database, rand
     # Overwrite value of lying result to force different results.
     producer.strategy._value = 11
 
-    assert len(producer._produce_lies()) == 4
+    assert len(produce_lies(producer)) == 4
     lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
     assert len(lying_trials) == 4
 
     # Overwrite value of lying result to force different results.
     producer.strategy._value = new_lying_value = 12
 
-    lying_trials = producer._produce_lies()
+    lying_trials = produce_lies(producer)
     assert len(lying_trials) == 4
     nb_lying_trials = database.lying_trials.count({'experiment': producer.experiment.id})
     assert nb_lying_trials == 4 + 4
@@ -336,7 +351,7 @@ def test_naive_algo_trained_on_all_non_completed_trials(producer, database, rand
 
     # Executing the actual test
     producer.update()
-    assert len(producer._produce_lies()) == 6
+    assert len(produce_lies(producer)) == 6
 
     assert len(producer.algorithm.algorithm._points) == 1
     assert len(producer.naive_algorithm.algorithm._points) == (1 + 6)
@@ -349,7 +364,7 @@ def test_naive_algo_is_discared(producer, database, monkeypatch):
     producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru')]
 
     producer.update()
-    assert len(producer._produce_lies()) == 4
+    assert len(produce_lies(producer)) == 4
 
     first_naive_algorithm = producer.naive_algorithm
 
@@ -359,13 +374,13 @@ def test_naive_algo_is_discared(producer, database, monkeypatch):
     producer.produce()
 
     # Only update the original algo, naive algo is still not discarded
-    producer._update_algorithm()
+    update_algorithm(producer)
     assert len(producer.algorithm.algorithm._points) == 3
     assert first_naive_algorithm == producer.naive_algorithm
     assert len(producer.naive_algorithm.algorithm._points) == (3 + 4)
 
     # Discard naive algo and create a new one, now trained on 5 points.
-    producer._update_naive_algorithm()
+    update_naive_algorithm(producer)
     assert first_naive_algorithm != producer.naive_algorithm
     assert len(producer.naive_algorithm.algorithm._points) == (3 + 5)
 

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -344,10 +344,6 @@ def test_naive_algo_trained_on_all_non_completed_trials(producer, database, rand
 
 def test_naive_algo_is_discared(producer, database, monkeypatch):
     """Verify that naive algo is discarded and recopied from original algo"""
-    # Get rid of the mock on datetime.datetime.utcnow() otherwise fetch_completed_trials always
-    # fetch all trials since _last_fetched never changes.
-    monkeypatch.undo()
-
     # Set values for predictions
     producer.experiment.pool_size = 1
     producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru')]

--- a/tests/unittests/core/worker/test_trials_history.py
+++ b/tests/unittests/core/worker/test_trials_history.py
@@ -14,6 +14,29 @@ class DummyTrial(object):
         self.parents = parents
 
 
+def test_history_contains_new_child():
+    """Verify that __contains__ return True for a new child"""
+    trials_history = TrialsHistory()
+    new_child = DummyTrial(1, [])
+    assert new_child not in trials_history
+    trials_history.update([new_child])
+    assert new_child in trials_history
+
+
+def test_history_contains_old_child():
+    """Verify that __contains__ return True for a new child"""
+    trials_history = TrialsHistory()
+    old_child = DummyTrial(1, [])
+    trials_history.update([old_child])
+    new_child = DummyTrial(2, [old_child.id])
+    assert new_child not in trials_history
+    trials_history.update([new_child])
+    assert old_child.id not in trials_history.children
+    assert old_child in trials_history
+    assert new_child.id in trials_history.children
+    assert new_child in trials_history
+
+
 def test_added_children_without_ancestors():
     """Verify that children are added to history"""
     trials_history = TrialsHistory()


### PR DESCRIPTION
### Fetch all completed trials instead of subset
Why:

When there is a high number of workers and communication gets slower,
it happens that fetches based on last trial's end time will miss some of
them. Since is no simple way of defining a backward internal to catch
them all, and since the actual cost of fetching all trials is relatively
cheap (which may most likely be less than 1000), it may be better to
simple fetch them all every time and filter locally.

How:

Add `__contains__` to TrialsHistory.
Move filtering in `Producer` which contains `TrialsHistory`.

### Bundle update calls in Producer for consistency
Why:

There can be modifications in trials status between the call to
`fetch_completed_trials` and `fetch_noncompleted_trials`, leading
to inconsistent states, where very recently completed trials are neither
in completed trials, nor noncompleted trials. This is problematic for
ASHA, because a promoted trial may be observed by the naive algorithm
while the base trial (non-promoted one) is lost between the 2 calls.
When this happens the naive algo crashes because the rungs are
inconsistent.

How:

Fetch all trials once and then pass the completed ones to
`update_algorithm` and pass the non completed ones to
`update_naive_algorithm`. This way the fetch is a single snapshot and
garantees consistency.