### PR TITLE
Skip exp update in ExpView

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -487,7 +487,7 @@ class Experiment(object):
         # object from a getter.
         return copy.deepcopy(config)
 
-    def configure(self, config, enable_branching=True):
+    def configure(self, config, enable_branching=True, enable_update=True):
         """Set `Experiment` by overwriting current attributes.
 
         If `Experiment` was already set and an overwrite is needed, a *branch*
@@ -539,6 +539,9 @@ class Experiment(object):
         self._instantiate_config(final_config)
 
         self._init_done = True
+
+        if not enable_update:
+            return
 
         # If everything is alright, push new config to database
         if is_new:
@@ -773,7 +776,8 @@ class ExperimentView(object):
                              (self._experiment.name, self._experiment.metadata['user']))
 
         try:
-            self._experiment.configure(self._experiment.configuration, enable_branching=False)
+            self._experiment.configure(self._experiment.configuration, enable_branching=False,
+                                       enable_update=False)
         except ValueError as e:
             if "Configuration is different and generates a branching event" in str(e):
                 raise RuntimeError(

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -876,6 +876,37 @@ class TestInitExperimentView(object):
         with pytest.raises(AttributeError):
             exp.reserve_trial
 
+    @pytest.mark.usefixtures("with_user_tsirif", "create_db_instance")
+    def test_existing_experiment_view_not_modified(self, exp_config, monkeypatch):
+        """Experiment should not be modified if fetched in another verion of Oríon.
+
+        When loading a view the original config is used to configure the experiment, but
+        this process may modify the config if the version of Oríon is different. This should not be
+        saved in database.
+        """
+        terrible_message = 'oh no, I have been modified!'
+        original_configuration = ExperimentView('supernaedo2').configuration
+
+        def modified_configuration(self):
+            mocked_config = copy.deepcopy(original_configuration)
+            mocked_config['metadata']['datetime'] = terrible_message
+            return mocked_config
+
+        with monkeypatch.context() as m:
+            m.setattr(Experiment, 'configuration', property(modified_configuration))
+            exp = ExperimentView('supernaedo2')
+
+            # The mock is still in place and overwrites the configuration
+            assert exp.configuration['metadata']['datetime'] == terrible_message
+
+        # The mock is reverted and original config is returned, but modification is still in
+        # metadata
+        assert exp.metadata['datetime'] == terrible_message
+
+        # Loading again from DB confirms the DB was not overwritten
+        reloaded_exp = ExperimentView('supernaedo2')
+        assert reloaded_exp.configuration['metadata']['datetime'] != terrible_message
+
 
 def test_fetch_completed_trials_from_view(hacked_exp, exp_config, random_dt):
     """Fetch a list of the unseen yet completed trials."""


### PR DESCRIPTION
Why:

The ExperimentView should not update the experiment in the database.
Fields doesn't get updated when loading the View per say, but loading a
view within a different version of Oríon could lead to modification of
the configuration dictionary of the experiment, which would lead to a
modified experiment in the database.

How:

Add `enable_update` argument to `Experiment.configure` so that
`ExperimentView` can call it without updating the DB.

Note:

All this should get refactored once the global and experiment
configuration refactoring is completed.