### PR TITLE
Use yaml.safe_load instead of yaml

### DIFF
--- a/src/orion/core/io/convert.py
+++ b/src/orion/core/io/convert.py
@@ -94,7 +94,7 @@ class YAMLConverter(BaseConverter):
 
         """
         with open(filepath) as f:
-            return self.yaml.load(stream=f)
+            return self.yaml.safe_load(stream=f)
 
     def generate(self, filepath, data):
         """Create a configuration file at `filepath` using dictionary `data`."""


### PR DESCRIPTION
Why:

Since pyyaml v5.1 the function `yaml.load` prints a warning if not
called with a specified `Loader`. This is because the default behavior
was unsecure. Details about the issue are available here:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

How:

Use `yaml.safe_load` instead which uses the SafeLoader internally.