### PR TITLE
Remove upsert from `write`

### DIFF
--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -65,7 +65,10 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
     def initiate_connection(self):
         """Connect to database, unless `AbstractDB` `is_connected`.
 
-        :raises :exc:`DatabaseError`: if connection or authentication fails
+        Raises
+        ------
+        DatabaseError
+            If connection or authentication fails
 
         """
         pass
@@ -94,10 +97,11 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
            `DuplicateKeyError`.
            Defaults to False.
 
-        .. note::
-            Depending on the backend, the indexing operation might operate in
-            background. This means some operations on the database might occur
-            before the indexes are totally built.
+        Notes
+        -----
+        Depending on the backend, the indexing operation might operate in
+        background. This means some operations on the database might occur
+        before the indexes are totally built.
 
         """
         pass
@@ -115,20 +119,25 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         query : dict, optional
            Assumes an update operation: filter entries in collection to be updated.
 
-        :return: operation success.
+        Returns
+        -------
+        int
+            Number of new documents if no query, otherwise number of modified documents.
 
-        .. note::
-           In the case of an insert operation, `data` variable will be updated
-           to contain a unique *_id* key.
+        Notes
+        -----
+        In the case of an insert operation, `data` variable will be updated
+        to contain a unique *_id* key.
 
-        .. note::
-           In the case of an update operation, if `query` fails to find a
-           document that matches, insert of `data` will be performed instead.
+        In the case of an update operation, if `query` fails to find a
+        document that matches, no operation is performed.
 
-        :raises :exc:`DuplicateKeyError`: if the operation is creating duplicate
-            keys in two different documents. Only occurs if the keys have
-            unique indexes. See :meth:`AbstractDB.ensure_index` for more
-            information about indexes.
+        Raises
+        ------
+        DuplicateKeyError
+            If the operation is creating duplicate keys in two different documents. Only occurs if
+            the keys have unique indexes. See :meth:`AbstractDB.ensure_index` for more information
+            about indexes.
 
         """
         pass
@@ -146,7 +155,10 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         selection : dict, optional
            Elements of matched entries to return, the projection.
 
-        :return: list of matched document[s]
+        Returns
+        -------
+        list
+            List of matched document[s]
 
         """
         pass
@@ -170,12 +182,17 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         selection : dict, optional
            Elements of matched entries to return, the projection.
 
-        :return: updated first matched document or None if nothing found
+        Returns
+        -------
+        dict or None
+            Updated first matched document or None if nothing found
 
-        :raises :exc:`DuplicateKeyError`: if the operation is creating duplicate
-            keys in two different documents. Only occurs if the keys have
-            unique indexes. See :meth:`AbstractDB.ensure_index` for more
-            information about indexes.
+        Raises
+        ------
+        DuplicateKeyError
+            If the operation is creating duplicate keys in two different documents. Only occurs if
+            the keys have unique indexes. See :meth:`AbstractDB.ensure_index` for more information
+            about indexes.
 
         """
         pass
@@ -205,7 +222,10 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         query : dict
            Filter entries in collection.
 
-        :return: operation success.
+        Returns
+        -------
+        int
+            Number of documents removed
 
         """
         pass
@@ -213,12 +233,7 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 
 # pylint: disable=too-few-public-methods
 class ReadOnlyDB(object):
-    """Read-only view on a database.
-
-    .. seealso::
-
-        :py:class:`orion.core.io.database.AbstractDB`
-    """
+    """Read-only view on a database."""
 
     __slots__ = ('_database', )
 
@@ -259,10 +274,7 @@ class DuplicateKeyError(DatabaseError):
 
 # pylint: disable=too-few-public-methods,abstract-method
 class Database(AbstractDB, metaclass=SingletonFactory):
-    """Class used to inject dependency on a database framework.
-
-    .. seealso:: `Factory` metaclass and `AbstractDB` interface.
-    """
+    """Class used to inject dependency on a database framework."""
 
     pass
 

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -166,8 +166,11 @@ class EphemeralCollection(object):
     def _validate_index(self, document, indexes=None):
         """Validate index values of a document
 
-        :raises: :exc:`DuplicateKeyError`: if the document contains unique indexes which are already
-        present in the database.
+        Raises
+        ------
+        DuplicateKeyError
+            If the document contains unique indexes which are already present in the database.
+
         """
         if indexes is None:
             indexes = self._indexes.keys()
@@ -191,8 +194,11 @@ class EphemeralCollection(object):
         If the documents do not have a keys `_id`, they are assigned by default
         the max id + 1.
 
-        :raises: :exc:`DuplicateKeyError`: if the document contains unique indexes which are
-            already present in the database.
+        Raises
+        ------
+        DuplicateKeyError
+            If the document contains unique indexes which are already present in the database.
+
         """
         for document in documents:
             if '_id' not in document:
@@ -202,16 +208,16 @@ class EphemeralCollection(object):
             self._documents.append(ephemeral_document)
             self._register_keys(ephemeral_document)
 
-        return True
+        return len(documents)
 
     def update_many(self, query, update):
-        """Update documents or upsert if not found.
+        """Update documents matching the query
 
-        If the document is not found, a new document which is the merge of query and update will be
-        inserted in the database.
+        Raises
+        ------
+        DuplicateKeyError
+            If the update creates a duplication of unique indexes in the database.
 
-        :raises: :exc:`DuplicateKeyError`: if the update creates a duplication of unique indexes in
-            the database.
         """
         updates = 0
         for document in self._documents:
@@ -219,10 +225,7 @@ class EphemeralCollection(object):
                 document.update(update)
                 updates += 1
 
-        if not updates:
-            self._upsert(query, update)
-
-        return True
+        return updates
 
     def _upsert(self, query, update):
         """Insert the document when query was not found.
@@ -242,6 +245,7 @@ class EphemeralCollection(object):
         """Count the number of documents in a collection which match the `query`.
 
         .. seealso:: :meth:`AbstractDB.count` for argument documentation.
+
         """
         return len(self.find(query))
 
@@ -251,14 +255,17 @@ class EphemeralCollection(object):
         .. seealso:: :meth:`AbstractDB.remove` for argument documentation.
 
         """
+        deleted = 0
         retained_documents = []
         for document in self._documents:
             if not document.match(query):
                 retained_documents.append(document)
+            else:
+                deleted += 1
 
         self._documents = retained_documents
 
-        return True
+        return deleted
 
     def drop(self):
         """Drop the collection, removing all documents and indexes."""

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -186,14 +186,14 @@ class MongoDB(AbstractDB):
             if type(data) not in (list, tuple):
                 data = [data]
             result = dbcollection.insert_many(documents=data)
-            return result.acknowledged
+            return len(result.inserted_ids)
 
         update_data = {'$set': data}
 
         result = dbcollection.update_many(filter=query,
                                           update=update_data,
-                                          upsert=True)
-        return result.acknowledged
+                                          upsert=False)
+        return result.modified_count
 
     def read(self, collection_name, query=None, selection=None):
         """Read a collection and return a value according to the query.
@@ -249,7 +249,7 @@ class MongoDB(AbstractDB):
         dbcollection = self._db[collection_name]
 
         result = dbcollection.delete_many(filter=query)
-        return result.acknowledged
+        return result.deleted_count
 
     def _sanitize_attrs(self):
         """Sanitize attributes using MongoDB's 'uri_parser' module."""

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -28,19 +28,17 @@ class PickledDB(AbstractDB):
     This is a very simple and inefficient implementation of a permanent database on disk for Oríon.
     The data is loaded from disk for every operation, and every operation is protected with a
     filelock.
+
+    Parameters
+    ----------
+    host: str
+        File path to save pickled ephemeraldb.  Default is {user data dir}/orion/orion_db.pkl ex:
+        $HOME/.local/share/orion/orion_db.pkl
+
     """
 
     # pylint: disable=unused-argument
     def __init__(self, host=DEFAULT_HOST, *args, **kwargs):
-        """Initialize the DB
-
-        Base folder defined by `host` is created during init.
-
-        :param host: File path to save pickled ephemeraldb.
-                     Default is {user data dir}/orion/orion_db.pkl
-                     ex: $HOME/.local/share/orion/orion_db.pkl
-        :type host: str
-        """
         super(PickledDB, self).__init__(host)
 
         if os.path.dirname(host):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -253,13 +253,12 @@ class Experiment(object):
         if selected_trial.status == 'new':
             update["start_time"] = datetime.datetime.utcnow()
 
-        selected_trial_dict = self._db.read_and_write(
-            'trials', query=query, data=update)
+        reserved = self._db.write('trials', query=query, data=update)
 
-        if selected_trial_dict is None:
+        if not reserved:
             selected_trial = self.reserve_trial(score_handle=score_handle)
         else:
-            selected_trial = Trial(**selected_trial_dict)
+            selected_trial = self.fetch_trials({'_id': selected_trial.id})[0]
             TrialMonitor(self, selected_trial.id).start()
 
         return selected_trial
@@ -282,7 +281,9 @@ class Experiment(object):
 
         for trial in trials:
             query['_id'] = trial.id
-            self._db.write('trials', {'status': 'interrupted'}, query)
+            log.debug('Setting lost trial %s status to interrupted...', trial.id)
+            updated = self._db.write('trials', {'status': 'interrupted'}, query)
+            log.debug('success' if updated else 'failed')
 
     def push_completed_trial(self, trial):
         """Inform database about an evaluated `trial` with resultlts.

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -161,7 +161,7 @@ class TestWrite(object):
                 'user': 'tsirif'}
         count_before = database['experiments'].count()
         # call interface
-        assert orion_db.write('experiments', item) is True
+        assert orion_db.write('experiments', item) == 1
         assert database['experiments'].count() == count_before + 1
         value = database['experiments'].find({'exp_name': 'supernaekei'})[0]
         assert value == item
@@ -174,7 +174,7 @@ class TestWrite(object):
                  'user': 'tsirif'}]
         count_before = database['experiments'].count()
         # call interface
-        assert orion_db.write('experiments', item) is True
+        assert orion_db.write('experiments', item) == 2
         assert database['experiments'].count() == count_before + 2
         value = database['experiments'].find({'exp_name': 'supernaekei2'})[0]
         assert value == item[0]
@@ -185,8 +185,9 @@ class TestWrite(object):
         """Should match existing entries, and update some of their keys."""
         filt = {'metadata.user': 'tsirif'}
         count_before = database['experiments'].count()
+        count_query = database['experiments'].count(filt)
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 16}, filt) is True
+        assert orion_db.write('experiments', {'pool_size': 16}, filt) == count_query
         assert database['experiments'].count() == count_before
         value = list(database['experiments'].find({}))
         assert value[0]['pool_size'] == 16
@@ -199,25 +200,12 @@ class TestWrite(object):
         filt = {'_id': exp_config[0][1]['_id']}
         count_before = database['experiments'].count()
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 36}, filt) is True
+        assert orion_db.write('experiments', {'pool_size': 36}, filt) == 1
         assert database['experiments'].count() == count_before
         value = list(database['experiments'].find())
         assert value[0]['pool_size'] == 2
         assert value[1]['pool_size'] == 36
         assert value[2]['pool_size'] == 2
-
-    def test_upsert_with_id(self, database, orion_db):
-        """Query with a non-existent ``_id`` should upsert something."""
-        filt = {'_id': 'lalalathisisnew'}
-        count_before = database['experiments'].count()
-        # call interface
-        assert orion_db.write('experiments', {'pool_size': 66}, filt) is True
-        assert database['experiments'].count() == count_before + 1
-        value = list(database['experiments'].find(filt))
-        assert len(value) == 1
-        assert len(value[0]) == 2
-        assert value[0]['_id'] == 'lalalathisisnew'
-        assert value[0]['pool_size'] == 66
 
     def test_insert_duplicate(self, database, orion_db):
         """Verify that duplicates cannot by inserted if index is unique"""
@@ -291,7 +279,7 @@ class TestRemove(object):
         count_before = database['experiments'].count()
         count_filt = database['experiments'].count(filt)
         # call interface
-        assert orion_db.remove('experiments', filt) is True
+        assert orion_db.remove('experiments', filt) == count_filt
         assert database['experiments'].count() == count_before - count_filt
         assert database['experiments'].count() == 1
         assert list(database['experiments'].find()) == [exp_config[0][3]]
@@ -302,7 +290,7 @@ class TestRemove(object):
 
         count_before = database['experiments'].count()
         # call interface
-        assert orion_db.remove('experiments', filt) is True
+        assert orion_db.remove('experiments', filt) == 1
         assert database['experiments'].count() == count_before - 1
         assert database['experiments'].find() == exp_config[0][1:]
 

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -51,7 +51,10 @@ def patch_sample2(monkeypatch):
 
 @pytest.fixture()
 def patch_sample_concurrent(monkeypatch, create_db_instance, exp_config):
-    """Patch ``random.sample`` to return the first one and check call."""
+    """Patch ``random.sample`` to return the first one and check call.
+
+    The first trial is marked as new, but in DB it is reserved.
+    """
     def mock_sample(a_list, should_be_one):
         assert type(a_list) == list
         assert len(a_list) >= 1
@@ -85,7 +88,10 @@ def patch_sample_concurrent(monkeypatch, create_db_instance, exp_config):
 
 @pytest.fixture()
 def patch_sample_concurrent2(monkeypatch, create_db_instance, exp_config):
-    """Patch ``random.sample`` to return the first one and check call."""
+    """Patch ``random.sample`` to return the first one and check call.
+
+    All trials are marked as new, but in DB they are reserved.
+    """
     def mock_sample(a_list, should_be_one):
         assert type(a_list) == list
         assert len(a_list) >= 1
@@ -687,6 +693,25 @@ class TestReserveTrial(object):
         exp_query['status'] = 'interrupted'
 
         assert len(hacked_exp.fetch_trials(exp_query)) == 1
+
+    def test_fix_lost_trials_race_condition(self, hacked_exp, random_dt, monkeypatch):
+        """Test that a lost trial fixed by a concurrent process does not cause error."""
+        exp_query = {'experiment': hacked_exp.id}
+        trial = hacked_exp.fetch_trials(exp_query)[0]
+        heartbeat = random_dt - datetime.timedelta(seconds=180)
+
+        Database().write('trials', {'status': 'interrupted', 'heartbeat': heartbeat},
+                         {'experiment': hacked_exp.id, '_id': trial.id})
+
+        assert hacked_exp.fetch_trials(exp_query)[0].status == 'interrupted'
+
+        def fetch_lost_trials(self, query):
+            trial.status = 'reserved'
+            return [trial]
+
+        with monkeypatch.context() as m:
+            m.setattr(hacked_exp.__class__, 'fetch_trials', fetch_lost_trials)
+            hacked_exp.fix_lost_trials()
 
 
 @pytest.mark.usefixtures("patch_sample")

--- a/tests/unittests/core/test_pickleddb.py
+++ b/tests/unittests/core/test_pickleddb.py
@@ -151,7 +151,7 @@ class TestWrite(object):
                 'user': 'tsirif'}
         count_before = orion_db._get_database().count('experiments')
         # call interface
-        assert orion_db.write('experiments', item) is True
+        assert orion_db.write('experiments', item) == 1
         assert orion_db._get_database().count('experiments') == count_before + 1
         value = orion_db._get_database()._db['experiments'].find({'exp_name': 'supernaekei'})[0]
         assert value == item
@@ -164,7 +164,7 @@ class TestWrite(object):
                  'user': 'tsirif'}]
         count_before = orion_db._get_database()._db['experiments'].count()
         # call interface
-        assert orion_db.write('experiments', item) is True
+        assert orion_db.write('experiments', item) == 2
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before + 2
         value = database['experiments'].find({'exp_name': 'supernaekei2'})[0]
@@ -176,8 +176,9 @@ class TestWrite(object):
         """Should match existing entries, and update some of their keys."""
         filt = {'metadata.user': 'tsirif'}
         count_before = orion_db._get_database().count('experiments')
+        count_query = orion_db._get_database().count('experiments', filt)
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 16}, filt) is True
+        assert orion_db.write('experiments', {'pool_size': 16}, filt) == count_query
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before
         value = list(database['experiments'].find({}))
@@ -191,27 +192,13 @@ class TestWrite(object):
         filt = {'_id': exp_config[0][1]['_id']}
         count_before = orion_db._get_database().count('experiments')
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 36}, filt) is True
+        assert orion_db.write('experiments', {'pool_size': 36}, filt) == 1
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before
         value = list(database['experiments'].find())
         assert value[0]['pool_size'] == 2
         assert value[1]['pool_size'] == 36
         assert value[2]['pool_size'] == 2
-
-    def test_upsert_with_id(self, orion_db):
-        """Query with a non-existent ``_id`` should upsert something."""
-        filt = {'_id': 'lalalathisisnew'}
-        count_before = orion_db._get_database().count('experiments')
-        # call interface
-        assert orion_db.write('experiments', {'pool_size': 66}, filt) is True
-        database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before + 1
-        value = list(database['experiments'].find(filt))
-        assert len(value) == 1
-        assert len(value[0]) == 2
-        assert value[0]['_id'] == 'lalalathisisnew'
-        assert value[0]['pool_size'] == 66
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -287,7 +274,7 @@ class TestRemove(object):
         count_before = database['experiments'].count()
         count_filt = database['experiments'].count(filt)
         # call interface
-        assert orion_db.remove('experiments', filt) is True
+        assert orion_db.remove('experiments', filt) == count_filt
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before - count_filt
         assert database['experiments'].count() == 1
@@ -300,7 +287,7 @@ class TestRemove(object):
         database = orion_db._get_database()._db
         count_before = database['experiments'].count()
         # call interface
-        assert orion_db.remove('experiments', filt) is True
+        assert orion_db.remove('experiments', filt) == 1
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before - 1
         assert database['experiments'].find() == exp_config[0][1:]


### PR DESCRIPTION
Why:

The upsert behavior was never used and was causing unexpected
DuplicateKeyError in `fix_lost_trials`. This was not observed before
because locked update with queries was previously done with
`read_and_write` in `reserve_trials` which does not update if the query
fails.

How:

Do not update if query fails and return number of updated document
instead of `result.acknowledment` so that we can verify if `db.write()`
successfully updated documents or not.

Since the current error due to race condition was not catched in
unit-tests for `fix_lost_trials()`, I added one that does catch the
error if there is a DuplicateKeyError.