### PR TITLE
Handle broken refers in experiment configuration 

### DIFF
--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -29,8 +29,8 @@ def add_subparser(parser):
 
 def main(args):
     """Fetch config and info experiments"""
-    experiment_view = EVCBuilder().build_view_from(args)
-    print(format_info(experiment_view))
+    experiment = EVCBuilder().build_from(args)
+    print(format_info(experiment))
 
 
 INFO_TEMPLATE = """\

--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -45,7 +45,8 @@ def main(args):
     if args['name']:
         root_experiments = experiments
     else:
-        root_experiments = [exp for exp in experiments if exp['refers']['root_id'] == exp['_id']]
+        root_experiments = [exp for exp in experiments
+                            if exp['refers'].get('root_id', exp['_id']) == exp['_id']]
 
     for root_experiment in root_experiments:
         root = EVCBuilder().build_view_from({'name': root_experiment['name']}).node

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -547,8 +547,8 @@ class Experiment(object):
             self._id = final_config['_id']
 
             # Update refers in db if experiment is root
-            if not self.refers:
-                self.refers = {'root_id': self._id, 'parent_id': None, 'adapter': []}
+            if self.refers['parent_id'] is None:
+                self.refers['root_id'] = self._id
                 self._storage.update_experiment(self, refers=self.refers)
 
         else:
@@ -661,7 +661,10 @@ class Experiment(object):
         except KeyError:
             pass
 
-        if self.refers and not isinstance(self.refers.get('adapter'), BaseAdapter):
+        self.refers.setdefault('parent_id', None)
+        self.refers.setdefault('root_id', self._id)
+        self.refers.setdefault('adapter', [])
+        if self.refers['adapter'] and not isinstance(self.refers.get('adapter'), BaseAdapter):
             self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
         if not self.producer.get('strategy'):
@@ -767,8 +770,11 @@ class ExperimentView(object):
         # TODO: Views are not fully configured until configuration is refactored
         #       This snippet is to instantiate adapters anyhow, because it is required for
         #       experiment views in EVC.
-        if self.refers and not isinstance(self.refers.get('adapter'), BaseAdapter):
-            self._experiment.refers['adapter'] = Adapter.build(self.refers['adapter'])
+        self.refers.setdefault('parent_id', None)
+        self.refers.setdefault('root_id', self._id)
+        self.refers.setdefault('adapter', [])
+        if self.refers['adapter'] and not isinstance(self.refers.get('adapter'), BaseAdapter):
+            self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
         # try:
         #     self._experiment.configure(self._experiment.configuration, enable_branching=False,

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the info command."""
-import os
-
 import orion.core.cli
 
 
@@ -17,6 +15,15 @@ def test_info_no_hit(clean_db, one_experiment, capsys):
 
 def test_info_hit(clean_db, one_experiment, capsys):
     """Test info if existing experiment."""
+    orion.core.cli.main(['info', 'test_single_exp'])
+
+    captured = capsys.readouterr().out
+
+    assert '--x~uniform(0,1)' in captured
+
+
+def test_info_broken(clean_db, broken_refers, capsys):
+    """Test info if experiment.refers is missing."""
     orion.core.cli.main(['info', 'test_single_exp'])
 
     captured = capsys.readouterr().out

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test of the info command."""
+import os
+
+import orion.core.cli
+
+
+def test_info_no_hit(clean_db, one_experiment, capsys):
+    """Test info if no experiment with given name."""
+    orion.core.cli.main(['info', 'i do not exist'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == 'Error: No commandline configuration found for new experiment.\n'
+
+
+def test_info_hit(clean_db, one_experiment, capsys):
+    """Test info if existing experiment."""
+    orion.core.cli.main(['info', 'test_single_exp'])
+
+    captured = capsys.readouterr().out
+
+    assert '--x~uniform(0,1)' in captured

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -25,6 +25,15 @@ def test_single_exp(clean_db, one_experiment, capsys):
     assert captured == " test_single_exp\n"
 
 
+def test_broken_refers(clean_db, broken_refers, capsys):
+    """Test that experiment without refers dict can be handled properly."""
+    orion.core.cli.main(['list'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == " test_single_exp\n"
+
+
 def test_two_exp(capsys, clean_db, two_experiments):
     """Test that experiment and child are printed."""
     orion.core.cli.main(['list'])


### PR DESCRIPTION
Why:

If the process is stopped between the registration of the experiment and
the update of exp[refers][self._id], then the experiment will be somehow
broken, i.e., many code parts will crash because of it.

How:

Handle refers creation during configuration with default values if
nothing is set so that abortion during registration will in worst case
lead to inconsistant refers that is easier to fix. Previously broken
refers would be {}, which is irrecuperable for child experiments. Now
broken refers would be {parent_id: ok, adapter: ok, root_id: None},
which is simple to infer and fix.