### PR TITLE
Move TrialMonitor/TrialPacemaker inside consumer

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -27,7 +27,6 @@ from orion.core.utils.format_trials import trial_to_tuple
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import (BaseParallelStrategy,
                                         Strategy)
-from orion.core.worker.trial_monitor import TrialMonitor
 from orion.storage.base import ReadOnlyStorageProtocol, StorageProtocol
 
 log = logging.getLogger(__name__)
@@ -260,7 +259,6 @@ class Experiment(object):
         else:
             log.debug('%s found suitable trial', '<' * _depth)
             selected_trial = self.fetch_trials({'_id': selected_trial.id})[0]
-            TrialMonitor(self, selected_trial.id).start()
 
         log.debug('%s reserved trial (trial: %s)', '<' * _depth, selected_trial)
         return selected_trial

--- a/src/orion/core/worker/trial_pacemaker.py
+++ b/src/orion/core/worker/trial_pacemaker.py
@@ -10,12 +10,10 @@
 import datetime
 import threading
 
-from orion.core.io.database import Database
 
-
-class TrialMonitor(threading.Thread):
+class TrialPacemaker(threading.Thread):
     """Monitor a given trial inside a thread, updating its heartbeat
-    at a given interval  of time.
+    at a given interval of time.
 
     Parameters
     ----------
@@ -25,7 +23,6 @@ class TrialMonitor(threading.Thread):
     """
 
     def __init__(self, exp, trial_id, wait_time=60):
-        """Initialize a TrialMonitor."""
         threading.Thread.__init__(self)
         self.stopped = threading.Event()
         self.exp = exp
@@ -47,7 +44,8 @@ class TrialMonitor(threading.Thread):
         trials = self.exp.fetch_trials(query)
 
         if trials:
-            update = dict(heartbeat=datetime.datetime.utcnow())
-            Database().write('trials', update, query)
+            update = datetime.datetime.utcnow()
+            if not self.exp.update_trial(trials[0], where=query, heartbeat=update):
+                self.stopped.set()
         else:
             self.stopped.set()

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -471,3 +471,16 @@ def test_resilience(monkeypatch):
 
     exp = ExperimentBuilder().build_from({'name': 'demo_random_search'})
     assert len(exp.fetch_trials({'status': 'broken'})) == 3
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_demo_with_shutdown_quickly(monkeypatch):
+    """Check simple pipeline with random search is reasonably fast."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    process = subprocess.Popen(
+        ["orion", "hunt", "--config", "./orion_config_random.yaml", "--max-trials", "30",
+         "./black_box.py", "-x~uniform(-50, 50)"])
+
+    assert process.wait(timeout=10) == 0


### PR DESCRIPTION
Why:

We need access to the pacemaker when the trials is completed so that we
can stop it. Otherwise, the thread continues until if makes another
heartbeat before it crashes and quit, which can take lot of time. The
execution of Orion hangs at the end of experiment until the pacemaker
stops.

How:

Move pacemaker inside Consumer so that it can be stopped right at end of
trial execution. Note that there is some delay between the reservation
and the start of pacemaker, which makes it possible to loose the
reservation before execution begins. That is not very likely however
since there is not a large time gap between reservation and execution.