### PR TITLE
Add configuration object for global configuration

### DIFF
--- a/src/orion/core/io/config.py
+++ b/src/orion/core/io/config.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.io.config` -- Configuration object
+===================================================
+
+.. module:: config
+   :platform: Unix
+   :synopsis: Configuration object to define package configuration
+
+
+Highly inspired from https://github.com/mila-iqia/blocks/blob/master/blocks/config.py.
+
+"""
+import logging
+import os
+
+import yaml
+
+from orion.core.utils.flatten import flatten
+
+
+logger = logging.getLogger(__name__)
+
+
+NOT_SET = object()
+
+
+class ConfigurationError(Exception):
+    """Error raised when a configuration value is requested but not set."""
+
+
+class Configuration:
+    """Configuration object
+
+    Provides default values configurable at different levels. The configuration object can have
+    global default values, which may be overriden by user with yaml configuration files, environment
+    variables or by setting directly the values in the configuration object. In order, direct
+    definition overrides, environment variables, which overrides yaml configuration, which overrides
+    default values in configuration object definition.
+
+    Examples
+    --------
+    >>> config = Configuration()
+    >>> config.add_option('test', str, 'hello', 'TEST_ENV')
+    >>> config.test
+    'hello'
+    >>> config.load_yaml('some_config.yaml')
+    >>> config.test
+    'in yaml!'
+    >>> os.environ['TEST_ENV'] = 'there!'
+    >>> config.test
+    'there!'
+    >>> config.test = 'here'
+    >>> config.test
+    'here'
+
+    """
+
+    def __init__(self):
+        self.config = {}
+
+    def load_yaml(self, path):
+        """Load yaml file and set global default configuration
+
+        Parameters
+        ----------
+        path: str
+            Path to the global configuration file.
+
+        Raises
+        -------
+        ConfigurationError
+            If some option in the yaml file does not exist in the config
+
+        """
+        with open(path) as f:
+            cfg = yaml.safe_load(f)
+            if cfg is None:
+                return
+            # implies that yaml must be in dict form
+            for key, value in flatten(cfg).items():
+                default = self[key]
+                logger.debug('Overwritting "%s" default %s with %s', key, default, value)
+                self.config[key]['yaml'] = value
+
+    def __getattr__(self, key):
+        """Get the value of the option
+
+        Parameters
+        ----------
+        key: str
+            Name of the option
+
+        Returns
+        -------
+            Value of the option.
+
+        Raises
+        -------
+        ConfigurationError
+            If the option does not exist
+
+        """
+        if key == 'config':
+            raise AttributeError
+        if key not in self.config:
+            raise ConfigurationError("Configuration does not have an attribute "
+                                     "'{}'.".format(key))
+
+        config_setting = self.config[key]
+        if 'value' in config_setting:
+            value = config_setting['value']
+        elif ('env_var' in config_setting and
+              config_setting['env_var'] in os.environ):
+            value = os.environ[config_setting['env_var']]
+        elif 'yaml' in config_setting:
+            value = config_setting['yaml']
+        elif 'default' in config_setting:
+            value = config_setting['default']
+        else:
+            raise ConfigurationError("Configuration not set and no default "
+                                     "provided: {}.".format(key))
+
+        return config_setting['type'](value)
+
+    def __setattr__(self, key, value):
+        """Set option value or subconfiguration
+
+        Parameters
+        ----------
+        key: str
+            The key or namespace to set the value of the configuration.
+            If the configuration has subconfiguration, the key may be
+            hierarchical with each level seperated by dots.
+            Ex: 'first.second.third'
+        value: object or Configuration
+            A general object to set an option or a configuration object to set
+            a sub configuration.
+
+        Raises
+        ------
+        TypeError
+            - If value is a configuration and an option is already defined for
+            given key, or
+            - If the value has an invalid type for the given option, or
+            - If no option exists for the given key and the value is not a
+            configuration object.
+
+        """
+        if key != 'config' and key in self.config:
+            if isinstance(value, Configuration):
+                raise TypeError("Cannot overwrite option {} with a configuration".format(key))
+
+            try:
+                self.config[key]['type'](value)
+            except ValueError as e:
+                message = "Option {} of type {} cannot be set to {} with type {}".format(
+                    key, self.config[key]['type'], value, type(value))
+                raise TypeError(message) from e
+
+            self.config[key]['value'] = value
+
+        elif key == 'config' or isinstance(value, Configuration):
+            super(Configuration, self).__setattr__(key, value)
+
+        else:
+            raise TypeError("Can only set {} as a Configuration, not {}. Use add_option to set a "
+                            "new option.".format(key, type(value)))
+
+    def __setitem__(self, key, value):
+        """Set option value using dict-like syntax
+
+        Parameters
+        ----------
+        key: str
+            The key or namespace to set the value of the configuration.
+            If the configuration has subconfiguration, the key may be
+            hierarchical with each levels seperated by dots.
+            Ex: 'first.second.third'
+        value: object
+            A general object to set an option.
+
+        """
+        keys = key.split(".")
+        # Recursively in sub configurations
+        if len(keys) > 1:
+            subconfig = getattr(self, keys[0])
+            if subconfig is None:
+                raise KeyError("'{}' is not defined in configuration.".format(keys[0]))
+            subconfig[".".join(keys[1:])] = value
+        # Set in current configuration
+        else:
+            setattr(self, keys[0], value)
+
+    def __getitem__(self, key):
+        """Get option value using dict-like syntax
+
+        Parameters
+        ----------
+        key: str
+            The key or namespace to set the value of the configuration.
+            If the configuration has subconfiguration, the key may be
+            hierarchical with each levels seperated by dots.
+            Ex: 'first.second.third'
+
+        """
+        keys = key.split(".")
+        # Recursively in sub configurations
+        if len(keys) > 1:
+            subconfig = getattr(self, keys[0])
+            if subconfig is None:
+                raise KeyError("'{}' is not defined in configuration.".format(keys[0]))
+            return subconfig[".".join(keys[1:])]
+        # Set in current configuration
+        else:
+            return getattr(self, keys[0])
+
+    def add_option(self, key, option_type, default=NOT_SET, env_var=None):
+        """Add a configuration setting.
+
+        Parameters
+        ----------
+        key : str
+            The name of the configuration setting. This must be a valid
+            Python attribute name i.e. alphanumeric with underscores.
+        option_type : function
+            A function such as ``float``, ``int`` or ``str`` which takes
+            the configuration value and returns an object of the correct
+            type.  Note that the values retrieved from environment
+            variables are always strings, while those retrieved from the
+            YAML file might already be parsed. Hence, the function provided
+            here must accept both types of input.
+        default : object, optional
+            The default configuration to return if not set. By default none
+            is set and an error is raised instead.
+        env_var : str, optional
+            The environment variable name that holds this configuration
+            value. If not given, this configuration can only be set in the
+            YAML configuration file.
+
+        """
+        self.config[key] = {'type': option_type}
+        if env_var is not None:
+            self.config[key]['env_var'] = env_var
+        if default is not NOT_SET:
+            self.config[key]['default'] = default

--- a/src/orion/core/utils/flatten.py
+++ b/src/orion/core/utils/flatten.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.utils.flatten` -- Flatten and unflatten dicts
+==============================================================
+
+.. module:: flatten
+   :platform: Unix
+   :synopsis: Turn deep dictionaries into flat key.subkey versions and vice-versa.
+
+"""
+
+
+import copy
+
+
+def flatten(dictionary):
+    """Turn all nested dict keys into a {key}.{subkey} format"""
+    def _flatten(dictionary):
+        if dictionary == {}:
+            return dictionary
+
+        key, value = dictionary.popitem()
+        if not isinstance(value, dict) or not value:
+            new_dictionary = {key: value}
+            new_dictionary.update(_flatten(dictionary))
+            return new_dictionary
+
+        flat_sub_dictionary = _flatten(value)
+        for flat_sub_key in list(flat_sub_dictionary.keys()):
+            flat_key = key + '.' + flat_sub_key
+            flat_sub_dictionary[flat_key] = flat_sub_dictionary.pop(flat_sub_key)
+
+        new_dictionary = flat_sub_dictionary
+        new_dictionary.update(_flatten(dictionary))
+        return new_dictionary
+
+    return _flatten(copy.deepcopy(dictionary))
+
+
+def unflatten(dictionary):
+    """Turn all keys with format {key}.{subkey} into nested dictionaries"""
+    unflattened_dictionary = dict()
+    for key, value in dictionary.items():
+        parts = key.split(".")
+        sub_dictionary = unflattened_dictionary
+        for part in parts[:-1]:
+            if part not in sub_dictionary:
+                sub_dictionary[part] = dict()
+            sub_dictionary = sub_dictionary[part]
+        sub_dictionary[parts[-1]] = value
+    return unflattened_dictionary

--- a/tests/unittests/core/io/test_config.py
+++ b/tests/unittests/core/io/test_config.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example usage and tests for :mod:`orion.core.io.config`."""
+
+import os
+
+import pytest
+import yaml
+
+from orion.core.io.config import Configuration, ConfigurationError
+
+
+@pytest.fixture
+def yaml_path():
+    """Create a temporary yaml file and return the path"""
+    file_path = './my.yaml'
+    with open(file_path, 'w') as f:
+        f.write(yaml.dump({'test': 'from my yaml!'}))
+
+    yield file_path
+
+    os.remove(file_path)
+
+
+def test_fetch_non_existing_option():
+    """Test that access to a non existing key raises ConfigurationError"""
+    config = Configuration()
+    with pytest.raises(ConfigurationError) as exc:
+        config.voici_voila
+
+    assert 'Configuration does not have an attribute \'voici_voila\'.' in str(exc.value)
+
+
+def test_access_to_config():
+    """Test that access to config returns properly config.
+
+    This is because getattr() could grasp any key including `config` and makes
+    it impossible to access the later
+    """
+    assert Configuration().config == {}
+
+
+def test_set_subconfig():
+    """Test that setting a subconfig works"""
+    config = Configuration()
+    config.test = Configuration()
+
+    assert isinstance(config.test, Configuration)
+
+    with pytest.raises(ConfigurationError):
+        config.test.voici_voila
+
+
+def test_access_config_without_values():
+    """Test that access to config without values raises ConfigurationError"""
+    config = Configuration()
+    config.add_option('test', option_type=int)
+    with pytest.raises(ConfigurationError) as exc:
+        config.test
+
+    assert 'Configuration not set and no default provided: test.' in str(exc.value)
+
+
+def test_set_non_existing_option():
+    """Test that setting a non existing option crash"""
+    config = Configuration()
+    with pytest.raises(TypeError) as exc:
+        config.test = 1
+    assert "Can only set test as a Configuration, not <class 'int'>" in str(exc.value)
+
+
+def test_set_subconfig_over_option():
+    """Test that overwritting an option with a subconfig is not possible"""
+    config = Configuration()
+    config.add_option('test', option_type=int)
+    config.test = 1
+    assert config.test == 1
+    with pytest.raises(TypeError) as exc:
+        config.test = Configuration()
+    assert "Cannot overwrite option test with a configuration" in str(exc.value)
+
+
+def test_set_int_value():
+    """Test that an integer option can have its value set"""
+    config = Configuration()
+    config.add_option('test', option_type=int)
+
+    with pytest.raises(ConfigurationError) as exc:
+        config.test
+
+    config.test = 1
+    assert config.test == 1
+    config.test = "1"
+    assert config.test == 1
+    with pytest.raises(TypeError) as exc:
+        config.test = "voici_voila"
+    assert "<class 'int'> cannot be set to voici_voila with type <class 'str'>" in str(exc.value)
+
+
+def test_set_real_value():
+    """Test that a float option can have its value set"""
+    config = Configuration()
+    config.add_option('test', option_type=float)
+
+    with pytest.raises(ConfigurationError) as exc:
+        config.test
+
+    config.test = 1
+    assert config.test == 1.0
+    config.test = "1"
+    assert config.test == 1.0
+    with pytest.raises(TypeError) as exc:
+        config.test = "voici_voila"
+    assert "<class 'float'> cannot be set to voici_voila with type <class 'str'>" in str(exc.value)
+
+
+def test_set_str_value():
+    """Test that a string option can have its value set"""
+    config = Configuration()
+    config.add_option('test', option_type=str)
+
+    with pytest.raises(ConfigurationError):
+        config.test
+
+    config.test = "1"
+    assert config.test == "1"
+    config.test = 1
+    assert config.test == "1"
+
+
+def test_set_value_of_subconfig_directly():
+    """Test that we can access subconfig and set value directly"""
+    config = Configuration()
+    config.sub = Configuration()
+    config.sub.add_option('test', option_type=str)
+
+    with pytest.raises(ConfigurationError):
+        config.test
+
+    config.sub.test = "1"
+    assert config.sub.test == "1"
+    config.sub.test = 1
+    assert config.sub.test == "1"
+
+
+def test_set_value_like_dict():
+    """Test that we can set values like a dictionary"""
+    config = Configuration()
+    config.add_option('test', option_type=str)
+
+    with pytest.raises(ConfigurationError):
+        config.test
+
+    config['test'] = "1"
+    assert config.test == "1"
+    config['test'] = 1
+    assert config.test == "1"
+
+
+def test_set_subconfig_value_like_dict():
+    """Test that we can set values like a dictionary"""
+    config = Configuration()
+    config.sub = Configuration()
+    config.sub.add_option('test', option_type=str)
+
+    with pytest.raises(ConfigurationError):
+        config.test
+
+    config['sub.test'] = "1"
+    assert config.sub.test == "1"
+    config['sub.test'] = 1
+    assert config.sub.test == "1"
+
+
+def test_set_invalid_subconfig_value_like_dict():
+    """Test that deep keys cannot be set if subconfig does not exist"""
+    config = Configuration()
+    with pytest.raises(BaseException) as exc:
+        config['sub.test'] = "1"
+    assert 'Configuration does not have an attribute \'sub\'.' in str(exc.value)
+
+
+def test_yaml_loading_empty_config(yaml_path):
+    """Test loading for empty config fails like setting non existing attributes."""
+    config = Configuration()
+
+    with pytest.raises(ConfigurationError) as exc:
+        config.load_yaml(yaml_path)
+
+    assert 'Configuration does not have an attribute \'test\'.' in str(exc.value)
+
+
+def test_default_value():
+    """Test that default value is given only when nothing else is available"""
+    config = Configuration()
+    config.add_option('test', option_type=str, default="voici_voila")
+    assert config.test == "voici_voila"
+
+
+def test_yaml_precedence(yaml_path):
+    """Test that yaml definition has precedence over default values"""
+    config = Configuration()
+    config.add_option('test', option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE")
+    assert config.test == "voici_voila"
+
+    config.load_yaml(yaml_path)
+    assert config.test == "from my yaml!"
+
+
+def test_env_var_precedence(yaml_path):
+    """Test that env_var has precedence over yaml values"""
+    config = Configuration()
+    config.add_option('test', option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE")
+    assert config.test == "voici_voila"
+
+    config.load_yaml(yaml_path)
+    assert config.test == "from my yaml!"
+
+    os.environ['TOP_SECRET_MESSAGE'] = 'coussi_coussa'
+    assert config.test == "coussi_coussa"
+    del os.environ['TOP_SECRET_MESSAGE']
+
+    assert config.test == "from my yaml!"
+
+
+def test_local_precedence(yaml_path):
+    """Test local setting has precedence over env var values"""
+    config = Configuration()
+    config.add_option('test', option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE")
+    assert config.test == "voici_voila"
+
+    config.load_yaml(yaml_path)
+    assert config.test == "from my yaml!"
+
+    os.environ['TOP_SECRET_MESSAGE'] = 'coussi_coussa'
+    assert config.test == "coussi_coussa"
+
+    config.test = "comme_ci_comme_ca"
+    assert config.test == "comme_ci_comme_ca"
+
+    del os.environ['TOP_SECRET_MESSAGE']


### PR DESCRIPTION
Why:

The current implementation of the default > global > env var
configuration hierarchy is scattered is resolve_config and
experiment_builder. We should centralize this in an object which can
also be easily accessed from any submodule.

How:

Take blocks's Configuration class and make a few changes to support
subconfigurations.