### PR TITLE
Fix problem with incrementing version on experiment with no same-named children

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1608,7 +1608,7 @@ class ExperimentNameConflict(Conflict):
             # If we made it this far, new_name is actually the name of the parent.
             parent = self.conflict.old_config
 
-            query = {'refers.parent_id': parent['_id']}
+            query = {'name': parent['name'], 'refers.parent_id': parent['_id']}
             children = len(get_storage().fetch_experiments(query))
 
             return bool(children)

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -125,7 +125,6 @@ class Experiment:
         self._storage = get_storage()
 
         config = self._storage.fetch_experiments({'name': name, 'metadata.user': user})
-        print(config)
 
         if config:
             log.debug("Found existing experiment, %s, under user, %s, registered in database.",

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -125,6 +125,7 @@ class Experiment:
         self._storage = get_storage()
 
         config = self._storage.fetch_experiments({'name': name, 'metadata.user': user})
+        print(config)
 
         if config:
             log.debug("Found existing experiment, %s, under user, %s, registered in database.",

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -144,8 +144,8 @@ class Experiment:
 
                 self.version = min(self.version, max_version)
 
-                log.info("Many versions for experiment %s have been found. Using latest\
-                          version %s.", name, self.version)
+                log.info("Many versions for experiment %s have been found. Using latest "
+                         "version %s.", name, self.version)
                 config = filter(lambda exp: exp['version'] == self.version, config)
 
             config = sorted(config, key=lambda x: x['metadata']['datetime'],

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -575,7 +575,7 @@ class Experiment:
             raise DuplicateKeyError("Cannot register an existing experiment with a new config")
 
         # Copy and simulate instantiating given configuration
-        experiment = Experiment(self.name)
+        experiment = Experiment(self.name, version=self.version)
         experiment._instantiate_config(self.configuration)
         experiment._instantiate_config(config)
         experiment._init_done = True

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -497,3 +497,16 @@ def test_init_w_version_gt_max(clean_db, monkeypatch, database):
 
     exp = database.experiments.find({'name': 'experiment', 'version': 3})
     assert len(list(exp))
+
+
+def test_init_check_increment_w_children(clean_db, monkeypatch, database):
+    """Test that incrementing version works with not same-named children."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main("init_only -n experiment ./black_box.py -x~normal(0,1)".split(" "))
+    orion.core.cli.main("init_only -n experiment --branch experiment_2 ./black_box.py "
+                        "-x~normal(0,1) -y~+normal(0,1)".split(" "))
+    orion.core.cli.main("init_only -n experiment ./black_box.py "
+                        "-x~normal(0,1) -z~+normal(0,1)".split(" "))
+
+    exp = database.experiments.find({'name': 'experiment', 'version': 2})
+    assert len(list(exp))

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -510,3 +510,17 @@ def test_init_check_increment_w_children(clean_db, monkeypatch, database):
 
     exp = database.experiments.find({'name': 'experiment', 'version': 2})
     assert len(list(exp))
+
+
+def test_branch_from_selected_version(clean_db, monkeypatch, database):
+    """Test that branching from a version passed with `--version` works."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main("init_only -n experiment ./black_box.py -x~normal(0,1)".split(" "))
+    orion.core.cli.main("init_only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+                        .split(" "))
+    orion.core.cli.main("init_only -n experiment --version 1 -b experiment_2 ./black_box.py "
+                        "-x~normal(0,1) -z~+normal(0,1)".split(" "))
+
+    parent = database.experiments.find({'name': 'experiment', 'version': 1})[0]
+    exp = database.experiments.find({'name': 'experiment_2'})[0]
+    assert exp['refers']['parent_id'] == parent['_id']

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -641,6 +641,20 @@ class TestConfigProperty(object):
 
         assert not exp.is_done
 
+    def test_no_increment_when_child_exist(self, create_db_instance):
+        """Check that experiment is not incremented when asked for v1 while v2 exists."""
+        query = dict(name='experiment_test', metadata={'user': 'corneauf'}, version=1)
+        get_storage().create_experiment(query)
+
+        query['version'] = 2
+        query.pop('_id')
+
+        get_storage().create_experiment(query)
+
+        exp = Experiment('experiment_test', version=1)
+
+        assert exp.version == 1
+
 
 @pytest.mark.usefixtures("create_db_instance", "with_user_bouthilx")
 def test_forcing_user(exp_config):


### PR DESCRIPTION
If an experiment name `root` already has at least one child not name `root`, maybe `child_1`, then it is impossible to create a new experiment name `root` to increment its version number.

While we're at it, also fixed a bug where branching from a selected version through `--version` would fail and branch from latest version.
This PR depends on #244 