### PR TITLE
Add version to `list` output

### DIFF
--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -49,5 +49,6 @@ def main(args):
                             if exp['refers'].get('root_id', exp['_id']) == exp['_id']]
 
     for root_experiment in root_experiments:
-        root = EVCBuilder().build_view_from({'name': root_experiment['name']}).node
+        root = EVCBuilder().build_view_from({'name': root_experiment['name'],
+                                             'version': root_experiment['version']}).node
         print_tree(root, nameattr='tree_name')

--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -50,4 +50,4 @@ def main(args):
 
     for root_experiment in root_experiments:
         root = EVCBuilder().build_view_from({'name': root_experiment['name']}).node
-        print_tree(root)
+        print_tree(root, nameattr='tree_name')

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -122,7 +122,7 @@ class ExperimentNode(TreeNode):
     def tree_name(self):
         """Return a formatted name of the Node for a tree pretty-print."""
         if self.item is not None:
-            return self.name + " - v.{}".format(self.item.version)
+            return self.name + "-v{}".format(self.item.version)
 
         return self.name
 

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -56,6 +56,7 @@ class ExperimentNode(TreeNode):
         """
         super(ExperimentNode, self).__init__(experiment, parent, children)
         self.name = name
+
         self._no_parent_lookup = True
         self._no_children_lookup = True
 
@@ -116,6 +117,14 @@ class ExperimentNode(TreeNode):
     def adapter(self):
         """Get the adapter of the experiment with respect to its parent"""
         return self.item.refers["adapter"]
+
+    @property
+    def tree_name(self):
+        """Return a formatted name of the Node for a tree pretty-print."""
+        if self.item is not None:
+            return self.name + " v.{}".format(self.item.version)
+
+        return self.name
 
     def fetch_trials(self, query, selection=None):
         """Fetch trials recursively in the EVC tree

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -122,7 +122,7 @@ class ExperimentNode(TreeNode):
     def tree_name(self):
         """Return a formatted name of the Node for a tree pretty-print."""
         if self.item is not None:
-            return self.name + " v.{}".format(self.item.version)
+            return self.name + " - v.{}".format(self.item.version)
 
         return self.name
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -746,7 +746,8 @@ class Experiment:
 
     def __repr__(self):
         """Represent the object as a string."""
-        return "Experiment(name=%s, metadata.user=%s)" % (self.name, self.metadata['user'])
+        return "Experiment(name=%s, metadata.user=%s, version=%s)" % \
+            (self.name, self.metadata['user'], self.version)
 
 
 # pylint: disable=too-few-public-methods
@@ -820,4 +821,5 @@ class ExperimentView(object):
 
     def __repr__(self):
         """Represent the object as a string."""
-        return "ExperimentView(name=%s, metadata.user=%s)" % (self.name, self.metadata['user'])
+        return "ExperimentView(name=%s, metadata.user=%s, version=%s)" % \
+            (self.name, self.metadata['user'], self.version)

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -126,14 +126,15 @@ def only_experiments_db(clean_db, database, exp_config):
     database.experiments.insert_many(exp_config[0])
 
 
-def ensure_deterministic_id(name, db_instance, update=None):
+def ensure_deterministic_id(name, db_instance, version=1, update=None):
     """Change the id of experiment to its name."""
-    experiment = db_instance.read('experiments', {'name': name})[0]
+    experiment = db_instance.read('experiments', {'name': name, 'version': version})[0]
     db_instance.remove('experiments', {'_id': experiment['_id']})
-    experiment['_id'] = name
+    _id = name + "_" + str(version)
+    experiment['_id'] = _id
 
     if experiment['refers']['parent_id'] is None:
-        experiment['refers']['root_id'] = name
+        experiment['refers']['root_id'] = _id
 
     if update is not None:
         experiment.update(update)
@@ -294,3 +295,33 @@ def three_family_branch_with_trials(three_experiments_family_branch, family_with
         trial = Trial(experiment=exp.id, params=[x, y, z], status=status)
         x_value += 1
         Database().write('trials', trial.to_dict())
+
+
+@pytest.fixture
+def two_experiments_same_name(one_experiment, db_instance):
+    """Create two experiments with the same name but different versions."""
+    orion.core.cli.main(['init_only', '-n', 'test_single_exp',
+                         './black_box.py', '--x~uniform(0,1)', '--y~+normal(0,1)'])
+    ensure_deterministic_id('test_single_exp', db_instance, version=2)
+
+
+@pytest.fixture
+def three_experiments_family_same_name(two_experiments_same_name, db_instance):
+    """Create three experiments, two of them with the same name but different versions and one
+    with a child.
+    """
+    orion.core.cli.main(['init_only', '-n', 'test_single_exp', '-v', '1', '-b',
+                         'test_single_exp_child', './black_box.py', '--x~uniform(0,1)',
+                         '--y~+normal(0,1)'])
+    ensure_deterministic_id('test_single_exp_child', db_instance)
+
+
+@pytest.fixture
+def three_experiments_branch_same_name(two_experiments_same_name, db_instance):
+    """Create three experiments, two of them with the same name but different versions and last one
+    with a child.
+    """
+    orion.core.cli.main(['init_only', '-n', 'test_single_exp', '-b',
+                         'test_single_exp_child', './black_box.py', '--x~uniform(0,1)',
+                         '--y~normal(0,1)', '--z~+normal(0,1)'])
+    ensure_deterministic_id('test_single_exp_child', db_instance)

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -22,7 +22,7 @@ def test_single_exp(clean_db, one_experiment, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_single_exp\n"
+    assert captured == " test_single_exp - v.1\n"
 
 
 def test_broken_refers(clean_db, broken_refers, capsys):
@@ -31,7 +31,7 @@ def test_broken_refers(clean_db, broken_refers, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_single_exp\n"
+    assert captured == " test_single_exp - v.1\n"
 
 
 def test_two_exp(capsys, clean_db, two_experiments):
@@ -40,7 +40,10 @@ def test_two_exp(capsys, clean_db, two_experiments):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_double_exp┐\n                └test_double_exp_child\n"
+    assert captured == """\
+ test_double_exp - v.1┐
+                      └test_double_exp_child - v.1
+"""
 
 
 def test_three_exp(capsys, clean_db, three_experiments):
@@ -49,8 +52,11 @@ def test_three_exp(capsys, clean_db, three_experiments):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_double_exp┐\n                └test_double_exp_child\n \
-test_single_exp\n"
+    assert captured == """\
+ test_double_exp - v.1┐
+                      └test_double_exp_child - v.1
+ test_single_exp - v.1
+"""
 
 
 def test_no_exp_name(clean_db, three_experiments, monkeypatch, capsys):
@@ -70,7 +76,7 @@ def test_exp_name(clean_db, three_experiments, monkeypatch, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_single_exp\n"
+    assert captured == " test_single_exp - v.1\n"
 
 
 def test_exp_name_with_child(clean_db, three_experiments, monkeypatch, capsys):
@@ -80,7 +86,10 @@ def test_exp_name_with_child(clean_db, three_experiments, monkeypatch, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_double_exp┐\n                └test_double_exp_child\n"
+    assert captured == """\
+ test_double_exp - v.1┐
+                      └test_double_exp_child - v.1
+"""
 
 
 def test_exp_name_child(clean_db, three_experiments, monkeypatch, capsys):
@@ -90,4 +99,50 @@ def test_exp_name_child(clean_db, three_experiments, monkeypatch, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_double_exp_child\n"
+    assert captured == " test_double_exp_child - v.1\n"
+
+
+def test_exp_same_name(clean_db, two_experiments_same_name, monkeypatch, capsys):
+    """Test that two experiments with the same name and different versions are correctly printed."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == """\
+ test_single_exp - v.1┐
+                      └test_single_exp - v.2
+"""
+
+
+def test_exp_family_same_name(clean_db, three_experiments_family_same_name, monkeypatch, capsys):
+    """Test that two experiments with the same name and different versions are correctly printed
+    even when one of them has a child.
+    """
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == """\
+                      ┌test_single_exp - v.2
+ test_single_exp - v.1┤
+                      └test_single_exp_child - v.1
+"""
+
+
+def test_exp_family_branch_same_name(clean_db, three_experiments_branch_same_name,
+                                     monkeypatch, capsys):
+    """Test that two experiments with the same name and different versions are correctly printed
+    even when last one has a child.
+    """
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['list'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == """\
+ test_single_exp - v.1┐
+                      └test_single_exp - v.2┐
+                                            └test_single_exp_child - v.1
+"""

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -22,7 +22,7 @@ def test_single_exp(clean_db, one_experiment, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_single_exp - v.1\n"
+    assert captured == " test_single_exp-v1\n"
 
 
 def test_broken_refers(clean_db, broken_refers, capsys):
@@ -31,7 +31,7 @@ def test_broken_refers(clean_db, broken_refers, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_single_exp - v.1\n"
+    assert captured == " test_single_exp-v1\n"
 
 
 def test_two_exp(capsys, clean_db, two_experiments):
@@ -41,8 +41,8 @@ def test_two_exp(capsys, clean_db, two_experiments):
     captured = capsys.readouterr().out
 
     assert captured == """\
- test_double_exp - v.1┐
-                      └test_double_exp_child - v.1
+ test_double_exp-v1┐
+                   └test_double_exp_child-v1
 """
 
 
@@ -53,9 +53,9 @@ def test_three_exp(capsys, clean_db, three_experiments):
     captured = capsys.readouterr().out
 
     assert captured == """\
- test_double_exp - v.1┐
-                      └test_double_exp_child - v.1
- test_single_exp - v.1
+ test_double_exp-v1┐
+                   └test_double_exp_child-v1
+ test_single_exp-v1
 """
 
 
@@ -76,7 +76,7 @@ def test_exp_name(clean_db, three_experiments, monkeypatch, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_single_exp - v.1\n"
+    assert captured == " test_single_exp-v1\n"
 
 
 def test_exp_name_with_child(clean_db, three_experiments, monkeypatch, capsys):
@@ -87,8 +87,8 @@ def test_exp_name_with_child(clean_db, three_experiments, monkeypatch, capsys):
     captured = capsys.readouterr().out
 
     assert captured == """\
- test_double_exp - v.1┐
-                      └test_double_exp_child - v.1
+ test_double_exp-v1┐
+                   └test_double_exp_child-v1
 """
 
 
@@ -99,7 +99,7 @@ def test_exp_name_child(clean_db, three_experiments, monkeypatch, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == " test_double_exp_child - v.1\n"
+    assert captured == " test_double_exp_child-v1\n"
 
 
 def test_exp_same_name(clean_db, two_experiments_same_name, monkeypatch, capsys):
@@ -110,8 +110,8 @@ def test_exp_same_name(clean_db, two_experiments_same_name, monkeypatch, capsys)
     captured = capsys.readouterr().out
 
     assert captured == """\
- test_single_exp - v.1┐
-                      └test_single_exp - v.2
+ test_single_exp-v1┐
+                   └test_single_exp-v2
 """
 
 
@@ -125,9 +125,9 @@ def test_exp_family_same_name(clean_db, three_experiments_family_same_name, monk
     captured = capsys.readouterr().out
 
     assert captured == """\
-                      ┌test_single_exp - v.2
- test_single_exp - v.1┤
-                      └test_single_exp_child - v.1
+                   ┌test_single_exp-v2
+ test_single_exp-v1┤
+                   └test_single_exp_child-v1
 """
 
 
@@ -142,7 +142,7 @@ def test_exp_family_branch_same_name(clean_db, three_experiments_branch_same_nam
     captured = capsys.readouterr().out
 
     assert captured == """\
- test_single_exp - v.1┐
-                      └test_single_exp - v.2┐
-                                            └test_single_exp_child - v.1
+ test_single_exp-v1┐
+                   └test_single_exp-v2┐
+                                      └test_single_exp_child-v1
 """

--- a/tests/functional/commands/test_status_command.py
+++ b/tests/functional/commands/test_status_command.py
@@ -322,12 +322,12 @@ test_single_exp
 ===============
 id                                status         min obj
 --------------------------------  -----------  ---------
-ec6ee7892275400a9acbf4f4d5cd530d  broken
-c4c44cb46d075546824e2a32f800fece  completed            0
-2b5059fa8fdcdc01f769c31e63d93f24  interrupted
-7e8eade99d5fb1aa59a1985e614732bc  new
-507496236ff94d0f3ad332949dfea484  reserved
-caf6afc856536f6d061676e63d14c948  suspended
+9f360d1b4eb2707f19dd619d0d898dd9  broken
+47564e5e390348b9d1335d4013895eb4  completed            0
+aefd38473f108016fd4842aa855732ff  interrupted
+0695f63ecaf7d78f4b85d4cb344e0dc0  new
+b0ea9850c09370215b45b81edd33c7d3  reserved
+b49e902aebccce14e834d96e411f896e  suspended
 
 
 """
@@ -346,11 +346,11 @@ test_single_exp
 ===============
 id                                status
 --------------------------------  -----------
-ec6ee7892275400a9acbf4f4d5cd530d  broken
-2b5059fa8fdcdc01f769c31e63d93f24  interrupted
-7e8eade99d5fb1aa59a1985e614732bc  new
-507496236ff94d0f3ad332949dfea484  reserved
-caf6afc856536f6d061676e63d14c948  suspended
+9f360d1b4eb2707f19dd619d0d898dd9  broken
+aefd38473f108016fd4842aa855732ff  interrupted
+0695f63ecaf7d78f4b85d4cb344e0dc0  new
+b0ea9850c09370215b45b81edd33c7d3  reserved
+b49e902aebccce14e834d96e411f896e  suspended
 
 
 """
@@ -369,24 +369,24 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
 test_single_exp
 ===============
 id                                status         min obj
 --------------------------------  -----------  ---------
-ec6ee7892275400a9acbf4f4d5cd530d  broken
-c4c44cb46d075546824e2a32f800fece  completed            0
-2b5059fa8fdcdc01f769c31e63d93f24  interrupted
-7e8eade99d5fb1aa59a1985e614732bc  new
-507496236ff94d0f3ad332949dfea484  reserved
-caf6afc856536f6d061676e63d14c948  suspended
+9f360d1b4eb2707f19dd619d0d898dd9  broken
+47564e5e390348b9d1335d4013895eb4  completed            0
+aefd38473f108016fd4842aa855732ff  interrupted
+0695f63ecaf7d78f4b85d4cb344e0dc0  new
+b0ea9850c09370215b45b81edd33c7d3  reserved
+b49e902aebccce14e834d96e411f896e  suspended
 
 
 """
@@ -405,24 +405,24 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
   test_double_exp_child
   =====================
   id                                status
   --------------------------------  -----------
-  45c359f1c753a10f2cfeca4073a3a7ef  broken
-  e79761fe3fc24dcbb7850939ede84b68  completed
-  69928939792d67f6fe30e9b8459be1ec  interrupted
-  5f4a9c92b8f7c26654b5b37ecd3d5d32  new
-  58c4019fb2f92da88a0e63fafb36b3da  reserved
-  82f340cb9d90cbf024169926b60aeef2  suspended
+  9bd1ebc475bcb9e077a9e81a7c954a65  broken
+  3c1af2af2c8dc9862df2cef0a65d6e1f  completed
+  614ec3fc127d52129bc9d66d9aeec36c  interrupted
+  4487e7fc87c288d254f94dfa82cd79cc  new
+  7877287c718d7844570003fd654f66ba  reserved
+  ff997e666e20c5a8c1a816dde0b5e2e9  suspended
 
 
 """
@@ -441,36 +441,36 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
   test_double_exp_child
   =====================
   id                                status
   --------------------------------  -----------
-  45c359f1c753a10f2cfeca4073a3a7ef  broken
-  e79761fe3fc24dcbb7850939ede84b68  completed
-  69928939792d67f6fe30e9b8459be1ec  interrupted
-  5f4a9c92b8f7c26654b5b37ecd3d5d32  new
-  58c4019fb2f92da88a0e63fafb36b3da  reserved
-  82f340cb9d90cbf024169926b60aeef2  suspended
+  9bd1ebc475bcb9e077a9e81a7c954a65  broken
+  3c1af2af2c8dc9862df2cef0a65d6e1f  completed
+  614ec3fc127d52129bc9d66d9aeec36c  interrupted
+  4487e7fc87c288d254f94dfa82cd79cc  new
+  7877287c718d7844570003fd654f66ba  reserved
+  ff997e666e20c5a8c1a816dde0b5e2e9  suspended
 
 
 test_single_exp
 ===============
 id                                status         min obj
 --------------------------------  -----------  ---------
-ec6ee7892275400a9acbf4f4d5cd530d  broken
-c4c44cb46d075546824e2a32f800fece  completed            0
-2b5059fa8fdcdc01f769c31e63d93f24  interrupted
-7e8eade99d5fb1aa59a1985e614732bc  new
-507496236ff94d0f3ad332949dfea484  reserved
-caf6afc856536f6d061676e63d14c948  suspended
+9f360d1b4eb2707f19dd619d0d898dd9  broken
+47564e5e390348b9d1335d4013895eb4  completed            0
+aefd38473f108016fd4842aa855732ff  interrupted
+0695f63ecaf7d78f4b85d4cb344e0dc0  new
+b0ea9850c09370215b45b81edd33c7d3  reserved
+b49e902aebccce14e834d96e411f896e  suspended
 
 
 """
@@ -489,36 +489,36 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
   test_double_exp_child
   =====================
   id                                status
   --------------------------------  -----------
-  45c359f1c753a10f2cfeca4073a3a7ef  broken
-  e79761fe3fc24dcbb7850939ede84b68  completed
-  69928939792d67f6fe30e9b8459be1ec  interrupted
-  5f4a9c92b8f7c26654b5b37ecd3d5d32  new
-  58c4019fb2f92da88a0e63fafb36b3da  reserved
-  82f340cb9d90cbf024169926b60aeef2  suspended
+  9bd1ebc475bcb9e077a9e81a7c954a65  broken
+  3c1af2af2c8dc9862df2cef0a65d6e1f  completed
+  614ec3fc127d52129bc9d66d9aeec36c  interrupted
+  4487e7fc87c288d254f94dfa82cd79cc  new
+  7877287c718d7844570003fd654f66ba  reserved
+  ff997e666e20c5a8c1a816dde0b5e2e9  suspended
 
 
   test_double_exp_child2
   ======================
   id                                status
   --------------------------------  -----------
-  d0f4aa931345bfd864201b7dd93ae667  broken
-  5005c35be98025a24731d7dfdf4423de  completed
-  c9fa9f0682a370396c8c4265c4e775dd  interrupted
-  3d8163138be100e37f1656b7b591179e  new
-  790d3c4c965e0d91ada9cbdaebe220cf  reserved
-  6efdb99952d5f80f55adbba9c61dc288  suspended
+  2c2b64df1859b45a0b01362ca146584a  broken
+  225b4a17dd29d5c0423a81c1ddda8f0e  completed
+  fb0bb45bd0a45225e2368a8158df0427  interrupted
+  57bd3071c7c1c39ceb997a7b37c5470d  new
+  673449a3910fdea777ac8cb8576cdbe3  reserved
+  01a38cce74701c3b40eb3d92143bc90f  suspended
 
 
 """
@@ -537,36 +537,36 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
   test_double_exp_child
   =====================
   id                                status
   --------------------------------  -----------
-  45c359f1c753a10f2cfeca4073a3a7ef  broken
-  e79761fe3fc24dcbb7850939ede84b68  completed
-  69928939792d67f6fe30e9b8459be1ec  interrupted
-  5f4a9c92b8f7c26654b5b37ecd3d5d32  new
-  58c4019fb2f92da88a0e63fafb36b3da  reserved
-  82f340cb9d90cbf024169926b60aeef2  suspended
+  9bd1ebc475bcb9e077a9e81a7c954a65  broken
+  3c1af2af2c8dc9862df2cef0a65d6e1f  completed
+  614ec3fc127d52129bc9d66d9aeec36c  interrupted
+  4487e7fc87c288d254f94dfa82cd79cc  new
+  7877287c718d7844570003fd654f66ba  reserved
+  ff997e666e20c5a8c1a816dde0b5e2e9  suspended
 
 
     test_double_exp_grand_child
     ===========================
     id                                status
     --------------------------------  -----------
-    994602c021c470989d6f392b06cb37dd  broken
-    24c228352de31010d8d3bf253604a82d  completed
-    a3c8a1f4c80c094754c7217a83aae5e2  interrupted
-    d667f5d719ddaa4e1da2fbe568e11e46  new
-    a40748e487605df3ed04a5ac7154d4f6  reserved
-    229622a6d7132c311b7d4c57a08ecf08  suspended
+    82f82a325b7cf09251a34c9264e1812a  broken
+    94baf74a4e94f800b6865d8ab5675428  completed
+    e24b2e542c0869064abdb20c2de250eb  interrupted
+    960bad983c3ee6349b8767fe452ecbb3  new
+    8d8578e31c740c1c0fc385c961702481  reserved
+    584375e2b32af0573f4692cb47a2ec99  suspended
 
 
 """
@@ -729,24 +729,24 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
 test_single_exp
 ===============
 id                                status         min obj
 --------------------------------  -----------  ---------
-ec6ee7892275400a9acbf4f4d5cd530d  broken
-c4c44cb46d075546824e2a32f800fece  completed            0
-2b5059fa8fdcdc01f769c31e63d93f24  interrupted
-7e8eade99d5fb1aa59a1985e614732bc  new
-507496236ff94d0f3ad332949dfea484  reserved
-caf6afc856536f6d061676e63d14c948  suspended
+9f360d1b4eb2707f19dd619d0d898dd9  broken
+47564e5e390348b9d1335d4013895eb4  completed            0
+aefd38473f108016fd4842aa855732ff  interrupted
+0695f63ecaf7d78f4b85d4cb344e0dc0  new
+b0ea9850c09370215b45b81edd33c7d3  reserved
+b49e902aebccce14e834d96e411f896e  suspended
 
 
 """
@@ -765,13 +765,13 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-ad6ea2decff2f298594b948fdaea03b2  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+d5f1c1cae188608b581ded20cd198679  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
 """
@@ -790,25 +790,25 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-ad6ea2decff2f298594b948fdaea03b2  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+d5f1c1cae188608b581ded20cd198679  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
 test_single_exp
 ===============
 id                                status         min obj
 --------------------------------  -----------  ---------
-ec6ee7892275400a9acbf4f4d5cd530d  broken
-c4c44cb46d075546824e2a32f800fece  completed            0
-2b5059fa8fdcdc01f769c31e63d93f24  interrupted
-7e8eade99d5fb1aa59a1985e614732bc  new
-507496236ff94d0f3ad332949dfea484  reserved
-caf6afc856536f6d061676e63d14c948  suspended
+9f360d1b4eb2707f19dd619d0d898dd9  broken
+47564e5e390348b9d1335d4013895eb4  completed            0
+aefd38473f108016fd4842aa855732ff  interrupted
+0695f63ecaf7d78f4b85d4cb344e0dc0  new
+b0ea9850c09370215b45b81edd33c7d3  reserved
+b49e902aebccce14e834d96e411f896e  suspended
 
 
 """
@@ -827,14 +827,14 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-ad6ea2decff2f298594b948fdaea03b2  new
-f357f8c185ccab3037c65dcf721b9e71  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+d5f1c1cae188608b581ded20cd198679  new
+e5bf1dd6dec1a0c690ed62ff9146e5b8  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
 """
@@ -853,14 +853,14 @@ test_double_exp
 ===============
 id                                status
 --------------------------------  -----------
-a8f8122af9e5162e1e2328fdd5dd75db  broken
-ab82b1fa316de5accb4306656caa07d0  completed
-c187684f7c7d9832ba953f246900462d  interrupted
-1497d4f27622520439c4bc132c6046b1  new
-ad6ea2decff2f298594b948fdaea03b2  new
-8f763d441db41d0f56e4e6aa40cc2321  new
-bd0999e1a3b00bf8658303b14867b30e  reserved
-b9f1506db880645a25ad9b5d2cfa0f37  suspended
+c2187f4954884c801e423d851aec9a0b  broken
+e42cc22a15188d72df315b9eac79c9c0  completed
+b849f69cc3a77f39382d7435d0d41b14  interrupted
+7fbbd152f7ca2c064bf00441e311609d  new
+d5f1c1cae188608b581ded20cd198679  new
+183148e187a1399989a06ffb02059920  new
+667513aa2cb2244bee9c4f41c7ff1cea  reserved
+557b9fdb9f96569dff7eb2de10d3946f  suspended
 
 
 """


### PR DESCRIPTION
This PR changes the output of `orion list` by adding the version of each experiment. This change has impacted `ExperimentNode` only but I decided to change `Experiment.__repr__()` anyways just because.