### PR TITLE
Add support for `--version` inside `info` command

### DIFF
--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -11,6 +11,7 @@
 """
 import logging
 
+from orion.core.cli.base import get_basic_args_group
 from orion.core.io.evc_builder import EVCBuilder
 
 log = logging.getLogger(__name__)
@@ -19,8 +20,7 @@ log = logging.getLogger(__name__)
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
     info_parser = parser.add_parser('info', help='info help')
-
-    info_parser.add_argument('name')
+    get_basic_args_group(info_parser)
 
     info_parser.set_defaults(func=main)
 
@@ -34,6 +34,8 @@ def main(args):
 
 
 INFO_TEMPLATE = """\
+{identification}
+
 {commandline}
 
 {configuration}
@@ -53,6 +55,7 @@ INFO_TEMPLATE = """\
 def format_info(experiment):
     """Render a string for all info of experiment"""
     info_string = INFO_TEMPLATE.format(
+        identification=format_identification(experiment),
         commandline=format_commandline(experiment),
         configuration=format_config(experiment),
         algorithm=format_algorithm(experiment),
@@ -235,6 +238,25 @@ def format_list(a_list, depth=0, width=4, templates=None):
             list_string += item_template.format(tab=subtab, id=i, item=item)
 
     return list_template.format(tab=tab, items=list_string.rstrip("\n"))
+
+
+ID_TEMPLATE = """\
+{title}
+name: {name}
+version: {version}
+user: {user}
+"""
+
+
+def format_identification(experiment):
+    """Render a string for identification section"""
+    identification_string = ID_TEMPLATE.format(
+        title=format_title("Identification"),
+        name=experiment.name,
+        version=experiment.version,
+        user=experiment.metadata['user'])
+
+    return identification_string
 
 
 COMMANDLINE_TEMPLATE = """\

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -46,9 +46,9 @@ class ExperimentNode(TreeNode):
 
     """
 
-    __slots__ = ('name', '_no_parent_lookup', '_no_children_lookup') + TreeNode.__slots__
+    __slots__ = ('name', 'version', '_no_parent_lookup', '_no_children_lookup') + TreeNode.__slots__
 
-    def __init__(self, name, experiment=None, parent=None, children=tuple()):
+    def __init__(self, name, version, experiment=None, parent=None, children=tuple()):
         """Initialize experiment node with item, experiment, parent and children
 
         .. seealso::
@@ -56,6 +56,7 @@ class ExperimentNode(TreeNode):
         """
         super(ExperimentNode, self).__init__(experiment, parent, children)
         self.name = name
+        self.version = version
 
         self._no_parent_lookup = True
         self._no_children_lookup = True
@@ -68,7 +69,7 @@ class ExperimentNode(TreeNode):
         not done already.
         """
         if self._item is None:
-            self._item = ExperimentView(self.name)
+            self._item = ExperimentView(self.name, version=self.version)
             self._item.connect_to_version_control_tree(self)
 
         return self._item
@@ -86,11 +87,13 @@ class ExperimentNode(TreeNode):
         if self._parent is None and self._no_parent_lookup:
             self._no_parent_lookup = False
             query = {'_id': self.item.refers['parent_id']}
-            selection = {'name': 1}
+            selection = {'name': 1, 'version': 1}
             experiments = get_storage().fetch_experiments(query, selection)
-            if experiments:
-                self.set_parent(ExperimentNode(name=experiments[0]['name']))
 
+            if experiments:
+                parent = experiments[0]
+                exp_node = ExperimentNode(name=parent['name'], version=parent['version'])
+                self.set_parent(exp_node)
         return self._parent
 
     @property
@@ -106,10 +109,10 @@ class ExperimentNode(TreeNode):
         if not self._children and self._no_children_lookup:
             self._no_children_lookup = False
             query = {'refers.parent_id': self.item.id}
-            selection = {'name': 1}
+            selection = {'name': 1, 'version': 1}
             experiments = get_storage().fetch_experiments(query, selection)
             for child in experiments:
-                self.add_children(ExperimentNode(name=child['name']))
+                self.add_children(ExperimentNode(name=child['name'], version=child['version']))
 
         return self._children
 

--- a/src/orion/core/io/evc_builder.py
+++ b/src/orion/core/io/evc_builder.py
@@ -36,7 +36,7 @@ class EVCBuilder(object):
     # pylint:disable=no-self-use
     def connect_to_version_control_tree(self, experiment):
         """Build the EVC and connect the experiment to it"""
-        experiment_node = ExperimentNode(experiment.name, experiment=experiment)
+        experiment_node = ExperimentNode(experiment.name, experiment.version, experiment=experiment)
         experiment.connect_to_version_control_tree(experiment_node)
 
     def build_view_from(self, cmdargs):

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -6,7 +6,7 @@ import orion.core.cli
 
 def test_info_no_hit(clean_db, one_experiment, capsys):
     """Test info if no experiment with given name."""
-    orion.core.cli.main(['info','--name' , 'i do not exist'])
+    orion.core.cli.main(['info', '--name', 'i do not exist'])
 
     captured = capsys.readouterr().out
 

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -6,7 +6,7 @@ import orion.core.cli
 
 def test_info_no_hit(clean_db, one_experiment, capsys):
     """Test info if no experiment with given name."""
-    orion.core.cli.main(['info', 'i do not exist'])
+    orion.core.cli.main(['info','--name' , 'i do not exist'])
 
     captured = capsys.readouterr().out
 
@@ -15,7 +15,7 @@ def test_info_no_hit(clean_db, one_experiment, capsys):
 
 def test_info_hit(clean_db, one_experiment, capsys):
     """Test info if existing experiment."""
-    orion.core.cli.main(['info', 'test_single_exp'])
+    orion.core.cli.main(['info', '--name', 'test_single_exp'])
 
     captured = capsys.readouterr().out
 
@@ -24,7 +24,7 @@ def test_info_hit(clean_db, one_experiment, capsys):
 
 def test_info_broken(clean_db, broken_refers, capsys):
     """Test info if experiment.refers is missing."""
-    orion.core.cli.main(['info', 'test_single_exp'])
+    orion.core.cli.main(['info', '--name', 'test_single_exp'])
 
     captured = capsys.readouterr().out
 

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -6,9 +6,9 @@ import itertools
 import pytest
 
 from orion.core.cli.info import (
-    format_algorithm, format_commandline, format_config, format_dict, format_info, format_list,
-    format_metadata, format_refers, format_space, format_stats, format_title, get_trial_params,
-    format_identification)
+    format_algorithm, format_commandline, format_config, format_dict, format_identification,
+    format_info, format_list, format_metadata, format_refers, format_space, format_stats,
+    format_title, get_trial_params)
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.worker.trial import Trial
 

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -7,7 +7,8 @@ import pytest
 
 from orion.core.cli.info import (
     format_algorithm, format_commandline, format_config, format_dict, format_info, format_list,
-    format_metadata, format_refers, format_space, format_stats, format_title, get_trial_params)
+    format_metadata, format_refers, format_space, format_stats, format_title, get_trial_params,
+    format_identification)
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.worker.trial import Trial
 
@@ -362,6 +363,21 @@ def test_format_dict_with_list(dummy_list_of_objects):
 """
 
 
+def test_format_identification():
+    """Test commandline section formatting"""
+    experiment = DummyExperiment()
+    experiment.name = "test"
+    experiment.version = 1
+    experiment.metadata = {'user': 'corneauf'}
+    assert format_identification(experiment) == """\
+Identification
+==============
+name: test
+version: 1
+user: corneauf
+"""
+
+
 def test_format_commandline():
     """Test commandline section formatting"""
     experiment = DummyExperiment()
@@ -539,6 +555,8 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment = DummyExperiment()
     commandline = ['executing.sh', '--some~choices(["random", "or", "not"])',
                    '--command~uniform(0, 1)']
+    experiment.name = 'test'
+    experiment.version = 1
     experiment.metadata = {'user_args': commandline}
     experiment.pool_size = 10
     experiment.max_trials = 100
@@ -580,6 +598,13 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment.fetch_trials = lambda query: [dummy_trial]
 
     assert format_info(experiment) == """\
+Identification
+==============
+name: test
+version: 1
+user: user
+
+
 Commandline
 ===========
 executing.sh --some~choices(["random", "or", "not"]) --command~uniform(0, 1)

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -23,7 +23,7 @@ def test_parent_fetch_trials(create_db_instance):
     leaf_names = ['supernaedo2.3']
 
     experiment = ExperimentView(experiment_name)
-    exp_node = ExperimentNode(experiment.name, experiment=experiment)
+    exp_node = ExperimentNode(experiment.name, experiment.version, experiment=experiment)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
 
     assert exp_node.item.name == experiment_name


### PR DESCRIPTION
And fix a bug where `ExperimentNode` would enter an infinite loop. You're welcome.