### PR TITLE
Fix iter(space)

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -834,7 +834,11 @@ class Space(dict):
 
     def keys(self):
         """Return sorted keys"""
-        return list(sorted(super(Space, self).keys()))
+        return list(iter(self))
+
+    def __iter__(self):
+        """Return sorted keys"""
+        return iter(sorted(super(Space, self).keys()))
 
 
 def pack_point(point, space):

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -674,6 +674,10 @@ class TestSpace(object):
         space2.register(Categorical('yolo4', ('asdfa', 2)))
         space2.register(Integer('yolo2', 'uniform', -3, 6, shape=(2,)))
 
+        assert list(space1) == list(space1.keys())
+        assert list(space2) == list(space2.keys())
+        assert list(space1.values()) == list(space2.values())
+        assert list(space1.items()) == list(space2.items())
         assert list(space1.keys()) == list(space2.keys())
         assert list(space1.values()) == list(space2.values())
         assert list(space1.items()) == list(space2.items())


### PR DESCRIPTION
Why:

The space was supposed to have sorted keys, values and items, but `iter`
was forgotten and this caused issues in cmdline `insert` in which order
of space.keys() did not match order of `iter(space)`.