### PR TITLE
Handle status --name <exp> when empty

### DIFF
--- a/src/orion/core/cli/status.py
+++ b/src/orion/core/cli/status.py
@@ -55,6 +55,10 @@ def main(args):
 
     experiments = get_experiments(args)
 
+    if not experiments:
+        print("No experiment found")
+        return
+
     if args.get('name'):
         print_status(experiments[0], all_trials=args.get('all'), collapse=args.get('collapse'))
         return

--- a/tests/functional/commands/test_status_command.py
+++ b/tests/functional/commands/test_status_command.py
@@ -15,7 +15,7 @@ def test_no_experiments(clean_db, monkeypatch, capsys):
 
     captured = capsys.readouterr().out
 
-    assert captured == ""
+    assert captured == "No experiment found\n"
 
 
 def test_experiment_without_trials_wout_ac(clean_db, one_experiment, capsys):
@@ -868,6 +868,16 @@ d5f1c1cae188608b581ded20cd198679  new
 """
 
     assert captured == expected
+
+
+def test_no_experiments_w_name(clean_db, monkeypatch, capsys):
+    """Test status when --name <exp> does not exist."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(['status', '--name', 'test_ghost_exp'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == "No experiment found\n"
 
 
 def test_experiment_wout_child_w_name(clean_db, unrelated_with_trials, capsys):


### PR DESCRIPTION
Why:

The command would crash when no experiment matches the name passed with
--name.