### PR TITLE
Fix backward compatibility for metadata.user index

### DIFF
--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -19,6 +19,7 @@ import logging
 from orion.core.utils import (AbstractSingletonType, SingletonFactory)
 
 
+# pylint: disable=too-many-public-methods
 class AbstractDB(object, metaclass=AbstractSingletonType):
     """Base class for database framework wrappers.
 
@@ -105,6 +106,38 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 
         """
         pass
+
+    @abstractmethod
+    def index_information(self, collection_name):
+        """Return dict of names and sorting order of indexes
+
+        Paramaters
+        ----------
+        collection_name : str
+           A collection inside database, a table.
+
+        Returns
+        -------
+        dict
+            Dictionary of indexes where each key is the name in the format {name}_{order}
+            and each value represents whether the index is unique.
+
+        """
+        return self._db[collection_name].index_information()
+
+    @abstractmethod
+    def drop_index(self, collection_name, name):
+        """Remove index from the database
+
+        Paramaters
+        ----------
+        collection_name : str
+           A collection inside database, a table.
+        name: str
+            Index name in the format {name}_{order}
+
+        """
+        self._db[collection_name].drop_index(name)
 
     @abstractmethod
     def write(self, collection_name, data, query=None):

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -56,6 +56,7 @@ def find_unpickable_field(doc):
     return None, None
 
 
+# pylint: disable=too-many-public-methods
 class PickledDB(AbstractDB):
     """Pickled EphemeralDB to support permanancy and concurrency
 
@@ -98,6 +99,16 @@ class PickledDB(AbstractDB):
         """
         with self.locked_database() as database:
             database.ensure_index(collection_name, keys, unique=unique)
+
+    def index_information(self, collection_name):
+        """Return dict of names and sorting order of indexes"""
+        with self.locked_database(write=False) as database:
+            return database.index_information(collection_name)
+
+    def drop_index(self, collection_name, name):
+        """Remove index from the database"""
+        with self.locked_database() as database:
+            return database.drop_index(collection_name, name)
 
     def write(self, collection_name, data, query=None):
         """Write new information to a collection. Perform insert or update.
@@ -154,7 +165,11 @@ class PickledDB(AbstractDB):
             return EphemeralDB()
 
         with open(self.host, 'rb') as f:
-            database = pickle.load(f)
+            data = f.read()
+            if not data:
+                database = EphemeralDB()
+            else:
+                database = pickle.loads(data)
 
         return database
 

--- a/src/orion/core/utils/tests.py
+++ b/src/orion/core/utils/tests.py
@@ -25,13 +25,6 @@ from orion.storage.base import get_storage, Storage
 from orion.storage.legacy import Legacy
 
 
-def _remove(file_name):
-    try:
-        os.remove(file_name)
-    except FileNotFoundError:
-        pass
-
-
 def _select(lhs, rhs):
     if lhs:
         return lhs
@@ -107,7 +100,6 @@ class OrionState:
     trials = []
     resources = []
     workers = []
-    tempfile = None
 
     def __init__(self, experiments=None, trials=None, workers=None, lies=None, resources=None,
                  from_yaml=None, database=None):
@@ -128,6 +120,7 @@ class OrionState:
         """Initialize environment before testing"""
         self.storage()
         self.database = get_storage()._db
+        self.cleanup()
         self.load_experience_configuration()
         return self
 
@@ -143,7 +136,8 @@ class OrionState:
 
     def cleanup(self):
         """Cleanup after testing"""
-        _remove(self.tempfile)
+        self.database.remove('experiments', {})
+        self.database.remove('trials', {})
 
     def load_experience_configuration(self):
         """Load an example database."""
@@ -164,20 +158,22 @@ class OrionState:
             self.experiments[i]['version'] = 1
             self.experiments[i]['_id'] = i
 
-        self.database.write('experiments', self.experiments)
-        self.database.write('trials', self.trials)
-        self.database.write('workers', self.workers)
-        self.database.write('resources', self.resources)
-        self.database.write('lying_trials', self.lies)
+        if self.experiments:
+            self.database.write('experiments', self.experiments)
+        if self.trials:
+            self.database.write('trials', self.trials)
+        if self.workers:
+            self.database.write('workers', self.workers)
+        if self.resources:
+            self.database.write('resources', self.resources)
+        if self.lies:
+            self.database.write('lying_trials', self.lies)
 
     def __enter__(self):
         """Load a new database state"""
-        self.tempfile = self.database_config.get('host')
-
         for singleton in self.SINGLETONS:
             self.new_singleton(singleton, new_value=None)
 
-        self.cleanup()
         return self.init()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -199,7 +195,7 @@ class OrionState:
     def storage(self):
         """Return test storage"""
         try:
-            storage_type = self.database_config.pop('storage_type')
+            storage_type = self.database_config.pop('storage_type', 'legacy')
             config = {
                 'database': self.database_config
             }

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -68,6 +68,13 @@ class Legacy(BaseStorageProtocol):
                               [('name', Database.ASCENDING),
                                ('version', Database.ASCENDING)],
                               unique=True)
+
+        # For backward compatibility
+        index_info = self._db.index_information('experiments')
+        for depracated_idx in ['name_1_metadata.user_1', 'name_1_metadata.user_1_version_1']:
+            if depracated_idx in index_info:
+                self._db.drop_index('experiments', depracated_idx)
+
         self._db.ensure_index('experiments', 'metadata.datetime')
 
         self._db.ensure_index('trials', 'experiment')

--- a/tests/unittests/core/test_pickleddb.py
+++ b/tests/unittests/core/test_pickleddb.py
@@ -46,32 +46,32 @@ class TestEnsureIndex(object):
 
     def test_new_index(self, orion_db):
         """Index should be added to pickled database"""
-        assert ("new_field", ) not in orion_db._get_database()._db['new_collection']._indexes
+        assert "new_field_1" not in orion_db._get_database()._db['new_collection']._indexes
 
         orion_db.ensure_index('new_collection', 'new_field', unique=False)
-        assert ("new_field", ) not in orion_db._get_database()._db['new_collection']._indexes
+        assert "new_field_1" not in orion_db._get_database()._db['new_collection']._indexes
 
         orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert ("new_field", ) in orion_db._get_database()._db['new_collection']._indexes
+        assert "new_field_1" in orion_db._get_database()._db['new_collection']._indexes
 
     def test_existing_index(self, orion_db):
         """Index should be added to pickled database and reattempt should do nothing"""
-        assert ("new_field", ) not in orion_db._get_database()._db['new_collection']._indexes
+        assert "new_field_1" not in orion_db._get_database()._db['new_collection']._indexes
 
         orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert ("new_field", ) in orion_db._get_database()._db['new_collection']._indexes
+        assert "new_field_1" in orion_db._get_database()._db['new_collection']._indexes
 
         # reattempt
         orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert ("new_field", ) in orion_db._get_database()._db['new_collection']._indexes
+        assert "new_field_1" in orion_db._get_database()._db['new_collection']._indexes
 
     def test_compound_index(self, orion_db):
         """Tuple of Index should be added as a compound index."""
-        assert ("name", "metadata.user") not in orion_db._get_database()._db['experiments']._indexes
+        assert "name_1_metadata.user_1" not in orion_db._get_database()._db['experiments']._indexes
         orion_db.ensure_index('experiments',
                               [('name', Database.ASCENDING),
                                ('metadata.user', Database.ASCENDING)], unique=True)
-        assert ("name", "metadata.user") in orion_db._get_database()._db['experiments']._indexes
+        assert "name_1_metadata.user_1" in orion_db._get_database()._db['experiments']._indexes
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -354,6 +354,13 @@ class TestConcurreny(object):
         Pool(10).starmap(write, (('unique', 1) for i in range(10)))
 
         assert orion_db.count('concurrent', {'unique': 1}) == 1
+
+
+def test_empty_file(orion_db):
+    """Check that db loading can handle empty files"""
+    with open(orion_db.host, 'wb') as f:
+        f.write(b'')
+    orion_db._get_database()
 
 
 def test_unpickable_error_find_document():

--- a/tests/unittests/storage/test_legacy.py
+++ b/tests/unittests/storage/test_legacy.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.storage`."""
+
+import pytest
+
+from orion.core.io.database import Database, DuplicateKeyError
+from orion.core.utils.tests import OrionState
+
+
+base_experiment = {
+    'name': 'default_name',
+    'version': 0,
+    'metadata': {
+        'user': 'default_user',
+        'user_script': 'abc',
+        'datetime': '2017-11-23T02:00:00'
+    }
+}
+
+db_backends = [
+    # {
+    #     'type': 'PickledDB',
+    #     'name': 'orion_test'
+    # },
+    # {
+    #     'type': 'EphemeralDB',
+    #     'name': 'orion_test'
+    # },
+    {
+        'type': 'MongoDB',
+        'name': 'orion_test',
+        'username': 'user',
+        'password': 'pass'
+    }
+]
+
+
+@pytest.mark.parametrize('db_backend', db_backends)
+def test_backward_compatible_drop_user_index(db_backend):
+    """Test that indexes from old versions are removed"""
+    with OrionState(experiments=[], database=db_backend) as cfg:
+        storage = cfg.storage()
+        database = cfg.database
+
+        database.ensure_index(
+            'experiments',
+            [('name', Database.ASCENDING), ('metadata.user', Database.ASCENDING)],
+            unique=True)
+
+        database.ensure_index(
+            'experiments',
+            [('name', Database.ASCENDING),
+             ('metadata.user', Database.ASCENDING),
+             ('version', Database.ASCENDING)],
+            unique=True)
+
+        storage.create_experiment(base_experiment)
+        base_experiment.pop('_id')
+        base_experiment['version'] = 1
+
+        with pytest.raises(DuplicateKeyError):
+            storage.create_experiment(base_experiment)
+
+        experiments = storage.fetch_experiments({})
+        assert len(experiments) == 1, 'Only first experiment in the database'
+
+        # Remove old indexes for backward-compatibility
+        storage._setup_db()  # pylint: disable=protected-access
+
+        assert storage.create_experiment(base_experiment)
+
+        experiments = storage.fetch_experiments({})
+        assert len(experiments) == 2, 'Both experiments in the database'


### PR DESCRIPTION
### Add `index_information` and `drop_index` to DB
Why:

The index metadata.user will be removed in v0.1.6, but this will cause
issues with experiments from previous versions since the index will
still be present.

How:

Use the same API as mongodb for both, with a simplified
`index_information` where the output is simply a dictionay mapping
{name}_{order} to {True, False} whether the index is unique or not.

###  Make legacy backward compatible
Why:

Version 0.1.6 will remove the index metadata.user, so we need to make
sure we remove it from the db as well.