### PR TITLE
Fix ASHA termination condition and branching with fidelity()

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -670,6 +670,8 @@ class Fidelity(Dimension):
     ----------
     name : str
         Name of the dimension
+    default_value: int
+        Maximum of the fidelity interval.
 
     """
 
@@ -688,6 +690,11 @@ class Fidelity(Dimension):
         self.prior = None
         self._prior_name = 'None'
 
+    @property
+    def default_value(self):
+        """Return `high`"""
+        return self.high
+
     def get_prior_string(self):
         """Build the string corresponding to current prior"""
         return 'fidelity({}, {}, {})'.format(self.low, self.high, self.base)
@@ -698,7 +705,7 @@ class Fidelity(Dimension):
 
     def sample(self, n_samples=1, seed=None):
         """Do not do anything."""
-        return ['fidelity']
+        return [self.high]
 
     def interval(self, alpha=1.0):
         """Do not do anything."""

--- a/src/orion/core/worker/__init__.py
+++ b/src/orion/core/worker/__init__.py
@@ -25,7 +25,7 @@ def reserve_trial(experiment, producer):
     """Reserve a new trial, or produce and reserve a trial if none are available."""
     trial = experiment.reserve_trial(score_handle=producer.algorithm.score)
 
-    if trial is None:
+    if trial is None and not experiment.is_done:
         log.debug("#### Failed to pull a new trial from database.")
 
         log.debug("#### Fetch most recent completed trials and update algorithm.")
@@ -63,8 +63,9 @@ def workon(experiment, worker_trials=None):
         log.debug("#### Try to reserve a new trial to evaluate.")
         trial = reserve_trial(experiment, producer)
 
-        log.debug("#### Successfully reserved %s to evaluate. Consuming...", trial)
-        consumer.consume(trial)
+        if trial is not None:
+            log.debug("#### Successfully reserved %s to evaluate. Consuming...", trial)
+            consumer.consume(trial)
 
     stats = experiment.stats
 

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -71,7 +71,7 @@ class Producer(object):
         sampled_points = 0
 
         start = time.time()
-        while sampled_points < self.pool_size:
+        while sampled_points < self.pool_size and not self.algorithm.is_done:
             if time.time() - start > self.max_idle_time:
                 raise RuntimeError(
                     "Algorithm could not sample new points in less than {} seconds".format(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,8 @@ class DumbAlgo(BaseAlgorithm):
     @property
     def state_dict(self):
         """Return a state dict that can be used to reset the state of the algorithm."""
-        return {'index': self._index, 'suggested': self._suggested, 'num': self._num}
+        return {'index': self._index, 'suggested': self._suggested, 'num': self._num,
+                'done': self.done}
 
     def set_state(self, state_dict):
         """Reset the state of the algorithm based on the given state_dict
@@ -63,6 +64,7 @@ class DumbAlgo(BaseAlgorithm):
         self._index = state_dict['index']
         self._suggested = state_dict['suggested']
         self._num = state_dict['num']
+        self.done = state_dict['done']
 
     def suggest(self, num=1):
         """Suggest based on `value`."""

--- a/tests/functional/algos/asha_config.yaml
+++ b/tests/functional/algos/asha_config.yaml
@@ -1,0 +1,21 @@
+name: demo_algo
+
+pool_size: 1
+max_trials: 100
+
+algorithms:
+  asha:
+    seed: 1
+    num_rungs: 4
+    num_brackets: 1
+    grace_period: null
+    max_resources: null
+    reduction_factor: null
+
+producer:
+  strategy: StubParallelStrategy
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/functional/algos/black_box.py
+++ b/tests/functional/algos/black_box.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Simple one dimensional example with noise level for a possible user's script."""
+import argparse
+import random
+
+from orion.client import report_results
+
+
+def function(x, noise):
+    """Evaluate partial information of a quadratic."""
+    z = (x - 34.56789) * random.gauss(0, noise)
+    return 4 * z**2 + 23.4, 8 * z
+
+
+def execute():
+    """Execute a simple pipeline as an example."""
+    # 1. Receive inputs as you want
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument('--fidelity', type=int, default=10)
+    inputs = parser.parse_args()
+
+    assert 0 <= inputs.fidelity <= 10
+
+    noise = (1 - inputs.fidelity / 10) + 0.0001
+
+    # 2. Perform computations
+    y, dy = function(inputs.x, noise)
+
+    # 3. Gather and report results
+    results = list()
+    results.append(dict(
+        name='example_objective',
+        type='objective',
+        value=y))
+    results.append(dict(
+        name='example_gradient',
+        type='gradient',
+        value=[dy]))
+
+    report_results(results)
+
+
+if __name__ == "__main__":
+    execute()

--- a/tests/functional/algos/random_config.yaml
+++ b/tests/functional/algos/random_config.yaml
@@ -1,0 +1,13 @@
+name: demo_algo
+
+pool_size: 1
+max_trials: 100
+
+algorithms:
+  random:
+    seed: 1
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test for algos included with orion."""
+import os
+
+import pytest
+import yaml
+
+import orion.core.cli
+from orion.storage.base import get_storage
+
+
+config_files = ['random_config.yaml']
+fidelity_config_files = ['random_config.yaml', 'asha_config.yaml']
+fidelity_only_config_files = list(set(fidelity_config_files) - set(config_files))
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.parametrize('config_file', fidelity_only_config_files)
+def test_missing_fidelity(monkeypatch, config_file):
+    """Test a simple usage scenario."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    with pytest.raises(RuntimeError) as exc:
+        orion.core.cli.main(["hunt", "--config", config_file,
+                             "./black_box.py", "-x~uniform(-50, 50)"])
+    assert "https://orion.readthedocs.io/en/develop/user/algorithms.html" in str(exc.value)
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.parametrize('config_file', config_files)
+def test_simple(monkeypatch, config_file):
+    """Test a simple usage scenario."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(["hunt", "--config", config_file,
+                         "./black_box.py", "-x~uniform(-50, 50)"])
+
+    with open(config_file, 'rb') as f:
+        config = yaml.safe_load(f)
+
+    storage = get_storage()
+    exp = list(storage.fetch_experiments({'name': config['name']}))
+    assert len(exp) == 1
+    exp = exp[0]
+    assert '_id' in exp
+    exp_id = exp['_id']
+    assert exp['name'] == config['name']
+    assert exp['pool_size'] == 1
+    assert exp['max_trials'] == 100
+    assert exp['algorithms'] == config['algorithms']
+    assert 'user' in exp['metadata']
+    assert 'datetime' in exp['metadata']
+    assert 'orion_version' in exp['metadata']
+    assert 'user_script' in exp['metadata']
+    assert os.path.isabs(exp['metadata']['user_script'])
+    assert exp['metadata']['user_args'] == ['-x~uniform(-50, 50)']
+
+    trials = storage.fetch_trials(uid=exp_id)
+    assert len(trials) <= config['max_trials']
+    assert trials[-1].status == 'completed'
+
+    best_trial = next(iter(sorted(trials, key=lambda trial: trial.objective.value)))
+    assert best_trial.objective.name == 'example_objective'
+    assert abs(best_trial.objective.value - 23.4) < 1e-5
+    assert len(best_trial.params) == 1
+    param = best_trial.params[0]
+    assert param.name == '/x'
+    assert param.type == 'real'
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.parametrize('config_file', fidelity_config_files)
+def test_with_fidelity(database, monkeypatch, config_file):
+    """Test a scenario with fidelity."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    orion.core.cli.main(["hunt", "--config", config_file,
+                         "./black_box.py", "-x~uniform(-50, 50)", "--fidelity~fidelity(1,10,4)"])
+
+    with open(config_file, 'rb') as f:
+        config = yaml.safe_load(f)
+
+    storage = get_storage()
+    exp = list(storage.fetch_experiments({'name': config['name']}))
+    assert len(exp) == 1
+    exp = exp[0]
+    assert '_id' in exp
+    exp_id = exp['_id']
+    assert exp['name'] == config['name']
+    assert exp['pool_size'] == 1
+    assert exp['max_trials'] == 100
+    assert exp['algorithms'] == config['algorithms']
+    assert 'user' in exp['metadata']
+    assert 'datetime' in exp['metadata']
+    assert 'orion_version' in exp['metadata']
+    assert 'user_script' in exp['metadata']
+    assert os.path.isabs(exp['metadata']['user_script'])
+    assert exp['metadata']['user_args'] == ['-x~uniform(-50, 50)', "--fidelity~fidelity(1,10,4)"]
+
+    trials = storage.fetch_trials(uid=exp_id)
+    assert len(trials) <= config['max_trials']
+    assert trials[-1].status == 'completed'
+
+    best_trial = next(iter(sorted(trials, key=lambda trial: trial.objective.value)))
+    assert best_trial.objective.name == 'example_objective'
+    assert abs(best_trial.objective.value - 23.4) < 1e-5
+    assert len(best_trial.params) == 2
+    fidelity = best_trial.params[0]
+    assert fidelity.name == '/fidelity'
+    assert fidelity.type == 'fidelity'
+    assert fidelity.value == 10
+    param = best_trial.params[1]
+    assert param.name == '/x'
+    assert param.type == 'real'

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -454,9 +454,22 @@ def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):
     orion.core.cli.main(
         ("init_only -n {name} --branch {branch} ./black_box_with_y.py "
          "-x~uniform(0,10) "
-         "-w~choices(['a','b'],default_value='a')").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {name} script -x=2 -w=b".format(name=branch).split(" "))
-    orion.core.cli.main("insert -n {name} script -x=1".format(name=branch).split(" "))
+         "-w~choices(['a','b'])").format(name=name, branch=branch).split(" "))
+
+
+def test_auto_resolution_with_fidelity(init_full_x_full_y, monkeypatch):
+    """Test that auto-resolution does resolve all conflicts including new fidelity"""
+    # Patch cmdloop to avoid autoresolution's prompt
+    monkeypatch.setattr('sys.__stdin__.isatty', lambda: True)
+
+    name = "full_x_full_y"
+    branch = "half_x_no_y_new_w"
+    # If autoresolution was not succesfull, this to fail with a sys.exit without registering the
+    # experiment
+    orion.core.cli.main(
+        ("init_only -n {name} --branch {branch} ./black_box_with_y.py "
+         "-x~uniform(0,10) "
+         "-w~fidelity(1,10)").format(name=name, branch=branch).split(" "))
 
 
 def test_init_w_version_from_parent_w_children(clean_db, monkeypatch):

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -384,6 +384,7 @@ class TestASHA():
         """Test that ASHA opts out when last rung is full."""
         asha.brackets = [bracket]
         bracket.asha = asha
+        bracket.rungs[1] = rung_1
         bracket.rungs[2] = rung_2
 
         points = asha.suggest()

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -528,10 +528,18 @@ class TestFidelity(object):
         assert "Base should be greater than 1" == str(exc.value)
 
     def test_sampling(self):
-        """Make sure Fidelity simply returns `fidelity`"""
+        """Make sure Fidelity simply returns `high`"""
         dim = Fidelity('epoch', 1, 2)
+        assert dim.sample() == [2]
+        dim = Fidelity('epoch', 1, 5)
+        assert dim.sample() == [5]
 
-        assert dim.sample() == ['fidelity']
+    def test_default_value(self):
+        """Make sure Fidelity simply returns `high`"""
+        dim = Fidelity('epoch', 1, 2)
+        assert dim.default_value == 2
+        dim = Fidelity('epoch', 1, 5)
+        assert dim.default_value == 5
 
     def test_contains(self):
         """Make sure fidelity.__contains__ tests based on (min, max)"""


### PR DESCRIPTION
### Improve documentation of ASHA
Why:

There was no documentation on the fact that ASHA requires the
SubParallelStrategy. There was also no documentation at all about the
parallel strategies...

### Stop producer.produce when algo is done
Why:

If an algo is done, but only *realizes* during an update in `produce`,
then the algo will opt out indefinitely and the process will crash. This
should be handled and leave gracefully.

How:

Check for algo.is_done at each loop iteration in `produce` and stop if
True.

### Add default_value to fidelity 
Why:

The EVC is using the default_value to build adapters. Also this default
value can be used as a fall-back if the algorithms does not support
multi-fidelity optimization. This is handy is we want to try different
algorithms with the same experiment configuration.

### Fix ASHA termination condition
Why:

The termination condition was wrong and would stop when the penultimate
rung was filled, making it impossible to ever run the final trial with
max resources.