### PR TITLE
Avoid branching in `info`

### DIFF
--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -247,13 +247,15 @@ class ReadOnlyStorageProtocol(object):
 
     __slots__ = ('_storage', )
     valid_attributes = {
+        'get_trial',
         'fetch_trials',
         'fetch_experiments',
         'count_broken_trials',
         'count_completed_trials',
         'fetch_noncompleted_trials',
         'fetch_pending_trials',
-        'fetch_lost_trials'
+        'fetch_lost_trials',
+        'fetch_trial_by_status'
     }
 
     def __init__(self, protocol):

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -156,6 +156,18 @@ def one_experiment(monkeypatch, db_instance):
 
 
 @pytest.fixture
+def one_experiment_changed_vcs(one_experiment):
+    """Create an experiment without trials."""
+    experiment = ExperimentBuilder().build_from({'name': one_experiment['name']})
+
+    experiment.metadata['VCS'] = {
+        'type': 'git', 'is_dirty': False, 'HEAD_sha': 'new', 'active_branch': 'master',
+        'diff_sha': None}
+
+    get_storage().update_experiment(experiment, metadata=experiment.metadata)
+
+
+@pytest.fixture
 def one_experiment_no_version(monkeypatch, one_experiment):
     """Create an experiment without trials."""
     one_experiment['name'] = one_experiment['name'] + '-no-version'

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the info command."""
+import pytest
+
 import orion.core.cli
+import orion.core.io.resolve_config
 
 
 def test_info_no_hit(clean_db, one_experiment, capsys):
     """Test info if no experiment with given name."""
-    orion.core.cli.main(['info', '--name', 'i do not exist'])
+    with pytest.raises(SystemExit) as exc:
+        orion.core.cli.main(['info', '--name', 'i do not exist'])
+
+    assert str(exc.value) == '1'
 
     captured = capsys.readouterr().out
 
-    assert captured == 'Error: No commandline configuration found for new experiment.\n'
+    assert captured == 'Experiment i do not exist not found in db.\n'
 
 
 def test_info_hit(clean_db, one_experiment, capsys):
@@ -29,3 +35,15 @@ def test_info_broken(clean_db, broken_refers, capsys):
     captured = capsys.readouterr().out
 
     assert '--x~uniform(0,1)' in captured
+
+
+def test_info_no_branching(clean_db, one_experiment_changed_vcs, capsys):
+    """Test info if config file is different
+
+    Version should not increase!
+    """
+    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+
+    captured = capsys.readouterr().out
+
+    assert '\nversion: 1\n' in captured

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -440,13 +440,25 @@ def test_format_metadata():
     experiment.metadata = dict(
         user='user',
         datetime='now',
-        orion_version='1.0.1')
+        orion_version='1.0.1',
+        VCS=dict(
+            HEAD_sha='sha',
+            active_branch='branch',
+            diff_sha='smt',
+            is_dirty=True,
+            type='git'))
     assert format_metadata(experiment) == """\
 Meta-data
 =========
 user: user
 datetime: now
 orion version: 1.0.1
+VCS:
+  HEAD_sha: sha
+  active_branch: branch
+  diff_sha: smt
+  is_dirty: True
+  type: git
 """
 
 
@@ -569,7 +581,13 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment.metadata.update(dict(
         user='user',
         datetime='now',
-        orion_version='1.0.1'))
+        orion_version='1.0.1',
+        VCS=dict(
+            HEAD_sha='sha',
+            active_branch='branch',
+            diff_sha='smt',
+            is_dirty=True,
+            type='git')))
 
     ROOT_NAME = 'root-name'
     PARENT_NAME = 'parent-name'
@@ -639,6 +657,12 @@ Meta-data
 user: user
 datetime: now
 orion version: 1.0.1
+VCS:
+  HEAD_sha: sha
+  active_branch: branch
+  diff_sha: smt
+  is_dirty: True
+  type: git
 
 
 Parent experiment


### PR DESCRIPTION
Why:

When something is different in the environment, the experiment may
branch since we are not using a `View` in `info`. We should rather use a
view but for now they don't have access to instantiated space and
algorithms which are required by `info`.

How:

Use a view and reconfigure it to instantiate the space and algo. This is
not done by default in `View` because they crash if the users scripts in
the experiment are not present on the current FS. At least now this only
happens in `info`, which was already the case anyway since we were not
using a `View`.