### PR TITLE
Add env-vars to consumer

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -18,6 +18,7 @@
    user/monitoring
    user/searchspace
    user/algorithms
+   user/script
    user/evc
 
 .. toctree::

--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -1,0 +1,127 @@
+******************
+Script Integration
+******************
+
+This section describes how to adapt the integration of the user script with Oríon.
+To customize how Oríon parses the commandline or execution environment see :ref:`customization`.
+If the user script requires information about the running trial, such as its id,
+the working directory or the experiment's name, look at :ref:`commandline_templates` or
+:ref:`env_vars`.
+
+.. _customization:
+
+Orion customization
+===================
+
+``user_script_config``
+----------------------
+
+By default Oríon will only consider the file passed through the argument ``--config`` as a
+configuration file for the user script. However, it is possible to change the default argument
+inside the global configuration file of Oríon through the ``user_script_config`` argument, like
+this:
+
+.. code-block:: yaml
+
+    user_script_config: configuration
+
+.. code-block:: console
+
+   orion hunt --config my_orion_config.yaml ./my_script --configuration my_script_config.txt
+
+As you can see, the configuration file for the user script is now passed through
+``--configuration``.
+
+.. note::
+
+   This value of ``user_script_config`` is only configurable from the global configuration yaml file
+   at the moment.
+
+``working_dir``
+---------------
+
+By default the working directory where trial configuration scripts are saved will be a temporary
+folder that is deleted at end of execution of the trial. To keep the data in a particular folder,
+you can specify ``--working-dir`` or define it in the configuration file, either the global one or
+the local one passed to
+``hunt --config <file_path>``. This working directory is where all trial directories will be
+created. To access the particular working directory of a trial, see next sections
+:ref:`commandline_templates` and :ref:`env_vars`.
+
+.. _commandline_templates:
+
+Command-line templating
+=======================
+
+When parsing the commandline of the experiment to execute a trial, Oríon will replace any
+templates referencing the experiment or the trial. This means that execution of the following line
+
+.. code-block:: console
+
+   orion hunt [...] ./my_script [...] --dir '{trial.working_dir}'
+
+
+would replace ``{trial.working_dir}`` with the actual path of the trial's working dir. Since it is
+using templating, you can place the templates wherever you want including formats such as
+
+.. code-block:: console
+
+   orion hunt [...] ./my_script [...] --some-arg some-weird-{exp.name}-{trial.id}-value
+
+
+Here is a list of convenient attributes of the ``Experiment`` and ``Trial`` objects which
+are available through templates.
+
+========================== ====================================
+Templates                  Description
+========================== ====================================
+``exp.id``                 ID of the experiment
+
+``exp.name``               Name of the experiment
+
+``exp.version``            Version of the experiment
+
+``exp.working_dir``        Global working dir of the experiment
+
+``trial.id``               Unique ID of the trial
+
+``trial.working_dir``      Working dir of the trial
+========================== ====================================
+
+.. note::
+
+   Templates are only supported in commandline and not in user script at the moment.
+   We plan to support both in the future. Contributions are very welcome. :)
+
+.. _env_vars:
+
+Environment variables
+=====================
+
+When executing the trial, Oríon will set local environment variables available to the user script.
+We list them below.
+
+.. envvar:: ORION_EXPERIMENT_ID
+
+   Current experiment that is being ran.
+
+.. envvar::  ORION_EXPERIMENT_NAME
+
+   Name of the experiment the worker is currently working on.
+
+.. envvar::  ORION_EXPERIMENT_VERSION
+
+   Version of the experiment the worker is currently working on.
+
+.. envvar:: ORION_TRIAL_ID
+
+   Current trial id that is currently being executed in this process.
+
+.. envvar:: ORION_WORKING_DIRECTORY
+
+   Trial's current working directory.
+
+.. envvar:: ORION_RESULTS_PATH
+
+   Trial's results file that is read by the legacy protocol to get the results of the trial
+   after a successful run.

--- a/docs/src/user/searchspace.rst
+++ b/docs/src/user/searchspace.rst
@@ -149,21 +149,10 @@ Configuration file
 You can use configuration files to define search space with placeholder
 ``'orion~dist(*args, **kwargs)'`` in yaml and json files or
 ``name~dist(*args, **kwargs)`` in any other text-based file.
+
 By default Oríon will only consider the file passed through the argument ``--config`` as a
-configuration file for the user script. However, it is possible to change the default argument
-inside the configuration file of Oríon through the `user_script_config` argument, like this:
-
-.. code-block:: yaml
-
-    user_script_config: configuration
-
-
-.. code-block:: console
-
-   orion hunt --config my_orion_config.yaml ./my_script --configuration my_script_config.txt
-
-As you can see, the configuration file for the user script is now passed through `--configuration`.
-
+configuration file for the user script. To change this behavior, take a look at the documentation
+:ref:`here <customization>`.
 This should not be confused with the argument ``--config`` of ``orion hunt``,
 which is the configuration of Oríon. We are here referring the configuration of the user script,
 represented with ``my_script_config.txt`` in the following example.

--- a/tests/functional/demo/black_box.py
+++ b/tests/functional/demo/black_box.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Simple one dimensional example for a possible user's script."""
 import argparse
+import os
 
 from orion.client import report_results
 
@@ -17,7 +18,21 @@ def execute():
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
     parser.add_argument('-x', type=float, required=True)
+    parser.add_argument('--test-env', action='store_true')
+    parser.add_argument('--experiment-id', type=str)
+    parser.add_argument('--experiment-name', type=str)
+    parser.add_argument('--experiment-version', type=str)
+    parser.add_argument('--trial-id', type=str)
+    parser.add_argument('--working-dir', type=str)
+
     inputs = parser.parse_args()
+
+    if inputs.test_env:
+        assert inputs.experiment_id == os.environ['ORION_EXPERIMENT_ID']
+        assert inputs.experiment_name == os.environ['ORION_EXPERIMENT_NAME']
+        assert inputs.experiment_version == os.environ['ORION_EXPERIMENT_VERSION']
+        assert inputs.trial_id == os.environ['ORION_TRIAL_ID']
+        assert inputs.working_dir == os.environ['ORION_WORKING_DIR']
 
     # 2. Perform computations
     y, dy = function(inputs.x)

--- a/tests/functional/demo/black_box_w_config.py
+++ b/tests/functional/demo/black_box_w_config.py
@@ -22,7 +22,7 @@ def execute():
     inputs = parser.parse_args()
 
     with open(inputs.config, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
 
     # 2. Perform computations
     y, dy = function(config['x'])

--- a/tests/functional/demo/black_box_w_config_other.py
+++ b/tests/functional/demo/black_box_w_config_other.py
@@ -22,7 +22,7 @@ def execute():
     inputs = parser.parse_args()
 
     with open(inputs.configuration, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
 
     # 2. Perform computations
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -398,16 +398,13 @@ def test_run_with_parallel_strategy(database, monkeypatch, strategy):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     with open('strategy_config.yaml') as f:
-        config = yaml.load(f.read())
+        config = yaml.safe_load(f.read())
 
     config_file = '{}_strategy_config.yaml'.format(strategy)
 
     with open(config_file, 'w') as f:
         config['producer']['strategy'] = strategy
         f.write(yaml.dump(config))
-
-    with open(config_file, 'r') as f:
-        print(yaml.load(f.read()))
 
     orion.core.cli.main(["hunt", "--max-trials", "20", "--pool-size", "1",
                          "--config", config_file,


### PR DESCRIPTION
Note: Documentation missing.

### Add env-vars to consumer

Why:

The user may require the experiment name, experiment id, trial id or
working-dir through another mean than commandline arguments. The
environment variables seams a legitimate way to communicate this
information.