### PR TITLE
Handle race conditions during version increment

### DIFF
--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -19,3 +19,9 @@ class CheckError(Exception):
     """Raise when a check has failed."""
 
     pass
+
+
+class RaceCondition(Exception):
+    """Raise when a race condition occured."""
+
+    pass

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -18,11 +18,12 @@ import sys
 import orion.core
 from orion.core.cli.evc import fetch_branching_configuration
 from orion.core.evc.adapters import Adapter, BaseAdapter
-from orion.core.evc.conflicts import detect_conflicts
+from orion.core.evc.conflicts import detect_conflicts, ExperimentNameConflict
 from orion.core.io.database import DuplicateKeyError
 from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
 from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
 from orion.core.io.space_builder import SpaceBuilder
+from orion.core.utils.exceptions import RaceCondition
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import (BaseParallelStrategy,
                                         Strategy)
@@ -506,9 +507,14 @@ class Experiment:
             configuration['_id'] = self._id
             conflicts = detect_conflicts(configuration, experiment.configuration)
             must_branch = len(conflicts.get()) > 1 or branching_configuration.get('branch')
-            if must_branch and not enable_branching:
-                raise ValueError("Configuration is different and generate a "
-                                 "branching event")
+
+            name_conflict = conflicts.get([ExperimentNameConflict])[0]
+            if not name_conflict.is_resolved and not config.get('version'):
+                raise RaceCondition('There was likely a race condition during version increment.')
+
+            elif must_branch and not enable_branching:
+                raise ValueError("Configuration is different and generate a branching event")
+
             elif must_branch:
                 experiment._branch_config(conflicts, branching_configuration)
 

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -13,6 +13,7 @@ import pytest
 from orion.algo.base import BaseAlgorithm
 import orion.core
 from orion.core.io.database import DuplicateKeyError
+from orion.core.utils.exceptions import RaceCondition
 from orion.core.utils.tests import OrionState
 import orion.core.worker.experiment
 from orion.core.worker.experiment import Experiment, ExperimentView
@@ -529,8 +530,8 @@ class TestConfigProperty(object):
 
         assert not exp.is_done
 
-    def test_no_increment_when_child_exist(self, create_db_instance):
-        """Check that experiment is not incremented when asked for v1 while v2 exists."""
+    def test_new_child_with_branch(self):
+        """Check that experiment is not incremented when branching with a new name."""
         user_args = ['--x~normal(0,1)']
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
@@ -538,13 +539,6 @@ class TestConfigProperty(object):
 
         get_storage().create_experiment(config)
         original = Experiment('experiment_test', version=1)
-
-        config['version'] = 2
-        config['metadata']['user_args'].append("--y~+normal(0,1)")
-        config.pop('_id')
-
-        get_storage().create_experiment(config)
-        config.pop('_id')
 
         config['branch'] = ['experiment_2']
         config['metadata']['user_args'].pop()
@@ -555,38 +549,133 @@ class TestConfigProperty(object):
 
         assert exp.version == 1
         assert '/z' in exp.space
-        assert '/y' not in exp.space
         assert exp.refers['parent_id'] == original.id
 
-    def test_old_experiment_wout_version(self, create_db_instance, parent_version_config,
+    def test_no_increment_when_child_exist(self):
+        """Check that experiment cannot be incremented when asked for v1 while v2 exists."""
+        user_args = ['--x~normal(0,1)']
+        metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
+        algorithms = {'random': {'seed': None}}
+        config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+
+        get_storage().create_experiment(config)
+        parent_id = config.pop('_id')
+
+        config['version'] = 2
+        config['metadata']['user_args'].append("--y~+normal(0,1)")
+        config['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
+
+        get_storage().create_experiment(config)
+        config.pop('_id')
+
+        config['metadata']['user_args'].pop()
+        config['metadata']['user_args'].append("--z~+normal(0,1)")
+        config['version'] = 1
+        config.pop('refers')
+        exp = Experiment('experiment_test', version=1)
+
+        with pytest.raises(ValueError) as exc_info:
+            exp.configure(config)
+        assert 'Configuration is different and generates a branching' in str(exc_info.value)
+
+    def test_old_experiment_wout_version(self, parent_version_config,
                                          child_version_config):
         """Create an already existing experiment without a version."""
         algorithm = {'random': {'seed': None}}
         parent_version_config['algorithms'] = algorithm
         child_version_config['algorithms'] = algorithm
 
-        create_db_instance.write('experiments', parent_version_config)
-        create_db_instance.write('experiments', child_version_config)
+        storage = get_storage()
+        storage.create_experiment(parent_version_config)
+        storage.create_experiment(child_version_config)
 
         exp = Experiment("old_experiment", user="corneauf")
         exp.configure(child_version_config)
 
         assert exp.version == 2
 
-    def test_old_experiment_w_version(self, create_db_instance, parent_version_config,
+    def test_old_experiment_w_version(self, parent_version_config,
                                       child_version_config):
         """Create an already existing experiment with a version."""
         algorithm = {'random': {'seed': None}}
         parent_version_config['algorithms'] = algorithm
         child_version_config['algorithms'] = algorithm
 
-        create_db_instance.write('experiments', parent_version_config)
-        create_db_instance.write('experiments', child_version_config)
+        storage = get_storage()
+        storage.create_experiment(parent_version_config)
+        storage.create_experiment(child_version_config)
 
         exp = Experiment("old_experiment", user="corneauf", version=1)
         exp.configure(parent_version_config)
 
         assert exp.version == 1
+
+    def test_race_condition_w_version(self):
+        """Test that an experiment loosing the race condition during version increment cannot
+        be resolved automatically if a version number was specified.
+
+        Note that if we would raise RaceCondition, the conflict would still occur since
+        the version number fetched will not be the new one from the resolution but the requested
+        one. Therefore raising and handling RaceCondition would lead to infinite recursion in
+        the experiment builder.
+        """
+        user_args = ['--x~normal(0,1)']
+        metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
+        algorithms = {'random': {'seed': None}}
+        config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+
+        get_storage().create_experiment(config)
+        parent_id = config.pop('_id')
+
+        looser = Experiment('experiment_test', version=1)
+
+        # Simulate exp2 winning the race condition
+        config2 = copy.deepcopy(config)
+        config2['version'] = 2
+        config2['metadata']['user_args'].append("--y~+normal(0,1)")
+        config2['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
+        get_storage().create_experiment(config2)
+
+        # Now exp3 losses the race condition
+        config3 = copy.deepcopy(config)
+        config3['metadata']['user_args'].pop()
+        config3['metadata']['user_args'].append("--z~+normal(0,1)")
+        config3['version'] = 1
+
+        with pytest.raises(ValueError) as exc_info:
+            looser.configure(config3)
+        assert 'Configuration is different and generates a branching' in str(exc_info.value)
+
+    def test_race_condition_wout_version(self):
+        """Test that an experiment loosing the race condition during version increment raises
+        RaceCondition if version number was not specified.
+        """
+        user_args = ['--x~normal(0,1)']
+        metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
+        algorithms = {'random': {'seed': None}}
+        config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+
+        get_storage().create_experiment(config)
+        parent_id = config.pop('_id')
+
+        looser = Experiment('experiment_test', version=1)
+
+        # Simulate exp2 winning the race condition
+        config2 = copy.deepcopy(config)
+        config2['version'] = 2
+        config2['metadata']['user_args'].append("--y~+normal(0,1)")
+        config2['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
+        get_storage().create_experiment(config2)
+
+        # Now exp3 losses the race condition
+        config3 = copy.deepcopy(config)
+        config3['metadata']['user_args'].pop()
+        config3['metadata']['user_args'].append("--z~+normal(0,1)")
+        config3.pop('version')
+
+        with pytest.raises(RaceCondition) as exc_info:
+            looser.configure(config3)
+        assert 'There was likely a race condition' in str(exc_info.value)
 
 
 class TestReserveTrial(object):


### PR DESCRIPTION
Why:

If 2 experiments are created simultaneously and both lead to the same
version increment, one may be created as version=1 and then fail to
resolve the name conflict because version=2 has been registered
meanwhile. This should be resolved by raising an error signaling a race
condition to force the experiment builder to restart the experiment
creation from scratch, as it is done to handle race conditions for
experiment registration during experiment creation.

How:

During conflict detection in experiment.configure, if the
ExperimentNameConflict is not resolved and version number was not
requested (experiment should take last version), then we raise a
RaceCondition error to signal the race condition.