### PR TITLE
Add functional tests for backward-compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,13 @@ jobs:
         dist: xenial
         sudo: true
       - <<: *test
-        env: TOXENV=demo_random
+        env: TOXENV=demo-random
+        python: 3.6
+      - <<: *test
+        env: TOXENV=backward-compatibility, ORION_DB_TYPE=mongodb
+        python: 3.6
+      - <<: *test
+        env: TOXENV=backward-compatibility, ORION_DB_TYPE=pickleddb
         python: 3.6
       - stage: packaging
         env: TOXENV=packaging

--- a/src/orion/core/cli/test_db.py
+++ b/src/orion/core/cli/test_db.py
@@ -42,18 +42,16 @@ def main(args):
     operations_stage = OperationsStage(creation_stage)
     stages = [presence_stage, creation_stage, operations_stage]
 
-    try:
-        for stage in stages:
-            for check in stage.checks():
-                print(check.__doc__, end='.. ')
+    for stage in stages:
+        for check in stage.checks():
+            print(check.__doc__, end='.. ')
+            try:
                 status, msg = check()
                 print(status)
-
                 if status == "Skipping":
                     print(msg)
+            except CheckError as ex:
+                print("Failure")
+                print(ex)
 
-            stage.post_stage()
-
-    except CheckError as ex:
-        print("Failure")
-        print(ex)
+        stage.post_stage()

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -149,6 +149,20 @@ class EphemeralCollection(object):
         self._indexes = dict()
         self.create_index('_id', unique=True)
 
+    def __setstate__(self, state):
+        """Set state while ensuring backward compatibility"""
+        self._documents = state['_documents']
+
+        # if indexes are from <=v0.1.6
+        if state['_indexes'] and isinstance(next(iter(state['_indexes'].keys())), tuple):
+            self._indexes = dict()
+            for keys in state['_indexes'].keys():
+                # Re-introduce fake ordering
+                keys = [(key, None) for key in keys]
+                self.create_index(keys, unique=True)
+        else:
+            self._indexes = state['_indexes']
+
     def create_index(self, keys, unique=False):
         """Create given indexes if they do not already exist for this collection.
 

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.utils.backward` -- Backward compatibility utils
+================================================================
+
+.. module:: info
+   :platform: Unix
+   :synopsis: Helper functions to support backward compatibility
+
+"""
+
+import orion.core
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
+
+
+def populate_priors(metadata):
+    """Compute parser state and priors based on user_args and populate metadata."""
+    if 'user_args' not in metadata:
+        return
+
+    parser = OrionCmdlineParser(orion.core.config.user_script_config)
+    parser.parse(metadata["user_args"])
+    metadata["parser"] = parser.get_state_dict()
+    metadata["priors"] = dict(parser.priors)

--- a/src/orion/core/utils/tests.py
+++ b/src/orion/core/utils/tests.py
@@ -14,25 +14,15 @@ import tempfile
 
 import yaml
 
-import orion.core
 from orion.core.io.database import Database
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.mongodb import MongoDB
 from orion.core.io.database.pickleddb import PickledDB
-from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils import SingletonAlreadyInstantiatedError
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage, Storage
 from orion.storage.legacy import Legacy
-
-
-def populate_parser_fields(config):
-    """Compute parser state and priors based on user_args and populate metadata."""
-    parser = OrionCmdlineParser(orion.core.config.user_script_config)
-    parser.parse(config["metadata"]["user_args"])
-    config["metadata"]["parser"] = parser.get_state_dict()
-    config["metadata"]["priors"] = dict(parser.priors)
 
 
 def _select(lhs, rhs):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -23,6 +23,7 @@ from orion.core.io.database import DuplicateKeyError
 from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
 from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
 from orion.core.io.space_builder import SpaceBuilder
+import orion.core.utils.backward as backward
 from orion.core.utils.exceptions import RaceCondition
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import (BaseParallelStrategy,
@@ -150,6 +151,9 @@ class Experiment:
 
             config = sorted(config, key=lambda x: x['metadata']['datetime'],
                             reverse=True)[0]
+
+            backward.populate_priors(config['metadata'])
+
             for attrname in self.__slots__:
                 if not attrname.startswith('_') and attrname in config:
                     setattr(self, attrname, config[attrname])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 from orion.core.worker.trial import Trial
 from orion.storage.base import Storage
 from orion.storage.legacy import Legacy
@@ -169,7 +169,7 @@ def exp_config():
     for config in exp_config[0]:
         config["metadata"]["user_script"] = os.path.join(
             os.path.dirname(__file__), config["metadata"]["user_script"])
-        populate_parser_fields(config)
+        backward.populate_priors(config['metadata'])
         config['version'] = 1
 
     return exp_config

--- a/tests/functional/backward_compatibility/black_box.py
+++ b/tests/functional/backward_compatibility/black_box.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Simple one dimensional example with noise level for a possible user's script."""
+import argparse
+import random
+
+from orion.client import report_results
+
+
+def function(x, noise):
+    """Evaluate partial information of a quadratic."""
+    z = (x - 34.56789) * random.gauss(0, noise)
+    return 4 * z**2 + 23.4, 8 * z
+
+
+def execute():
+    """Execute a simple pipeline as an example."""
+    # 1. Receive inputs as you want
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument('--fidelity', type=int, default=10)
+    inputs = parser.parse_args()
+
+    assert 0 <= inputs.fidelity <= 10
+
+    noise = (1 - inputs.fidelity / 10) + 0.0001
+
+    # 2. Perform computations
+    y, dy = function(inputs.x, noise)
+
+    # 3. Gather and report results
+    results = list()
+    results.append(dict(
+        name='example_objective',
+        type='objective',
+        value=y))
+    results.append(dict(
+        name='example_gradient',
+        type='gradient',
+        value=[dy]))
+
+    report_results(results)
+
+
+if __name__ == "__main__":
+    execute()

--- a/tests/functional/backward_compatibility/random.yaml
+++ b/tests/functional/backward_compatibility/random.yaml
@@ -1,0 +1,6 @@
+pool_size: 1
+max_trials: 10
+
+algorithms:
+  random:
+    seed: 1

--- a/tests/functional/backward_compatibility/test_versions.py
+++ b/tests/functional/backward_compatibility/test_versions.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform functional tests to verify backward compatibility."""
+import os
+import shutil
+import subprocess
+
+from pymongo import MongoClient
+import pytest
+
+
+DIRNAME = os.path.dirname(os.path.abspath(__file__))
+
+SCRIPT_PATH = os.path.join(DIRNAME, 'black_box.py')
+CONFIG_FILE = os.path.join(DIRNAME, 'random.yaml')
+
+
+def get_package(version):
+    """Get package name based on version.
+
+    Package changed to orion instead of orion.core at 0.1.6
+    """
+    if version >= '0.1.6':
+        return 'orion'
+
+    return 'orion.core'
+
+
+# Ignore pre-0.1.3 because there was no PickleDB backend.
+VERSIONS = ['0.1.3', '0.1.4', '0.1.5', '0.1.6']
+
+
+def clean_mongodb():
+    """Clean collections."""
+    client = MongoClient(username='user', password='pass', authSource='orion_test')
+    database = client.orion_test
+    database.experiments.drop()
+    database.lying_trials.drop()
+    database.trials.drop()
+    database.workers.drop()
+    database.resources.drop()
+    client.close()
+
+
+def set_env():
+    """Set the env vars for the db.
+
+    Notes
+    -----
+    This function expects the env var ORION_DB_TYPE to be set.
+
+    """
+    db_type = os.environ['ORION_DB_TYPE']
+    if db_type == 'pickleddb':
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'save.pkl')
+        os.environ['ORION_DB_ADDRESS'] = file_path
+        if os.path.exists(file_path):
+            os.remove(file_path)
+    elif db_type == 'mongodb':
+        os.environ['ORION_DB_ADDRESS'] = 'mongodb://user:pass@localhost'
+        os.environ['ORION_DB_NAME'] = 'orion_test'
+        clean_mongodb()
+
+
+def execute(command):
+    """Execute a command and return the decoded stdout."""
+    out = subprocess.check_output(command.split())
+    return out.decode('utf-8')
+
+
+def setup_virtualenv(version):
+    """Create a virtualenv and install Oríon in it for the given version"""
+    virtualenv_dir = get_virtualenv_dir(version)
+    if os.path.exists(virtualenv_dir):
+        shutil.rmtree(virtualenv_dir)
+    execute('virtualenv {}'.format(virtualenv_dir))
+    command = '{}/bin/pip install --ignore-installed {}=={}'.format(
+        virtualenv_dir, get_package(version), version)
+    execute(command)
+
+
+def get_version(orion_script):
+    """Get Oríon version for given Oríon executer's path."""
+    command = '{} --version'.format(orion_script)
+    stdout = subprocess.check_output(command, shell=True)
+
+    return stdout.decode('utf-8').strip('\n')
+
+
+def get_virtualenv_dir(version):
+    """Get virtualenv directory for given version."""
+    return 'version-{}'.format(version)
+
+
+@pytest.fixture(scope='class', params=VERSIONS)
+def fill_db(request):
+    """Add experiments and trials in DB for given version of Oríon."""
+    set_env()
+
+    version = request.param
+
+    setup_virtualenv(version)
+
+    orion_script = os.path.join(get_virtualenv_dir(version), 'bin', 'orion')
+
+    orion_version = get_version(orion_script)
+    assert orion_version == 'orion {}'.format(version)
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'init_only', '--name', 'init',
+        '--config', CONFIG_FILE,
+        SCRIPT_PATH, '-x~uniform(-50,50)'])))
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'init_only', '--name', 'init',
+        '--branch', 'init-branch-old',
+        '--config', CONFIG_FILE])))
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'hunt', '--name', 'hunt',
+        '--config', CONFIG_FILE,
+        SCRIPT_PATH, '-x~uniform(-50,50)'])))
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'hunt', '--name', 'hunt',
+        '--branch', 'hunt-branch-old',
+        '--config', CONFIG_FILE])))
+
+    orion_version = get_version('orion')
+    assert orion_version != 'orion {}'.format(version)
+
+
+@pytest.mark.usefixtures('fill_db')
+class TestBackwardCompatibility:
+    """Tests for backward compatibility between Oríon versions."""
+
+    def test_db(self):
+        """Verify test-db command"""
+        out = execute('orion test-db')
+        assert 'Failure' not in out
+
+    def test_list(self):
+        """Verify list command"""
+        out = execute('orion list')
+        assert 'init-v1' in out
+        assert 'init-branch-old-v1' in out
+        assert 'hunt-v1' in out
+        assert 'hunt-branch-old-v1' in out
+
+    def test_status(self):
+        """Verify status command"""
+        out = execute('orion status')
+        assert 'init-v1' in out
+        assert 'init-branch-old-v1' in out
+        assert 'hunt-v1' in out
+        assert 'hunt-branch-old-v1' in out
+
+    def test_info(self):
+        """Verify info command"""
+        out = execute('orion info --name hunt')
+        assert 'name: hunt' in out
+
+    def test_init_only(self):
+        """Verify init_only command"""
+        print(execute(' '.join([
+            'orion', 'init_only', '--name', 'init',
+            '--branch', 'init-branch'])))
+
+    def test_hunt(self):
+        """Verify hunt command"""
+        print(execute(' '.join([
+            'orion', 'hunt', '--name', 'hunt',
+            '--branch', 'hunt-branch'])))
+
+    # orion.core.cli.main('init-only') # TODO: deprecate init_only

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -11,7 +11,7 @@ from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
 import orion.core.cli
 from orion.core.io.database import Database
 from orion.core.io.experiment_builder import ExperimentBuilder
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage
 
@@ -90,7 +90,7 @@ def exp_config():
         exp_config = list(yaml.safe_load_all(f))
 
     for config in exp_config[0]:
-        populate_parser_fields(config)
+        backward.populate_priors(config['metadata'])
 
     return exp_config
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -13,7 +13,7 @@ import yaml
 
 import orion.core.cli
 from orion.core.io.experiment_builder import ExperimentBuilder
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 from orion.core.worker import workon
 from orion.core.worker.experiment import Experiment
 
@@ -204,7 +204,7 @@ def test_workon(database):
     config['metadata']['user_script'] = os.path.abspath(os.path.join(
         os.path.dirname(__file__), "black_box.py"))
     config['metadata']['user_args'] = ["-x~uniform(-50, 50)"]
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
     experiment.configure(config)
 
     workon(experiment)

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -12,7 +12,8 @@ from orion.algo.space import (Categorical, Integer, Real, Space)
 from orion.core.evc import conflicts
 from orion.core.io.convert import (JSONConverter, YAMLConverter)
 from orion.core.io.space_builder import DimensionBuilder
-from orion.core.utils.tests import default_datetime, MockDatetime, populate_parser_fields
+import orion.core.utils.backward as backward
+from orion.core.utils.tests import default_datetime, MockDatetime
 from orion.core.worker.experiment import Experiment
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -205,7 +206,7 @@ def new_config():
                   ['--new~normal(0,2)', '--changed~normal(0,2)'],
                   'user': 'some_user_name'})
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     return config
 
@@ -228,7 +229,7 @@ def old_config(create_db_instance):
                   ['--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
                   'user': 'some_user_name'})
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     create_db_instance.write('experiments', config)
     return config
@@ -308,7 +309,7 @@ def cli_conflict(old_config, new_config):
     new_config = copy.deepcopy(new_config)
     new_config['metadata']['user_args'].append("--some-new=args")
     new_config['metadata']['user_args'].append("--bool-arg")
-    populate_parser_fields(new_config)
+    backward.populate_priors(new_config['metadata'])
     return conflicts.CommandLineConflict(old_config, new_config)
 
 
@@ -334,7 +335,7 @@ def bad_exp_parent_config():
         version=1,
         algorithms='random')
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     return config
 

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -9,7 +9,7 @@ import pytest
 from orion.algo.space import Dimension
 from orion.core import evc
 from orion.core.evc import conflicts as conflict
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 
 
 @pytest.fixture
@@ -328,8 +328,8 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_diff_config}}
 
-        populate_parser_fields(old_config)
-        populate_parser_fields(new_config)
+        backward.populate_priors(old_config['metadata'])
+        backward.populate_priors(new_config['metadata'])
 
         conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
         assert len(conflicts) == 1
@@ -339,8 +339,8 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
 
-        populate_parser_fields(old_config)
-        populate_parser_fields(new_config)
+        backward.populate_priors(old_config['metadata'])
+        backward.populate_priors(new_config['metadata'])
 
         assert list(conflict.ScriptConfigConflict.detect(old_config, new_config)) == []
 

--- a/tests/unittests/core/test_branch_config.py
+++ b/tests/unittests/core/test_branch_config.py
@@ -14,7 +14,7 @@ from orion.core.evc.conflicts import (
     detect_conflicts, ExperimentNameConflict, MissingDimensionConflict, NewDimensionConflict,
     ScriptConfigConflict)
 from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 
 
 def filter_true(c):
@@ -66,7 +66,7 @@ def parent_config(user_config):
 
     config['metadata']['user_args'].append('--config=%s' % config_file_path)
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     yield config
     os.remove(config_file_path)
@@ -87,7 +87,7 @@ def missing_config(child_config):
     """Create a child config with a missing dimension"""
     del(child_config['metadata']['user_args'][1])  # del -x
     del(child_config['metadata']['user_args'][1])  # del -y
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -95,7 +95,7 @@ def missing_config(child_config):
 def new_config(child_config):
     """Create a child config with a new dimension"""
     child_config['metadata']['user_args'].append('-w_d~normal(0,1)')
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -105,7 +105,7 @@ def changed_config(child_config):
     second_element = child_config['metadata']['user_args'][2]
     second_element = second_element.replace('normal', 'uniform')
     child_config['metadata']['user_args'][2] = second_element
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -130,7 +130,7 @@ def same_userconfig_config(user_config, child_config):
     with open(config_file_path, 'w') as f:
         yaml.dump(user_config, f)
     child_config['metadata']['user_args'][-1] = '--config=%s' % config_file_path
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     yield child_config
     os.remove(config_file_path)
 
@@ -144,7 +144,7 @@ def changed_userconfig_config(user_config, child_config):
     with open(config_file_path, 'w') as f:
         yaml.dump(user_config, f)
     child_config['metadata']['user_args'][-1] = '--config=%s' % config_file_path
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     yield child_config
     os.remove(config_file_path)
 
@@ -153,7 +153,7 @@ def changed_userconfig_config(user_config, child_config):
 def changed_cli_config(child_config):
     """Create a child config with a changed dimension"""
     child_config['metadata']['user_args'] += ['-u=0', '--another=test', 'positional']
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -164,7 +164,7 @@ def list_arg_with_equals_cli_config(child_config):
     """
     child_config['metadata']['user_args'] += ['--args=1',
                                               '--args=2', '--args=3']
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -181,7 +181,7 @@ def cl_config(create_db_instance):
                   ['--nameless=option', '-x~>w_d', '-w_d~+normal(0,1)', '-y~+uniform(0,1)', '-z~-',
                    '--omega~+normal(0,1)'],
                   'user': 'some_user_name'})
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
     return config
 
 
@@ -318,7 +318,7 @@ class TestResolutions(object):
     def test_add_single_hit(self, parent_config, new_config):
         """Test if adding a dimension only touches the correct status"""
         del new_config['metadata']['user_args'][1]
-        populate_parser_fields(new_config)
+        backward.populate_priors(new_config['metadata'])
         conflicts = detect_conflicts(parent_config, new_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
         branch_builder.add_dimension('w_d')
@@ -373,7 +373,7 @@ class TestResolutions(object):
     def test_rename_missing(self, parent_config, missing_config):
         """Test if renaming a dimension to another solves both conflicts"""
         missing_config['metadata']['user_args'].append('-w_d~uniform(0,1)')
-        populate_parser_fields(missing_config)
+        backward.populate_priors(missing_config['metadata'])
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
         branch_builder.rename_dimension('x', 'w_d')
@@ -398,7 +398,7 @@ class TestResolutions(object):
         creates a new one which is not solved
         """
         missing_config['metadata']['user_args'].append('-w_d~normal(0,1)')
-        populate_parser_fields(missing_config)
+        backward.populate_priors(missing_config['metadata'])
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -447,8 +447,8 @@ class TestResolutions(object):
 
     def test_name_experiment(self, bad_exp_parent_config, bad_exp_child_config, create_db_instance):
         """Test if having the same experiment name does not create a conflict."""
-        populate_parser_fields(bad_exp_parent_config)
-        populate_parser_fields(bad_exp_child_config)
+        backward.populate_priors(bad_exp_parent_config['metadata'])
+        backward.populate_priors(bad_exp_child_config['metadata'])
         create_db_instance.write('experiments', bad_exp_parent_config)
         create_db_instance.write('experiments', bad_exp_child_config)
         conflicts = detect_conflicts(bad_exp_parent_config, bad_exp_parent_config)
@@ -629,7 +629,7 @@ class TestResolutionsWithMarkers(object):
     def test_add_new_default(self, parent_config, new_config):
         """Test if new dimension conflict is automatically resolved"""
         new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1,default_value=0)'
-        populate_parser_fields(new_config)
+        backward.populate_priors(new_config['metadata'])
         conflicts = detect_conflicts(parent_config, new_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -645,7 +645,7 @@ class TestResolutionsWithMarkers(object):
     def test_add_bad_default(self, parent_config, new_config):
         """Test if new dimension conflict raises an error if marked with invalid default value"""
         new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1,default_value=\'a\')'
-        populate_parser_fields(new_config)
+        backward.populate_priors(new_config['metadata'])
         with pytest.raises(TypeError) as exc:
             detect_conflicts(parent_config, new_config)
         assert "Parameter \'/w_d\': Incorrect arguments." in str(exc.value)
@@ -668,7 +668,7 @@ class TestResolutionsWithMarkers(object):
     def test_remove_missing(self, parent_config, child_config):
         """Test if missing dimension conflict is automatically resolved"""
         child_config['metadata']['user_args'][1] = '-x~-'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -683,7 +683,7 @@ class TestResolutionsWithMarkers(object):
     def test_remove_missing_default(self, parent_config, child_config):
         """Test if missing dimension conflict is automatically resolved"""
         child_config['metadata']['user_args'][1] = '-x~-0.5'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -699,7 +699,7 @@ class TestResolutionsWithMarkers(object):
     def test_remove_missing_bad_default(self, parent_config, child_config):
         """Test if missing dimension conflict raises an error if marked with invalid default"""
         child_config['metadata']['user_args'][1] = '-x~--100'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -716,7 +716,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~normal(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_a'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -740,7 +740,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~uniform(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_c'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         with pytest.raises(ValueError) as exc:
             ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
@@ -753,7 +753,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~normal(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_b'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -780,7 +780,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~+normal(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_b'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -939,7 +939,7 @@ class TestAdapters(object):
     def test_adapter_rename_missing(self, parent_config, cl_config):
         """Test if a DimensionRenaming is created when solving a new conflict"""
         cl_config['metadata']['user_args'] = ['-x~>w_d', '-w_d~+uniform(0,1)']
-        populate_parser_fields(cl_config)
+        backward.populate_priors(cl_config['metadata'])
 
         conflicts = detect_conflicts(parent_config, cl_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -9,8 +9,8 @@ import time
 import pytest
 
 from orion.core.io.experiment_builder import ExperimentBuilder
+import orion.core.utils.backward as backward
 from orion.core.utils.format_trials import tuple_to_trial
-from orion.core.utils.tests import populate_parser_fields
 import orion.core.worker.consumer as consumer
 
 
@@ -24,7 +24,7 @@ def config(exp_config):
     config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
     config['name'] = 'exp'
     config['working_dir'] = "/tmp/orion"
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
     return config
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,14 +33,25 @@ passenv = CI TRAVIS TRAVIS_*
 deps =
     -rtests/requirements.txt
     coverage
-usedevelop = True
 commands =
     pip install -U {toxinidir}/tests/functional/gradient_descent_algo
-    coverage run --parallel-mode setup.py test --addopts '--timeout=180 {posargs}'
+    coverage run --parallel-mode -m pytest -vv --ignore tests/functional/backward_compatibility --timeout=180
     coverage combine
     coverage report -m
 
-[testenv:demo_random]
+[testenv:backward-compatibility]
+description = Run all versions of Orion to assert backward compatibility
+setenv = COVERAGE_FILE=.coverage.backward_compatibility
+passenv = CI TRAVIS TRAVIS_* ORION_DB_TYPE
+deps =
+    -rtests/requirements.txt
+    coverage
+commands =
+    coverage run --parallel-mode -m pytest -vv tests/functional/backward_compatibility/test_versions.py
+    coverage combine
+    coverage report -m
+
+[testenv:demo-random]
 description = Run a demo with random search algorithm
 setenv = COVERAGE_FILE=.coverage.random
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
### Why:

During release v0.1.6 two bugs have been introduced that made it
impossible to reuse data created with v0.1.5 with the PickledDB
backend. This kind of problems should be automatically detected when
making changes in the develop branch.

### How:

For each previous versions (starting with 0.1.3), a db is created using
the old version (0.1.3, 0.1.4, etc) and then all commands are tested in
the current version (test-db, list, status, hunt, etc). The outputs are
not tested thouroughly, this should be covered by the unit-tests. The
tests here only verify that commands run successfully. All tests are run
for each db backend.

### Note:

This should fail in the PickledDB tests until #284 is merged in `develop`.