### PR TITLE
Add mention of windows in install doc

### DIFF
--- a/docs/src/install/core.rst
+++ b/docs/src/install/core.rst
@@ -2,6 +2,9 @@
 Installation of Orion's core
 ****************************
 
+Oríon should work on most Linux distributions and Mac OS X. It is tested on Ubuntu 16.04 LTS and Mac
+OS X 10.13. We do not support Windows and there is no short term plan to do so.
+
 Via PyPI
 ========
 


### PR DESCRIPTION
Why:

It was not mentioned anywhere that we only support Linux and OSX.