### PR TITLE
Save parser state in DB

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -89,8 +89,10 @@ hierarchy. From the more global to the more specific, there is:
 import copy
 import logging
 
+import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import DuplicateKeyError
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils.exceptions import NoConfigurationError, RaceCondition
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.storage.base import Storage
@@ -267,12 +269,19 @@ class ExperimentBuilder(object):
         experiment = Experiment(config['name'], config.get('user', None),
                                 config.get('version', None))
 
+        # TODO: Handle both from cmdline and python APIs.
+        if 'priors' not in config['metadata'] and 'user_args' not in config['metadata']:
+            raise NoConfigurationError
+
+        # Parse to generate priors
+        if 'user_args' in config['metadata']:
+            parser = OrionCmdlineParser(orion.core.config.user_script_config)
+            parser.parse(config['metadata']['user_args'])
+            config['metadata']['parser'] = parser.get_state_dict()
+            config['metadata']['priors'] = dict(parser.priors)
+
         # Finish experiment's configuration and write it to database.
-        try:
-            experiment.configure(config)
-        except AttributeError as ex:
-            if 'user_script' not in config['metadata']:
-                raise NoConfigurationError from ex
+        experiment.configure(config)
 
         return experiment
 

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -87,6 +87,32 @@ class OrionCmdlineParser():
         # Look for anything followed by a tilt and possible branching attributes + prior
         self.prior_regex = re.compile(r'(.+)~([\+\-\>]?.+)')
 
+    def get_state_dict(self):
+        """Give state dict that can be used to reconstruct the parser"""
+        return dict(
+            parser=self.parser.get_state_dict(),
+            cmd_priors=list(map(list, self.cmd_priors.items())),
+            file_priors=list(map(list, self.file_priors.items())),
+            config_file_data=self.config_file_data,
+            config_prefix=self.config_prefix,
+            file_config_path=self.file_config_path,
+            converter=self.converter.get_state_dict() if self.converter else None)
+
+    def set_state_dict(self, state):
+        """Reset the parser based on previous state"""
+        self.parser.set_state_dict(state['parser'])
+
+        self.cmd_priors = OrderedDict(state['cmd_priors'])
+        self.file_priors = OrderedDict(state['file_priors'])
+
+        self.config_file_data = state['config_file_data']
+        self.config_prefix = state['config_prefix']
+        self.file_config_path = state['file_config_path']
+
+        if self.file_config_path:
+            self.converter = infer_converter_from_file_type(self.file_config_path)
+            self.converter.set_state_dict(state['converter'])
+
     def parse(self, commandline):
         """Parse the commandline given for the definition of priors.
 

--- a/src/orion/core/utils/tests.py
+++ b/src/orion/core/utils/tests.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.core.utils.state` -- Encapsulate Orion state
-========================================================
+:mod:`orion.core.utils.tests` -- Utils for tests
+================================================
 .. module:: state
    :platform: Unix
-   :synopsis: Encapsulate orion state
+   :synopsis: Helper functions for tests
 
 """
 
@@ -14,15 +14,25 @@ import tempfile
 
 import yaml
 
+import orion.core
 from orion.core.io.database import Database
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.mongodb import MongoDB
 from orion.core.io.database.pickleddb import PickledDB
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils import SingletonAlreadyInstantiatedError
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage, Storage
 from orion.storage.legacy import Legacy
+
+
+def populate_parser_fields(config):
+    """Compute parser state and priors based on user_args and populate metadata."""
+    parser = OrionCmdlineParser(orion.core.config.user_script_config)
+    parser.parse(config["metadata"]["user_args"])
+    config["metadata"]["parser"] = parser.get_state_dict()
+    config["metadata"]["priors"] = dict(parser.priors)
 
 
 def _select(lhs, rhs):

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -14,7 +14,8 @@ import signal
 import subprocess
 import tempfile
 
-from orion.core.io.space_builder import SpaceBuilder
+import orion.core
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils.working_dir import WorkingDir
 from orion.core.worker.trial_pacemaker import TrialPacemaker
 
@@ -60,8 +61,8 @@ class Consumer(object):
                                " initialization.")
 
         # Fetch space builder
-        self.template_builder = SpaceBuilder()
-        self.template_builder.build_from(experiment.metadata['user_args'])
+        self.template_builder = OrionCmdlineParser(orion.core.config.user_script_config)
+        self.template_builder.set_state_dict(experiment.metadata['parser'])
         # Get path to user's script and infer trial configuration directory
         if experiment.working_dir:
             self.working_dir = os.path.abspath(experiment.working_dir)
@@ -171,7 +172,7 @@ class Consumer(object):
 
         log.debug("## Building command line argument and configuration for trial.")
         env = self.get_execution_environment(trial, results_file.name)
-        cmd_args = self.template_builder.build_to(config_file.name, trial, self.experiment)
+        cmd_args = self.template_builder.format(config_file.name, trial, self.experiment)
 
         log.debug("## Launch user's script as a subprocess and wait for finish.")
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -585,9 +585,10 @@ class Experiment:
 
             setattr(self, section, value)
 
+        # TODO: Can we get rid of this try-except clause?
         try:
             space_builder = SpaceBuilder()
-            space = space_builder.build_from(config['metadata']['user_args'])
+            space = space_builder.build(config['metadata']['priors'])
 
             if not space:
                 raise ValueError("Parameter space is empty. There is nothing to optimize.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
+from orion.core.utils.tests import populate_parser_fields
 from orion.core.worker.trial import Trial
 from orion.storage.base import Storage
 from orion.storage.legacy import Legacy
@@ -165,10 +166,11 @@ def exp_config():
     for i, t_dict in enumerate(exp_config[1]):
         exp_config[1][i] = Trial(**t_dict).to_dict()
 
-    for i, _ in enumerate(exp_config[0]):
-        exp_config[0][i]["metadata"]["user_script"] = os.path.join(
-            os.path.dirname(__file__), exp_config[0][i]["metadata"]["user_script"])
-        exp_config[0][i]['version'] = 1
+    for config in exp_config[0]:
+        config["metadata"]["user_script"] = os.path.join(
+            os.path.dirname(__file__), config["metadata"]["user_script"])
+        populate_parser_fields(config)
+        config['version'] = 1
 
     return exp_config
 

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -11,6 +11,7 @@ from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
 import orion.core.cli
 from orion.core.io.database import Database
 from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.tests import populate_parser_fields
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage
 
@@ -87,6 +88,10 @@ def exp_config():
     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
               'experiment.yaml')) as f:
         exp_config = list(yaml.safe_load_all(f))
+
+    for config in exp_config[0]:
+        populate_parser_fields(config)
+
     return exp_config
 
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -13,6 +13,7 @@ import yaml
 
 import orion.core.cli
 from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.tests import populate_parser_fields
 from orion.core.worker import workon
 from orion.core.worker.experiment import Experiment
 
@@ -203,6 +204,7 @@ def test_workon(database):
     config['metadata']['user_script'] = os.path.abspath(os.path.join(
         os.path.dirname(__file__), "black_box.py"))
     config['metadata']['user_args'] = ["-x~uniform(-50, 50)"]
+    populate_parser_fields(config)
     experiment.configure(config)
 
     workon(experiment)
@@ -466,11 +468,14 @@ def test_resilience(monkeypatch):
     """Test if Oríon stops after enough broken trials."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
+    MAX_BROKEN = 3
+    orion.core.config.worker.max_broken = 3
+
     orion.core.cli.main(["hunt", "--config", "./orion_config_random.yaml", "./broken_box.py",
                          "-x~uniform(-50, 50)"])
 
     exp = ExperimentBuilder().build_from({'name': 'demo_random_search'})
-    assert len(exp.fetch_trials_by_status('broken')) == 3
+    assert len(exp.fetch_trials_by_status('broken')) == MAX_BROKEN
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/tests/functional/gradient_descent_algo/setup.py
+++ b/tests/functional/gradient_descent_algo/setup.py
@@ -19,7 +19,7 @@ setup_args = dict(
             'gradient_descent = orion.algo.gradient_descent:Gradient_Descent'
             ],
         },
-    install_requires=['orion.core'],
+    install_requires=['orion'],
     setup_requires=['setuptools'],
     # "Zipped eggs don't play nicely with namespace packaging"
     # from https://github.com/pypa/sample-namespace-packages

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -12,7 +12,7 @@ from orion.algo.space import (Categorical, Integer, Real, Space)
 from orion.core.evc import conflicts
 from orion.core.io.convert import (JSONConverter, YAMLConverter)
 from orion.core.io.space_builder import DimensionBuilder
-from orion.core.utils.tests import default_datetime, MockDatetime
+from orion.core.utils.tests import default_datetime, MockDatetime, populate_parser_fields
 from orion.core.worker.experiment import Experiment
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -20,6 +20,7 @@ YAML_SAMPLE = os.path.join(TEST_DIR, 'sample_config.yml')
 YAML_DIFF_SAMPLE = os.path.join(TEST_DIR, 'sample_config_diff.yml')
 JSON_SAMPLE = os.path.join(TEST_DIR, 'sample_config.json')
 UNKNOWN_SAMPLE = os.path.join(TEST_DIR, 'sample_config.txt')
+UNKNOWN_TEMPLATE = os.path.join(TEST_DIR, 'sample_config_template.txt')
 
 
 @pytest.fixture(scope='session')
@@ -62,6 +63,12 @@ def json_config(json_sample_path):
 def unknown_type_sample_path():
     """Return path with a sample file of unknown configuration filetype."""
     return UNKNOWN_SAMPLE
+
+
+@pytest.fixture(scope='session')
+def unknown_type_template_path():
+    """Return path with a template file of unknown configuration filetype."""
+    return UNKNOWN_TEMPLATE
 
 
 @pytest.fixture(scope='session')
@@ -188,7 +195,7 @@ def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_inst
 @pytest.fixture
 def new_config():
     """Generate a new experiment configuration"""
-    return dict(
+    config = dict(
         name='test',
         algorithms='fancy',
         version=1,
@@ -197,6 +204,10 @@ def new_config():
                   'user_args':
                   ['--new~normal(0,2)', '--changed~normal(0,2)'],
                   'user': 'some_user_name'})
+
+    populate_parser_fields(config)
+
+    return config
 
 
 @pytest.fixture
@@ -216,6 +227,8 @@ def old_config(create_db_instance):
                   'user_args':
                   ['--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
                   'user': 'some_user_name'})
+
+    populate_parser_fields(config)
 
     create_db_instance.write('experiments', config)
     return config
@@ -295,6 +308,7 @@ def cli_conflict(old_config, new_config):
     new_config = copy.deepcopy(new_config)
     new_config['metadata']['user_args'].append("--some-new=args")
     new_config['metadata']['user_args'].append("--bool-arg")
+    populate_parser_fields(new_config)
     return conflicts.CommandLineConflict(old_config, new_config)
 
 
@@ -313,12 +327,16 @@ def experiment_name_conflict(old_config, new_config):
 @pytest.fixture
 def bad_exp_parent_config():
     """Generate a new experiment configuration"""
-    return dict(
+    config = dict(
         _id='test',
         name='test',
         metadata={'user': 'corneauf', 'user_args': ['--x~normal(0,1)']},
         version=1,
         algorithms='random')
+
+    populate_parser_fields(config)
+
+    return config
 
 
 @pytest.fixture

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -9,6 +9,7 @@ import pytest
 from orion.algo.space import Dimension
 from orion.core import evc
 from orion.core.evc import conflicts as conflict
+from orion.core.utils.tests import populate_parser_fields
 
 
 @pytest.fixture
@@ -327,6 +328,9 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_diff_config}}
 
+        populate_parser_fields(old_config)
+        populate_parser_fields(new_config)
+
         conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
         assert len(conflicts) == 1
 
@@ -334,6 +338,9 @@ class TestScriptConfigConflict(object):
         """Test that identical configs are not detected as conflict."""
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
+
+        populate_parser_fields(old_config)
+        populate_parser_fields(new_config)
 
         assert list(conflict.ScriptConfigConflict.detect(old_config, new_config)) == []
 

--- a/tests/unittests/core/io/test_cmdline_parser.py
+++ b/tests/unittests/core/io/test_cmdline_parser.py
@@ -59,11 +59,11 @@ def test_parse_paths(monkeypatch):
 def test_parse_arguments(basic_config):
     """Test the parsing of the commandline arguments"""
     cmdline_parser = CmdlineParser()
-    cmdline_parser._parse_arguments(
+    arguments = cmdline_parser._parse_arguments(
         "python script.py some pos args --with args --and multiple args "
         "--plus --booleans --equal=value".split(" "))
 
-    assert cmdline_parser.arguments == basic_config
+    assert arguments == basic_config
 
 
 def test_parse_arguments_template():
@@ -86,7 +86,9 @@ def test_format(to_format):
 
     cmdline_parser.parse(to_format.split(' '))
 
-    formatted = cmdline_parser.format(cmdline_parser.arguments)
+    arguments = cmdline_parser._parse_arguments(to_format.split(' '))
+
+    formatted = cmdline_parser.format(arguments)
 
     assert formatted == to_format.split(' ')
 
@@ -116,3 +118,28 @@ def test_has_already_been_parsed():
         cmdline_parser.parse(command.split(' '))
 
     assert "already" in str(exc_info.value)
+
+
+def test_get_state_dict():
+    """Test getting state dict."""
+    cmdline_parser = CmdlineParser()
+
+    cmdline_parser.parse(
+        "python script.py some pos args "
+        "--with args --and multiple args --plus --booleans --equal=value".split(" "))
+
+    assert cmdline_parser.get_state_dict() == {
+        'arguments': list(map(list, cmdline_parser.arguments.items())),
+        'template': cmdline_parser.template}
+
+
+def test_set_state_dict():
+    """Test that set_state_dict sets state properly to generate new cmdline."""
+    cmdline_parser = CmdlineParser()
+
+    cmdline_parser.set_state_dict({
+        'arguments': {},
+        'template': ['{_pos_0}', '{_pos_1}', '--with', '{with}', '--plus', '--booleans']})
+
+    assert cmdline_parser.format({'_pos_0': 'voici', '_pos_1': 'voila', 'with': 'classe'}) == [
+        'voici', 'voila', '--with', 'classe', '--plus', '--booleans']

--- a/tests/unittests/core/io/test_converters.py
+++ b/tests/unittests/core/io/test_converters.py
@@ -187,3 +187,38 @@ a_var = o~>a_serious_name
 
 +gaussian(0, 0.1, shape=(100, 3))
 """
+
+    def test_get_state_dict(self, unknown_type_sample_path, unknown_type_template_path,
+                            generic_converter):
+        """Test getting state dict."""
+        generic_converter.parse(unknown_type_sample_path)
+        assert generic_converter.get_state_dict() == {
+            'expression_prefix': 'o~',
+            'has_leading': {
+                '/lala//iela': '/',
+                '/lala/iela': '/',
+                'lala/la': '/'},
+            'regex': '([\\/]?[\\w|\\/|-]+)~([\\+]?.*\\)|\\-|\\>[A-Za-z_]\\w*)',
+            'template': open(unknown_type_template_path, 'r').read()}
+
+    def test_set_state_dict(self, tmpdir, generic_converter):
+        """Test that set_state_dict sets state properly to generate new config."""
+        generic_converter.set_state_dict({
+            'expression_prefix': '',
+            'has_leading': {
+                'voici': '/'},
+            'regex': generic_converter.regex.pattern,
+            'template': """\
+voici = {/voici}
+voila = voici + {voila}"""})
+
+        output_file = str(tmpdir.join("output.lalal"))
+
+        generic_converter.generate(output_file, {'/voici': 'me voici', 'voila': 'me voila'})
+
+        with open(output_file) as f:
+            out = f.read()
+
+        assert out == """\
+voici = me voici
+voila = voici + me voila"""

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -248,3 +248,93 @@ def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
     assert '/training/lr0' in config
     assert '/training/mbs' in config
     assert '/something-same' in config
+
+
+def test_get_state_dict_before_parse(commandline):
+    """Test getting state dict."""
+    parser = OrionCmdlineParser()
+
+    assert parser.get_state_dict() == {
+        'parser': {
+            'arguments': [],
+            'template': []},
+        'cmd_priors': list(map(list, parser.cmd_priors.items())),
+        'file_priors': list(map(list, parser.file_priors.items())),
+        'config_file_data': parser.config_file_data,
+        'config_prefix': parser.config_prefix,
+        'file_config_path': parser.file_config_path,
+        'converter': None}
+
+
+def test_get_state_dict_after_parse_no_config_file(commandline):
+    """Test getting state dict."""
+    parser = OrionCmdlineParser()
+
+    parser.parse(commandline)
+
+    assert parser.get_state_dict() == {
+        'parser': parser.parser.get_state_dict(),
+        'cmd_priors': list(map(list, parser.cmd_priors.items())),
+        'file_priors': list(map(list, parser.file_priors.items())),
+        'config_file_data': parser.config_file_data,
+        'config_prefix': parser.config_prefix,
+        'file_config_path': parser.file_config_path,
+        'converter': None}
+
+
+def test_get_state_dict_after_parse_with_config_file(yaml_config, commandline):
+    """Test getting state dict."""
+    parser = OrionCmdlineParser()
+
+    cmd_args = yaml_config
+    cmd_args.extend(commandline)
+
+    parser.parse(cmd_args)
+
+    assert parser.get_state_dict() == {
+        'parser': parser.parser.get_state_dict(),
+        'cmd_priors': list(map(list, parser.cmd_priors.items())),
+        'file_priors': list(map(list, parser.file_priors.items())),
+        'config_file_data': parser.config_file_data,
+        'config_prefix': parser.config_prefix,
+        'file_config_path': parser.file_config_path,
+        'converter': parser.converter.get_state_dict()}
+
+
+def test_set_state_dict(parser, commandline, json_config, tmpdir, json_converter):
+    """Test that set_state_dict sets state properly to generate new config."""
+    cmd_args = json_config
+    cmd_args.extend(commandline)
+
+    parser.parse(cmd_args)
+
+    state = parser.get_state_dict()
+    parser = None
+
+    blank_parser = OrionCmdlineParser()
+
+    blank_parser.set_state_dict(state)
+
+    trial = Trial(params=[
+        {'name': '/lr', 'type': 'real', 'value': -2.4},
+        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
+        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
+        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
+        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
+        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
+        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
+        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+
+    output_file = str(tmpdir.join("output.json"))
+
+    cmd_inst = blank_parser.format(output_file, trial)
+
+    assert cmd_inst == ['--config', output_file, "--seed", "555", "--lr", "-2.4",
+                        "--non-prior", "choices({'sgd': 0.2, 'adam': 0.8})", "--prior", "sgd"]
+
+    output_data = json_converter.parse(output_file)
+    assert output_data == {'yo': 5, 'training': {'lr0': 0.032, 'mbs': 64},
+                           'layers': [{'width': 64, 'type': 'relu'},
+                                      {'width': 100, 'type': 'relu'},
+                                      {'width': 16, 'type': 'sigmoid'}],
+                           'something-same': '3'}

--- a/tests/unittests/core/sample_config_template.txt
+++ b/tests/unittests/core/sample_config_template.txt
@@ -1,0 +1,31 @@
+{lalala!s}
+
+{/lala/la!s}
+{//lala/iela!s}
+{//lala//iela!s}
+
+a:
+   b:
+    [asdfa~/Iamapath/dont_capture_me,
+      ~/Iamapath/dont_capture_me]
+
+yo:
+           {aaalispera!s}
+
+[naedw]
+a_var={a!s}
+
+~
+
+[naekei:naedw]
+other_var = ~
+# Rename it who_names_their_variables_a_seriously
+a_var = {b!s}
+
+{{'oups':
+# remove it
+'{a_serious_name!s}',
+'iela':'{another_serious_name!s}'
+}}
+
+{lala/l2a!s}

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -10,6 +10,7 @@ import pytest
 
 from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.utils.format_trials import tuple_to_trial
+from orion.core.utils.tests import populate_parser_fields
 import orion.core.worker.consumer as consumer
 
 
@@ -23,6 +24,7 @@ def config(exp_config):
     config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
     config['name'] = 'exp'
     config['working_dir'] = "/tmp/orion"
+    populate_parser_fields(config)
     return config
 
 

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -14,7 +14,7 @@ from orion.algo.base import BaseAlgorithm
 import orion.core
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.exceptions import RaceCondition
-from orion.core.utils.tests import OrionState
+from orion.core.utils.tests import OrionState, populate_parser_fields
 import orion.core.worker.experiment
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.trial import Trial
@@ -51,19 +51,26 @@ def new_config(random_dt):
         # and in general anything which is not in Experiment's slots
         something_to_be_ignored='asdfa'
         )
+
+    populate_parser_fields(new_config)
+
     return new_config
 
 
 @pytest.fixture
 def parent_version_config():
     """Return a configuration for an experiment."""
-    return dict(_id='parent_config',
-                name="old_experiment",
-                version=1,
-                algorithms='random',
-                metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
-                          'user_args': ['--x~normal(0,1)']}
-                )
+    config = dict(
+        _id='parent_config',
+        name="old_experiment",
+        version=1,
+        algorithms='random',
+        metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
+                  'user_args': ['--x~normal(0,1)']})
+
+    populate_parser_fields(config)
+
+    return config
 
 
 @pytest.fixture
@@ -75,6 +82,7 @@ def child_version_config(parent_version_config):
     config['refers'] = {'parent_id': 'parent_config'}
     config['metadata']['datetime'] = datetime.datetime.utcnow()
     config['metadata']['user_args'].append('--y~+normal(0,1)')
+    populate_parser_fields(config)
     return config
 
 
@@ -536,6 +544,7 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         original = Experiment('experiment_test', version=1)
@@ -543,6 +552,7 @@ class TestConfigProperty(object):
         config['branch'] = ['experiment_2']
         config['metadata']['user_args'].pop()
         config['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config)
         config['version'] = 1
         exp = Experiment('experiment_test', version=1)
         exp.configure(config)
@@ -557,12 +567,14 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         parent_id = config.pop('_id')
 
         config['version'] = 2
         config['metadata']['user_args'].append("--y~+normal(0,1)")
+        populate_parser_fields(config)
         config['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
 
         get_storage().create_experiment(config)
@@ -570,6 +582,7 @@ class TestConfigProperty(object):
 
         config['metadata']['user_args'].pop()
         config['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config)
         config['version'] = 1
         config.pop('refers')
         exp = Experiment('experiment_test', version=1)
@@ -623,6 +636,7 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         parent_id = config.pop('_id')
@@ -633,6 +647,7 @@ class TestConfigProperty(object):
         config2 = copy.deepcopy(config)
         config2['version'] = 2
         config2['metadata']['user_args'].append("--y~+normal(0,1)")
+        populate_parser_fields(config2)
         config2['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
         get_storage().create_experiment(config2)
 
@@ -640,6 +655,7 @@ class TestConfigProperty(object):
         config3 = copy.deepcopy(config)
         config3['metadata']['user_args'].pop()
         config3['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config3)
         config3['version'] = 1
 
         with pytest.raises(ValueError) as exc_info:
@@ -654,6 +670,7 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         parent_id = config.pop('_id')
@@ -664,6 +681,7 @@ class TestConfigProperty(object):
         config2 = copy.deepcopy(config)
         config2['version'] = 2
         config2['metadata']['user_args'].append("--y~+normal(0,1)")
+        populate_parser_fields(config2)
         config2['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
         get_storage().create_experiment(config2)
 
@@ -671,6 +689,7 @@ class TestConfigProperty(object):
         config3 = copy.deepcopy(config)
         config3['metadata']['user_args'].pop()
         config3['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config3)
         config3.pop('version')
 
         with pytest.raises(RaceCondition) as exc_info:
@@ -918,7 +937,9 @@ def test_is_done_property_with_algo(hacked_exp):
 def test_broken_property(hacked_exp):
     """Check experiment stopping conditions for maximum number of broken."""
     assert not hacked_exp.is_broken
-    trials = hacked_exp.fetch_trials()[:3]
+    MAX_BROKEN = 3
+    orion.core.config.worker.max_broken = MAX_BROKEN
+    trials = hacked_exp.fetch_trials()[:MAX_BROKEN]
 
     for trial in trials:
         get_storage().set_trial_status(trial, status='broken')
@@ -929,19 +950,18 @@ def test_broken_property(hacked_exp):
 def test_configurable_broken_property(hacked_exp):
     """Check if max_broken changes after configuration."""
     assert not hacked_exp.is_broken
-    trials = hacked_exp.fetch_trials({})[:3]
-    old_broken_value = orion.core.config.worker.max_broken
+    MAX_BROKEN = 3
+    orion.core.config.worker.max_broken = MAX_BROKEN
+    trials = hacked_exp.fetch_trials()[:MAX_BROKEN]
 
     for trial in trials:
         get_storage().set_trial_status(trial, status='broken')
 
     assert hacked_exp.is_broken
 
-    orion.core.config.worker.max_broken = 4
+    orion.core.config.worker.max_broken += 1
 
     assert not hacked_exp.is_broken
-
-    orion.core.config.worker.max_broken = old_broken_value
 
 
 def test_experiment_stats(hacked_exp, exp_config, random_dt):


### PR DESCRIPTION
Why:

We need the parser state to be able to resume the experiment without the
configuration file. It is also convenient for monitoring scripts where
the configuration file often isn't available locally.
Finally, this is a step in direction of support for python API, as the
prior dict in metadata[prior] will serve as the config used to create
the space instead of metadata[user_args]. This will uniformize how
cmdline and python APIs are handled.

How:

OrionCmdlineParser, CmdlineParser and all Converters now have
`get_state_dict()` and `set_state_dict()` methods so that we can save
the state in metadata and restore the parser without the cmdline and config file.