### PR TITLE
Turn test-db into db test

### DIFF
--- a/docs/src/code/core/cli.rst
+++ b/docs/src/code/core/cli.rst
@@ -13,5 +13,5 @@ Command lines
    cli/insert
    cli/init_only
    cli/setup
-   cli/test_db
+   cli/db
    cli/evc

--- a/docs/src/code/core/cli.rst
+++ b/docs/src/code/core/cli.rst
@@ -12,6 +12,5 @@ Command lines
    cli/hunt
    cli/insert
    cli/init_only
-   cli/setup
    cli/db
    cli/evc

--- a/docs/src/code/core/cli/db.rst
+++ b/docs/src/code/core/cli/db.rst
@@ -8,4 +8,5 @@ db commands
    :maxdepth: 1
    :caption: DB command line modules
 
-   cli/db/test
+   db/test
+   db/setup

--- a/docs/src/code/core/cli/db.rst
+++ b/docs/src/code/core/cli/db.rst
@@ -1,0 +1,11 @@
+db commands
+===========
+
+.. automodule:: orion.core.cli.db_main
+   :members:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: DB command line modules
+
+   cli/db/test

--- a/docs/src/code/core/cli/db/setup.rst
+++ b/docs/src/code/core/cli/db/setup.rst
@@ -1,5 +1,5 @@
 setup command
 =============
 
-# .. automodule:: orion.core.cli.setup
+# .. automodule:: orion.core.cli.db.setup
 #    :members:

--- a/docs/src/code/core/cli/db/test.rst
+++ b/docs/src/code/core/cli/db/test.rst
@@ -1,0 +1,5 @@
+db test command
+===============
+
+.. automodule:: orion.core.cli.db.test
+   :members:

--- a/docs/src/code/core/cli/test_db.rst
+++ b/docs/src/code/core/cli/test_db.rst
@@ -1,5 +1,0 @@
-test-db command
-===============
-
-.. automodule:: orion.core.cli.test_db
-   :members:

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -199,11 +199,11 @@ EphemeralDB has no arguments.
 Test connection
 ===============
 
-You can use the command ``orion test-db`` to test the setup of your database backend.
+You can use the command ``orion db test`` to test the setup of your database backend.
 
 .. code-block:: sh
 
-   $ orion test-db
+   $ orion db test
 
    Check for a configuration inside the default paths...
        {'type': 'mongodb', 'name': 'mydb', 'host': 'localhost'}
@@ -227,7 +227,7 @@ stage. Here's an example including all three configuration methods.
 
 .. code-block:: sh
 
-   $ ORION_DB_PORT=27018 orion test_db --config local.yaml
+   $ ORION_DB_PORT=27018 orion db test --config local.yaml
 
    Check for a configuration inside the global paths...
        {'type': 'mongodb', 'name': 'mydb', 'host': 'localhost'}
@@ -244,7 +244,7 @@ that will be used and then prints the instance created to confirm the database t
 
 .. code-block:: sh
 
-   $ orion test-db
+   $ orion db test
 
    [...]
 
@@ -257,7 +257,7 @@ tests fail because of insufficient user access rights on the database.
 
 .. code-block:: sh
 
-   $ orion test-db
+   $ orion db test
 
    [...]
 

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -91,7 +91,7 @@ Configuring Oríon's Database
 
 There are different ways that database backend attributes can be configured.
 The first one is by using a global configuration file, which can easily be done
-using the command ``orion setup``. This will create a yaml file
+using the command ``orion db setup``. This will create a yaml file
 of the following format.
 
    .. code-block:: yaml

--- a/src/orion/core/cli/db/__init__.py
+++ b/src/orion/core/cli/db/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db` -- Functions that define console scripts for database
+==============================================================================
+
+.. module:: cli
+   :platform: Unix
+   :synopsis: Commands to maintain database
+
+"""

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.setup` -- Module running the setup command
+===============================================================
+
+.. module:: setup
+   :platform: Unix
+   :synopsis: Creates a configurarion file for the database.
+"""
+
+import logging
+import os
+
+import yaml
+
+import orion.core
+
+log = logging.getLogger(__name__)
+
+
+def add_subparser(parser):
+    """Return the parser that needs to be used for this command"""
+    setup_parser = parser.add_parser('setup', help='setup help')
+
+    setup_parser.set_defaults(func=main)
+
+    return setup_parser
+
+
+def ask_question(question, default=None):
+    """Ask a question to the user and receive an answer.
+
+    Parameters
+    ----------
+    question: str
+        The question to be asked.
+    default: str
+        The default value to use if the user enters nothing.
+
+    Returns
+    -------
+    str
+        The answer provided by the user.
+
+    """
+    if default is not None:
+        question = question + " (default: {}) ".format(default)
+
+    answer = input(question)
+
+    if answer.strip() == "":
+        return default
+
+    return answer
+
+
+# pylint: disable = unused-argument
+def main(*args):
+    """Build a configuration file."""
+    default_file = orion.core.DEF_CONFIG_FILES_PATHS[-1]
+
+    if os.path.exists(default_file):
+        cancel = ''
+        while cancel.strip().lower() not in ['y', 'n']:
+            cancel = ask_question(
+                "This will overwrite {}, do you want to proceed? (y/n) ".format(default_file), "n")
+
+        if cancel.strip().lower() == 'n':
+            return
+
+    _type = ask_question("Enter the database type: ", "mongodb")
+    name = ask_question("Enter the database name: ", "test")
+    host = ask_question("Enter the database host: ", "localhost")
+
+    config = {'database': {'type': _type, 'name': name, 'host': host}}
+
+    print("Default configuration file will be saved at: ")
+    print(default_file)
+
+    dirs = '/'.join(default_file.split('/')[:-1])
+    os.makedirs(dirs, exist_ok=True)
+
+    with open(default_file, 'w') as output:
+        yaml.dump(config, output, default_flow_style=False)

--- a/src/orion/core/cli/db/test.py
+++ b/src/orion/core/cli/db/test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.test` -- Module to check if the DB worrks
+=================================================================
+
+.. module:: test_db
+   :platform: Unix
+   :synopsis: Runs multiple checks to see if the database was correctly setup.
+
+"""
+import argparse
+import logging
+
+from orion.core.cli.checks.creation import CreationStage
+from orion.core.cli.checks.operations import OperationsStage
+from orion.core.cli.checks.presence import PresenceStage
+from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.exceptions import CheckError
+
+log = logging.getLogger(__name__)
+
+
+def add_subparser(parser):
+    """Add the subparser that needs to be used for this command"""
+    test_db_parser = parser.add_parser('test', help='test_db help')
+
+    test_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
+                                metavar='path-to-config', help="user provided "
+                                "orion configuration file")
+
+    test_db_parser.set_defaults(func=main)
+
+    return test_db_parser
+
+
+def main(args):
+    """Run through all checks for database."""
+    experiment_builder = ExperimentBuilder()
+    presence_stage = PresenceStage(experiment_builder, args)
+    creation_stage = CreationStage(presence_stage)
+    operations_stage = OperationsStage(creation_stage)
+    stages = [presence_stage, creation_stage, operations_stage]
+
+    for stage in stages:
+        for check in stage.checks():
+            print(check.__doc__, end='.. ')
+            try:
+                status, msg = check()
+                print(status)
+                if status == "Skipping":
+                    print(msg)
+            except CheckError as ex:
+                print("Failure")
+                print(ex)
+
+        stage.post_stage()

--- a/src/orion/core/cli/db_main.py
+++ b/src/orion/core/cli/db_main.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.test_db` -- Module to check if the DB worrks
+=================================================================
+
+.. module:: test_db
+   :platform: Unix
+   :synopsis: Runs multiple checks to see if the database was correctly setup.
+
+"""
+import logging
+
+from orion.core.utils import module_import
+
+log = logging.getLogger(__name__)
+
+
+def add_subparser(parser):
+    """Add the subparsers that needs to be used for this command"""
+    # Fetch experiment name, user's script path and command line arguments
+    # Use `-h` option to show help
+
+    db_parser = parser.add_parser('db', help='test_db help')
+    subparsers = db_parser.add_subparsers(help='sub-command help')
+
+    load_modules_parser(subparsers)
+
+    return db_parser
+
+
+def load_modules_parser(subparsers):
+    """Search through the `cli.db` folder for any module containing a `get_parser` function"""
+    modules = module_import.load_modules_in_path('orion.core.cli.db',
+                                                 lambda m: hasattr(m, 'add_subparser'))
+
+    for module in modules:
+        get_parser = getattr(module, 'add_subparser')
+        get_parser(subparsers)

--- a/src/orion/core/cli/setup.py
+++ b/src/orion/core/cli/setup.py
@@ -10,11 +10,9 @@
 """
 
 import logging
-import os
 
-import yaml
+from orion.core.cli.db.setup import main
 
-import orion.core
 
 log = logging.getLogger(__name__)
 
@@ -28,58 +26,10 @@ def add_subparser(parser):
     return setup_parser
 
 
-def ask_question(question, default=None):
-    """Ask a question to the user and receive an answer.
-
-    Parameters
-    ----------
-    question: str
-        The question to be asked.
-    default: str
-        The default value to use if the user enters nothing.
-
-    Returns
-    -------
-    str
-        The answer provided by the user.
-
-    """
-    if default is not None:
-        question = question + " (default: {}) ".format(default)
-
-    answer = input(question)
-
-    if answer.strip() == "":
-        return default
-
-    return answer
-
-
 # pylint: disable = unused-argument
-def main(*args):
+def wrap_main(args):
     """Build a configuration file."""
-    default_file = orion.core.DEF_CONFIG_FILES_PATHS[-1]
+    log.warning('Command `orion setup` is deprecated and will be removed in v0.2.0. Use '
+                '`orion db setup` instead.')
 
-    if os.path.exists(default_file):
-        cancel = ''
-        while cancel.strip().lower() not in ['y', 'n']:
-            cancel = ask_question(
-                "This will overwrite {}, do you want to proceed? (y/n) ".format(default_file), "n")
-
-        if cancel.strip().lower() == 'n':
-            return
-
-    _type = ask_question("Enter the database type: ", "mongodb")
-    name = ask_question("Enter the database name: ", "test")
-    host = ask_question("Enter the database host: ", "localhost")
-
-    config = {'database': {'type': _type, 'name': name, 'host': host}}
-
-    print("Default configuration file will be saved at: ")
-    print(default_file)
-
-    dirs = '/'.join(default_file.split('/')[:-1])
-    os.makedirs(dirs, exist_ok=True)
-
-    with open(default_file, 'w') as output:
-        yaml.dump(config, output, default_flow_style=False)
+    main(args)

--- a/src/orion/core/cli/test_db.py
+++ b/src/orion/core/cli/test_db.py
@@ -12,11 +12,8 @@
 import argparse
 import logging
 
-from orion.core.cli.checks.creation import CreationStage
-from orion.core.cli.checks.operations import OperationsStage
-from orion.core.cli.checks.presence import PresenceStage
-from orion.core.io.experiment_builder import ExperimentBuilder
-from orion.core.utils.exceptions import CheckError
+from orion.core.cli.db.test import main
+
 
 log = logging.getLogger(__name__)
 
@@ -29,29 +26,14 @@ def add_subparser(parser):
                                 metavar='path-to-config', help="user provided "
                                 "orion configuration file")
 
-    test_db_parser.set_defaults(func=main)
+    test_db_parser.set_defaults(func=wrap_main)
 
     return test_db_parser
 
 
-def main(args):
+def wrap_main(args):
     """Run through all checks for database."""
-    experiment_builder = ExperimentBuilder()
-    presence_stage = PresenceStage(experiment_builder, args)
-    creation_stage = CreationStage(presence_stage)
-    operations_stage = OperationsStage(creation_stage)
-    stages = [presence_stage, creation_stage, operations_stage]
+    log.warning('Command `orion test-db` is deprecated and will be removed in v0.2.0. Use '
+                '`orion db test` instead.')
 
-    for stage in stages:
-        for check in stage.checks():
-            print(check.__doc__, end='.. ')
-            try:
-                status, msg = check()
-                print(status)
-                if status == "Skipping":
-                    print(msg)
-            except CheckError as ex:
-                print("Failure")
-                print(ex)
-
-        stage.post_stage()
+    main(args)

--- a/tests/functional/backward_compatibility/test_versions.py
+++ b/tests/functional/backward_compatibility/test_versions.py
@@ -134,9 +134,9 @@ def fill_db(request):
 class TestBackwardCompatibility:
     """Tests for backward compatibility between Oríon versions."""
 
-    def test_db(self):
-        """Verify test-db command"""
-        out = execute('orion test-db')
+    def test_db_test(self):
+        """Verify db test command"""
+        out = execute('orion db test')
         assert 'Failure' not in out
 
     def test_list(self):

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -33,7 +33,7 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
     except FileNotFoundError:
         pass
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     assert os.path.exists(config_path)
 
@@ -54,7 +54,7 @@ def test_creation_when_exists(monkeypatch, tmp_path):
     with open(config_path, 'w') as output:
         yaml.dump(dump, output)
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     with open(config_path, 'r') as output:
         content = yaml.safe_load(output)
@@ -73,7 +73,7 @@ def test_stop_creation_when_exists(monkeypatch, tmp_path):
     with open(config_path, 'w') as output:
         yaml.dump(dump, output)
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     with open(config_path, 'r') as output:
         content = yaml.safe_load(output)
@@ -87,7 +87,7 @@ def test_defaults(monkeypatch, tmp_path):
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
     monkeypatch.setattr(builtins, "input", _mock_input(['', '', '']))
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     with open(config_path, 'r') as output:
         content = yaml.safe_load(output)


### PR DESCRIPTION
Why:

We will shortly add more database related commands such as `remove` and
`upgrade`. They should all be grouped within `orion db`.