### PR TITLE
Instantiate adapter even if empty

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -546,7 +546,7 @@ class Experiment:
             if self.refers['parent_id'] is None:
                 log.debug('update refers (name: %s)', config['name'])
                 self.refers['root_id'] = self._id
-                self._storage.update_experiment(self, refers=self.refers)
+                self._storage.update_experiment(self, refers=self.configuration['refers'])
 
         else:
             # Writing the final config to an already existing experiment raises
@@ -605,7 +605,7 @@ class Experiment:
         self.refers.setdefault('parent_id', None)
         self.refers.setdefault('root_id', self._id)
         self.refers.setdefault('adapter', [])
-        if self.refers['adapter'] and not isinstance(self.refers.get('adapter'), BaseAdapter):
+        if not isinstance(self.refers.get('adapter'), BaseAdapter):
             self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
         if not self.producer.get('strategy'):
@@ -716,7 +716,7 @@ class ExperimentView(object):
         self.refers.setdefault('parent_id', None)
         self.refers.setdefault('root_id', self._id)
         self.refers.setdefault('adapter', [])
-        if self.refers['adapter'] and not isinstance(self.refers.get('adapter'), BaseAdapter):
+        if not isinstance(self.refers.get('adapter'), BaseAdapter):
             self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
         # try:

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -11,7 +11,9 @@ import tempfile
 import pytest
 
 from orion.algo.base import BaseAlgorithm
+from orion.algo.space import Space
 import orion.core
+from orion.core.evc.adapters import BaseAdapter
 from orion.core.io.database import DuplicateKeyError
 import orion.core.utils.backward as backward
 from orion.core.utils.exceptions import RaceCondition
@@ -389,6 +391,19 @@ class TestConfigProperty(object):
         assert exp._id == exp_config[0][0].pop('_id')
         assert exp.configuration == exp_config[0][0]
         assert experiment_count_before == count_experiment(exp)
+
+    def test_instantiation_after_init(self, exp_config):
+        """Verify that algo, space and refers was instanciated properly"""
+        exp = Experiment('supernaedo2-dendi')
+        assert not isinstance(exp.algorithms, BaseAlgorithm)
+        assert not isinstance(exp.space, Space)
+        assert not isinstance(exp.refers['adapter'], BaseAdapter)
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][0])
+        assert exp._init_done is True
+        assert isinstance(exp.algorithms, BaseAlgorithm)
+        assert isinstance(exp.space, Space)
+        assert isinstance(exp.refers['adapter'], BaseAdapter)
 
     def test_try_set_after_init(self, exp_config):
         """Cannot set a configuration after init (currently)."""
@@ -1001,6 +1016,7 @@ class TestInitExperimentView(object):
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.version == exp_config[0][0]['version']
+        assert isinstance(exp.refers['adapter'], BaseAdapter)
         # TODO: Views are not fully configured until configuration is refactored
         # assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 


### PR DESCRIPTION
Why:

When handling the configured experiment, we expect the adapter to be
instiantiated even if it does nothing (empty CompositeAdapter).