### PR TITLE
Release v0.1.7rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,13 @@ jobs:
         dist: xenial
         sudo: true
       - <<: *test
-        env: TOXENV=demo_random
+        env: TOXENV=demo-random
+        python: 3.6
+      - <<: *test
+        env: TOXENV=backward-compatibility, ORION_DB_TYPE=mongodb
+        python: 3.6
+      - <<: *test
+        env: TOXENV=backward-compatibility, ORION_DB_TYPE=pickleddb
         python: 3.6
       - stage: packaging
         env: TOXENV=packaging

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 # Roadmap
-Last update August 26th, 2019
+Last update October 8th, 2019
 
 ## Next releases - Short-Term
 
-### v0.1.7
+### v0.1.8
 
 #### Preliminary Python API
 Library API to simplify usage of algorithms without Oríon's worker.

--- a/docs/src/code/core/cli.rst
+++ b/docs/src/code/core/cli.rst
@@ -13,5 +13,5 @@ Command lines
    cli/insert
    cli/init_only
    cli/setup
-   cli/test_db
+   cli/db
    cli/evc

--- a/docs/src/code/core/cli.rst
+++ b/docs/src/code/core/cli.rst
@@ -12,6 +12,5 @@ Command lines
    cli/hunt
    cli/insert
    cli/init_only
-   cli/setup
    cli/db
    cli/evc

--- a/docs/src/code/core/cli/db.rst
+++ b/docs/src/code/core/cli/db.rst
@@ -8,4 +8,5 @@ db commands
    :maxdepth: 1
    :caption: DB command line modules
 
-   cli/db/test
+   db/test
+   db/setup

--- a/docs/src/code/core/cli/db.rst
+++ b/docs/src/code/core/cli/db.rst
@@ -1,0 +1,11 @@
+db commands
+===========
+
+.. automodule:: orion.core.cli.db_main
+   :members:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: DB command line modules
+
+   cli/db/test

--- a/docs/src/code/core/cli/db/setup.rst
+++ b/docs/src/code/core/cli/db/setup.rst
@@ -1,5 +1,5 @@
 setup command
 =============
 
-# .. automodule:: orion.core.cli.setup
+# .. automodule:: orion.core.cli.db.setup
 #    :members:

--- a/docs/src/code/core/cli/db/test.rst
+++ b/docs/src/code/core/cli/db/test.rst
@@ -1,0 +1,5 @@
+db test command
+===============
+
+.. automodule:: orion.core.cli.db.test
+   :members:

--- a/docs/src/code/core/cli/test_db.rst
+++ b/docs/src/code/core/cli/test_db.rst
@@ -1,5 +1,0 @@
-test-db command
-===============
-
-.. automodule:: orion.core.cli.test_db
-   :members:

--- a/docs/src/install/core.rst
+++ b/docs/src/install/core.rst
@@ -2,6 +2,9 @@
 Installation of Orion's core
 ****************************
 
+Oríon should work on most Linux distributions and Mac OS X. It is tested on Ubuntu 16.04 LTS and Mac
+OS X 10.13. We do not support Windows and there is no short term plan to do so.
+
 Via PyPI
 ========
 

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -199,11 +199,11 @@ EphemeralDB has no arguments.
 Test connection
 ===============
 
-You can use the command ``orion test-db`` to test the setup of your database backend.
+You can use the command ``orion db test`` to test the setup of your database backend.
 
 .. code-block:: sh
 
-   $ orion test-db
+   $ orion db test
 
    Check for a configuration inside the default paths...
        {'type': 'mongodb', 'name': 'mydb', 'host': 'localhost'}
@@ -227,7 +227,7 @@ stage. Here's an example including all three configuration methods.
 
 .. code-block:: sh
 
-   $ ORION_DB_PORT=27018 orion test_db --config local.yaml
+   $ ORION_DB_PORT=27018 orion db test --config local.yaml
 
    Check for a configuration inside the global paths...
        {'type': 'mongodb', 'name': 'mydb', 'host': 'localhost'}
@@ -244,7 +244,7 @@ that will be used and then prints the instance created to confirm the database t
 
 .. code-block:: sh
 
-   $ orion test-db
+   $ orion db test
 
    [...]
 
@@ -257,7 +257,7 @@ tests fail because of insufficient user access rights on the database.
 
 .. code-block:: sh
 
-   $ orion test-db
+   $ orion db test
 
    [...]
 

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -91,7 +91,7 @@ Configuring Oríon's Database
 
 There are different ways that database backend attributes can be configured.
 The first one is by using a global configuration file, which can easily be done
-using the command ``orion setup``. This will create a yaml file
+using the command ``orion db setup``. This will create a yaml file
 of the following format.
 
    .. code-block:: yaml

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -265,3 +265,22 @@ tests fail because of insufficient user access rights on the database.
    Check if database supports read operation... Success
    Check if database supports count operation... Success
    Check if database supports delete operation... Success
+
+
+Upgrade Database
+================
+
+Database scheme may change from one version of Oríon to another. If such change happens, you will
+get the following error after upgrading Oríon.
+
+.. code-block:: sh
+
+   The database is outdated. You can upgrade it with the command `orion db upgrade`.
+
+Make sure to create a backup of your database before upgrading it. You should also make sure that no
+process writes to the database during the upgrade otherwise the latter could fail. When ready,
+simply run the upgrade command.
+
+.. code-block:: sh
+
+   orion db upgrade

--- a/docs/src/user/algorithms.rst
+++ b/docs/src/user/algorithms.rst
@@ -157,9 +157,8 @@ Configuration
 .. code-block:: yaml
 
      algorithms:
-        bayesopt:
+        BayesianOptimizer:
            seed: null
-           strategy: cl_min
            n_initial_points: 10
            acq_func: gp_hedge
            alpha: 1e-10
@@ -168,13 +167,6 @@ Configuration
            normalize_y: False
 
 ``seed``
-
-
-``strategy``
-
-Method to use to sample multiple points.
-Supported options are `"cl_min"`, `"cl_mean"` or `"cl_max"`.
-Check skopt docs for details.
 
 ``n_initial_points``
 

--- a/src/orion/core/cli/db/__init__.py
+++ b/src/orion/core/cli/db/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db` -- Functions that define console scripts for database
+==============================================================================
+
+.. module:: cli
+   :platform: Unix
+   :synopsis: Commands to maintain database
+
+"""

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.setup` -- Module running the setup command
+===============================================================
+
+.. module:: setup
+   :platform: Unix
+   :synopsis: Creates a configurarion file for the database.
+"""
+
+import logging
+import os
+
+import yaml
+
+import orion.core
+
+log = logging.getLogger(__name__)
+
+
+def add_subparser(parser):
+    """Return the parser that needs to be used for this command"""
+    setup_parser = parser.add_parser('setup', help='setup help')
+
+    setup_parser.set_defaults(func=main)
+
+    return setup_parser
+
+
+def ask_question(question, default=None):
+    """Ask a question to the user and receive an answer.
+
+    Parameters
+    ----------
+    question: str
+        The question to be asked.
+    default: str
+        The default value to use if the user enters nothing.
+
+    Returns
+    -------
+    str
+        The answer provided by the user.
+
+    """
+    if default is not None:
+        question = question + " (default: {}) ".format(default)
+
+    answer = input(question)
+
+    if answer.strip() == "":
+        return default
+
+    return answer
+
+
+# pylint: disable = unused-argument
+def main(*args):
+    """Build a configuration file."""
+    default_file = orion.core.DEF_CONFIG_FILES_PATHS[-1]
+
+    if os.path.exists(default_file):
+        cancel = ''
+        while cancel.strip().lower() not in ['y', 'n']:
+            cancel = ask_question(
+                "This will overwrite {}, do you want to proceed? (y/n) ".format(default_file), "n")
+
+        if cancel.strip().lower() == 'n':
+            return
+
+    _type = ask_question("Enter the database type: ", "mongodb")
+    name = ask_question("Enter the database name: ", "test")
+    host = ask_question("Enter the database host: ", "localhost")
+
+    config = {'database': {'type': _type, 'name': name, 'host': host}}
+
+    print("Default configuration file will be saved at: ")
+    print(default_file)
+
+    dirs = '/'.join(default_file.split('/')[:-1])
+    os.makedirs(dirs, exist_ok=True)
+
+    with open(default_file, 'w') as output:
+        yaml.dump(config, output, default_flow_style=False)

--- a/src/orion/core/cli/db/test.py
+++ b/src/orion/core/cli/db/test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.test` -- Module to check if the DB worrks
+=================================================================
+
+.. module:: test_db
+   :platform: Unix
+   :synopsis: Runs multiple checks to see if the database was correctly setup.
+
+"""
+import argparse
+import logging
+
+from orion.core.cli.checks.creation import CreationStage
+from orion.core.cli.checks.operations import OperationsStage
+from orion.core.cli.checks.presence import PresenceStage
+from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.exceptions import CheckError
+
+log = logging.getLogger(__name__)
+
+
+def add_subparser(parser):
+    """Add the subparser that needs to be used for this command"""
+    test_db_parser = parser.add_parser('test', help='test_db help')
+
+    test_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
+                                metavar='path-to-config', help="user provided "
+                                "orion configuration file")
+
+    test_db_parser.set_defaults(func=main)
+
+    return test_db_parser
+
+
+def main(args):
+    """Run through all checks for database."""
+    experiment_builder = ExperimentBuilder()
+    presence_stage = PresenceStage(experiment_builder, args)
+    creation_stage = CreationStage(presence_stage)
+    operations_stage = OperationsStage(creation_stage)
+    stages = [presence_stage, creation_stage, operations_stage]
+
+    for stage in stages:
+        for check in stage.checks():
+            print(check.__doc__, end='.. ')
+            try:
+                status, msg = check()
+                print(status)
+                if status == "Skipping":
+                    print(msg)
+            except CheckError as ex:
+                print("Failure")
+                print(ex)
+
+        stage.post_stage()

--- a/src/orion/core/cli/db/upgrade.py
+++ b/src/orion/core/cli/db/upgrade.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.upgrade` -- Module to upgrade DB schemes
+================================================================
+
+.. module:: test_db
+   :platform: Unix
+   :synopsis: Upgrade the scheme of the databases
+
+"""
+import argparse
+import logging
+import sys
+
+from orion.core.io.database.ephemeraldb import EphemeralCollection
+from orion.core.io.database.mongodb import MongoDB
+from orion.core.io.database.pickleddb import PickledDB
+from orion.core.io.experiment_builder import ExperimentBuilder
+import orion.core.utils.backward as backward
+from orion.storage.base import get_storage
+from orion.storage.legacy import Legacy
+
+
+log = logging.getLogger(__name__)
+
+
+# TODO: Move somewhere else to share with `db setup`.
+def ask_question(question, default=None):
+    """Ask a question to the user and receive an answer.
+
+    Parameters
+    ----------
+    question: str
+        The question to be asked.
+    default: str
+        The default value to use if the user enters nothing.
+
+    Returns
+    -------
+    str
+        The answer provided by the user.
+
+    """
+    if default is not None:
+        question = question + " (default: {}) ".format(default)
+
+    answer = input(question)
+
+    if answer.strip() == "":
+        return default
+
+    return answer
+
+
+def add_subparser(parser):
+    """Add the subparser that needs to be used for this command"""
+    upgrade_db_parser = parser.add_parser('upgrade', help='Upgrade the database scheme')
+
+    upgrade_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
+                                   metavar='path-to-config', help="user provided "
+                                   "orion configuration file")
+
+    upgrade_db_parser.add_argument('-f', '--force', action='store_true',
+                                   help="Don't prompt user")
+
+    upgrade_db_parser.set_defaults(func=main)
+
+    return upgrade_db_parser
+
+
+def main(args):
+    """Upgrade the databases for current version"""
+    print("Upgrading your database may damage your data. Make sure to make a backup before the "
+          "upgrade and stop any other process that may read/write the database during the upgrade.")
+
+    if not args.get('force'):
+        action = ''
+        while action not in ['y', 'yes', 'no', 'n']:
+            action = ask_question("Do you wish to proceed? (y/N)", "N").lower()
+
+        if action in ['no', 'n']:
+            sys.exit(0)
+
+    experiment_builder = ExperimentBuilder()
+    local_config = experiment_builder.fetch_full_config(args, use_db=False)
+    local_config['protocol'] = {'type': 'legacy', 'setup': False}
+
+    experiment_builder.setup_storage(local_config)
+
+    storage = get_storage()
+
+    upgrade_db_specifics(storage)
+
+    print('Updating documents...')
+    upgrade_documents(storage)
+    print('Database upgrade completed successfully')
+
+
+def upgrade_db_specifics(storage):
+    """Make upgrades that are specific to some backends"""
+    if isinstance(storage, Legacy):
+        database = storage._db  # pylint: disable=protected-access
+        print('Updating indexes...')
+        update_indexes(database)
+        if isinstance(database, PickledDB):
+            print('Updating pickledb scheme...')
+            upgrade_pickledb(database)
+        elif isinstance(database, MongoDB):
+            print('Updating mongodb scheme...')
+            upgrade_mongodb(database)
+
+
+def upgrade_documents(storage):
+    """Upgrade scheme of the documents"""
+    for experiment in storage.fetch_experiments({}):
+        add_version(experiment)
+        add_priors(experiment)
+        storage.update_experiment(uid=experiment.pop('_id'), **experiment)
+
+
+def add_version(experiment):
+    """Add version 1 if not present"""
+    experiment.setdefault('version', 1)
+
+
+def add_priors(experiment):
+    """Add priors to metadata if not present"""
+    backward.populate_priors(experiment['metadata'])
+
+
+def update_indexes(database):
+    """Remove user from unique indices.
+
+    This is required for migration to v0.1.6+
+    """
+    # For backward compatibility
+    index_info = database.index_information('experiments')
+    deprecated_indices = [('name', 'metadata.user'), ('name', 'metadata.user', 'version'),
+                          'name_1_metadata.user_1', 'name_1_metadata.user_1_version_1']
+
+    for deprecated_idx in deprecated_indices:
+        if deprecated_idx in index_info:
+            database.drop_index('experiments', deprecated_idx)
+
+
+# pylint: disable=unused-argument
+def upgrade_mongodb(database):
+    """Update mongo specific db scheme."""
+    pass
+
+
+def upgrade_pickledb(database):
+    """Update pickledb specific db scheme."""
+    # pylint: disable=protected-access
+    def upgrade_state(self, state):
+        """Set state while ensuring backward compatibility"""
+        self._documents = state['_documents']
+
+        # if indexes are from <=v0.1.6
+        if state['_indexes'] and isinstance(next(iter(state['_indexes'].keys())), tuple):
+            self._indexes = dict()
+            for keys, values in state['_indexes'].items():
+                if isinstance(keys, str):
+                    self._indexes[keys] = values
+                # Convert keys that were registered with old index signature
+                else:
+                    keys = [(key, None) for key in keys]
+                    self.create_index(keys, unique=True)
+        else:
+            self._indexes = state['_indexes']
+
+    old_setstate = getattr(EphemeralCollection, '__setstate__', None)
+    EphemeralCollection.__setstate__ = upgrade_state
+
+    document = database.read('experiments', {})[0]
+    # One document update is enough to fix all collections
+    database.write('experiments', document, query={'_id': document['_id']})
+
+    if old_setstate is not None:
+        EphemeralCollection.__setstate__ = old_setstate
+    else:
+        del EphemeralCollection.__setstate__

--- a/src/orion/core/cli/db_main.py
+++ b/src/orion/core/cli/db_main.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.test_db` -- Module to check if the DB worrks
+=================================================================
+
+.. module:: test_db
+   :platform: Unix
+   :synopsis: Runs multiple checks to see if the database was correctly setup.
+
+"""
+import logging
+
+from orion.core.utils import module_import
+
+log = logging.getLogger(__name__)
+
+
+def add_subparser(parser):
+    """Add the subparsers that needs to be used for this command"""
+    # Fetch experiment name, user's script path and command line arguments
+    # Use `-h` option to show help
+
+    db_parser = parser.add_parser('db', help='test_db help')
+    subparsers = db_parser.add_subparsers(help='sub-command help')
+
+    load_modules_parser(subparsers)
+
+    return db_parser
+
+
+def load_modules_parser(subparsers):
+    """Search through the `cli.db` folder for any module containing a `get_parser` function"""
+    modules = module_import.load_modules_in_path('orion.core.cli.db',
+                                                 lambda m: hasattr(m, 'add_subparser'))
+
+    for module in modules:
+        get_parser = getattr(module, 'add_subparser')
+        get_parser(subparsers)

--- a/src/orion/core/cli/setup.py
+++ b/src/orion/core/cli/setup.py
@@ -10,11 +10,9 @@
 """
 
 import logging
-import os
 
-import yaml
+from orion.core.cli.db.setup import main
 
-import orion.core
 
 log = logging.getLogger(__name__)
 
@@ -28,58 +26,10 @@ def add_subparser(parser):
     return setup_parser
 
 
-def ask_question(question, default=None):
-    """Ask a question to the user and receive an answer.
-
-    Parameters
-    ----------
-    question: str
-        The question to be asked.
-    default: str
-        The default value to use if the user enters nothing.
-
-    Returns
-    -------
-    str
-        The answer provided by the user.
-
-    """
-    if default is not None:
-        question = question + " (default: {}) ".format(default)
-
-    answer = input(question)
-
-    if answer.strip() == "":
-        return default
-
-    return answer
-
-
 # pylint: disable = unused-argument
-def main(*args):
+def wrap_main(args):
     """Build a configuration file."""
-    default_file = orion.core.DEF_CONFIG_FILES_PATHS[-1]
+    log.warning('Command `orion setup` is deprecated and will be removed in v0.2.0. Use '
+                '`orion db setup` instead.')
 
-    if os.path.exists(default_file):
-        cancel = ''
-        while cancel.strip().lower() not in ['y', 'n']:
-            cancel = ask_question(
-                "This will overwrite {}, do you want to proceed? (y/n) ".format(default_file), "n")
-
-        if cancel.strip().lower() == 'n':
-            return
-
-    _type = ask_question("Enter the database type: ", "mongodb")
-    name = ask_question("Enter the database name: ", "test")
-    host = ask_question("Enter the database host: ", "localhost")
-
-    config = {'database': {'type': _type, 'name': name, 'host': host}}
-
-    print("Default configuration file will be saved at: ")
-    print(default_file)
-
-    dirs = '/'.join(default_file.split('/')[:-1])
-    os.makedirs(dirs, exist_ok=True)
-
-    with open(default_file, 'w') as output:
-        yaml.dump(config, output, default_flow_style=False)
+    main(args)

--- a/src/orion/core/cli/test_db.py
+++ b/src/orion/core/cli/test_db.py
@@ -12,11 +12,8 @@
 import argparse
 import logging
 
-from orion.core.cli.checks.creation import CreationStage
-from orion.core.cli.checks.operations import OperationsStage
-from orion.core.cli.checks.presence import PresenceStage
-from orion.core.io.experiment_builder import ExperimentBuilder
-from orion.core.utils.exceptions import CheckError
+from orion.core.cli.db.test import main
+
 
 log = logging.getLogger(__name__)
 
@@ -29,29 +26,14 @@ def add_subparser(parser):
                                 metavar='path-to-config', help="user provided "
                                 "orion configuration file")
 
-    test_db_parser.set_defaults(func=main)
+    test_db_parser.set_defaults(func=wrap_main)
 
     return test_db_parser
 
 
-def main(args):
+def wrap_main(args):
     """Run through all checks for database."""
-    experiment_builder = ExperimentBuilder()
-    presence_stage = PresenceStage(experiment_builder, args)
-    creation_stage = CreationStage(presence_stage)
-    operations_stage = OperationsStage(creation_stage)
-    stages = [presence_stage, creation_stage, operations_stage]
+    log.warning('Command `orion test-db` is deprecated and will be removed in v0.2.0. Use '
+                '`orion db test` instead.')
 
-    for stage in stages:
-        for check in stage.checks():
-            print(check.__doc__, end='.. ')
-            try:
-                status, msg = check()
-                print(status)
-                if status == "Skipping":
-                    print(msg)
-            except CheckError as ex:
-                print("Failure")
-                print(ex)
-
-        stage.post_stage()
+    main(args)

--- a/src/orion/core/cli/test_db.py
+++ b/src/orion/core/cli/test_db.py
@@ -42,18 +42,16 @@ def main(args):
     operations_stage = OperationsStage(creation_stage)
     stages = [presence_stage, creation_stage, operations_stage]
 
-    try:
-        for stage in stages:
-            for check in stage.checks():
-                print(check.__doc__, end='.. ')
+    for stage in stages:
+        for check in stage.checks():
+            print(check.__doc__, end='.. ')
+            try:
                 status, msg = check()
                 print(status)
-
                 if status == "Skipping":
                     print(msg)
+            except CheckError as ex:
+                print("Failure")
+                print(ex)
 
-            stage.post_stage()
-
-    except CheckError as ex:
-        print("Failure")
-        print(ex)
+        stage.post_stage()

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -305,6 +305,12 @@ class DuplicateKeyError(DatabaseError):
     pass
 
 
+class OutdatedDatabaseError(DatabaseError):
+    """Exception type used when the database is outdated."""
+
+    pass
+
+
 # pylint: disable=too-few-public-methods,abstract-method
 class Database(AbstractDB, metaclass=SingletonFactory):
     """Class used to inject dependency on a database framework."""

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -442,10 +442,15 @@ class EphemeralDocument(object):
                     (key.startswith(selected_key) and
                      key.replace(selected_key, '')[0] == "."))
 
-        for key, value in self._data.items():
-            for selected_key, include in keys.items():
+        for selected_key, include in filter(lambda item: item[1], keys.items()):
+            match = False
+            for key, value in self._data.items():
                 if include and key_is_match(key, selected_key):
+                    match = True
                     selection[key] = value
+
+            if not match:
+                selection[selected_key] = None
 
         return unflatten(selection)
 
@@ -468,7 +473,7 @@ class EphemeralDocument(object):
 
     def __getitem__(self, key):
         """Get the item corresponding to the given key in the document"""
-        return self._data[key]
+        return self._data.get(key, None)
 
     def __contains__(self, key):
         """Test whether the given key is present in the document"""

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -149,20 +149,6 @@ class EphemeralCollection(object):
         self._indexes = dict()
         self.create_index('_id', unique=True)
 
-    def __setstate__(self, state):
-        """Set state while ensuring backward compatibility"""
-        self._documents = state['_documents']
-
-        # if indexes are from <=v0.1.6
-        if state['_indexes'] and isinstance(next(iter(state['_indexes'].keys())), tuple):
-            self._indexes = dict()
-            for keys in state['_indexes'].keys():
-                # Re-introduce fake ordering
-                keys = [(key, None) for key in keys]
-                self.create_index(keys, unique=True)
-        else:
-            self._indexes = state['_indexes']
-
     def create_index(self, keys, unique=False):
         """Create given indexes if they do not already exist for this collection.
 

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -149,6 +149,20 @@ class EphemeralCollection(object):
         self._indexes = dict()
         self.create_index('_id', unique=True)
 
+    def __setstate__(self, state):
+        """Set state while ensuring backward compatibility"""
+        self._documents = state['_documents']
+
+        # if indexes are from <=v0.1.6
+        if state['_indexes'] and isinstance(next(iter(state['_indexes'].keys())), tuple):
+            self._indexes = dict()
+            for keys in state['_indexes'].keys():
+                # Re-introduce fake ordering
+                keys = [(key, None) for key in keys]
+                self.create_index(keys, unique=True)
+        else:
+            self._indexes = state['_indexes']
+
     def create_index(self, keys, unique=False):
         """Create given indexes if they do not already exist for this collection.
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -89,8 +89,10 @@ hierarchy. From the more global to the more specific, there is:
 import copy
 import logging
 
+import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import DuplicateKeyError
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils.exceptions import NoConfigurationError, RaceCondition
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.storage.base import Storage
@@ -267,12 +269,19 @@ class ExperimentBuilder(object):
         experiment = Experiment(config['name'], config.get('user', None),
                                 config.get('version', None))
 
+        # TODO: Handle both from cmdline and python APIs.
+        if 'priors' not in config['metadata'] and 'user_args' not in config['metadata']:
+            raise NoConfigurationError
+
+        # Parse to generate priors
+        if 'user_args' in config['metadata']:
+            parser = OrionCmdlineParser(orion.core.config.user_script_config)
+            parser.parse(config['metadata']['user_args'])
+            config['metadata']['parser'] = parser.get_state_dict()
+            config['metadata']['priors'] = dict(parser.priors)
+
         # Finish experiment's configuration and write it to database.
-        try:
-            experiment.configure(config)
-        except AttributeError as ex:
-            if 'user_script' not in config['metadata']:
-                raise NoConfigurationError from ex
+        experiment.configure(config)
 
         return experiment
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -247,6 +247,8 @@ class ExperimentBuilder(object):
             if handle_racecondition:
                 experiment = self.build_from(cmdargs, handle_racecondition=False)
 
+            raise
+
         return experiment
 
     def build_from_config(self, config):
@@ -295,12 +297,12 @@ class ExperimentBuilder(object):
 
         """
         # TODO: Fix this in config refactoring
-        db_opts = config.get('protocol', {'type': 'legacy'})
-        dbtype = db_opts.pop('type')
+        storage_opts = config.get('protocol', {'type': 'legacy'})
+        storage_type = storage_opts.pop('type')
 
-        log.debug("Creating %s database client with args: %s", dbtype, db_opts)
+        log.debug("Creating %s storage client with args: %s", storage_type, storage_opts)
         try:
-            Storage(of_type=dbtype, config=config, **db_opts)
+            Storage(of_type=storage_type, config=config, **storage_opts)
         except ValueError:
-            if Storage().__class__.__name__.lower() != dbtype.lower():
+            if Storage().__class__.__name__.lower() != storage_type.lower():
                 raise

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -87,6 +87,32 @@ class OrionCmdlineParser():
         # Look for anything followed by a tilt and possible branching attributes + prior
         self.prior_regex = re.compile(r'(.+)~([\+\-\>]?.+)')
 
+    def get_state_dict(self):
+        """Give state dict that can be used to reconstruct the parser"""
+        return dict(
+            parser=self.parser.get_state_dict(),
+            cmd_priors=list(map(list, self.cmd_priors.items())),
+            file_priors=list(map(list, self.file_priors.items())),
+            config_file_data=self.config_file_data,
+            config_prefix=self.config_prefix,
+            file_config_path=self.file_config_path,
+            converter=self.converter.get_state_dict() if self.converter else None)
+
+    def set_state_dict(self, state):
+        """Reset the parser based on previous state"""
+        self.parser.set_state_dict(state['parser'])
+
+        self.cmd_priors = OrderedDict(state['cmd_priors'])
+        self.file_priors = OrderedDict(state['file_priors'])
+
+        self.config_file_data = state['config_file_data']
+        self.config_prefix = state['config_prefix']
+        self.file_config_path = state['file_config_path']
+
+        if self.file_config_path:
+            self.converter = infer_converter_from_file_type(self.file_config_path)
+            self.converter.set_state_dict(state['converter'])
+
     def parse(self, commandline):
         """Parse the commandline given for the definition of priors.
 

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -23,3 +23,12 @@ def populate_priors(metadata):
     parser.parse(metadata["user_args"])
     metadata["parser"] = parser.get_state_dict()
     metadata["priors"] = dict(parser.priors)
+
+
+def db_is_outdated(database):
+    """Return True if the database scheme is outdated."""
+    deprecated_indices = [('name', 'metadata.user'), ('name', 'metadata.user', 'version'),
+                          'name_1_metadata.user_1', 'name_1_metadata.user_1_version_1']
+
+    index_information = database.index_information('experiments')
+    return any(index in deprecated_indices for index in index_information.keys())

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.utils.backward` -- Backward compatibility utils
+================================================================
+
+.. module:: info
+   :platform: Unix
+   :synopsis: Helper functions to support backward compatibility
+
+"""
+
+import orion.core
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
+
+
+def populate_priors(metadata):
+    """Compute parser state and priors based on user_args and populate metadata."""
+    if 'user_args' not in metadata:
+        return
+
+    parser = OrionCmdlineParser(orion.core.config.user_script_config)
+    parser.parse(metadata["user_args"])
+    metadata["parser"] = parser.get_state_dict()
+    metadata["priors"] = dict(parser.priors)

--- a/src/orion/core/utils/tests.py
+++ b/src/orion/core/utils/tests.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.core.utils.state` -- Encapsulate Orion state
-========================================================
+:mod:`orion.core.utils.tests` -- Utils for tests
+================================================
 .. module:: state
    :platform: Unix
-   :synopsis: Encapsulate orion state
+   :synopsis: Helper functions for tests
 
 """
 
@@ -14,15 +14,25 @@ import tempfile
 
 import yaml
 
+import orion.core
 from orion.core.io.database import Database
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.mongodb import MongoDB
 from orion.core.io.database.pickleddb import PickledDB
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils import SingletonAlreadyInstantiatedError
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage, Storage
 from orion.storage.legacy import Legacy
+
+
+def populate_parser_fields(config):
+    """Compute parser state and priors based on user_args and populate metadata."""
+    parser = OrionCmdlineParser(orion.core.config.user_script_config)
+    parser.parse(config["metadata"]["user_args"])
+    config["metadata"]["parser"] = parser.get_state_dict()
+    config["metadata"]["priors"] = dict(parser.priors)
 
 
 def _select(lhs, rhs):

--- a/src/orion/core/utils/tests.py
+++ b/src/orion/core/utils/tests.py
@@ -14,25 +14,15 @@ import tempfile
 
 import yaml
 
-import orion.core
 from orion.core.io.database import Database
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.mongodb import MongoDB
 from orion.core.io.database.pickleddb import PickledDB
-from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils import SingletonAlreadyInstantiatedError
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage, Storage
 from orion.storage.legacy import Legacy
-
-
-def populate_parser_fields(config):
-    """Compute parser state and priors based on user_args and populate metadata."""
-    parser = OrionCmdlineParser(orion.core.config.user_script_config)
-    parser.parse(config["metadata"]["user_args"])
-    config["metadata"]["parser"] = parser.get_state_dict()
-    config["metadata"]["priors"] = dict(parser.priors)
 
 
 def _select(lhs, rhs):

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -14,7 +14,8 @@ import signal
 import subprocess
 import tempfile
 
-from orion.core.io.space_builder import SpaceBuilder
+import orion.core
+from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils.working_dir import WorkingDir
 from orion.core.worker.trial_pacemaker import TrialPacemaker
 
@@ -60,8 +61,8 @@ class Consumer(object):
                                " initialization.")
 
         # Fetch space builder
-        self.template_builder = SpaceBuilder()
-        self.template_builder.build_from(experiment.metadata['user_args'])
+        self.template_builder = OrionCmdlineParser(orion.core.config.user_script_config)
+        self.template_builder.set_state_dict(experiment.metadata['parser'])
         # Get path to user's script and infer trial configuration directory
         if experiment.working_dir:
             self.working_dir = os.path.abspath(experiment.working_dir)
@@ -171,7 +172,7 @@ class Consumer(object):
 
         log.debug("## Building command line argument and configuration for trial.")
         env = self.get_execution_environment(trial, results_file.name)
-        cmd_args = self.template_builder.build_to(config_file.name, trial, self.experiment)
+        cmd_args = self.template_builder.format(config_file.name, trial, self.experiment)
 
         log.debug("## Launch user's script as a subprocess and wait for finish.")
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -546,7 +546,7 @@ class Experiment:
             if self.refers['parent_id'] is None:
                 log.debug('update refers (name: %s)', config['name'])
                 self.refers['root_id'] = self._id
-                self._storage.update_experiment(self, refers=self.refers)
+                self._storage.update_experiment(self, refers=self.configuration['refers'])
 
         else:
             # Writing the final config to an already existing experiment raises
@@ -605,7 +605,7 @@ class Experiment:
         self.refers.setdefault('parent_id', None)
         self.refers.setdefault('root_id', self._id)
         self.refers.setdefault('adapter', [])
-        if self.refers['adapter'] and not isinstance(self.refers.get('adapter'), BaseAdapter):
+        if not isinstance(self.refers.get('adapter'), BaseAdapter):
             self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
         if not self.producer.get('strategy'):
@@ -716,7 +716,7 @@ class ExperimentView(object):
         self.refers.setdefault('parent_id', None)
         self.refers.setdefault('root_id', self._id)
         self.refers.setdefault('adapter', [])
-        if self.refers['adapter'] and not isinstance(self.refers.get('adapter'), BaseAdapter):
+        if not isinstance(self.refers.get('adapter'), BaseAdapter):
             self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
         # try:

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -585,9 +585,10 @@ class Experiment:
 
             setattr(self, section, value)
 
+        # TODO: Can we get rid of this try-except clause?
         try:
             space_builder = SpaceBuilder()
-            space = space_builder.build_from(config['metadata']['user_args'])
+            space = space_builder.build(config['metadata']['priors'])
 
             if not space:
                 raise ValueError("Parameter space is empty. There is nothing to optimize.")

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -23,6 +23,7 @@ from orion.core.io.database import DuplicateKeyError
 from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
 from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
 from orion.core.io.space_builder import SpaceBuilder
+import orion.core.utils.backward as backward
 from orion.core.utils.exceptions import RaceCondition
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import (BaseParallelStrategy,
@@ -150,6 +151,9 @@ class Experiment:
 
             config = sorted(config, key=lambda x: x['metadata']['datetime'],
                             reverse=True)[0]
+
+            backward.populate_priors(config['metadata'])
+
             for attrname in self.__slots__:
                 if not attrname.startswith('_') and attrname in config:
                     setattr(self, attrname, config[attrname])

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -270,6 +270,10 @@ class Enumerate(Transformer):
         self._map = numpy.vectorize(lambda x: map_dict[x], otypes='i')
         self._imap = numpy.vectorize(lambda x: categories[x], otypes=[numpy.object])
 
+    def __deepcopy__(self, memo):
+        """Make a deepcopy"""
+        return type(self)(self.categories)
+
     def transform(self, point):
         """Return integers corresponding uniquely to the categories in `point`.
 

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -35,13 +35,16 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         """Insert a new experiment inside the database"""
         raise NotImplementedError()
 
-    def update_experiment(self, experiment, where=None, **kwargs):
+    def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
         """Update a the fields of a given trials
 
         Parameters
         ----------
-        experiment: Experiment
-            Experiment object to update
+        experiment: Experiment, optional
+           experiment object to retrieve from the database
+
+        uid: str, optional
+            experiment id used to retrieve the trial object
 
         where: Optional[dict]
             constraint experiment must respect
@@ -52,6 +55,14 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         Returns
         -------
         returns true if the underlying storage was updated
+
+        Raises
+        ------
+        UndefinedCall
+            if both experiment and uid are not set
+
+        AssertionError
+            if both experiment and uid are provided and they do not match
 
         """
         raise NotImplementedError()

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -91,12 +91,21 @@ class Legacy(BaseStorageProtocol):
         """See :func:`~orion.storage.BaseStorageProtocol.create_experiment`"""
         return self._db.write('experiments', data=config, query=None)
 
-    def update_experiment(self, experiment, where=None, **kwargs):
+    def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_experiment`"""
+        if experiment is not None and uid is not None:
+            assert experiment._id == uid
+
+        if uid is None:
+            if experiment is None:
+                raise MissingArguments('Either `experiment` or `uid` should be set')
+
+            uid = experiment._id
+
         if where is None:
             where = dict()
 
-        where['_id'] = experiment._id
+        where['_id'] = uid
         return self._db.write('experiments', data=kwargs, query=where)
 
     def fetch_experiments(self, query, selection=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 from orion.core.worker.trial import Trial
 from orion.storage.base import Storage
 from orion.storage.legacy import Legacy
@@ -169,7 +169,7 @@ def exp_config():
     for config in exp_config[0]:
         config["metadata"]["user_script"] = os.path.join(
             os.path.dirname(__file__), config["metadata"]["user_script"])
-        populate_parser_fields(config)
+        backward.populate_priors(config['metadata'])
         config['version'] = 1
 
     return exp_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
+from orion.core.io.database.pickleddb import PickledDB
 import orion.core.utils.backward as backward
 from orion.core.worker.trial import Trial
 from orion.storage.base import Storage
@@ -205,6 +206,7 @@ def null_db_instances():
     Legacy.instance = None
     Database.instance = None
     MongoDB.instance = None
+    PickledDB.instance = None
 
 
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
+from orion.core.utils.tests import populate_parser_fields
 from orion.core.worker.trial import Trial
 from orion.storage.base import Storage
 from orion.storage.legacy import Legacy
@@ -165,10 +166,11 @@ def exp_config():
     for i, t_dict in enumerate(exp_config[1]):
         exp_config[1][i] = Trial(**t_dict).to_dict()
 
-    for i, _ in enumerate(exp_config[0]):
-        exp_config[0][i]["metadata"]["user_script"] = os.path.join(
-            os.path.dirname(__file__), exp_config[0][i]["metadata"]["user_script"])
-        exp_config[0][i]['version'] = 1
+    for config in exp_config[0]:
+        config["metadata"]["user_script"] = os.path.join(
+            os.path.dirname(__file__), config["metadata"]["user_script"])
+        populate_parser_fields(config)
+        config['version'] = 1
 
     return exp_config
 

--- a/tests/functional/backward_compatibility/black_box.py
+++ b/tests/functional/backward_compatibility/black_box.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Simple one dimensional example with noise level for a possible user's script."""
+import argparse
+import random
+
+from orion.client import report_results
+
+
+def function(x, noise):
+    """Evaluate partial information of a quadratic."""
+    z = (x - 34.56789) * random.gauss(0, noise)
+    return 4 * z**2 + 23.4, 8 * z
+
+
+def execute():
+    """Execute a simple pipeline as an example."""
+    # 1. Receive inputs as you want
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument('--fidelity', type=int, default=10)
+    inputs = parser.parse_args()
+
+    assert 0 <= inputs.fidelity <= 10
+
+    noise = (1 - inputs.fidelity / 10) + 0.0001
+
+    # 2. Perform computations
+    y, dy = function(inputs.x, noise)
+
+    # 3. Gather and report results
+    results = list()
+    results.append(dict(
+        name='example_objective',
+        type='objective',
+        value=y))
+    results.append(dict(
+        name='example_gradient',
+        type='gradient',
+        value=[dy]))
+
+    report_results(results)
+
+
+if __name__ == "__main__":
+    execute()

--- a/tests/functional/backward_compatibility/random.yaml
+++ b/tests/functional/backward_compatibility/random.yaml
@@ -1,0 +1,6 @@
+pool_size: 1
+max_trials: 10
+
+algorithms:
+  random:
+    seed: 1

--- a/tests/functional/backward_compatibility/test_versions.py
+++ b/tests/functional/backward_compatibility/test_versions.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform functional tests to verify backward compatibility."""
+import os
+import shutil
+import subprocess
+
+from pymongo import MongoClient
+import pytest
+
+
+DIRNAME = os.path.dirname(os.path.abspath(__file__))
+
+SCRIPT_PATH = os.path.join(DIRNAME, 'black_box.py')
+CONFIG_FILE = os.path.join(DIRNAME, 'random.yaml')
+
+
+def get_package(version):
+    """Get package name based on version.
+
+    Package changed to orion instead of orion.core at 0.1.6
+    """
+    if version >= '0.1.6':
+        return 'orion'
+
+    return 'orion.core'
+
+
+# Ignore pre-0.1.3 because there was no PickleDB backend.
+VERSIONS = ['0.1.3', '0.1.4', '0.1.5', '0.1.6']
+
+
+def clean_mongodb():
+    """Clean collections."""
+    client = MongoClient(username='user', password='pass', authSource='orion_test')
+    database = client.orion_test
+    database.experiments.drop()
+    database.lying_trials.drop()
+    database.trials.drop()
+    database.workers.drop()
+    database.resources.drop()
+    client.close()
+
+
+def set_env():
+    """Set the env vars for the db.
+
+    Notes
+    -----
+    This function expects the env var ORION_DB_TYPE to be set.
+
+    """
+    db_type = os.environ['ORION_DB_TYPE']
+    if db_type == 'pickleddb':
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'save.pkl')
+        os.environ['ORION_DB_ADDRESS'] = file_path
+        if os.path.exists(file_path):
+            os.remove(file_path)
+    elif db_type == 'mongodb':
+        os.environ['ORION_DB_ADDRESS'] = 'mongodb://user:pass@localhost'
+        os.environ['ORION_DB_NAME'] = 'orion_test'
+        clean_mongodb()
+
+
+def execute(command):
+    """Execute a command and return the decoded stdout."""
+    out = subprocess.check_output(command.split())
+    return out.decode('utf-8')
+
+
+def setup_virtualenv(version):
+    """Create a virtualenv and install Oríon in it for the given version"""
+    virtualenv_dir = get_virtualenv_dir(version)
+    if os.path.exists(virtualenv_dir):
+        shutil.rmtree(virtualenv_dir)
+    execute('virtualenv {}'.format(virtualenv_dir))
+    command = '{}/bin/pip install --ignore-installed {}=={}'.format(
+        virtualenv_dir, get_package(version), version)
+    execute(command)
+
+
+def get_version(orion_script):
+    """Get Oríon version for given Oríon executer's path."""
+    command = '{} --version'.format(orion_script)
+    stdout = subprocess.check_output(command, shell=True)
+
+    return stdout.decode('utf-8').strip('\n')
+
+
+def get_virtualenv_dir(version):
+    """Get virtualenv directory for given version."""
+    return 'version-{}'.format(version)
+
+
+@pytest.fixture(scope='class', params=VERSIONS)
+def fill_db(request):
+    """Add experiments and trials in DB for given version of Oríon."""
+    set_env()
+
+    version = request.param
+
+    setup_virtualenv(version)
+
+    orion_script = os.path.join(get_virtualenv_dir(version), 'bin', 'orion')
+
+    orion_version = get_version(orion_script)
+    assert orion_version == 'orion {}'.format(version)
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'init_only', '--name', 'init',
+        '--config', CONFIG_FILE,
+        SCRIPT_PATH, '-x~uniform(-50,50)'])))
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'init_only', '--name', 'init',
+        '--branch', 'init-branch-old',
+        '--config', CONFIG_FILE])))
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'hunt', '--name', 'hunt',
+        '--config', CONFIG_FILE,
+        SCRIPT_PATH, '-x~uniform(-50,50)'])))
+
+    print(execute(' '.join([
+        orion_script, '-vv', 'hunt', '--name', 'hunt',
+        '--branch', 'hunt-branch-old',
+        '--config', CONFIG_FILE])))
+
+    orion_version = get_version('orion')
+    assert orion_version != 'orion {}'.format(version)
+
+
+@pytest.mark.usefixtures('fill_db')
+class TestBackwardCompatibility:
+    """Tests for backward compatibility between Oríon versions."""
+
+    def test_db(self):
+        """Verify test-db command"""
+        out = execute('orion test-db')
+        assert 'Failure' not in out
+
+    def test_list(self):
+        """Verify list command"""
+        out = execute('orion list')
+        assert 'init-v1' in out
+        assert 'init-branch-old-v1' in out
+        assert 'hunt-v1' in out
+        assert 'hunt-branch-old-v1' in out
+
+    def test_status(self):
+        """Verify status command"""
+        out = execute('orion status')
+        assert 'init-v1' in out
+        assert 'init-branch-old-v1' in out
+        assert 'hunt-v1' in out
+        assert 'hunt-branch-old-v1' in out
+
+    def test_info(self):
+        """Verify info command"""
+        out = execute('orion info --name hunt')
+        assert 'name: hunt' in out
+
+    def test_init_only(self):
+        """Verify init_only command"""
+        print(execute(' '.join([
+            'orion', 'init_only', '--name', 'init',
+            '--branch', 'init-branch'])))
+
+    def test_hunt(self):
+        """Verify hunt command"""
+        print(execute(' '.join([
+            'orion', 'hunt', '--name', 'hunt',
+            '--branch', 'hunt-branch'])))
+
+    # orion.core.cli.main('init-only') # TODO: deprecate init_only

--- a/tests/functional/backward_compatibility/test_versions.py
+++ b/tests/functional/backward_compatibility/test_versions.py
@@ -134,9 +134,9 @@ def fill_db(request):
 class TestBackwardCompatibility:
     """Tests for backward compatibility between Oríon versions."""
 
-    def test_db(self):
-        """Verify test-db command"""
-        out = execute('orion test-db')
+    def test_db_test(self):
+        """Verify db test command"""
+        out = execute('orion db test')
         assert 'Failure' not in out
 
     def test_list(self):

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -11,6 +11,7 @@ from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
 import orion.core.cli
 from orion.core.io.database import Database
 from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.tests import populate_parser_fields
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage
 
@@ -87,6 +88,10 @@ def exp_config():
     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
               'experiment.yaml')) as f:
         exp_config = list(yaml.safe_load_all(f))
+
+    for config in exp_config[0]:
+        populate_parser_fields(config)
+
     return exp_config
 
 

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -11,7 +11,7 @@ from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
 import orion.core.cli
 from orion.core.io.database import Database
 from orion.core.io.experiment_builder import ExperimentBuilder
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage
 
@@ -90,7 +90,7 @@ def exp_config():
         exp_config = list(yaml.safe_load_all(f))
 
     for config in exp_config[0]:
-        populate_parser_fields(config)
+        backward.populate_priors(config['metadata'])
 
     return exp_config
 

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -33,7 +33,7 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
     except FileNotFoundError:
         pass
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     assert os.path.exists(config_path)
 
@@ -54,7 +54,7 @@ def test_creation_when_exists(monkeypatch, tmp_path):
     with open(config_path, 'w') as output:
         yaml.dump(dump, output)
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     with open(config_path, 'r') as output:
         content = yaml.safe_load(output)
@@ -73,7 +73,7 @@ def test_stop_creation_when_exists(monkeypatch, tmp_path):
     with open(config_path, 'w') as output:
         yaml.dump(dump, output)
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     with open(config_path, 'r') as output:
         content = yaml.safe_load(output)
@@ -87,7 +87,7 @@ def test_defaults(monkeypatch, tmp_path):
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
     monkeypatch.setattr(builtins, "input", _mock_input(['', '', '']))
 
-    orion.core.cli.main(["setup"])
+    orion.core.cli.main(["db", "setup"])
 
     with open(config_path, 'r') as output:
         content = yaml.safe_load(output)

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -13,7 +13,7 @@ import yaml
 
 import orion.core.cli
 from orion.core.io.experiment_builder import ExperimentBuilder
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 from orion.core.worker import workon
 from orion.core.worker.experiment import Experiment
 
@@ -204,7 +204,7 @@ def test_workon(database):
     config['metadata']['user_script'] = os.path.abspath(os.path.join(
         os.path.dirname(__file__), "black_box.py"))
     config['metadata']['user_args'] = ["-x~uniform(-50, 50)"]
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
     experiment.configure(config)
 
     workon(experiment)

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -13,6 +13,7 @@ import yaml
 
 import orion.core.cli
 from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.utils.tests import populate_parser_fields
 from orion.core.worker import workon
 from orion.core.worker.experiment import Experiment
 
@@ -203,6 +204,7 @@ def test_workon(database):
     config['metadata']['user_script'] = os.path.abspath(os.path.join(
         os.path.dirname(__file__), "black_box.py"))
     config['metadata']['user_args'] = ["-x~uniform(-50, 50)"]
+    populate_parser_fields(config)
     experiment.configure(config)
 
     workon(experiment)
@@ -466,11 +468,14 @@ def test_resilience(monkeypatch):
     """Test if Oríon stops after enough broken trials."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
+    MAX_BROKEN = 3
+    orion.core.config.worker.max_broken = 3
+
     orion.core.cli.main(["hunt", "--config", "./orion_config_random.yaml", "./broken_box.py",
                          "-x~uniform(-50, 50)"])
 
     exp = ExperimentBuilder().build_from({'name': 'demo_random_search'})
-    assert len(exp.fetch_trials_by_status('broken')) == 3
+    assert len(exp.fetch_trials_by_status('broken')) == MAX_BROKEN
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/tests/functional/gradient_descent_algo/setup.py
+++ b/tests/functional/gradient_descent_algo/setup.py
@@ -19,7 +19,7 @@ setup_args = dict(
             'gradient_descent = orion.algo.gradient_descent:Gradient_Descent'
             ],
         },
-    install_requires=['orion.core'],
+    install_requires=['orion'],
     setup_requires=['setuptools'],
     # "Zipped eggs don't play nicely with namespace packaging"
     # from https://github.com/pypa/sample-namespace-packages

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -12,7 +12,7 @@ from orion.algo.space import (Categorical, Integer, Real, Space)
 from orion.core.evc import conflicts
 from orion.core.io.convert import (JSONConverter, YAMLConverter)
 from orion.core.io.space_builder import DimensionBuilder
-from orion.core.utils.tests import default_datetime, MockDatetime
+from orion.core.utils.tests import default_datetime, MockDatetime, populate_parser_fields
 from orion.core.worker.experiment import Experiment
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -20,6 +20,7 @@ YAML_SAMPLE = os.path.join(TEST_DIR, 'sample_config.yml')
 YAML_DIFF_SAMPLE = os.path.join(TEST_DIR, 'sample_config_diff.yml')
 JSON_SAMPLE = os.path.join(TEST_DIR, 'sample_config.json')
 UNKNOWN_SAMPLE = os.path.join(TEST_DIR, 'sample_config.txt')
+UNKNOWN_TEMPLATE = os.path.join(TEST_DIR, 'sample_config_template.txt')
 
 
 @pytest.fixture(scope='session')
@@ -62,6 +63,12 @@ def json_config(json_sample_path):
 def unknown_type_sample_path():
     """Return path with a sample file of unknown configuration filetype."""
     return UNKNOWN_SAMPLE
+
+
+@pytest.fixture(scope='session')
+def unknown_type_template_path():
+    """Return path with a template file of unknown configuration filetype."""
+    return UNKNOWN_TEMPLATE
 
 
 @pytest.fixture(scope='session')
@@ -188,7 +195,7 @@ def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_inst
 @pytest.fixture
 def new_config():
     """Generate a new experiment configuration"""
-    return dict(
+    config = dict(
         name='test',
         algorithms='fancy',
         version=1,
@@ -197,6 +204,10 @@ def new_config():
                   'user_args':
                   ['--new~normal(0,2)', '--changed~normal(0,2)'],
                   'user': 'some_user_name'})
+
+    populate_parser_fields(config)
+
+    return config
 
 
 @pytest.fixture
@@ -216,6 +227,8 @@ def old_config(create_db_instance):
                   'user_args':
                   ['--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
                   'user': 'some_user_name'})
+
+    populate_parser_fields(config)
 
     create_db_instance.write('experiments', config)
     return config
@@ -295,6 +308,7 @@ def cli_conflict(old_config, new_config):
     new_config = copy.deepcopy(new_config)
     new_config['metadata']['user_args'].append("--some-new=args")
     new_config['metadata']['user_args'].append("--bool-arg")
+    populate_parser_fields(new_config)
     return conflicts.CommandLineConflict(old_config, new_config)
 
 
@@ -313,12 +327,16 @@ def experiment_name_conflict(old_config, new_config):
 @pytest.fixture
 def bad_exp_parent_config():
     """Generate a new experiment configuration"""
-    return dict(
+    config = dict(
         _id='test',
         name='test',
         metadata={'user': 'corneauf', 'user_args': ['--x~normal(0,1)']},
         version=1,
         algorithms='random')
+
+    populate_parser_fields(config)
+
+    return config
 
 
 @pytest.fixture

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -12,7 +12,8 @@ from orion.algo.space import (Categorical, Integer, Real, Space)
 from orion.core.evc import conflicts
 from orion.core.io.convert import (JSONConverter, YAMLConverter)
 from orion.core.io.space_builder import DimensionBuilder
-from orion.core.utils.tests import default_datetime, MockDatetime, populate_parser_fields
+import orion.core.utils.backward as backward
+from orion.core.utils.tests import default_datetime, MockDatetime
 from orion.core.worker.experiment import Experiment
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -205,7 +206,7 @@ def new_config():
                   ['--new~normal(0,2)', '--changed~normal(0,2)'],
                   'user': 'some_user_name'})
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     return config
 
@@ -228,7 +229,7 @@ def old_config(create_db_instance):
                   ['--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
                   'user': 'some_user_name'})
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     create_db_instance.write('experiments', config)
     return config
@@ -308,7 +309,7 @@ def cli_conflict(old_config, new_config):
     new_config = copy.deepcopy(new_config)
     new_config['metadata']['user_args'].append("--some-new=args")
     new_config['metadata']['user_args'].append("--bool-arg")
-    populate_parser_fields(new_config)
+    backward.populate_priors(new_config['metadata'])
     return conflicts.CommandLineConflict(old_config, new_config)
 
 
@@ -334,7 +335,7 @@ def bad_exp_parent_config():
         version=1,
         algorithms='random')
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     return config
 

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -9,7 +9,7 @@ import pytest
 from orion.algo.space import Dimension
 from orion.core import evc
 from orion.core.evc import conflicts as conflict
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 
 
 @pytest.fixture
@@ -328,8 +328,8 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_diff_config}}
 
-        populate_parser_fields(old_config)
-        populate_parser_fields(new_config)
+        backward.populate_priors(old_config['metadata'])
+        backward.populate_priors(new_config['metadata'])
 
         conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
         assert len(conflicts) == 1
@@ -339,8 +339,8 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
 
-        populate_parser_fields(old_config)
-        populate_parser_fields(new_config)
+        backward.populate_priors(old_config['metadata'])
+        backward.populate_priors(new_config['metadata'])
 
         assert list(conflict.ScriptConfigConflict.detect(old_config, new_config)) == []
 

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -9,6 +9,7 @@ import pytest
 from orion.algo.space import Dimension
 from orion.core import evc
 from orion.core.evc import conflicts as conflict
+from orion.core.utils.tests import populate_parser_fields
 
 
 @pytest.fixture
@@ -327,6 +328,9 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_diff_config}}
 
+        populate_parser_fields(old_config)
+        populate_parser_fields(new_config)
+
         conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
         assert len(conflicts) == 1
 
@@ -334,6 +338,9 @@ class TestScriptConfigConflict(object):
         """Test that identical configs are not detected as conflict."""
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
+
+        populate_parser_fields(old_config)
+        populate_parser_fields(new_config)
 
         assert list(conflict.ScriptConfigConflict.detect(old_config, new_config)) == []
 

--- a/tests/unittests/core/io/test_cmdline_parser.py
+++ b/tests/unittests/core/io/test_cmdline_parser.py
@@ -59,11 +59,11 @@ def test_parse_paths(monkeypatch):
 def test_parse_arguments(basic_config):
     """Test the parsing of the commandline arguments"""
     cmdline_parser = CmdlineParser()
-    cmdline_parser._parse_arguments(
+    arguments = cmdline_parser._parse_arguments(
         "python script.py some pos args --with args --and multiple args "
         "--plus --booleans --equal=value".split(" "))
 
-    assert cmdline_parser.arguments == basic_config
+    assert arguments == basic_config
 
 
 def test_parse_arguments_template():
@@ -86,7 +86,9 @@ def test_format(to_format):
 
     cmdline_parser.parse(to_format.split(' '))
 
-    formatted = cmdline_parser.format(cmdline_parser.arguments)
+    arguments = cmdline_parser._parse_arguments(to_format.split(' '))
+
+    formatted = cmdline_parser.format(arguments)
 
     assert formatted == to_format.split(' ')
 
@@ -116,3 +118,28 @@ def test_has_already_been_parsed():
         cmdline_parser.parse(command.split(' '))
 
     assert "already" in str(exc_info.value)
+
+
+def test_get_state_dict():
+    """Test getting state dict."""
+    cmdline_parser = CmdlineParser()
+
+    cmdline_parser.parse(
+        "python script.py some pos args "
+        "--with args --and multiple args --plus --booleans --equal=value".split(" "))
+
+    assert cmdline_parser.get_state_dict() == {
+        'arguments': list(map(list, cmdline_parser.arguments.items())),
+        'template': cmdline_parser.template}
+
+
+def test_set_state_dict():
+    """Test that set_state_dict sets state properly to generate new cmdline."""
+    cmdline_parser = CmdlineParser()
+
+    cmdline_parser.set_state_dict({
+        'arguments': {},
+        'template': ['{_pos_0}', '{_pos_1}', '--with', '{with}', '--plus', '--booleans']})
+
+    assert cmdline_parser.format({'_pos_0': 'voici', '_pos_1': 'voila', 'with': 'classe'}) == [
+        'voici', 'voila', '--with', 'classe', '--plus', '--booleans']

--- a/tests/unittests/core/io/test_converters.py
+++ b/tests/unittests/core/io/test_converters.py
@@ -187,3 +187,38 @@ a_var = o~>a_serious_name
 
 +gaussian(0, 0.1, shape=(100, 3))
 """
+
+    def test_get_state_dict(self, unknown_type_sample_path, unknown_type_template_path,
+                            generic_converter):
+        """Test getting state dict."""
+        generic_converter.parse(unknown_type_sample_path)
+        assert generic_converter.get_state_dict() == {
+            'expression_prefix': 'o~',
+            'has_leading': {
+                '/lala//iela': '/',
+                '/lala/iela': '/',
+                'lala/la': '/'},
+            'regex': '([\\/]?[\\w|\\/|-]+)~([\\+]?.*\\)|\\-|\\>[A-Za-z_]\\w*)',
+            'template': open(unknown_type_template_path, 'r').read()}
+
+    def test_set_state_dict(self, tmpdir, generic_converter):
+        """Test that set_state_dict sets state properly to generate new config."""
+        generic_converter.set_state_dict({
+            'expression_prefix': '',
+            'has_leading': {
+                'voici': '/'},
+            'regex': generic_converter.regex.pattern,
+            'template': """\
+voici = {/voici}
+voila = voici + {voila}"""})
+
+        output_file = str(tmpdir.join("output.lalal"))
+
+        generic_converter.generate(output_file, {'/voici': 'me voici', 'voila': 'me voila'})
+
+        with open(output_file) as f:
+            out = f.read()
+
+        assert out == """\
+voici = me voici
+voila = voici + me voila"""

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -248,3 +248,93 @@ def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
     assert '/training/lr0' in config
     assert '/training/mbs' in config
     assert '/something-same' in config
+
+
+def test_get_state_dict_before_parse(commandline):
+    """Test getting state dict."""
+    parser = OrionCmdlineParser()
+
+    assert parser.get_state_dict() == {
+        'parser': {
+            'arguments': [],
+            'template': []},
+        'cmd_priors': list(map(list, parser.cmd_priors.items())),
+        'file_priors': list(map(list, parser.file_priors.items())),
+        'config_file_data': parser.config_file_data,
+        'config_prefix': parser.config_prefix,
+        'file_config_path': parser.file_config_path,
+        'converter': None}
+
+
+def test_get_state_dict_after_parse_no_config_file(commandline):
+    """Test getting state dict."""
+    parser = OrionCmdlineParser()
+
+    parser.parse(commandline)
+
+    assert parser.get_state_dict() == {
+        'parser': parser.parser.get_state_dict(),
+        'cmd_priors': list(map(list, parser.cmd_priors.items())),
+        'file_priors': list(map(list, parser.file_priors.items())),
+        'config_file_data': parser.config_file_data,
+        'config_prefix': parser.config_prefix,
+        'file_config_path': parser.file_config_path,
+        'converter': None}
+
+
+def test_get_state_dict_after_parse_with_config_file(yaml_config, commandline):
+    """Test getting state dict."""
+    parser = OrionCmdlineParser()
+
+    cmd_args = yaml_config
+    cmd_args.extend(commandline)
+
+    parser.parse(cmd_args)
+
+    assert parser.get_state_dict() == {
+        'parser': parser.parser.get_state_dict(),
+        'cmd_priors': list(map(list, parser.cmd_priors.items())),
+        'file_priors': list(map(list, parser.file_priors.items())),
+        'config_file_data': parser.config_file_data,
+        'config_prefix': parser.config_prefix,
+        'file_config_path': parser.file_config_path,
+        'converter': parser.converter.get_state_dict()}
+
+
+def test_set_state_dict(parser, commandline, json_config, tmpdir, json_converter):
+    """Test that set_state_dict sets state properly to generate new config."""
+    cmd_args = json_config
+    cmd_args.extend(commandline)
+
+    parser.parse(cmd_args)
+
+    state = parser.get_state_dict()
+    parser = None
+
+    blank_parser = OrionCmdlineParser()
+
+    blank_parser.set_state_dict(state)
+
+    trial = Trial(params=[
+        {'name': '/lr', 'type': 'real', 'value': -2.4},
+        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
+        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
+        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
+        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
+        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
+        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
+        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+
+    output_file = str(tmpdir.join("output.json"))
+
+    cmd_inst = blank_parser.format(output_file, trial)
+
+    assert cmd_inst == ['--config', output_file, "--seed", "555", "--lr", "-2.4",
+                        "--non-prior", "choices({'sgd': 0.2, 'adam': 0.8})", "--prior", "sgd"]
+
+    output_data = json_converter.parse(output_file)
+    assert output_data == {'yo': 5, 'training': {'lr0': 0.032, 'mbs': 64},
+                           'layers': [{'width': 64, 'type': 'relu'},
+                                      {'width': 100, 'type': 'relu'},
+                                      {'width': 16, 'type': 'sigmoid'}],
+                           'something-same': '3'}

--- a/tests/unittests/core/sample_config_template.txt
+++ b/tests/unittests/core/sample_config_template.txt
@@ -1,0 +1,31 @@
+{lalala!s}
+
+{/lala/la!s}
+{//lala/iela!s}
+{//lala//iela!s}
+
+a:
+   b:
+    [asdfa~/Iamapath/dont_capture_me,
+      ~/Iamapath/dont_capture_me]
+
+yo:
+           {aaalispera!s}
+
+[naedw]
+a_var={a!s}
+
+~
+
+[naekei:naedw]
+other_var = ~
+# Rename it who_names_their_variables_a_seriously
+a_var = {b!s}
+
+{{'oups':
+# remove it
+'{a_serious_name!s}',
+'iela':'{another_serious_name!s}'
+}}
+
+{lala/l2a!s}

--- a/tests/unittests/core/test_branch_config.py
+++ b/tests/unittests/core/test_branch_config.py
@@ -14,7 +14,7 @@ from orion.core.evc.conflicts import (
     detect_conflicts, ExperimentNameConflict, MissingDimensionConflict, NewDimensionConflict,
     ScriptConfigConflict)
 from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
-from orion.core.utils.tests import populate_parser_fields
+import orion.core.utils.backward as backward
 
 
 def filter_true(c):
@@ -66,7 +66,7 @@ def parent_config(user_config):
 
     config['metadata']['user_args'].append('--config=%s' % config_file_path)
 
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
 
     yield config
     os.remove(config_file_path)
@@ -87,7 +87,7 @@ def missing_config(child_config):
     """Create a child config with a missing dimension"""
     del(child_config['metadata']['user_args'][1])  # del -x
     del(child_config['metadata']['user_args'][1])  # del -y
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -95,7 +95,7 @@ def missing_config(child_config):
 def new_config(child_config):
     """Create a child config with a new dimension"""
     child_config['metadata']['user_args'].append('-w_d~normal(0,1)')
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -105,7 +105,7 @@ def changed_config(child_config):
     second_element = child_config['metadata']['user_args'][2]
     second_element = second_element.replace('normal', 'uniform')
     child_config['metadata']['user_args'][2] = second_element
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -130,7 +130,7 @@ def same_userconfig_config(user_config, child_config):
     with open(config_file_path, 'w') as f:
         yaml.dump(user_config, f)
     child_config['metadata']['user_args'][-1] = '--config=%s' % config_file_path
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     yield child_config
     os.remove(config_file_path)
 
@@ -144,7 +144,7 @@ def changed_userconfig_config(user_config, child_config):
     with open(config_file_path, 'w') as f:
         yaml.dump(user_config, f)
     child_config['metadata']['user_args'][-1] = '--config=%s' % config_file_path
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     yield child_config
     os.remove(config_file_path)
 
@@ -153,7 +153,7 @@ def changed_userconfig_config(user_config, child_config):
 def changed_cli_config(child_config):
     """Create a child config with a changed dimension"""
     child_config['metadata']['user_args'] += ['-u=0', '--another=test', 'positional']
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -164,7 +164,7 @@ def list_arg_with_equals_cli_config(child_config):
     """
     child_config['metadata']['user_args'] += ['--args=1',
                                               '--args=2', '--args=3']
-    populate_parser_fields(child_config)
+    backward.populate_priors(child_config['metadata'])
     return child_config
 
 
@@ -181,7 +181,7 @@ def cl_config(create_db_instance):
                   ['--nameless=option', '-x~>w_d', '-w_d~+normal(0,1)', '-y~+uniform(0,1)', '-z~-',
                    '--omega~+normal(0,1)'],
                   'user': 'some_user_name'})
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
     return config
 
 
@@ -318,7 +318,7 @@ class TestResolutions(object):
     def test_add_single_hit(self, parent_config, new_config):
         """Test if adding a dimension only touches the correct status"""
         del new_config['metadata']['user_args'][1]
-        populate_parser_fields(new_config)
+        backward.populate_priors(new_config['metadata'])
         conflicts = detect_conflicts(parent_config, new_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
         branch_builder.add_dimension('w_d')
@@ -373,7 +373,7 @@ class TestResolutions(object):
     def test_rename_missing(self, parent_config, missing_config):
         """Test if renaming a dimension to another solves both conflicts"""
         missing_config['metadata']['user_args'].append('-w_d~uniform(0,1)')
-        populate_parser_fields(missing_config)
+        backward.populate_priors(missing_config['metadata'])
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
         branch_builder.rename_dimension('x', 'w_d')
@@ -398,7 +398,7 @@ class TestResolutions(object):
         creates a new one which is not solved
         """
         missing_config['metadata']['user_args'].append('-w_d~normal(0,1)')
-        populate_parser_fields(missing_config)
+        backward.populate_priors(missing_config['metadata'])
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -447,8 +447,8 @@ class TestResolutions(object):
 
     def test_name_experiment(self, bad_exp_parent_config, bad_exp_child_config, create_db_instance):
         """Test if having the same experiment name does not create a conflict."""
-        populate_parser_fields(bad_exp_parent_config)
-        populate_parser_fields(bad_exp_child_config)
+        backward.populate_priors(bad_exp_parent_config['metadata'])
+        backward.populate_priors(bad_exp_child_config['metadata'])
         create_db_instance.write('experiments', bad_exp_parent_config)
         create_db_instance.write('experiments', bad_exp_child_config)
         conflicts = detect_conflicts(bad_exp_parent_config, bad_exp_parent_config)
@@ -629,7 +629,7 @@ class TestResolutionsWithMarkers(object):
     def test_add_new_default(self, parent_config, new_config):
         """Test if new dimension conflict is automatically resolved"""
         new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1,default_value=0)'
-        populate_parser_fields(new_config)
+        backward.populate_priors(new_config['metadata'])
         conflicts = detect_conflicts(parent_config, new_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -645,7 +645,7 @@ class TestResolutionsWithMarkers(object):
     def test_add_bad_default(self, parent_config, new_config):
         """Test if new dimension conflict raises an error if marked with invalid default value"""
         new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1,default_value=\'a\')'
-        populate_parser_fields(new_config)
+        backward.populate_priors(new_config['metadata'])
         with pytest.raises(TypeError) as exc:
             detect_conflicts(parent_config, new_config)
         assert "Parameter \'/w_d\': Incorrect arguments." in str(exc.value)
@@ -668,7 +668,7 @@ class TestResolutionsWithMarkers(object):
     def test_remove_missing(self, parent_config, child_config):
         """Test if missing dimension conflict is automatically resolved"""
         child_config['metadata']['user_args'][1] = '-x~-'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -683,7 +683,7 @@ class TestResolutionsWithMarkers(object):
     def test_remove_missing_default(self, parent_config, child_config):
         """Test if missing dimension conflict is automatically resolved"""
         child_config['metadata']['user_args'][1] = '-x~-0.5'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -699,7 +699,7 @@ class TestResolutionsWithMarkers(object):
     def test_remove_missing_bad_default(self, parent_config, child_config):
         """Test if missing dimension conflict raises an error if marked with invalid default"""
         child_config['metadata']['user_args'][1] = '-x~--100'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -716,7 +716,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~normal(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_a'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -740,7 +740,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~uniform(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_c'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         with pytest.raises(ValueError) as exc:
             ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
@@ -753,7 +753,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~normal(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_b'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -780,7 +780,7 @@ class TestResolutionsWithMarkers(object):
         child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
         child_config['metadata']['user_args'].append('-w_b~+normal(0,1)')
         child_config['metadata']['user_args'][1] = '-x~>w_b'
-        populate_parser_fields(child_config)
+        backward.populate_priors(child_config['metadata'])
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
 
@@ -939,7 +939,7 @@ class TestAdapters(object):
     def test_adapter_rename_missing(self, parent_config, cl_config):
         """Test if a DimensionRenaming is created when solving a new conflict"""
         cl_config['metadata']['user_args'] = ['-x~>w_d', '-w_d~+uniform(0,1)']
-        populate_parser_fields(cl_config)
+        backward.populate_priors(cl_config['metadata'])
 
         conflicts = detect_conflicts(parent_config, cl_config)
         branch_builder = ExperimentBranchBuilder(conflicts, {'manual_resolution': True})

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -17,6 +17,12 @@ from orion.core.worker.transformer import (build_required_space,
 class TestIdentity(object):
     """Test subclasses of `Identity` transformation."""
 
+    def test_deepcopy(self):
+        """Verify that the transformation object can be copied"""
+        t = Identity()
+        t.transform([2])
+        copy.deepcopy(t)
+
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do
         what's expected.
@@ -52,6 +58,12 @@ class TestIdentity(object):
 
 class TestReverse(object):
     """Test subclasses of `Reverse` transformation."""
+
+    def test_deepcopy(self):
+        """Verify that the transformation object can be copied"""
+        t = Reverse(Quantize())
+        t.transform([2])
+        copy.deepcopy(t)
 
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do
@@ -93,6 +105,12 @@ class TestReverse(object):
 
 class TestCompose(object):
     """Test subclasses of `Compose` transformation."""
+
+    def test_deepcopy(self):
+        """Verify that the transformation object can be copied"""
+        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
+        t.transform([2])
+        copy.deepcopy(t)
 
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do
@@ -189,6 +207,12 @@ class TestCompose(object):
 class TestQuantize(object):
     """Test subclasses of `Quantize` transformation."""
 
+    def test_deepcopy(self):
+        """Verify that the transformation object can be copied"""
+        t = Quantize()
+        t.transform([2])
+        copy.deepcopy(t)
+
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do
         what's expected.
@@ -224,6 +248,13 @@ class TestQuantize(object):
 
 class TestEnumerate(object):
     """Test subclasses of `Enumerate` transformation."""
+
+    def test_deepcopy(self):
+        """Verify that the transformation object can be copied"""
+        t = Enumerate([2, 'asfa', 'ipsi'])
+        # Copy won't fail if vectorized function is not called at least once.
+        t.transform([2])
+        copy.deepcopy(t)
 
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do
@@ -282,6 +313,12 @@ class TestEnumerate(object):
 
 class TestOneHotEncode(object):
     """Test subclasses of `OneHotEncode` transformation."""
+
+    def test_deepcopy(self):
+        """Verify that the transformation object can be copied"""
+        t = OneHotEncode(3)
+        t.transform([2])
+        copy.deepcopy(t)
 
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -10,6 +10,7 @@ import pytest
 
 from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.utils.format_trials import tuple_to_trial
+from orion.core.utils.tests import populate_parser_fields
 import orion.core.worker.consumer as consumer
 
 
@@ -23,6 +24,7 @@ def config(exp_config):
     config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
     config['name'] = 'exp'
     config['working_dir'] = "/tmp/orion"
+    populate_parser_fields(config)
     return config
 
 

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -9,8 +9,8 @@ import time
 import pytest
 
 from orion.core.io.experiment_builder import ExperimentBuilder
+import orion.core.utils.backward as backward
 from orion.core.utils.format_trials import tuple_to_trial
-from orion.core.utils.tests import populate_parser_fields
 import orion.core.worker.consumer as consumer
 
 
@@ -24,7 +24,7 @@ def config(exp_config):
     config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
     config['name'] = 'exp'
     config['working_dir'] = "/tmp/orion"
-    populate_parser_fields(config)
+    backward.populate_priors(config['metadata'])
     return config
 
 

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -11,7 +11,9 @@ import tempfile
 import pytest
 
 from orion.algo.base import BaseAlgorithm
+from orion.algo.space import Space
 import orion.core
+from orion.core.evc.adapters import BaseAdapter
 from orion.core.io.database import DuplicateKeyError
 import orion.core.utils.backward as backward
 from orion.core.utils.exceptions import RaceCondition
@@ -389,6 +391,19 @@ class TestConfigProperty(object):
         assert exp._id == exp_config[0][0].pop('_id')
         assert exp.configuration == exp_config[0][0]
         assert experiment_count_before == count_experiment(exp)
+
+    def test_instantiation_after_init(self, exp_config):
+        """Verify that algo, space and refers was instanciated properly"""
+        exp = Experiment('supernaedo2-dendi')
+        assert not isinstance(exp.algorithms, BaseAlgorithm)
+        assert not isinstance(exp.space, Space)
+        assert not isinstance(exp.refers['adapter'], BaseAdapter)
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][0])
+        assert exp._init_done is True
+        assert isinstance(exp.algorithms, BaseAlgorithm)
+        assert isinstance(exp.space, Space)
+        assert isinstance(exp.refers['adapter'], BaseAdapter)
 
     def test_try_set_after_init(self, exp_config):
         """Cannot set a configuration after init (currently)."""
@@ -1001,6 +1016,7 @@ class TestInitExperimentView(object):
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.version == exp_config[0][0]['version']
+        assert isinstance(exp.refers['adapter'], BaseAdapter)
         # TODO: Views are not fully configured until configuration is refactored
         # assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -14,7 +14,7 @@ from orion.algo.base import BaseAlgorithm
 import orion.core
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.exceptions import RaceCondition
-from orion.core.utils.tests import OrionState
+from orion.core.utils.tests import OrionState, populate_parser_fields
 import orion.core.worker.experiment
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.trial import Trial
@@ -51,19 +51,26 @@ def new_config(random_dt):
         # and in general anything which is not in Experiment's slots
         something_to_be_ignored='asdfa'
         )
+
+    populate_parser_fields(new_config)
+
     return new_config
 
 
 @pytest.fixture
 def parent_version_config():
     """Return a configuration for an experiment."""
-    return dict(_id='parent_config',
-                name="old_experiment",
-                version=1,
-                algorithms='random',
-                metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
-                          'user_args': ['--x~normal(0,1)']}
-                )
+    config = dict(
+        _id='parent_config',
+        name="old_experiment",
+        version=1,
+        algorithms='random',
+        metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
+                  'user_args': ['--x~normal(0,1)']})
+
+    populate_parser_fields(config)
+
+    return config
 
 
 @pytest.fixture
@@ -75,6 +82,7 @@ def child_version_config(parent_version_config):
     config['refers'] = {'parent_id': 'parent_config'}
     config['metadata']['datetime'] = datetime.datetime.utcnow()
     config['metadata']['user_args'].append('--y~+normal(0,1)')
+    populate_parser_fields(config)
     return config
 
 
@@ -536,6 +544,7 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         original = Experiment('experiment_test', version=1)
@@ -543,6 +552,7 @@ class TestConfigProperty(object):
         config['branch'] = ['experiment_2']
         config['metadata']['user_args'].pop()
         config['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config)
         config['version'] = 1
         exp = Experiment('experiment_test', version=1)
         exp.configure(config)
@@ -557,12 +567,14 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         parent_id = config.pop('_id')
 
         config['version'] = 2
         config['metadata']['user_args'].append("--y~+normal(0,1)")
+        populate_parser_fields(config)
         config['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
 
         get_storage().create_experiment(config)
@@ -570,6 +582,7 @@ class TestConfigProperty(object):
 
         config['metadata']['user_args'].pop()
         config['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config)
         config['version'] = 1
         config.pop('refers')
         exp = Experiment('experiment_test', version=1)
@@ -623,6 +636,7 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         parent_id = config.pop('_id')
@@ -633,6 +647,7 @@ class TestConfigProperty(object):
         config2 = copy.deepcopy(config)
         config2['version'] = 2
         config2['metadata']['user_args'].append("--y~+normal(0,1)")
+        populate_parser_fields(config2)
         config2['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
         get_storage().create_experiment(config2)
 
@@ -640,6 +655,7 @@ class TestConfigProperty(object):
         config3 = copy.deepcopy(config)
         config3['metadata']['user_args'].pop()
         config3['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config3)
         config3['version'] = 1
 
         with pytest.raises(ValueError) as exc_info:
@@ -654,6 +670,7 @@ class TestConfigProperty(object):
         metadata = dict(user='tsirif', datetime=datetime.datetime.utcnow(), user_args=user_args)
         algorithms = {'random': {'seed': None}}
         config = dict(name='experiment_test', metadata=metadata, version=1, algorithms=algorithms)
+        populate_parser_fields(config)
 
         get_storage().create_experiment(config)
         parent_id = config.pop('_id')
@@ -664,6 +681,7 @@ class TestConfigProperty(object):
         config2 = copy.deepcopy(config)
         config2['version'] = 2
         config2['metadata']['user_args'].append("--y~+normal(0,1)")
+        populate_parser_fields(config2)
         config2['refers'] = dict(parent_id=parent_id, root_id=parent_id, adapters=[])
         get_storage().create_experiment(config2)
 
@@ -671,6 +689,7 @@ class TestConfigProperty(object):
         config3 = copy.deepcopy(config)
         config3['metadata']['user_args'].pop()
         config3['metadata']['user_args'].append("--z~+normal(0,1)")
+        populate_parser_fields(config3)
         config3.pop('version')
 
         with pytest.raises(RaceCondition) as exc_info:
@@ -918,7 +937,9 @@ def test_is_done_property_with_algo(hacked_exp):
 def test_broken_property(hacked_exp):
     """Check experiment stopping conditions for maximum number of broken."""
     assert not hacked_exp.is_broken
-    trials = hacked_exp.fetch_trials()[:3]
+    MAX_BROKEN = 3
+    orion.core.config.worker.max_broken = MAX_BROKEN
+    trials = hacked_exp.fetch_trials()[:MAX_BROKEN]
 
     for trial in trials:
         get_storage().set_trial_status(trial, status='broken')
@@ -929,19 +950,18 @@ def test_broken_property(hacked_exp):
 def test_configurable_broken_property(hacked_exp):
     """Check if max_broken changes after configuration."""
     assert not hacked_exp.is_broken
-    trials = hacked_exp.fetch_trials({})[:3]
-    old_broken_value = orion.core.config.worker.max_broken
+    MAX_BROKEN = 3
+    orion.core.config.worker.max_broken = MAX_BROKEN
+    trials = hacked_exp.fetch_trials()[:MAX_BROKEN]
 
     for trial in trials:
         get_storage().set_trial_status(trial, status='broken')
 
     assert hacked_exp.is_broken
 
-    orion.core.config.worker.max_broken = 4
+    orion.core.config.worker.max_broken += 1
 
     assert not hacked_exp.is_broken
-
-    orion.core.config.worker.max_broken = old_broken_value
 
 
 def test_experiment_stats(hacked_exp, exp_config, random_dt):

--- a/tests/unittests/storage/test_legacy.py
+++ b/tests/unittests/storage/test_legacy.py
@@ -2,11 +2,6 @@
 # -*- coding: utf-8 -*-
 """Collection of tests for :mod:`orion.storage`."""
 
-import pytest
-
-from orion.core.io.database import Database, DuplicateKeyError
-from orion.core.utils.tests import OrionState
-
 
 base_experiment = {
     'name': 'default_name',
@@ -34,41 +29,3 @@ db_backends = [
         'password': 'pass'
     }
 ]
-
-
-@pytest.mark.parametrize('db_backend', db_backends)
-def test_backward_compatible_drop_user_index(db_backend):
-    """Test that indexes from old versions are removed"""
-    with OrionState(experiments=[], database=db_backend) as cfg:
-        storage = cfg.storage()
-        database = cfg.database
-
-        database.ensure_index(
-            'experiments',
-            [('name', Database.ASCENDING), ('metadata.user', Database.ASCENDING)],
-            unique=True)
-
-        database.ensure_index(
-            'experiments',
-            [('name', Database.ASCENDING),
-             ('metadata.user', Database.ASCENDING),
-             ('version', Database.ASCENDING)],
-            unique=True)
-
-        storage.create_experiment(base_experiment)
-        base_experiment.pop('_id')
-        base_experiment['version'] = 1
-
-        with pytest.raises(DuplicateKeyError):
-            storage.create_experiment(base_experiment)
-
-        experiments = storage.fetch_experiments({})
-        assert len(experiments) == 1, 'Only first experiment in the database'
-
-        # Remove old indexes for backward-compatibility
-        storage._setup_db()  # pylint: disable=protected-access
-
-        assert storage.create_experiment(base_experiment)
-
-        experiments = storage.fetch_experiments({})
-        assert len(experiments) == 2, 'Both experiments in the database'

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -151,6 +151,32 @@ class TestStorage:
             experiments = storage.fetch_experiments({'name': '-1', 'metadata.user': user})
             assert len(experiments) == 0
 
+    def test_update_experiment(self, monkeypatch, storage, name='0', user='a'):
+        """Test fetch experiments"""
+        with OrionState(experiments=generate_experiments(), database=storage) as cfg:
+            storage = cfg.storage()
+
+            class _Dummy():
+                pass
+
+            experiment = cfg.experiments[0]
+            mocked_experiment = _Dummy()
+            mocked_experiment._id = experiment['_id']
+
+            storage.update_experiment(mocked_experiment, test=True)
+            assert storage.fetch_experiments({'_id': experiment['_id']})[0]['test']
+            assert 'test' not in storage.fetch_experiments({'_id': cfg.experiments[1]['_id']})[0]
+
+            storage.update_experiment(uid=experiment['_id'], test2=True)
+            assert storage.fetch_experiments({'_id': experiment['_id']})[0]['test2']
+            assert 'test2' not in storage.fetch_experiments({'_id': cfg.experiments[1]['_id']})[0]
+
+            with pytest.raises(MissingArguments):
+                storage.update_experiment()
+
+            with pytest.raises(AssertionError):
+                storage.update_experiment(experiment=mocked_experiment, uid='123')
+
     def test_register_trial(self, storage):
         """Test register trial"""
         with OrionState(experiments=[base_experiment], database=storage) as cfg:

--- a/tox.ini
+++ b/tox.ini
@@ -33,14 +33,25 @@ passenv = CI TRAVIS TRAVIS_*
 deps =
     -rtests/requirements.txt
     coverage
-usedevelop = True
 commands =
     pip install -U {toxinidir}/tests/functional/gradient_descent_algo
-    coverage run --parallel-mode setup.py test --addopts '--timeout=180 {posargs}'
+    coverage run --parallel-mode -m pytest -vv --ignore tests/functional/backward_compatibility --timeout=180
     coverage combine
     coverage report -m
 
-[testenv:demo_random]
+[testenv:backward-compatibility]
+description = Run all versions of Orion to assert backward compatibility
+setenv = COVERAGE_FILE=.coverage.backward_compatibility
+passenv = CI TRAVIS TRAVIS_* ORION_DB_TYPE
+deps =
+    -rtests/requirements.txt
+    coverage
+commands =
+    coverage run --parallel-mode -m pytest -vv tests/functional/backward_compatibility/test_versions.py
+    coverage combine
+    coverage report -m
+
+[testenv:demo-random]
 description = Run a demo with random search algorithm
 setenv = COVERAGE_FILE=.coverage.random
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
# Important changes
## Database upgrade

There was an incompatibility introduced in v0.1.6 that would break pickleddb created with previous versions. This minor release introduces a new command `orion db upgrade` to upgrade the database scheme so that databases created with `orion<v0.1.6` can still be used in new versions.

# Detailed list of changes
## New feature
- Add `orion db upgrade` command (#293)

## Breaking changes
- Turn test-db into db test (#291)

## Bug fixes
- Handle non-existing fields in EphemeralDB (#284)
- Fix deepcopy of Enumerate transform (#290)
- Instantiate adapter even if empty (#295)

## Others improvements
- Add functional tests for backward-compatibility (#285)
- Save parser state in DB (#288)

## Documentation improvements
- Add mention of windows in install doc (#287)
- Update skopt doc and prepare v0.1.7 (#292)