### PR TITLE
Add Space definition in DB

### DIFF
--- a/src/orion/core/cli/db/upgrade.py
+++ b/src/orion/core/cli/db/upgrade.py
@@ -119,7 +119,7 @@ def upgrade_documents(storage):
     """Upgrade scheme of the documents"""
     for experiment in storage.fetch_experiments({}):
         add_version(experiment)
-        add_priors(experiment)
+        add_space(experiment)
         storage.update_experiment(uid=experiment.pop('_id'), **experiment)
 
 
@@ -128,9 +128,9 @@ def add_version(experiment):
     experiment.setdefault('version', 1)
 
 
-def add_priors(experiment):
-    """Add priors to metadata if not present"""
-    backward.populate_priors(experiment['metadata'])
+def add_space(experiment):
+    """Add space to metadata if not present"""
+    backward.populate_space(experiment)
 
 
 def update_indexes(database):

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -86,7 +86,7 @@ def _build_extended_user_args(config):
 def _build_space(config):
     """Build an optimization space based on given configuration"""
     space_builder = SpaceBuilder()
-    space_config = config.get('space', config['metadata']['priors'])
+    space_config = config['space']
     space = space_builder.build(space_config)
 
     return space

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -25,6 +25,14 @@ def populate_priors(metadata):
     metadata["priors"] = dict(parser.priors)
 
 
+def populate_space(config):
+    """Add the space definition at the root of config."""
+    populate_priors(config['metadata'])
+    # Overwrite space to make sure to include changes from user_args
+    if 'priors' in config['metadata']:
+        config['space'] = config['metadata']['priors']
+
+
 def db_is_outdated(database):
     """Return True if the database scheme is outdated."""
     deprecated_indices = [('name', 'metadata.user'), ('name', 'metadata.user', 'version'),

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -48,7 +48,9 @@ class Experiment:
        This attribute can be updated if the rest of the experiment configuration
        is the same. In that case, if trying to set to an already set experiment,
        it will overwrite the previous one.
-    algorithms : dict of dicts or an `PrimaryAlgo` object, after initialization is done.
+    space: Space
+       Object representing the optimization space.
+    algorithms : `PrimaryAlgo` object.
        Complete specification of the optimization and dynamical procedures taking
        place in this `Experiment`.
 
@@ -76,7 +78,7 @@ class Experiment:
     """
 
     __slots__ = ('name', 'refers', 'metadata', 'pool_size', 'max_trials', 'version',
-                 'algorithms', 'producer', 'working_dir', '_id',
+                 'space', 'algorithms', 'producer', 'working_dir', '_id',
                  '_node', '_storage')
     non_branching_attrs = ('pool_size', 'max_trials')
 
@@ -89,6 +91,7 @@ class Experiment:
         self.metadata = {}
         self.pool_size = None
         self.max_trials = None
+        self.space = None
         self.algorithms = None
         self.working_dir = None
         self.producer = {}
@@ -309,14 +312,6 @@ class Experiment:
         return num_broken_trials >= orion.core.config.worker.max_broken
 
     @property
-    def space(self):
-        """Return problem's parameter `orion.algo.space.Space`.
-
-        .. note:: It will return None, if experiment init is not done.
-        """
-        return self.algorithms.space
-
-    @property
     def configuration(self):
         """Return a copy of an `Experiment` configuration as a dictionary."""
         config = dict()
@@ -325,7 +320,7 @@ class Experiment:
                 continue
             attribute = copy.deepcopy(getattr(self, attrname))
             config[attrname] = attribute
-            if attrname == 'algorithms':
+            if attrname in ['algorithms', 'space']:
                 config[attrname] = attribute.configuration
             elif attrname == "refers" and isinstance(attribute.get("adapter"), BaseAdapter):
                 config[attrname]['adapter'] = config[attrname]['adapter'].configuration
@@ -409,7 +404,7 @@ class ExperimentView(object):
     valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials",
                          "version", "space"] +
                         # Properties
-                        ["id", "node", "is_done", "space", "algorithms", "stats", "configuration"] +
+                        ["id", "node", "is_done", "algorithms", "stats", "configuration"] +
                         # Methods
                         ["fetch_trials", "fetch_trials_by_status", "get_trial"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,7 @@ def exp_config():
     for config in exp_config[0]:
         config["metadata"]["user_script"] = os.path.join(
             os.path.dirname(__file__), config["metadata"]["user_script"])
-        backward.populate_priors(config['metadata'])
+        backward.populate_space(config)
         config['version'] = 1
 
     return exp_config

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -91,7 +91,7 @@ def exp_config():
         exp_config = list(yaml.safe_load_all(f))
 
     for config in exp_config[0]:
-        backward.populate_priors(config['metadata'])
+        backward.populate_space(config)
 
     return exp_config
 

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -157,6 +157,34 @@ class TestDimension(object):
         assert dim.prior is None
         assert dim._prior_name is 'None'
 
+    def test_get_prior_string(self):
+        """Test that prior string can be rebuilt."""
+        dim = Dimension('yolo', 'alpha', 1, 2, 3, some='args', plus='fluff', n=4)
+        assert dim.get_prior_string() == 'alpha(1, 2, 3, some=\'args\', plus=\'fluff\', n=4)'
+
+    def test_get_prior_string_uniform(self):
+        """Test special uniform args are handled properly."""
+        dim = Dimension('yolo', 'uniform', 1, 2)
+        assert dim.get_prior_string() == 'uniform(1, 3)'
+
+    def test_get_prior_string_default_values(self, monkeypatch):
+        """Test that default_value are included."""
+        def contains(self, value):
+            return True
+        monkeypatch.setattr(Dimension, '__contains__', contains)
+        dim = Dimension('yolo', 'alpha', 1, 2, default_value=1)
+        assert dim.get_prior_string() == 'alpha(1, 2, default_value=1)'
+
+    def test_get_prior_string_shape(self):
+        """Test that shape is included."""
+        dim = Dimension('yolo', 'alpha', 1, 2, shape=(2, 3))
+        assert dim.get_prior_string() == 'alpha(1, 2, shape=(2, 3))'
+
+    def test_get_prior_string_loguniform(self):
+        """Test that special loguniform prior name is replaced properly."""
+        dim = Dimension('yolo', 'reciprocal', 1e-10, 1)
+        assert dim.get_prior_string() == 'loguniform(1e-10, 1)'
+
 
 class TestReal(object):
     """Test methods of a `Real` object."""
@@ -322,6 +350,11 @@ class TestInteger(object):
         """Make sure array are cast to int and returned as array of values"""
         dim = Integer('yolo', 'uniform', -3, 4)
         assert np.all(dim.cast(np.array(['1', '2'])) == np.array([1, 2]))
+
+    def test_get_prior_string_discrete(self):
+        """Test that discrete is included."""
+        dim = Integer('yolo', 'uniform', 1, 2)
+        assert dim.get_prior_string() == 'uniform(1, 3, discrete=True)'
 
 
 class TestCategorical(object):
@@ -725,3 +758,17 @@ class TestSpace(object):
                              "default value=None),\n"\
                              "       Real(name=yolo3, prior={norm: (0.9,), {}}, shape=(), "\
                              "default value=None)])"
+
+    def test_configuration(self):
+        """Test that configuration contains all dimensions."""
+        space = Space()
+        space.register(Integer('yolo1', 'uniform', -3, 6, shape=(2,)))
+        space.register(Integer('yolo2', 'uniform', -3, 6, shape=(2,)))
+        space.register(Real('yolo3', 'norm', 0.9))
+        space.register(Categorical('yolo4', ('asdfa', 2)))
+
+        assert space.configuration == {
+            'yolo1': 'uniform(-3, 3, shape=(2,), discrete=True)',
+            'yolo2': 'uniform(-3, 3, shape=(2,), discrete=True)',
+            'yolo3': 'norm(0.9)',
+            'yolo4': 'choices([\'asdfa\', 2])'}

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -3,6 +3,7 @@
 """Example usage and tests for :mod:`orion.algo.space`."""
 
 from collections import (defaultdict, OrderedDict)
+import sys
 
 import numpy as np
 from numpy.testing import assert_array_equal as assert_eq
@@ -157,6 +158,7 @@ class TestDimension(object):
         assert dim.prior is None
         assert dim._prior_name is 'None'
 
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_get_prior_string(self):
         """Test that prior string can be rebuilt."""
         dim = Dimension('yolo', 'alpha', 1, 2, 3, some='args', plus='fluff', n=4)

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -206,7 +206,7 @@ def new_config():
                   ['--new~normal(0,2)', '--changed~normal(0,2)'],
                   'user': 'some_user_name'})
 
-    backward.populate_priors(config['metadata'])
+    backward.populate_space(config)
 
     return config
 
@@ -229,7 +229,7 @@ def old_config(create_db_instance):
                   ['--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
                   'user': 'some_user_name'})
 
-    backward.populate_priors(config['metadata'])
+    backward.populate_space(config)
 
     create_db_instance.write('experiments', config)
     return config
@@ -309,7 +309,7 @@ def cli_conflict(old_config, new_config):
     new_config = copy.deepcopy(new_config)
     new_config['metadata']['user_args'].append("--some-new=args")
     new_config['metadata']['user_args'].append("--bool-arg")
-    backward.populate_priors(new_config['metadata'])
+    backward.populate_space(new_config)
     return conflicts.CommandLineConflict(old_config, new_config)
 
 
@@ -335,7 +335,7 @@ def bad_exp_parent_config():
         version=1,
         algorithms='random')
 
-    backward.populate_priors(config['metadata'])
+    backward.populate_space(config)
 
     return config
 

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -328,8 +328,8 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_diff_config}}
 
-        backward.populate_priors(old_config['metadata'])
-        backward.populate_priors(new_config['metadata'])
+        backward.populate_space(old_config)
+        backward.populate_space(new_config)
 
         conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
         assert len(conflicts) == 1
@@ -339,8 +339,8 @@ class TestScriptConfigConflict(object):
         old_config = {'metadata': {'user_args': yaml_config}}
         new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
 
-        backward.populate_priors(old_config['metadata'])
-        backward.populate_priors(new_config['metadata'])
+        backward.populate_space(old_config)
+        backward.populate_space(new_config)
 
         assert list(conflict.ScriptConfigConflict.detect(old_config, new_config)) == []
 

--- a/tests/unittests/core/io/test_space_builder.py
+++ b/tests/unittests/core/io/test_space_builder.py
@@ -210,3 +210,11 @@ class TestSpaceBuilder(object):
 
         space = spacebuilder.build_from(["--seed=555", "--naedw"])
         assert not space
+
+    def test_configuration_rebuild(self, spacebuilder):
+        """Test that configuration can be used to recreate a space."""
+        prior = {'x': 'uniform(0, 10, discrete=True)',
+                 'y': 'loguniform(1e-08, 1)',
+                 'z': 'choices([\'voici\', \'voila\', 2])'}
+        space = spacebuilder.build(prior)
+        assert space.configuration == prior

--- a/tests/unittests/core/test_pickleddb.py
+++ b/tests/unittests/core/test_pickleddb.py
@@ -11,6 +11,7 @@ import pytest
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.io.database.ephemeraldb import EphemeralCollection
 from orion.core.io.database.pickleddb import find_unpickable_doc, find_unpickable_field, PickledDB
+import orion.core.utils.backward as backward
 
 
 @pytest.fixture()
@@ -94,6 +95,7 @@ class TestRead(object):
     def test_read_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
         loaded_config = orion_db.read('experiments', {'_id': exp_config[0][2]['_id']})
+        backward.populate_space(loaded_config[0])
         assert loaded_config == [exp_config[0][2]]
 
     def test_read_default(self, exp_config, orion_db):
@@ -220,6 +222,7 @@ class TestReadAndWrite(object):
             {'name': 'supernaedo4'},
             {'pool_size': 'lalala'})
         exp_config[0][3]['pool_size'] = 'lalala'
+        backward.populate_space(loaded_config)
         assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, orion_db, exp_config):
@@ -234,6 +237,7 @@ class TestReadAndWrite(object):
             {'pool_size': 'lalala'})
 
         exp_config[0][1]['pool_size'] = 'lalala'
+        backward.populate_space(loaded_config)
         assert loaded_config == exp_config[0][1]
 
         # Make sure it only changed the first document found
@@ -278,7 +282,9 @@ class TestRemove(object):
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before - count_filt
         assert database['experiments'].count() == 1
-        assert list(database['experiments'].find()) == [exp_config[0][0]]
+        loaded_config = list(database['experiments'].find())
+        backward.populate_space(loaded_config[0])
+        assert loaded_config == [exp_config[0][0]]
 
     def test_remove_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
@@ -290,7 +296,10 @@ class TestRemove(object):
         assert orion_db.remove('experiments', filt) == 1
         database = orion_db._get_database()._db
         assert database['experiments'].count() == count_before - 1
-        assert database['experiments'].find() == exp_config[0][1:]
+        loaded_configs = database['experiments'].find()
+        for loaded_config in loaded_configs:
+            backward.populate_space(loaded_config)
+        assert loaded_configs == exp_config[0][1:]
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -24,7 +24,7 @@ def config(exp_config):
     config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
     config['name'] = 'exp'
     config['working_dir'] = "/tmp/orion"
-    backward.populate_priors(config['metadata'])
+    backward.populate_space(config)
     config['space'] = config['metadata']['priors']
     return config
 

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -49,7 +49,7 @@ def new_config(random_dt):
         something_to_be_ignored='asdfa'
         )
 
-    backward.populate_priors(new_config['metadata'])
+    backward.populate_space(new_config)
 
     return new_config
 
@@ -65,7 +65,7 @@ def parent_version_config():
         metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
                   'user_args': ['--x~normal(0,1)']})
 
-    backward.populate_priors(config['metadata'])
+    backward.populate_space(config)
 
     return config
 
@@ -79,7 +79,7 @@ def child_version_config(parent_version_config):
     config['refers'] = {'parent_id': 'parent_config'}
     config['metadata']['datetime'] = datetime.datetime.utcnow()
     config['metadata']['user_args'].append('--y~+normal(0,1)')
-    backward.populate_priors(config['metadata'])
+    backward.populate_space(config)
     return config
 
 


### PR DESCRIPTION
Note:

Depends on #297 

Why:

The space definition used to be implicitely stored in
metadata[user_args] when the only API was the commandline one. With the
python API it becomes much more convenient to store the space definition
in the DB explicitely as it is how the user will provide it.

How:

If using the commandline API, parse the user_args, build the space and
save the configuration of the space in DB. If using the python API,
simply save the space in DB directly.