### PR TITLE
Drop python3.5 support and add python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ jobs:
         after_success:
           - tox -e final-coverage
           - tox -e codecov
-        env: TOXENV=py35
-        python: 3.5
-      - <<: *test
         env: TOXENV=py36
         python: 3.6
       - <<: *test
@@ -34,7 +31,12 @@ jobs:
       - <<: *test
         env: TOXENV=py37
         python: 3.7
-        dist: xenial
+        dist: bionic
+        sudo: true
+      - <<: *test
+        env: TOXENV=py38
+        python: 3.8
+        dist: bionic
         sudo: true
       - <<: *test
         env: TOXENV=demo-random

--- a/conda/conda_build.sh
+++ b/conda/conda_build.sh
@@ -16,9 +16,10 @@ conda update -q conda
 conda info -a
 conda install conda-build anaconda-client
 
-conda build conda --python 3.5
+conda build conda --python 3.6
 conda build conda --python 3.6
 conda build conda --python 3.7
+conda build conda --python 3.8
 
 if [[ -n "${TRAVIS_TAG}" ]]
 then

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup_args['classifiers'] = [
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ] + [('Programming Language :: Python :: %s' % x)
-     for x in '3 3.5 3.6 3.7'.split()]
+     for x in '3 3.6 3.7 3.8'.split()]
 
 if __name__ == '__main__':
     setup(**setup_args)

--- a/tests/functional/gradient_descent_algo/setup.py
+++ b/tests/functional/gradient_descent_algo/setup.py
@@ -47,7 +47,7 @@ setup_args['classifiers'] = [
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ] + [('Programming Language :: Python :: %s' % x)
-     for x in '3 3.4 3.5 3.6'.split()]
+     for x in '3 3.6 3.7 3.8'.split()]
 
 if __name__ == '__main__':
     setup(**setup_args)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,flake8,pylint,doc8,packaging,docs
+envlist = py36,py37,py38,flake8,pylint,doc8,packaging,docs
 minversion = 2.7.0
 
 ## Configure test + coverage process


### PR DESCRIPTION
Why:

Python 3.8 was released a few days ago.

For python 3.5, it lack of builtin ordered dictionary is growing
cumbersome and likely not worth the hassle.