### PR TITLE
Turn trial params to dicts

### DIFF
--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -15,6 +15,7 @@ import sys
 from orion.core.cli.base import get_basic_args_group
 import orion.core.io.experiment_builder as experiment_builder
 
+
 log = logging.getLogger(__name__)
 
 
@@ -427,4 +428,5 @@ def get_trial_params(trial_id, experiment):
     if not best_trial:
         return {}
 
-    return dict((param.name, param.value) for param in best_trial.params)
+    params = dict((param.name, param.value) for param in best_trial.params.values())
+    return params

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -217,7 +217,7 @@ def apply_if_valid(name, trial, callback=None, raise_if_not=True):
         Else, output of callback(trial, item).
 
     """
-    for param in trial.params:
+    for param in trial.params.values():
         if param.name == name:
             return callback is None or callback(trial, param)
 
@@ -282,7 +282,7 @@ class DimensionAddition(BaseAdapter):
                                    (self.param.name, trial))
 
             adapted_trial = copy.deepcopy(trial)
-            adapted_trial.params.append(copy.deepcopy(self.param))
+            adapted_trial.params[self.param.name] = copy.deepcopy(self.param)
             adapted_trials.append(adapted_trial)
 
         return adapted_trials
@@ -300,7 +300,7 @@ class DimensionAddition(BaseAdapter):
             """Remove the param and keep the trial if param has default value"""
             if param == self.param:
                 adapted_trial = copy.deepcopy(trial)
-                del adapted_trial.params[adapted_trial.params.index(self.param)]
+                del adapted_trial.params[self.param.name]
                 adapted_trials.append(adapted_trial)
                 return True
 
@@ -521,6 +521,7 @@ class DimensionRenaming(BaseAdapter):
         # pylint: disable=unused-argument
         def rename(trial, param):
             """Rename param to given new name"""
+            trial.params[self.new_name] = trial.params.pop(param.name)
             param.name = self.new_name
             return True
 

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -408,7 +408,7 @@ class OrionCmdlineParser():
         # Create a copy of the template
         instance = copy.deepcopy(self.config_file_data)
 
-        for param in trial.params:
+        for param in trial.params.values():
             # The param will only correspond to config keyd
             # that require a prior, so we make sure to skip
             # the ones that do not.
@@ -445,8 +445,8 @@ class OrionCmdlineParser():
     def _build_configuration(self, trial):
         configuration = copy.deepcopy(self.parser.arguments)
 
-        for param in trial.params:
-            name = param.name.lstrip('/')
+        for name, param in trial.params.items():
+            name = name.lstrip('/')
             configuration[name] = param.value
 
         return configuration

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -40,3 +40,15 @@ def update_db_config(config):
     if 'database' in config:
         config['storage'] = {'type': 'legacy'}
         config['storage']['database'] = config.pop('database')
+
+
+def params_to_dict(trial_dict):
+    """Convert list of params of trial to a dict"""
+    if isinstance(trial_dict['params'], dict):
+        return
+
+    params = {}
+    for param in trial_dict['params']:
+        params[param['name']] = param
+
+    trial_dict['params'] = params

--- a/src/orion/core/utils/format_trials.py
+++ b/src/orion/core/utils/format_trials.py
@@ -19,7 +19,7 @@ def trial_to_tuple(trial, space):
     The order within the tuple is dictated by the defined
     `orion.algo.space.Space` object.
     """
-    params = {param.name: param.value for param in trial.params}
+    params = {param.name: param.value for param in trial.params.values()}
     trial_keys = set(params.keys())
     space_keys = set(space.keys())
     if trial_keys != space_keys:
@@ -40,13 +40,13 @@ def tuple_to_trial(data, space):
     :type space: `orion.algo.space.Space`
     """
     assert len(data) == len(space)
-    params = []
+    params = dict()
     for i, dim in enumerate(space.values()):
-        params.append(dict(
+        params[dim.name] = dict(
             name=dim.name,
             type=dim.type,
             value=data[i]
-            ))
+            )
     return Trial(params=params)
 
 

--- a/src/orion/core/utils/tests.py
+++ b/src/orion/core/utils/tests.py
@@ -20,6 +20,7 @@ from orion.core.io.database.mongodb import MongoDB
 from orion.core.io.database.pickleddb import PickledDB
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils import SingletonAlreadyInstantiatedError
+import orion.core.utils.backward as backward
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage, Storage
 from orion.storage.legacy import Legacy
@@ -171,6 +172,7 @@ class BaseOrionState:
     def load_experience_configuration(self):
         """Load an example database."""
         for i, t_dict in enumerate(self._trials):
+            backward.params_to_dict(t_dict)
             self._trials[i] = Trial(**t_dict).to_dict()
 
         for i, t_dict in enumerate(self._lies):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,7 @@ def exp_config():
         exp_config = list(yaml.safe_load_all(f))
 
     for i, t_dict in enumerate(exp_config[1]):
+        backward.params_to_dict(t_dict)
         exp_config[1][i] = Trial(**t_dict).to_dict()
 
     for config in exp_config[0]:

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -65,7 +65,7 @@ def test_simple(monkeypatch, config_file):
     assert best_trial.objective.name == 'example_objective'
     assert abs(best_trial.objective.value - 23.4) < 1e-5
     assert len(best_trial.params) == 1
-    param = best_trial.params[0]
+    param = best_trial.params['/x']
     assert param.name == '/x'
     assert param.type == 'real'
 
@@ -107,10 +107,10 @@ def test_with_fidelity(database, monkeypatch, config_file):
     assert best_trial.objective.name == 'example_objective'
     assert abs(best_trial.objective.value - 23.4) < 1e-5
     assert len(best_trial.params) == 2
-    fidelity = best_trial.params[0]
+    fidelity = best_trial.params['/fidelity']
     assert fidelity.name == '/fidelity'
     assert fidelity.type == 'fidelity'
     assert fidelity.value == 10
-    param = best_trial.params[1]
+    param = best_trial.params['/x']
     assert param.name == '/x'
     assert param.type == 'real'

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -186,7 +186,7 @@ def get_name_value_pairs(trials):
     pairs = []
     for trial in trials:
         pairs.append([])
-        for param in trial.params:
+        for param in trial.params.values():
             pairs[-1].append((param.name, param.value))
 
         pairs[-1] = tuple(pairs[-1])

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -208,7 +208,7 @@ def single_without_success(one_experiment):
     x_value = 0
     for status in statuses:
         x['value'] = x_value
-        trial = Trial(experiment=exp.id, params=[x], status=status)
+        trial = Trial(experiment=exp.id, params={'/x': x}, status=status)
         x_value += 1
         Database().write('trials', trial.to_dict())
 
@@ -220,7 +220,7 @@ def single_with_trials(single_without_success):
 
     x = {'name': '/x', 'type': 'real', 'value': 100}
     results = {"name": "obj", "type": "objective", "value": 0}
-    trial = Trial(experiment=exp.id, params=[x], status='completed', results=[results])
+    trial = Trial(experiment=exp.id, params={'/x': x}, status='completed', results=[results])
     Database().write('trials', trial.to_dict())
 
 
@@ -250,9 +250,9 @@ def family_with_trials(two_experiments):
     for status in Trial.allowed_stati:
         x['value'] = x_value
         y['value'] = x_value
-        trial = Trial(experiment=exp.id, params=[x], status=status)
+        trial = Trial(experiment=exp.id, params={'/x': x}, status=status)
         x['value'] = x_value
-        trial2 = Trial(experiment=exp2.id, params=[x, y], status=status)
+        trial2 = Trial(experiment=exp2.id, params={'/x': x, '/y': y}, status=status)
         x_value += 1
         Database().write('trials', trial.to_dict())
         Database().write('trials', trial2.to_dict())
@@ -299,7 +299,7 @@ def three_family_with_trials(three_experiments_family, family_with_trials):
     for status in Trial.allowed_stati:
         x['value'] = x_value
         z['value'] = x_value * 100
-        trial = Trial(experiment=exp.id, params=[x, z], status=status)
+        trial = Trial(experiment=exp.id, params={'/x': x, '/z': z}, status=status)
         x_value += 1
         Database().write('trials', trial.to_dict())
 
@@ -330,7 +330,7 @@ def three_family_branch_with_trials(three_experiments_family_branch, family_with
         x['value'] = x_value
         y['value'] = x_value * 10
         z['value'] = x_value * 100
-        trial = Trial(experiment=exp.id, params=[x, y, z], status=status)
+        trial = Trial(experiment=exp.id, params={'/x': x, '/y': y, '/z': z}, status=status)
         x_value += 1
         Database().write('trials', trial.to_dict())
 

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -51,7 +51,7 @@ def test_insert_single_trial(database, monkeypatch, script_path):
     trial = trials[0]
 
     assert trial['status'] == 'new'
-    assert trial['params'][0]['value'] == 1
+    assert trial['params']['/x']['value'] == 1
 
 
 @pytest.mark.usefixtures("only_experiments_db")
@@ -76,7 +76,7 @@ def test_insert_single_trial_default_value(database, monkeypatch):
     trial = trials[0]
 
     assert trial['status'] == 'new'
-    assert trial['params'][0]['value'] == 1
+    assert trial['params']['/x']['value'] == 1
 
 
 @pytest.mark.usefixtures("only_experiments_db")
@@ -143,8 +143,8 @@ def test_insert_two_hyperparameters(database, monkeypatch):
     trial = trials[0]
 
     assert trial['status'] == 'new'
-    assert trial['params'][0]['value'] == 1
-    assert trial['params'][1]['value'] == 2
+    assert trial['params']['/x']['value'] == 1
+    assert trial['params']['/y']['value'] == 2
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -95,9 +95,9 @@ def test_demo(database, monkeypatch):
             assert result['name'] == 'example_gradient'
     params = trials[-1]['params']
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params['/x']['name'] == '/x'
+    assert params['/x']['type'] == 'real'
+    assert (params['/x']['value'] - 34.56789) < 1e-5
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -140,9 +140,9 @@ def test_demo_with_script_config(database, monkeypatch):
             assert result['name'] == 'example_gradient'
     params = trials[-1]['params']
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params['/x']['name'] == '/x'
+    assert params['/x']['type'] == 'real'
+    assert (params['/x']['value'] - 34.56789) < 1e-5
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -185,8 +185,8 @@ def test_demo_two_workers(database, monkeypatch):
     assert status['new'] < 5
     params = trials[-1]['params']
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
+    assert params['/x']['name'] == '/x'
+    assert params['/x']['type'] == 'real'
 
 
 def test_workon():
@@ -241,9 +241,9 @@ def test_workon():
                 assert result.name == 'example_gradient'
         params = trials[-1].params
         assert len(params) == 1
-        assert params[0].name == '/x'
-        assert params[0].type == 'real'
-        assert (params[0].value - 34.56789) < 1e-5
+        assert params['/x'].name == '/x'
+        assert params['/x'].type == 'real'
+        assert (params['/x'].value - 34.56789) < 1e-5
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -282,9 +282,9 @@ def test_stress_unique_folder_creation(database, monkeypatch, tmpdir, capfd):
     # things from the past. This is intended to be shown with the assertions
     # in the for-loop below.
     trials_c = list(database.trials.find({'experiment': exp_id, 'status': 'completed'}))
-    list_of_cx = [trial['params'][0]['value'] for trial in trials_c]
+    list_of_cx = [trial['params']['/x']['value'] for trial in trials_c]
     trials_b = list(database.trials.find({'experiment': exp_id, 'status': 'broken'}))
-    list_of_bx = [trial['params'][0]['value'] for trial in trials_b]
+    list_of_bx = [trial['params']['/x']['value'] for trial in trials_b]
     for bx in list_of_bx:
         assert bx in list_of_cx
 
@@ -533,8 +533,8 @@ def test_demo_with_nondefault_config_keyword(database, monkeypatch):
             assert result['name'] == 'example_gradient'
     params = trials[-1]['params']
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params['/x']['name'] == '/x'
+    assert params['/x']['type'] == 'real'
+    assert (params['/x']['value'] - 34.56789) < 1e-5
 
     orion.core.config.user_script_config = 'config'

--- a/tests/functional/gradient_descent_algo/setup.py
+++ b/tests/functional/gradient_descent_algo/setup.py
@@ -47,7 +47,7 @@ setup_args['classifiers'] = [
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ] + [('Programming Language :: Python :: %s' % x)
-     for x in '3 3.4 3.5 3.6'.split()]
+     for x in '3 3.5 3.6 3.7'.split()]
 
 if __name__ == '__main__':
     setup(**setup_args)

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -23,10 +23,10 @@ class DummyExperiment():
 def dummy_trial():
     """Return a dummy trial object"""
     trial = Trial()
-    trial.params = [
-        Trial.Param(name='a', type='real', value=0.0),
-        Trial.Param(name='b', type='integer', value=1),
-        Trial.Param(name='c', type='categorical', value='Some')]
+    trial.params = dict(
+        a=Trial.Param(name='a', type='real', value=0.0),
+        b=Trial.Param(name='b', type='integer', value=1),
+        c=Trial.Param(name='c', type='categorical', value='Some'))
     return trial
 
 

--- a/tests/unittests/core/evc/test_adapters.py
+++ b/tests/unittests/core/evc/test_adapters.py
@@ -71,11 +71,11 @@ def trials(small_prior, large_prior, normal_prior, disjoint_prior,
 
     trials = []
     for _ in range(N_TRIALS):
-        params = []
+        params = {}
         for name, prior in priors.items():
             dimension = DimensionBuilder().build(name, prior)
             value = dimension.sample()[0]
-            params.append(Trial.Param(name=name, type=dimension.type, value=value).to_dict())
+            params[name] = Trial.Param(name=name, type=dimension.type, value=value).to_dict()
         trials.append(Trial(params=params))
 
     return trials
@@ -290,9 +290,9 @@ class TestDimensionAdditionForwardBackward(object):
 
         adapted_trials = dimension_addition_adapter.forward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0].params[new_param.name] == new_param
+        assert adapted_trials[4].params[new_param.name] == new_param
+        assert adapted_trials[-1].params[new_param.name] == new_param
 
     def test_dimension_addition_forward_already_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
@@ -316,32 +316,32 @@ class TestDimensionAdditionForwardBackward(object):
         for trial in trials:
             random_param = new_param.to_dict()
             random_param['value'] = sampler.sample()
-            trial.params.append(Trial.Param(**random_param))
+            trial.params[random_param['name']] = Trial.Param(**random_param)
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 0
 
-        trials[0].params[-1].value = 1
-        assert trials[0].params[-1] == new_param
+        trials[0].params[new_param.name].value = 1
+        assert trials[0].params[new_param.name] == new_param
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 1
 
-        trials[4].params[-1].value = 1
-        assert trials[4].params[-1] == new_param
+        trials[4].params[new_param.name].value = 1
+        assert trials[4].params[new_param.name] == new_param
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 2
 
-        trials[-1].params[-1].value = 1
-        assert trials[-1].params[-1] == new_param
+        trials[-1].params[new_param.name].value = 1
+        assert trials[-1].params[new_param.name] == new_param
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 3
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[1].params)
-        assert new_param not in (adapted_trials[2].params)
+        assert new_param not in list(adapted_trials[0].params.values())
+        assert new_param not in list(adapted_trials[1].params.values())
+        assert new_param not in list(adapted_trials[2].params.values())
 
     def test_dimension_addition_backward_not_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
@@ -371,32 +371,32 @@ class TestDimensionDeletionForwardBackward(object):
         for trial in trials:
             random_param = new_param.to_dict()
             random_param['value'] = sampler.sample()
-            trial.params.append(Trial.Param(**random_param))
+            trial.params[random_param['name']] = Trial.Param(**random_param)
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 0
 
-        trials[0].params[-1].value = 1
-        assert trials[0].params[-1] == new_param
+        trials[0].params[new_param.name].value = 1
+        assert trials[0].params[new_param.name] == new_param
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 1
 
-        trials[4].params[-1].value = 1
-        assert trials[4].params[-1] == new_param
+        trials[4].params[new_param.name].value = 1
+        assert trials[4].params[new_param.name] == new_param
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 2
 
-        trials[-1].params[-1].value = 1
-        assert trials[-1].params[-1] == new_param
+        trials[-1].params[new_param.name].value = 1
+        assert trials[-1].params[new_param.name] == new_param
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 3
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[1].params)
-        assert new_param not in (adapted_trials[2].params)
+        assert new_param not in list(adapted_trials[0].params.values())
+        assert new_param not in list(adapted_trials[1].params.values())
+        assert new_param not in list(adapted_trials[2].params.values())
 
     def test_dimension_deletion_forward_not_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
@@ -418,9 +418,9 @@ class TestDimensionDeletionForwardBackward(object):
 
         adapted_trials = dimension_deletion_adapter.backward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0].params[new_param.name] == new_param
+        assert adapted_trials[4].params[new_param.name] == new_param
+        assert adapted_trials[-1].params[new_param.name] == new_param
 
     def test_dimension_deletion_backward_already_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
@@ -504,11 +504,11 @@ class TestDimensionRenamingForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert new_name in [param.name for param in adapted_trials[0].params]
-        assert old_name not in [param.name for param in adapted_trials[0].params]
+        assert new_name in [param.name for param in adapted_trials[0].params.values()]
+        assert old_name not in [param.name for param in adapted_trials[0].params.values()]
 
-        assert new_name in [param.name for param in adapted_trials[-1].params]
-        assert old_name not in [param.name for param in adapted_trials[-1].params]
+        assert new_name in [param.name for param in adapted_trials[-1].params.values()]
+        assert old_name not in [param.name for param in adapted_trials[-1].params.values()]
 
     def test_dimension_renaming_forward_incompatible(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
@@ -536,11 +536,11 @@ class TestDimensionRenamingForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert old_name in [param.name for param in adapted_trials[0].params]
-        assert new_name not in [param.name for param in adapted_trials[0].params]
+        assert old_name in [param.name for param in adapted_trials[0].params.values()]
+        assert new_name not in [param.name for param in adapted_trials[0].params.values()]
 
-        assert old_name in [param.name for param in adapted_trials[-1].params]
-        assert new_name not in [param.name for param in adapted_trials[-1].params]
+        assert old_name in [param.name for param in adapted_trials[-1].params.values()]
+        assert new_name not in [param.name for param in adapted_trials[-1].params.values()]
 
     def test_dimension_renaming_backward_incompatible(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
@@ -672,9 +672,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         adapted_trials = composite_adapter.forward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0].params[new_param.name] == new_param
+        assert adapted_trials[4].params[new_param.name] == new_param
+        assert adapted_trials[-1].params[new_param.name] == new_param
 
         composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
 
@@ -682,9 +682,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[4].params)
-        assert new_param not in (adapted_trials[-1].params)
+        assert new_param not in list(adapted_trials[0].params.values())
+        assert new_param not in list(adapted_trials[4].params.values())
+        assert new_param not in list(adapted_trials[-1].params.values())
 
     def test_composite_adapter_backward(self, dummy_param, trials):
         """Test :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with two adapters"""
@@ -697,9 +697,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         adapted_trials = composite_adapter.backward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0].params[new_param.name] == new_param
+        assert adapted_trials[4].params[new_param.name] == new_param
+        assert adapted_trials[-1].params[new_param.name] == new_param
 
         composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
 
@@ -707,9 +707,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[4].params)
-        assert new_param not in (adapted_trials[-1].params)
+        assert new_param not in list(adapted_trials[0].params.values())
+        assert new_param not in list(adapted_trials[4].params.values())
+        assert new_param not in list(adapted_trials[-1].params.values())
 
 
 def test_dimension_addition_configuration(dummy_param):

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -232,12 +232,14 @@ def test_renaming_forward(create_db_instance):
     assert len(parent_trials) == 6
     assert len(exp_node.item.fetch_trials(query)) == 4
 
-    assert all((trial.params[0].name == "/encoding_layer") for trial in parent_trials)
+    assert all((trial.params['/encoding_layer'].name == "/encoding_layer")
+               for trial in parent_trials)
 
     adapter = experiment.refers['adapter']
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 6
-    assert all((trial.params[0].name == "/encoding") for trial in adapted_parent_trials)
+    assert all((trial.params['/encoding_layer'].name == "/encoding")
+               for trial in adapted_parent_trials)
 
     assert len(experiment.fetch_trials_tree(query)) == 6 + 4
 
@@ -268,12 +270,13 @@ def test_renaming_backward(create_db_instance):
     assert len(children_trials) == 4
     assert len(exp_node.item.fetch_trials(query)) == 6
 
-    assert all((trial.params[0].name == "/encoding") for trial in children_trials)
+    assert all((trial.params["/encoding"].name == "/encoding") for trial in children_trials)
 
     adapter = exp_node.children[0].item.refers['adapter']
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 4
-    assert all((trial.params[0].name == "/encoding_layer") for trial in adapted_children_trials)
+    assert all((trial.params["/encoding_layer"].name == "/encoding_layer")
+               for trial in adapted_children_trials)
 
     assert len(experiment.fetch_trials_tree(query)) == 6 + 4
 

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -155,9 +155,11 @@ def test_format_commandline_only(parser, commandline):
     """Format the commandline using only args."""
     parser.parse(commandline)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'}])
+    trial = Trial(params={
+        '/lr': {
+            'name': '/lr', 'type': 'real', 'value': -2.4},
+        '/prior': {
+            'name': '/prior', 'type': 'categorical', 'value': 'sgd'}})
 
     cmd_inst = parser.format(trial=trial)
     assert cmd_inst == ["--seed", "555",
@@ -173,15 +175,15 @@ def test_format_commandline_and_config(parser, commandline, json_config, tmpdir,
 
     parser.parse(cmd_args)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
-        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
-        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
-        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
-        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
-        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
-        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+    trial = Trial(params={
+        '/lr': {'name': '/lr', 'type': 'real', 'value': -2.4},
+        '/prior': {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
+        '/layers/1/width': {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
+        '/layers/1/type': {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
+        '/layers/2/type': {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
+        '/training/lr0': {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
+        '/training/mbs': {'name': '/training/mbs', 'type': 'integer', 'value': 64},
+        '/something-same': {'name': '/something-same', 'type': 'categorical', 'value': '3'}})
 
     output_file = str(tmpdir.join("output.json"))
 
@@ -205,15 +207,15 @@ def test_format_without_config_path(parser, commandline, json_config, tmpdir, js
 
     parser.parse(cmd_args)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
-        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
-        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
-        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
-        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
-        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
-        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+    trial = Trial(params={
+        '/lr': {'name': '/lr', 'type': 'real', 'value': -2.4},
+        '/prior': {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
+        '/layers/1/width': {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
+        '/layers/1/type': {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
+        '/layers/2/type': {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
+        '/training/lr0': {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
+        '/training/mbs': {'name': '/training/mbs', 'type': 'integer', 'value': 64},
+        '/something-same': {'name': '/something-same', 'type': 'categorical', 'value': '3'}})
 
     with pytest.raises(ValueError) as exc_info:
         parser.format(trial=trial)
@@ -225,9 +227,9 @@ def test_format_with_properties(parser, cmd_with_properties, hacked_exp):
     """Test if format correctly puts the value of `trial` and `exp` when used as properties"""
     parser.parse(cmd_with_properties)
 
-    trial = Trial(experiment='trial_test', params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'}])
+    trial = Trial(experiment='trial_test', params={
+        '/lr': {'name': '/lr', 'type': 'real', 'value': -2.4},
+        '/prior': {'name': '/prior', 'type': 'categorical', 'value': 'sgd'}})
 
     cmd_line = parser.format(None, trial=trial, experiment=hacked_exp)
     print(cmd_line)
@@ -315,15 +317,15 @@ def test_set_state_dict(parser, commandline, json_config, tmpdir, json_converter
 
     blank_parser.set_state_dict(state)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
-        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
-        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
-        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
-        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
-        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
-        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+    trial = Trial(params={
+        '/lr': {'name': '/lr', 'type': 'real', 'value': -2.4},
+        '/prior': {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
+        '/layers/1/width': {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
+        '/layers/1/type': {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
+        '/layers/2/type': {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
+        '/training/lr0': {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
+        '/training/mbs': {'name': '/training/mbs', 'type': 'integer', 'value': 64},
+        '/something-same': {'name': '/something-same', 'type': 'categorical', 'value': '3'}})
 
     output_file = str(tmpdir.join("output.json"))
 

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -177,14 +177,15 @@ def test_register_new_trials(producer, database, random_dt):
     assert new_trials[0]['start_time'] is None
     assert new_trials[0]['end_time'] is None
     assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert new_trials[0]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'rnn'}}
 
 
 def test_no_lies_if_all_trials_completed(producer, database, random_dt):
@@ -423,23 +424,25 @@ def test_concurent_producers(producer, database, random_dt):
     assert new_trials[0]['start_time'] is None
     assert new_trials[0]['end_time'] is None
     assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert new_trials[0]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'rnn'}}
 
-    assert new_trials[1]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
+    assert new_trials[1]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'gru'}}
 
 
 def test_duplicate_within_pool(producer, database, random_dt):
@@ -469,23 +472,25 @@ def test_duplicate_within_pool(producer, database, random_dt):
     assert new_trials[0]['start_time'] is None
     assert new_trials[0]['end_time'] is None
     assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert new_trials[0]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'rnn'}}
 
-    assert new_trials[1]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
+    assert new_trials[1]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'gru'}}
 
 
 def test_duplicate_within_pool_and_db(producer, database, random_dt):
@@ -515,23 +520,25 @@ def test_duplicate_within_pool_and_db(producer, database, random_dt):
     assert new_trials[0]['start_time'] is None
     assert new_trials[0]['end_time'] is None
     assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert new_trials[0]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'rnn'}}
 
-    assert new_trials[1]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
+    assert new_trials[1]['params'] == {
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'gru'},
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'gru'}}
 
 
 def test_exceed_max_idle_time_because_of_duplicates(producer, database, random_dt):

--- a/tests/unittests/core/test_strategy.py
+++ b/tests/unittests/core/test_strategy.py
@@ -20,7 +20,7 @@ def observations():
 @pytest.fixture
 def incomplete_trial():
     """Return a single trial without results"""
-    return Trial(params=[{'name': 'a', 'type': 'integer', 'value': 6}])
+    return Trial(params=dict(a={'name': 'a', 'type': 'integer', 'value': 6}))
 
 
 class TestStrategyFactory:

--- a/tests/unittests/core/test_utils_format.py
+++ b/tests/unittests/core/test_utils_format.py
@@ -11,23 +11,22 @@ from orion.core.worker.trial import Trial
 @pytest.fixture()
 def trial():
     """Stab trial to match tuple from fixture `fixed_suggestion`."""
-    params = [
-        dict(
+    params = dict(
+        yolo=dict(
             name='yolo',
             type='categorical',
             value=('asdfa', 2)
             ),
-        dict(
+        yolo2=dict(
             name='yolo2',
             type='integer',
             value=0
             ),
-        dict(
+        yolo3=dict(
             name='yolo3',
             type='real',
             value=3.5
-            )
-        ]
+            ))
     return Trial(params=params)
 
 
@@ -36,13 +35,14 @@ def test_trial_to_tuple(space, trial, fixed_suggestion):
     data = trial_to_tuple(trial, space)
     assert data == fixed_suggestion
 
-    trial.params[0].name = 'lalala'
+    print(trial.params)
+    trial.params['yolo'].name = 'lalala'
     with pytest.raises(ValueError) as exc:
         trial_to_tuple(trial, space)
 
     assert "Trial params: [\'lalala\', \'yolo2\', \'yolo3\']" in str(exc.value)
 
-    trial.params.pop(0)
+    trial.params.pop('yolo')
     with pytest.raises(ValueError) as exc:
         trial_to_tuple(trial, space)
 
@@ -60,8 +60,8 @@ def test_tuple_to_trial(space, trial, fixed_suggestion):
     assert t.end_time is None
     assert t.results == []
     assert len(t.params) == len(trial.params)
-    for i in range(len(t.params)):
-        assert t.params[i].to_dict() == trial.params[i].to_dict()
+    for key in t.params:
+        assert t.params[key].to_dict() == trial.params[key].to_dict()
 
 
 def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
@@ -78,5 +78,5 @@ def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
     assert t.end_time is None
     assert t.results == []
     assert len(t.params) == len(trial.params)
-    for i in range(len(t.params)):
-        assert t.params[i].to_dict() == trial.params[i].to_dict()
+    for key in t.params:
+        assert t.params[key].to_dict() == trial.params[key].to_dict()

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -344,16 +344,18 @@ def test_register_trials(random_dt):
         exp._id = 0
 
         trials = [
-            Trial(params=[{'name': 'a', 'type': 'integer', 'value': 5}]),
-            Trial(params=[{'name': 'b', 'type': 'integer', 'value': 6}]),
+            Trial(params={'a': {'name': 'a', 'type': 'integer', 'value': 5}}),
+            Trial(params={'b': {'name': 'b', 'type': 'integer', 'value': 6}}),
             ]
         for trial in trials:
             exp.register_trial(trial)
 
         yo = list(map(lambda trial: trial.to_dict(), get_storage().fetch_trials(exp)))
         assert len(yo) == len(trials)
-        assert yo[0]['params'] == list(map(lambda x: x.to_dict(), trials[0].params))
-        assert yo[1]['params'] == list(map(lambda x: x.to_dict(), trials[1].params))
+        assert yo[0]['params'] == {name: param.to_dict()
+                                   for name, param in trials[0].params.items()}
+        assert yo[1]['params'] == {name: param.to_dict()
+                                   for name, param in trials[1].params.items()}
         assert yo[0]['status'] == 'new'
         assert yo[1]['status'] == 'new'
         assert yo[0]['submit_time'] == random_dt

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -56,14 +56,16 @@ base_trial = {
          'type': 'objective',  # objective, constraint
          'value': 2}
     ],
-    'params': [
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'},
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'lstm_with_attention'}
-    ]
+    'params': {
+        '/encoding_layer': {
+            'name': '/encoding_layer',
+            'type': 'categorical',
+            'value': 'rnn'},
+        '/decoding_layer': {
+            'name': '/decoding_layer',
+            'type': 'categorical',
+            'value': 'lstm_with_attention'}
+    }
 }
 
 
@@ -87,11 +89,11 @@ def make_lost_trial():
     obj['status'] = 'reserved'
     obj['heartbeat'] = (datetime.datetime.utcnow() -
                         datetime.timedelta(seconds=orion.core.config.worker.heartbeat * 2))
-    obj['params'].append({
+    obj['params']['/index'] = {
         'name': '/index',
         'type': 'categorical',
         'value': 'lost_trial'
-    })
+    }
     return obj
 
 
@@ -107,11 +109,11 @@ def generate_trials(status=None):
 
     # make each trial unique
     for i, trial in enumerate(new_trials):
-        trial['params'].append({
+        trial['params']['/index'] = {
             'name': '/index',
             'type': 'categorical',
             'value': i
-        })
+        }
 
     return new_trials
 


### PR DESCRIPTION
Note: py35 will fail until removed in #303 

Why:

The list structure is very cumbersome and does not match the interface
provided to users to define space. The params structure as a dict is
more coherent.