### PR TITLE
Expose trial.params as a dict

### DIFF
--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -427,4 +427,4 @@ def get_trial_params(trial_id, experiment):
     if not best_trial:
         return {}
 
-    return dict((param.name, param.value) for param in best_trial.params)
+    return best_trial.params

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -217,7 +217,7 @@ def apply_if_valid(name, trial, callback=None, raise_if_not=True):
         Else, output of callback(trial, item).
 
     """
-    for param in trial.params:
+    for param in trial._params:  # pylint: disable=protected-access
         if param.name == name:
             return callback is None or callback(trial, param)
 
@@ -282,7 +282,8 @@ class DimensionAddition(BaseAdapter):
                                    (self.param.name, trial))
 
             adapted_trial = copy.deepcopy(trial)
-            adapted_trial.params.append(copy.deepcopy(self.param))
+            # pylint: disable=protected-access
+            adapted_trial._params.append(copy.deepcopy(self.param))
             adapted_trials.append(adapted_trial)
 
         return adapted_trials
@@ -300,7 +301,8 @@ class DimensionAddition(BaseAdapter):
             """Remove the param and keep the trial if param has default value"""
             if param == self.param:
                 adapted_trial = copy.deepcopy(trial)
-                del adapted_trial.params[adapted_trial.params.index(self.param)]
+                # pylint: disable=protected-access
+                del adapted_trial._params[adapted_trial._params.index(self.param)]
                 adapted_trials.append(adapted_trial)
                 return True
 

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -408,16 +408,16 @@ class OrionCmdlineParser():
         # Create a copy of the template
         instance = copy.deepcopy(self.config_file_data)
 
-        for param in trial.params:
+        for name, value in trial.params.items():
             # The param will only correspond to config keyd
             # that require a prior, so we make sure to skip
             # the ones that do not.
-            if param.name not in self.file_priors.keys():
+            if name not in self.file_priors.keys():
                 continue
 
             # Since namespace start with '/', we must skip
             # the first element of the list.
-            path = param.name.split('/')[1:]
+            path = name.split('/')[1:]
             current_depth = instance
 
             for key in path:
@@ -436,7 +436,7 @@ class OrionCmdlineParser():
                         break
 
                 if isinstance(current_depth[key], str):
-                    current_depth[key] = param.value
+                    current_depth[key] = value
                 else:
                     current_depth = current_depth[key]
 
@@ -445,9 +445,9 @@ class OrionCmdlineParser():
     def _build_configuration(self, trial):
         configuration = copy.deepcopy(self.parser.arguments)
 
-        for param in trial.params:
-            name = param.name.lstrip('/')
-            configuration[name] = param.value
+        for name, value in trial.params.items():
+            name = name.lstrip('/')
+            configuration[name] = value
 
         return configuration
 

--- a/src/orion/core/utils/format_trials.py
+++ b/src/orion/core/utils/format_trials.py
@@ -19,7 +19,7 @@ def trial_to_tuple(trial, space):
     The order within the tuple is dictated by the defined
     `orion.algo.space.Space` object.
     """
-    params = {param.name: param.value for param in trial.params}
+    params = trial.params
     trial_keys = set(params.keys())
     space_keys = set(space.keys())
     if trial_keys != space_keys:

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -65,7 +65,7 @@ def test_simple(monkeypatch, config_file):
     assert best_trial.objective.name == 'example_objective'
     assert abs(best_trial.objective.value - 23.4) < 1e-5
     assert len(best_trial.params) == 1
-    param = best_trial.params[0]
+    param = best_trial._params[0]
     assert param.name == '/x'
     assert param.type == 'real'
 
@@ -107,10 +107,10 @@ def test_with_fidelity(database, monkeypatch, config_file):
     assert best_trial.objective.name == 'example_objective'
     assert abs(best_trial.objective.value - 23.4) < 1e-5
     assert len(best_trial.params) == 2
-    fidelity = best_trial.params[0]
+    fidelity = best_trial._params[0]
     assert fidelity.name == '/fidelity'
     assert fidelity.type == 'fidelity'
     assert fidelity.value == 10
-    param = best_trial.params[1]
+    param = best_trial._params[1]
     assert param.name == '/x'
     assert param.type == 'real'

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -186,7 +186,7 @@ def get_name_value_pairs(trials):
     pairs = []
     for trial in trials:
         pairs.append([])
-        for param in trial.params:
+        for param in trial._params:
             pairs[-1].append((param.name, param.value))
 
         pairs[-1] = tuple(pairs[-1])

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -239,7 +239,7 @@ def test_workon():
                 res = numpy.asarray(result.value)
                 assert 0.1 * numpy.sqrt(res.dot(res)) < 1e-7
                 assert result.name == 'example_gradient'
-        params = trials[-1].params
+        params = trials[-1]._params
         assert len(params) == 1
         assert params[0].name == '/x'
         assert params[0].type == 'real'

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -23,7 +23,7 @@ class DummyExperiment():
 def dummy_trial():
     """Return a dummy trial object"""
     trial = Trial()
-    trial.params = [
+    trial._params = [
         Trial.Param(name='a', type='real', value=0.0),
         Trial.Param(name='b', type='integer', value=1),
         Trial.Param(name='c', type='categorical', value='Some')]

--- a/tests/unittests/core/evc/test_adapters.py
+++ b/tests/unittests/core/evc/test_adapters.py
@@ -290,9 +290,9 @@ class TestDimensionAdditionForwardBackward(object):
 
         adapted_trials = dimension_addition_adapter.forward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0]._params[-1] == new_param
+        assert adapted_trials[4]._params[-1] == new_param
+        assert adapted_trials[-1]._params[-1] == new_param
 
     def test_dimension_addition_forward_already_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
@@ -316,32 +316,32 @@ class TestDimensionAdditionForwardBackward(object):
         for trial in trials:
             random_param = new_param.to_dict()
             random_param['value'] = sampler.sample()
-            trial.params.append(Trial.Param(**random_param))
+            trial._params.append(Trial.Param(**random_param))
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 0
 
-        trials[0].params[-1].value = 1
-        assert trials[0].params[-1] == new_param
+        trials[0]._params[-1].value = 1
+        assert trials[0]._params[-1] == new_param
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 1
 
-        trials[4].params[-1].value = 1
-        assert trials[4].params[-1] == new_param
+        trials[4]._params[-1].value = 1
+        assert trials[4]._params[-1] == new_param
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 2
 
-        trials[-1].params[-1].value = 1
-        assert trials[-1].params[-1] == new_param
+        trials[-1]._params[-1].value = 1
+        assert trials[-1]._params[-1] == new_param
 
         adapted_trials = dimension_addition_adapter.backward(trials)
         assert len(adapted_trials) == 3
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[1].params)
-        assert new_param not in (adapted_trials[2].params)
+        assert new_param not in (adapted_trials[0]._params)
+        assert new_param not in (adapted_trials[1]._params)
+        assert new_param not in (adapted_trials[2]._params)
 
     def test_dimension_addition_backward_not_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
@@ -371,32 +371,32 @@ class TestDimensionDeletionForwardBackward(object):
         for trial in trials:
             random_param = new_param.to_dict()
             random_param['value'] = sampler.sample()
-            trial.params.append(Trial.Param(**random_param))
+            trial._params.append(Trial.Param(**random_param))
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 0
 
-        trials[0].params[-1].value = 1
-        assert trials[0].params[-1] == new_param
+        trials[0]._params[-1].value = 1
+        assert trials[0]._params[-1] == new_param
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 1
 
-        trials[4].params[-1].value = 1
-        assert trials[4].params[-1] == new_param
+        trials[4]._params[-1].value = 1
+        assert trials[4]._params[-1] == new_param
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 2
 
-        trials[-1].params[-1].value = 1
-        assert trials[-1].params[-1] == new_param
+        trials[-1]._params[-1].value = 1
+        assert trials[-1]._params[-1] == new_param
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
         assert len(adapted_trials) == 3
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[1].params)
-        assert new_param not in (adapted_trials[2].params)
+        assert new_param not in (adapted_trials[0]._params)
+        assert new_param not in (adapted_trials[1]._params)
+        assert new_param not in (adapted_trials[2]._params)
 
     def test_dimension_deletion_forward_not_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
@@ -418,9 +418,9 @@ class TestDimensionDeletionForwardBackward(object):
 
         adapted_trials = dimension_deletion_adapter.backward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0]._params[-1] == new_param
+        assert adapted_trials[4]._params[-1] == new_param
+        assert adapted_trials[-1]._params[-1] == new_param
 
     def test_dimension_deletion_backward_already_existing(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
@@ -504,11 +504,11 @@ class TestDimensionRenamingForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert new_name in [param.name for param in adapted_trials[0].params]
-        assert old_name not in [param.name for param in adapted_trials[0].params]
+        assert new_name in [param.name for param in adapted_trials[0]._params]
+        assert old_name not in [param.name for param in adapted_trials[0]._params]
 
-        assert new_name in [param.name for param in adapted_trials[-1].params]
-        assert old_name not in [param.name for param in adapted_trials[-1].params]
+        assert new_name in [param.name for param in adapted_trials[-1]._params]
+        assert old_name not in [param.name for param in adapted_trials[-1]._params]
 
     def test_dimension_renaming_forward_incompatible(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
@@ -536,11 +536,11 @@ class TestDimensionRenamingForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert old_name in [param.name for param in adapted_trials[0].params]
-        assert new_name not in [param.name for param in adapted_trials[0].params]
+        assert old_name in [param.name for param in adapted_trials[0]._params]
+        assert new_name not in [param.name for param in adapted_trials[0]._params]
 
-        assert old_name in [param.name for param in adapted_trials[-1].params]
-        assert new_name not in [param.name for param in adapted_trials[-1].params]
+        assert old_name in [param.name for param in adapted_trials[-1]._params]
+        assert new_name not in [param.name for param in adapted_trials[-1]._params]
 
     def test_dimension_renaming_backward_incompatible(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
@@ -672,9 +672,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         adapted_trials = composite_adapter.forward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0]._params[-1] == new_param
+        assert adapted_trials[4]._params[-1] == new_param
+        assert adapted_trials[-1]._params[-1] == new_param
 
         composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
 
@@ -682,9 +682,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[4].params)
-        assert new_param not in (adapted_trials[-1].params)
+        assert new_param not in (adapted_trials[0]._params)
+        assert new_param not in (adapted_trials[4]._params)
+        assert new_param not in (adapted_trials[-1]._params)
 
     def test_composite_adapter_backward(self, dummy_param, trials):
         """Test :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with two adapters"""
@@ -697,9 +697,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         adapted_trials = composite_adapter.backward(trials)
 
-        assert adapted_trials[0].params[-1] == new_param
-        assert adapted_trials[4].params[-1] == new_param
-        assert adapted_trials[-1].params[-1] == new_param
+        assert adapted_trials[0]._params[-1] == new_param
+        assert adapted_trials[4]._params[-1] == new_param
+        assert adapted_trials[-1]._params[-1] == new_param
 
         composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
 
@@ -707,9 +707,9 @@ class TestCompositeAdapterForwardBackward(object):
 
         assert len(adapted_trials) == len(trials)
 
-        assert new_param not in (adapted_trials[0].params)
-        assert new_param not in (adapted_trials[4].params)
-        assert new_param not in (adapted_trials[-1].params)
+        assert new_param not in (adapted_trials[0]._params)
+        assert new_param not in (adapted_trials[4]._params)
+        assert new_param not in (adapted_trials[-1]._params)
 
 
 def test_dimension_addition_configuration(dummy_param):

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -232,12 +232,12 @@ def test_renaming_forward(create_db_instance):
     assert len(parent_trials) == 6
     assert len(exp_node.item.fetch_trials(query)) == 4
 
-    assert all((trial.params[0].name == "/encoding_layer") for trial in parent_trials)
+    assert all((trial._params[0].name == "/encoding_layer") for trial in parent_trials)
 
     adapter = experiment.refers['adapter']
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 6
-    assert all((trial.params[0].name == "/encoding") for trial in adapted_parent_trials)
+    assert all((trial._params[0].name == "/encoding") for trial in adapted_parent_trials)
 
     assert len(experiment.fetch_trials_tree(query)) == 6 + 4
 
@@ -268,12 +268,12 @@ def test_renaming_backward(create_db_instance):
     assert len(children_trials) == 4
     assert len(exp_node.item.fetch_trials(query)) == 6
 
-    assert all((trial.params[0].name == "/encoding") for trial in children_trials)
+    assert all((trial._params[0].name == "/encoding") for trial in children_trials)
 
     adapter = exp_node.children[0].item.refers['adapter']
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 4
-    assert all((trial.params[0].name == "/encoding_layer") for trial in adapted_children_trials)
+    assert all((trial._params[0].name == "/encoding_layer") for trial in adapted_children_trials)
 
     assert len(experiment.fetch_trials_tree(query)) == 6 + 4
 

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -21,7 +21,7 @@ class TestTrial(object):
         assert t.start_time is None
         assert t.end_time is None
         assert t.results == []
-        assert t.params == []
+        assert t.params == {}
         assert t.working_dir is None
 
     def test_init_full(self, exp_config):
@@ -37,7 +37,7 @@ class TestTrial(object):
         assert t.results[0].name == exp_config[1][1]['results'][0]['name']
         assert t.results[0].type == exp_config[1][1]['results'][0]['type']
         assert t.results[0].value == exp_config[1][1]['results'][0]['value']
-        assert list(map(lambda x: x.to_dict(), t.params)) == exp_config[1][1]['params']
+        assert list(map(lambda x: x.to_dict(), t._params)) == exp_config[1][1]['params']
         assert t.working_dir is None
 
     def test_higher_shapes_not_ndarray(self):
@@ -47,7 +47,7 @@ class TestTrial(object):
         params = [dict(name='/x', type='real', value=value)]
         trial = Trial(params=params)
 
-        assert trial.params[0].value == expected
+        assert trial._params[0].value == expected
 
     def test_bad_access(self):
         """Other than `Trial.__slots__` are not allowed."""
@@ -117,8 +117,8 @@ class TestTrial(object):
         """Compare Param objects using __eq__"""
         trials = Trial.build(exp_config[1])
 
-        assert trials[0].params[0] == Trial.Param(**exp_config[1][0]['params'][0])
-        assert trials[0].params[1] != Trial.Param(**exp_config[1][0]['params'][0])
+        assert trials[0]._params[0] == Trial.Param(**exp_config[1][0]['params'][0])
+        assert trials[0]._params[1] != Trial.Param(**exp_config[1][0]['params'][0])
 
     def test_str_trial(self, exp_config):
         """Test representation of `Trial`."""
@@ -129,8 +129,8 @@ class TestTrial(object):
     def test_str_value(self, exp_config):
         """Test representation of `Trial.Value`."""
         t = Trial(**exp_config[1][1])
-        assert str(t.params[1]) == "Param(name='/encoding_layer', "\
-                                   "type='categorical', value='gru')"
+        assert (str(t._params[1]) ==
+                "Param(name='/encoding_layer', type='categorical', value='gru')")
 
     def test_invalid_result(self, exp_config):
         """Test that invalid objectives cannot be set"""

--- a/tests/unittests/core/test_utils_format.py
+++ b/tests/unittests/core/test_utils_format.py
@@ -36,13 +36,13 @@ def test_trial_to_tuple(space, trial, fixed_suggestion):
     data = trial_to_tuple(trial, space)
     assert data == fixed_suggestion
 
-    trial.params[0].name = 'lalala'
+    trial._params[0].name = 'lalala'
     with pytest.raises(ValueError) as exc:
         trial_to_tuple(trial, space)
 
     assert "Trial params: [\'lalala\', \'yolo2\', \'yolo3\']" in str(exc.value)
 
-    trial.params.pop(0)
+    trial._params.pop(0)
     with pytest.raises(ValueError) as exc:
         trial_to_tuple(trial, space)
 
@@ -59,9 +59,9 @@ def test_tuple_to_trial(space, trial, fixed_suggestion):
     assert t.start_time is None
     assert t.end_time is None
     assert t.results == []
-    assert len(t.params) == len(trial.params)
+    assert len(t._params) == len(trial.params)
     for i in range(len(t.params)):
-        assert t.params[i].to_dict() == trial.params[i].to_dict()
+        assert t._params[i].to_dict() == trial._params[i].to_dict()
 
 
 def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
@@ -77,6 +77,6 @@ def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
     assert t.start_time is None
     assert t.end_time is None
     assert t.results == []
-    assert len(t.params) == len(trial.params)
-    for i in range(len(t.params)):
-        assert t.params[i].to_dict() == trial.params[i].to_dict()
+    assert len(t._params) == len(trial._params)
+    for i in range(len(t._params)):
+        assert t._params[i].to_dict() == trial._params[i].to_dict()

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -352,8 +352,8 @@ def test_register_trials(random_dt):
 
         yo = list(map(lambda trial: trial.to_dict(), get_storage().fetch_trials(exp)))
         assert len(yo) == len(trials)
-        assert yo[0]['params'] == list(map(lambda x: x.to_dict(), trials[0].params))
-        assert yo[1]['params'] == list(map(lambda x: x.to_dict(), trials[1].params))
+        assert yo[0]['params'] == list(map(lambda x: x.to_dict(), trials[0]._params))
+        assert yo[1]['params'] == list(map(lambda x: x.to_dict(), trials[1]._params))
         assert yo[0]['status'] == 'new'
         assert yo[1]['status'] == 'new'
         assert yo[0]['submit_time'] == random_dt


### PR DESCRIPTION
Why:

The list structure is very cumbersome and does not match the interface
provided to users to define space. The params structure as a dict is
more coherent. The ordering of the params is important however for the
hashing of the trial, hence we keep the list as a private attribute and
only expose a dict of {name:value} of the trials, which is more
convenient for the user interface.