### PR TITLE
Fix doc for bayesopt's alpha

### DIFF
--- a/docs/src/user/algorithms.rst
+++ b/docs/src/user/algorithms.rst
@@ -163,7 +163,7 @@ Configuration
            seed: null
            n_initial_points: 10
            acq_func: gp_hedge
-           alpha: 1e-10
+           alpha: 1.0e-10
            n_restarts_optimizer: 0
            noise: "gaussian"
            normalize_y: False


### PR DESCRIPTION
Why:

The format 1e-10 is not a valid format for scientific numbers in yaml
and will be converted to string.