### PR TITLE
Add support for space hierarchical structure

### DIFF
--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -15,6 +15,7 @@ import logging
 from numpy import inf as infinity
 
 from orion.core.io.database import DuplicateKeyError
+from orion.core.utils.flatten import flatten, unflatten
 import orion.core.utils.format_trials as format_trials
 import orion.core.worker
 from orion.core.worker.trial import Trial
@@ -457,13 +458,14 @@ class ExperimentClient:
 
         """
         trials = 0
+        kwargs = flatten(kwargs)
         while not self.is_done and trials < max_trials:
             trial = self.suggest()
             if trial is None:
                 log.warning('Algorithm could not sample new points')
                 return trials
-            kwargs.update(trial.params)
-            results = fct(**kwargs)
+            kwargs.update(flatten(trial.params))
+            results = fct(**unflatten(kwargs))
             self.observe(trial, results=results)
             trials += 1
 

--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -46,6 +46,8 @@ from scipy.stats import distributions as sp_dists
 from orion.algo.space import (Categorical, Fidelity, Integer, Real, Space)
 from orion.core import config as orion_config
 from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
+from orion.core.utils.flatten import flatten
+
 
 log = logging.getLogger(__name__)
 
@@ -292,7 +294,7 @@ class SpaceBuilder(object):
 
         """
         self.space = Space()
-        for namespace, expression in configuration.items():
+        for namespace, expression in flatten(configuration).items():
             if _should_not_be_built(expression):
                 continue
 

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -12,6 +12,9 @@
 import hashlib
 import logging
 
+from orion.core.utils.flatten import unflatten
+
+
 log = logging.getLogger(__name__)
 
 
@@ -218,7 +221,7 @@ class Trial:
     @property
     def params(self):
         """Parameters of the trial"""
-        return {param.name: param.value for param in self._params}
+        return unflatten({param.name: param.value for param in self._params})
 
     @property
     def results(self):

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -559,6 +559,26 @@ class TestBuild(object):
         assert isinstance(exp.space, Space)
         assert isinstance(exp.refers['adapter'], BaseAdapter)
 
+    def test_hierarchical_space(self, new_config):
+        """Verify space can have hierarchical structure"""
+        space = {'a': {'x': 'uniform(0, 10, discrete=True)'},
+                 'b': {'y': 'loguniform(1e-08, 1)',
+                       'z': 'choices([\'voici\', \'voila\', 2])'}}
+
+        with OrionState(experiments=[], trials=[]):
+            exp = experiment_builder.build('hierarchy', space=space)
+
+            exp2 = experiment_builder.build('hierarchy')
+
+        assert 'a.x' in exp.space
+        assert 'b.y' in exp.space
+        assert 'b.z' in exp.space
+
+        # Make sure it can be fetched properly from db as well
+        assert 'a.x' in exp2.space
+        assert 'b.y' in exp2.space
+        assert 'b.z' in exp2.space
+
     def test_try_set_after_race_condition(self, new_config, monkeypatch):
         """Cannot set a configuration after init if it looses a race
         condition.

--- a/tests/unittests/core/io/test_space_builder.py
+++ b/tests/unittests/core/io/test_space_builder.py
@@ -218,3 +218,14 @@ class TestSpaceBuilder(object):
                  'z': 'choices([\'voici\', \'voila\', 2])'}
         space = spacebuilder.build(prior)
         assert space.configuration == prior
+
+    def test_subdict_dimensions(self, spacebuilder):
+        """Test space can have hierarchical structure."""
+        prior = {'a': {'x': 'uniform(0, 10, discrete=True)'},
+                 'b': {'y': 'loguniform(1e-08, 1)',
+                       'z': 'choices([\'voici\', \'voila\', 2])'}}
+        space = spacebuilder.build(prior)
+        assert len(space) == 3
+        assert 'a.x' in space
+        assert 'b.y' in space
+        assert 'b.z' in space


### PR DESCRIPTION
Why:

The python API is convenient to use with a hierarchical space structure
if there is many dimensions, just as we would do in configuration files.
Note that this does not support conditional dimensions, each dimension
is independent, but the space is represented in a hierarchical
structure. See contributed unit-tests for an example.