### PR TITLE
Fix formatting of trial with subdict params

### DIFF
--- a/src/orion/core/utils/format_trials.py
+++ b/src/orion/core/utils/format_trials.py
@@ -20,7 +20,7 @@ def trial_to_tuple(trial, space):
     The order within the tuple is dictated by the defined
     `orion.algo.space.Space` object.
     """
-    params = trial.params
+    params = flatten(trial.params)
     trial_keys = set(params.keys())
     space_keys = set(space.keys())
     if trial_keys != space_keys:
@@ -28,7 +28,6 @@ def trial_to_tuple(trial, space):
 The trial {} has wrong params:
 Trial params: {}
 Space dims: {}""".format(trial.id, sorted(trial_keys), sorted(space_keys)))
-
     return tuple(params[name] for name in space.keys())
 
 

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -820,8 +820,8 @@ class TestWorkon:
 
         with create_experiment(exp_config=ext_config, stati=[]) as (cfg, experiment, client):
             assert len(experiment.fetch_trials()) == 0
-            client.workon(foo, max_trials=1, b={'y': default_y, 'z': default_z})
-            assert len(experiment.fetch_trials()) == 1
+            client.workon(foo, max_trials=5, b={'y': default_y, 'z': default_z})
+            assert len(experiment.fetch_trials()) == 5
             params = experiment.fetch_trials()[0].params
             assert len(params)
             assert 'x' in params['a']

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -111,6 +111,20 @@ def space():
 
 
 @pytest.fixture(scope='module')
+def hierarchical_space():
+    """Construct a space with hierarchical Dimensions."""
+    space = Space()
+    categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
+    dim = Categorical('yolo.first', categories, shape=2)
+    space.register(dim)
+    dim = Integer('yolo.second', 'uniform', -3, 6)
+    space.register(dim)
+    dim = Real('yoloflat', 'alpha', 0.9)
+    space.register(dim)
+    return space
+
+
+@pytest.fixture(scope='module')
 def fixed_suggestion():
     """Return the same tuple/sample from a possible space."""
     return (('asdfa', 2), 0, 3.5)

--- a/tests/unittests/core/test_utils_format.py
+++ b/tests/unittests/core/test_utils_format.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from orion.core.utils.format_trials import (trial_to_tuple, tuple_to_trial)
+from orion.core.utils.format_trials import (dict_to_trial, trial_to_tuple, tuple_to_trial)
 from orion.core.worker.trial import Trial
 
 
@@ -29,6 +29,41 @@ def trial():
             )
         ]
     return Trial(params=params)
+
+
+@pytest.fixture()
+def hierarchical_trial():
+    """Stab trial with hierarchical params."""
+    params = [
+        dict(
+            name='yolo.first',
+            type='categorical',
+            value=('asdfa', 2)
+            ),
+        dict(
+            name='yolo.second',
+            type='integer',
+            value=0
+            ),
+        dict(
+            name='yoloflat',
+            type='real',
+            value=3.5
+            )
+        ]
+    return Trial(params=params)
+
+
+@pytest.fixture()
+def dict_params():
+    """Return dictionary of params to build a trial like `fixed_suggestion`"""
+    return {'yolo': ('asdfa', 2), 'yolo2': 0, 'yolo3': 3.5}
+
+
+@pytest.fixture()
+def hierarchical_dict_params():
+    """Return dictionary of params to build a hierarchical trial"""
+    return {'yolo': {'first': ('asdfa', 2), 'second': 0}, 'yoloflat': 3.5}
 
 
 def test_trial_to_tuple(space, trial, fixed_suggestion):
@@ -64,6 +99,21 @@ def test_tuple_to_trial(space, trial, fixed_suggestion):
         assert t._params[i].to_dict() == trial._params[i].to_dict()
 
 
+def test_dict_to_trial(space, trial, dict_params):
+    """Check if dict is converted successfully to trial."""
+    t = dict_to_trial(dict_params, space)
+    assert t.experiment is None
+    assert t.status == 'new'
+    assert t.worker is None
+    assert t.submit_time is None
+    assert t.start_time is None
+    assert t.end_time is None
+    assert t.results == []
+    assert len(t._params) == len(trial._params)
+    for i in range(len(t.params)):
+        assert t._params[i].to_dict() == trial._params[i].to_dict()
+
+
 def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
     """The two functions should be inverse."""
     data = trial_to_tuple(tuple_to_trial(fixed_suggestion, space), space)
@@ -80,3 +130,26 @@ def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
     assert len(t._params) == len(trial._params)
     for i in range(len(t._params)):
         assert t._params[i].to_dict() == trial._params[i].to_dict()
+
+
+def test_hierarchical_trial_to_tuple(hierarchical_space, hierarchical_trial, fixed_suggestion):
+    """Check if hierarchical trial is correctly created from a sample/tuple."""
+    data = trial_to_tuple(hierarchical_trial, hierarchical_space)
+    assert data == fixed_suggestion
+
+
+def test_tuple_to_hierarchical_trial(hierarchical_space, hierarchical_trial, fixed_suggestion):
+    """Check if sample is recovered successfully from hierarchical trial."""
+    t = tuple_to_trial(fixed_suggestion, hierarchical_space)
+    assert len(t._params) == len(hierarchical_trial._params)
+    for i in range(len(t._params)):
+        assert t._params[i].to_dict() == hierarchical_trial._params[i].to_dict()
+
+
+def test_hierarchical_dict_to_trial(hierarchical_space, hierarchical_trial,
+                                    hierarchical_dict_params):
+    """Check if hierarchical dict is converted successfully to trial."""
+    t = dict_to_trial(hierarchical_dict_params, hierarchical_space)
+    assert len(t._params) == len(hierarchical_trial._params)
+    for i in range(len(t.params)):
+        assert t._params[i].to_dict() == hierarchical_trial._params[i].to_dict()


### PR DESCRIPTION
Why:

The formating was not flattening the params when turning them to tuple
for algo.observe.