### PR TITLE
Dev/recover experiment

### DIFF
--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -93,7 +93,8 @@ Templates                  Description
 
 ``trial.working_dir``      Working dir of the trial
 
-#MIRKO - also add hash_name (2 lines)
+``trial.hash_params``      md5sum hash for the parameters (w/o fidelity)
+
 ========================== ====================================
 
 .. note::

--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -92,6 +92,8 @@ Templates                  Description
 ``trial.id``               Unique ID of the trial
 
 ``trial.working_dir``      Working dir of the trial
+
+#MIRKO - also add hash_name (2 lines)
 ========================== ====================================
 
 .. note::

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -321,10 +321,10 @@ class Trial:
         return hashlib.md5((params_repr + experiment_repr + lie_repr).encode('utf-8')).hexdigest()
 
     @property
-    def AAAA_name(self): # MIRKO - change name
-        """Generate a unique name with an md5sum hash for this `Trial`.
+    def hash_params(self):
+        """Generate a unique param md5sum hash for this `Trial`.
 
-        .. note:: Two trials that have the same `params` must have the same `hash_name`.
+        .. note:: The params contributing to the hash do not include the fidelity.
         """
         if not self._params and not self.experiment:
             raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -298,9 +298,13 @@ class Trial:
         """Represent with a string the given values."""
         return sep.join(map(lambda value: "{0.name}:{0.value}".format(value), values))
 
-    def params_repr(self, sep=','):
+    def params_repr(self, sep=',', ignore_fidelity=False):
         """Represent with a string the parameters contained in this `Trial` object."""
-        return self._repr_values(self._params, sep)
+        if ignore_fidelity:
+            params = [x for x in self._params if x.type != 'fidelity']
+        else:
+            params = self._params
+        return self._repr_values(params, sep)
 
     @property
     def hash_name(self):
@@ -315,6 +319,19 @@ class Trial:
         experiment_repr = str(self.experiment)
         lie_repr = self._repr_values([self.lie]) if self.lie else ""
         return hashlib.md5((params_repr + experiment_repr + lie_repr).encode('utf-8')).hexdigest()
+
+    @property
+    def AAAA_name(self): # MIRKO - change name
+        """Generate a unique name with an md5sum hash for this `Trial`.
+
+        .. note:: Two trials that have the same `params` must have the same `hash_name`.
+        """
+        if not self._params and not self.experiment:
+            raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "
+                             "have not been set.")
+        params_repr = self.params_repr(ignore_fidelity=True)
+        experiment_repr = str(self.experiment)
+        return hashlib.md5((params_repr + experiment_repr).encode('utf-8')).hexdigest()
 
     def __hash__(self):
         """Return the hashname for this trial"""

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -227,6 +227,13 @@ class TestTrial(object):
             t.hash_name
         assert 'params' in str(exc.value)
 
+    def test_AAAA_name_property(self, exp_config):
+        """Check property `Trial.hash_name`."""
+        t = Trial(**exp_config[1][1])
+        #MIRKO
+        assert t.AAAA_name == "ebcf6c6c8604f96444af1c3e519aea7f"
+        t._params['']
+
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""
         t = Trial(**exp_config[1][1])

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -227,12 +227,14 @@ class TestTrial(object):
             t.hash_name
         assert 'params' in str(exc.value)
 
-    def test_AAAA_name_property(self, exp_config):
-        """Check property `Trial.hash_name`."""
-        t = Trial(**exp_config[1][1])
-        #MIRKO
-        assert t.AAAA_name == "ebcf6c6c8604f96444af1c3e519aea7f"
-        t._params['']
+    def test_param_name_property(self, exp_config):
+        """Check property `Trial.hash_params`."""
+        exp_config[1][1]['params'].append({'name': '/max_epoch', 'type': 'fidelity', 'value': '1'})
+        t1 = Trial(**exp_config[1][1])
+        exp_config[1][1]['params'][-1]['value'] = '2'  # changing the fidelity
+        t2 = Trial(**exp_config[1][1])
+        assert t1.hash_name != t2.hash_name
+        assert t1.hash_params == t2.hash_params
 
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""


### PR DESCRIPTION
Adds a `hash_params` id that does *not* include the fidelity.

Useful (e.g.,) to allow asha to recover an experiment (where the parameters are the same but the fidelity is different) and run it without starting from scratch.