### PR TITLE
make trial import lazy to avoid cyclic dependencies

### DIFF
--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -15,7 +15,6 @@ import orion.core
 from orion.core.io.convert import JSONConverter
 from orion.core.io.database import Database, OutdatedDatabaseError
 import orion.core.utils.backward as backward
-from orion.core.worker.trial import Trial
 from orion.storage.base import BaseStorageProtocol, FailedUpdate, MissingArguments
 
 log = logging.getLogger(__name__)
@@ -127,6 +126,8 @@ class Legacy(BaseStorageProtocol):
 
     def _fetch_trials(self, query, selection=None):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_trials`"""
+        from orion.core.worker.trial import Trial
+
         def sort_key(item):
             submit_time = item.submit_time
             if submit_time is None:
@@ -167,6 +168,8 @@ class Legacy(BaseStorageProtocol):
         This does not update the database!
 
         """
+        from orion.core.worker.trial import Trial
+
         if results_file is None:
             return trial
 
@@ -183,6 +186,8 @@ class Legacy(BaseStorageProtocol):
 
     def get_trial(self, trial=None, uid=None):
         """See :func:`~orion.storage.BaseStorageProtocol.get_trial`"""
+        from orion.core.worker.trial import Trial
+
         if trial is not None and uid is not None:
             assert trial._id == uid
 
@@ -198,7 +203,7 @@ class Legacy(BaseStorageProtocol):
 
         return Trial(**result[0])
 
-    def _update_trial(self, trial: Trial, where=None, **kwargs):
+    def _update_trial(self, trial, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_trial`"""
         if where is None:
             where = dict()
@@ -256,6 +261,8 @@ class Legacy(BaseStorageProtocol):
 
     def reserve_trial(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.reserve_trial`"""
+        from orion.core.worker.trial import Trial
+
         query = dict(
             experiment=experiment._id,
             status={'$in': ['interrupted', 'new', 'suspended']}

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -18,7 +18,6 @@ import sys
 import warnings
 
 from orion.core.io.database import DuplicateKeyError
-from orion.core.worker.trial import Trial as OrionTrial
 from orion.storage.base import BaseStorageProtocol, FailedUpdate, MissingArguments
 
 log = logging.getLogger(__name__)
@@ -167,6 +166,8 @@ class TrialAdapter:
     @property
     def _params(self):
         """See `~orion.core.worker.trial.Trial`"""
+        from orion.core.worker.trial import Trial as OrionTrial
+
         if self.memory is not None:
             return self.memory._params
 
@@ -221,6 +222,8 @@ class TrialAdapter:
     @property
     def objective(self):
         """See `~orion.core.worker.trial.Trial`"""
+        from orion.core.worker.trial import Trial as OrionTrial
+
         def result(val):
             return OrionTrial.Result(name=self.objective_key, value=val, type='objective')
 
@@ -251,6 +254,8 @@ class TrialAdapter:
     @property
     def results(self):
         """See `~orion.core.worker.trial.Trial`"""
+        from orion.core.worker.trial import Trial as OrionTrial
+
         self._results = []
 
         for k, values in self.storage.metrics.items():


### PR DESCRIPTION
Storage factory implicitly import backends when importing orion/storage/base which cause a cyclic dependency

Solution is to break the cycle by importing Trial lazily in the backends

```
Traceback (most recent call last):
  File "/home/setepenre/work/olympus/olympus/report/dashboard.py", line 13, in <module>
    from orion.storage.base import Storage
  File "/home/setepenre/work/orion/src/orion/storage/base.py", line 213, in <module>
    class Storage(BaseStorageProtocol, metaclass=SingletonFactory):
  File "/home/setepenre/work/orion/src/orion/core/utils/__init__.py", line 57, in __init__
    super(SingletonType, cls).__init__(name, bases, dictionary)
  File "/home/setepenre/work/orion/src/orion/core/utils/__init__.py", line 112, in __init__
    entry_point.load()
  File "/opt/anaconda3/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/opt/anaconda3/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/setepenre/work/orion/src/orion/storage/legacy.py", line 18, in <module>
    from orion.core.worker.trial import Trial
  File "/home/setepenre/work/orion/src/orion/core/worker/__init__.py", line 17, in <module>
    from orion.core.worker.consumer import Consumer
  File "/home/setepenre/work/orion/src/orion/core/worker/consumer.py", line 20, in <module>
    from orion.core.worker.trial_pacemaker import TrialPacemaker
  File "/home/setepenre/work/orion/src/orion/core/worker/trial_pacemaker.py", line 12, in <module>
    from orion.storage.base import get_storage
ImportError: cannot import name 'get_storage' from 'orion.storage.base' (/home/setepenre/work/orion/src/orion/storage/base.py
```