### PR TITLE
Algo redefinition should not drop algo config

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -186,6 +186,7 @@ def build(name, version=None, branching=None, **config):
 
     db_config = fetch_config_from_db(name, version)
 
+    new_config = config
     config = resolve_config.merge_configs(db_config, config)
 
     metadata = resolve_config.fetch_metadata(config.get('user'), config.get('user_args'))
@@ -194,8 +195,7 @@ def build(name, version=None, branching=None, **config):
 
     # TODO: Find a better solution
     if isinstance(config.get('algorithms'), dict) and len(config['algorithms']) > 1:
-        for key in list(db_config['algorithms'].keys()):
-            config['algorithms'].pop(key)
+        config['algorithms'] = new_config['algorithms']
 
     config.setdefault('name', name)
     config.setdefault('version', version)

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -447,11 +447,11 @@ def test_new_algo_not_resolved(init_full_x):
     assert "Configuration is different and generates a branching event" in str(exc.value)
 
 
-def test_new_algo_ignore_cli(init_full_x_ignore_cli):
+def test_ignore_cli(init_full_x_ignore_cli):
     """Test that a non-monitored parameter conflict is not generating a child"""
     name = "full_x"
     orion.core.cli.main(
-        ("init_only -n {name} --non-monitored-arguments a-new --config new_algo_config.yaml "
+        ("init_only -n {name} --non-monitored-arguments a-new "
          "--manual-resolution ./black_box.py -x~uniform(-10,10)")
         .format(name=name).split(" "))
 

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -559,6 +559,14 @@ class TestBuild(object):
         assert isinstance(exp.space, Space)
         assert isinstance(exp.refers['adapter'], BaseAdapter)
 
+    def test_algo_case_insensitive(self, new_config):
+        """Verify that algo with uppercase or lowercase leads to same experiment"""
+        with OrionState(experiments=[new_config], trials=[]):
+            new_config['algorithms']['DUMBALGO'] = new_config['algorithms'].pop('dumbalgo')
+            exp = experiment_builder.build(**new_config)
+
+            assert exp.version == 1
+
     def test_hierarchical_space(self, new_config):
         """Verify space can have hierarchical structure"""
         space = {'a': {'x': 'uniform(0, 10, discrete=True)'},


### PR DESCRIPTION
Why:

When the algo is passed again, it resulted in dropping the algo
configuration altogether. This lead to a reversal to RandomSearch and thus
the experiment would have a different algo and branch.

How:

Overwrite config[algo] with the user's defined algorithm since it has
precedence over db anyway.