### PR TITLE
Formatted commands and added a command description

### DIFF
--- a/docs/src/examples/pytorch_cifar.rst
+++ b/docs/src/examples/pytorch_cifar.rst
@@ -12,9 +12,9 @@ Example with pytorch-cifar
     Alternatively, you can test the example without setting up a database by
     using the option `--debug`, but note that all data gathered during an
     execution will be lost at the end of it.
-    
+
 Set up
-    
+
 .. code-block:: bash
 
     pip3 install torch torchvision
@@ -22,7 +22,7 @@ Set up
     git clone git@github.com:kuangliu/pytorch-cifar.git
 
     cd pytorch-cifar
-    
+
 Add python shebang (using ``sed`` here)
 
 .. code-block:: bash

--- a/docs/src/examples/pytorch_cifar.rst
+++ b/docs/src/examples/pytorch_cifar.rst
@@ -23,6 +23,7 @@ Set up
 
     cd pytorch-cifar
     
+Add python shebang (using ``sed`` here)
 
 .. code-block:: bash
 

--- a/docs/src/examples/pytorch_cifar.rst
+++ b/docs/src/examples/pytorch_cifar.rst
@@ -12,12 +12,17 @@ Example with pytorch-cifar
     Alternatively, you can test the example without setting up a database by
     using the option `--debug`, but note that all data gathered during an
     execution will be lost at the end of it.
+    
+Set up
+    
+.. code-block:: bash
 
-pip3 install torch torchvision
+    pip3 install torch torchvision
 
-git clone git@github.com:kuangliu/pytorch-cifar.git
+    git clone git@github.com:kuangliu/pytorch-cifar.git
 
-cd pytorch-cifar
+    cd pytorch-cifar
+    
 
 .. code-block:: bash
 


### PR DESCRIPTION
Why:
A few commands were not formatted and a sed command was shown without any explanation which is susceptible to deteriorate the readability and comprehension of the example, threatening the engagement of potential and current users.

How:
Formatted the commands similarly to the others in the example and added a minimum descriptions.