### PR TITLE
Clone via HTTPS instead of SSH

### DIFF
--- a/docs/src/examples/pytorch_cifar.rst
+++ b/docs/src/examples/pytorch_cifar.rst
@@ -15,7 +15,7 @@ Example with pytorch-cifar
 
 pip3 install torch torchvision
 
-git clone git@github.com:kuangliu/pytorch-cifar.git
+git clone https://github.com/kuangliu/pytorch-cifar.git
 
 cd pytorch-cifar
 

--- a/docs/src/user/pytorch.rst
+++ b/docs/src/user/pytorch.rst
@@ -16,7 +16,7 @@ PyTorch `examples repository`_:
 .. code-block:: bash
 
     $ pip3 install torch torchvision
-    $ git clone git@github.com:pytorch/examples.git
+    $ git clone https://github.com/pytorch/examples.git
 
 
 .. _examples repository: https://github.com/pytorch/examples


### PR DESCRIPTION
Cloning via HTTPS is the default option presented by GitHub and doesn't require extra configuration from the user.