### PR TITLE
Updated the roadmap for v0.1.8

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Change interface to support trial object instead of curated lists. This is neces
 
 #### More Optimizers
 - [PBT](https://arxiv.org/abs/1711.09846)
-- BOHB
+- [BOHB](https://ml.informatik.uni-freiburg.de/papers/18-ICML-BOHB.pdf)
 
 #### Simple dashboard specific to monitoring and benchmarking of Black-Box optimization
 - Specific to hyper parameter optimizations

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Last update February 12th, 2020
 ### v0.2
 #### Journal Protocol Plugins
 Offering:
-- no need to setup DB, can use one's existing backend
+- No need to setup DB, can use one's existing backend
 - Can re-use tools provided by backend for visualizations, etc.
 #### Python API
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,16 +3,6 @@ Last update February 12th, 2020
 
 ## Next releases - Short-Term
 
-### v0.1.8
-
-#### Preliminary Python API
-Library API to simplify usage of algorithms without Oríon's worker.
-
-#### Journal Protocol Plugins
-Offering:
-- no need to setup DB, can use one's existing backend
-- Can re-use tools provided by backend for visualizations, etc.
-
 ## Next releases - Mid-Term
 
 ### v0.2: ETA End of summer 2019

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,11 +36,11 @@ Change interface to support trial object instead of curated lists. This is neces
 - PBT
 - BOHB
 
-## Next releases - Long-Term
-
 #### Simple dashboard specific to monitoring and benchmarking of Black-Box optimization
 - Specific to hyper parameter optimizations
 - Provide status of experiments
+
+## Next releases - Long-Term
 
 #### Conditional Space
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Introducing new algorithms: [TPE](https://papers.nips.cc/paper/4443-algorithms-f
 Change interface to support trial object instead of curated lists. This is necessary to support algorithms such as PBT.
 
 #### More Optimizers
-- PBT
+- [PBT](https://arxiv.org/abs/1711.09846)
 - BOHB
 
 #### Simple dashboard specific to monitoring and benchmarking of Black-Box optimization

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,9 @@ results = dummy(**trial.arguments)
 experiment.observe(trial, results)
 ```
 
+### Algorithms
+Introducing new algorithms: [TPE](https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf), [HyperBand](https://arxiv.org/abs/1603.06560)
+
 ## Next releases - Mid-Term
 
 ### v0.3

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@ Last update February 12th, 2020
 
 ## Next releases - Short-Term
 
-### v0.2: ETA End of summer 2019
+### v0.2
 #### Journal Protocol Plugins
 Offering:
 - no need to setup DB, can use one's existing backend

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,6 @@ Last update February 12th, 2020
 
 ## Next releases - Short-Term
 
-## Next releases - Mid-Term
-
 ### v0.2: ETA End of summer 2019
 #### Journal Protocol Plugins
 Offering:
@@ -23,6 +21,8 @@ trial = experiment.suggest()
 results = dummy(**trial.arguments)
 experiment.observe(trial, results)
 ```
+
+## Next releases - Mid-Term
 
 ### v0.3
 #### Generic `Optimizer` interface supporting various types of algorithms

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,10 @@ Change interface to support trial object instead of curated lists. This is neces
 - Specific to hyper parameter optimizations
 - Provide status of experiments
 
+#### Leveraging previous experiences
+Leveraging the knowledge base contained in the EVC of previous trials to optimize and drive new
+ trials.
+
 ## Next releases - Long-Term
 
 #### Conditional Space

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # Roadmap
-Last update October 8th, 2019
+Last update February 12th, 2020
 
 ## Next releases - Short-Term
 


### PR DESCRIPTION
This PR refreshes the roadmap for the v0.1.8 release.

The major changes are:
- Removed the v0.1.8 section since it will be release at the time
- Moved v0.2 to Short-Term
- Added TPE and HyperBand to v0.2
- Moved visualization to Mid-Term
- Added the new feature of using the EVC as a knowledge base to optimize trials