### PR TITLE
Add more helper functions for cmdline client

### DIFF
--- a/docs/src/code/client.rst
+++ b/docs/src/code/client.rst
@@ -6,6 +6,7 @@ Client helper functions
    :maxdepth: 1
    :caption: Modules
 
+   client/cli
    client/experiment
    client/manual
 

--- a/docs/src/code/client/cli.rst
+++ b/docs/src/code/client/cli.rst
@@ -1,0 +1,5 @@
+Commandline client
+==================
+
+.. automodule:: orion.client.cli
+   :members:

--- a/docs/src/examples/pytorch_a2c_ppo.rst
+++ b/docs/src/examples/pytorch_a2c_ppo.rst
@@ -45,7 +45,7 @@ we add:
 .. code-block:: python
 
     #!/usr/bin/env python
-    from orion.client import report_results
+    from orion.client import report_objective
 
 
 and then we run
@@ -86,10 +86,7 @@ algorithm:
                                              args.cuda,
                                              eval_env_seeds)
 
-    report_results([dict(
-        name='validation_return',
-        type='objective',
-        value=np.mean(validation_returns))])
+    report_objective(name='validation_return', objective=np.mean(validation_returns))
 
 Now we're ready to go to run orion's hyperparameter optimization!
 

--- a/docs/src/examples/pytorch_cifar.rst
+++ b/docs/src/examples/pytorch_cifar.rst
@@ -40,10 +40,7 @@ Last line of the main() function
 
         test_error_rate = test(epoch)
 
-    report_results([dict(
-        name='test_error_rate',
-        type='objective',
-        value=test_error_rate)])
+    report_objective(objective, name='test_error_rate')
 
 .. code-block:: bash
 

--- a/docs/src/user/api.rst
+++ b/docs/src/user/api.rst
@@ -20,20 +20,26 @@ Suppose you normally execute your script with the following command
 
 .. code-block:: bash
 
-    $ ./main.py --lr 0.1
+    $ python main.py --lr 0.1
 
 Using the commandline API you can turn your script into a hyper-parameter process by wrapping it
 with Oríon.
 
 .. code-block:: bash
 
-    $ orion hunt -n exp-name ./main.py --lr~'loguniform(1e-5, 1.0)'
+    $ orion hunt -n exp-name python main.py --lr~'loguniform(1e-5, 1.0)'
 
 An experiment called ``exp-name`` will now be created and your script will be called with
-the argument ``--lr`` assigned to values sampled by the optimization algorthm.
+the argument ``--lr`` assigned to values sampled by the optimization algorithm.
 
 Configuration of the algorithm can be done inside a yaml file passed to ``--config`` as described in
 :ref:`Setup Algorithms`.
+
+To return the results to orion, you must add a call to
+:py:func:`orion.client.report_objective(value) <orion.client.cli.report_objective>`
+in your script at the end of the execution.
+
+See :py:mod:`orion.client.cli` for more information on all helper functions available.
 
 
 Python APIs

--- a/docs/src/user/pytorch.rst
+++ b/docs/src/user/pytorch.rst
@@ -28,8 +28,9 @@ Adapting the code for Oríon
 To use Oríon with any code we need to do three things
 
 1. make the ``main.py`` file a python executable
-2. import the ``orion.client.report_results`` helper function
-3. call `report_results` on the final objective output to be minimized (e.g. final test error rate)
+2. import the ``orion.client.report_objective`` helper function
+3. call `report_objective` on the final objective output to be minimized (e.g. final test error
+   rate)
 
 After cloning pytorch examples repository, cd to mnist folder:
 
@@ -46,11 +47,11 @@ the ``main.py`` and make it executable, for example:
     $ chmod +x main.py
 
 2. At the top of the file, below the imports, add one line of import the helper function
-``orion.client.report_results()``:
+``orion.client.report_objective()``:
 
 .. code-block:: python
 
-    from orion.client import report_results
+    from orion.client import report_objective
 
 3. We need the test error rate so we're going to add a line to the function ``test()`` to return it
 
@@ -58,18 +59,16 @@ the ``main.py`` and make it executable, for example:
 
     return 1 - (correct / len(test_loader.dataset))
 
-Finally, we get back this test error rate and call ``report_results`` to
-return the final objective value to Oríon. Note that ``report_results`` is meant to
+Finally, we get back this test error rate and call ``report_objective`` to
+return the final objective value to Oríon. Note that ``report_objective`` is meant to
 be called only once because Oríon only looks at 1 ``'objective'`` value per run.
 
 .. code-block:: python
 
         test_error_rate = test(args, model, device, test_loader)
 
-    report_results([dict(
-        name='test_error_rate',
-        type='objective',
-        value=test_error_rate)])
+    report_objective(test_error_rate)
+
 
 Execution
 =========
@@ -156,8 +155,12 @@ validation set.
 Oríon will always **minimize** the objective so make sure you never try to
 optimize something like the accuracy of the model unless you are looking for very very bad models.
 
-You can also ``report_results`` of types ``'gradient'`` and ``'constraint'`` for
-algorithms which require those parameters as well.
+You can also report results of types ``'gradient'`` and ``'constraint'`` for
+algorithms which require those parameters as well, or ``'statistic'`` for metrics
+to be saved with the trial. See
+:py:func:`report_results() <orion.client.cli.report_results>`
+for more details.
+
 
 Debugging
 =========

--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -21,6 +21,14 @@ log = logging.getLogger(__name__)
 class BaseAlgorithm(object, metaclass=ABCMeta):
     """Base class describing what an algorithm can do.
 
+    Parameters
+    ----------
+    space : `orion.algo.space.Space`
+       Definition of a problem's parameter space.
+    kwargs : dict
+       Tunable elements of a particular algorithm, a dictionary from
+       hyperparameter names to values.
+
     Notes
     -----
     We are using the No Free Lunch theorem's [1]_[3]_ formulation of an
@@ -85,17 +93,6 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
     requires = []
 
     def __init__(self, space, **kwargs):
-        """Declare problem's parameter space and set up algo's hyperparameters.
-
-        Parameters
-        ----------
-        space : `orion.algo.space.Space`
-           Definition of a problem's parameter space.
-        kwargs : dict
-           Tunable elements of a particular algorithm, a dictionary from
-           hyperparameter names to values.
-
-        """
         log.debug("Creating Algorithm object of %s type with parameters:\n%s",
                   type(self).__name__, kwargs)
         self._space = space

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.client` -- Helper function for returning results from script
-==========================================================================
+:mod:`orion.client` -- Python API
+=================================
 
 .. module:: client
    :platform: Unix
    :synopsis: Provides functions for communicating with `orion.core`.
 
 """
-import os
-
+from orion.client.cli import (
+    interrupt_trial, report_bad_trial, report_objective, report_results)
 from orion.client.experiment import ExperimentClient
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.exceptions import RaceCondition
@@ -17,48 +17,14 @@ from orion.core.utils.tests import update_singletons
 from orion.core.worker.producer import Producer
 
 
-IS_ORION_ON = False
-_HAS_REPORTED_RESULTS = False
-RESULTS_FILENAME = os.getenv('ORION_RESULTS_PATH', None)
-if RESULTS_FILENAME and os.path.isfile(RESULTS_FILENAME):
-    import json
-    IS_ORION_ON = True
-
-if RESULTS_FILENAME and not IS_ORION_ON:
-    raise RuntimeWarning("Results file path provided in environmental variable "
-                         "does not correspond to an existing file.")
-
-
-def report_results(data):
-    """Facilitate the reporting of results for a user's script acting as a
-    black-box computation.
-
-    :param data: A dictionary containing experimental results
-
-    .. note:: To be called only once in order to report a final evaluation
-       of a particular trial.
-
-    .. note:: In case that user's script is not running in a orion's context,
-       this function will act as a Python `print` function.
-
-    .. note:: For your own good, this can be called **only once**.
-
-    """
-    global _HAS_REPORTED_RESULTS  # pylint:disable=global-statement
-    if _HAS_REPORTED_RESULTS:
-        raise RuntimeWarning("Has already reported evaluation results once.")
-    if IS_ORION_ON:
-        with open(RESULTS_FILENAME, 'w') as results_file:
-            json.dump(data, results_file)
-    else:
-        print(data)
-    _HAS_REPORTED_RESULTS = True
+__all__ = ['interrupt_trial', 'report_bad_trial', 'report_objective', 'report_results']
 
 
 # pylint: disable=too-many-arguments
-def create_experiment(name, version=None, space=None, algorithms=None,
-                      strategy=None, max_trials=None, storage=None, branching=None,
-                      working_dir=None):
+def create_experiment(
+        name, version=None, space=None, algorithms=None,
+        strategy=None, max_trials=None, storage=None, branching=None,
+        working_dir=None):
     """Create an experiment
 
     There is 2 main scenarios

--- a/src/orion/client/cli.py
+++ b/src/orion/client/cli.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.client.cli` -- Helper function for returning results from script
+============================================================================
+
+.. module:: cli
+   :platform: Unix
+   :synopsis: Provides functions for communicating with `orion.core`.
+
+"""
+import os
+import sys
+
+from orion.core import config
+
+
+IS_ORION_ON = False
+_HAS_REPORTED_RESULTS = False
+RESULTS_FILENAME = os.getenv('ORION_RESULTS_PATH', None)
+if RESULTS_FILENAME and os.path.isfile(RESULTS_FILENAME):
+    import json
+    IS_ORION_ON = True
+
+if RESULTS_FILENAME and not IS_ORION_ON:
+    raise RuntimeWarning("Results file path provided in environmental variable "
+                         "does not correspond to an existing file.")
+
+
+def interrupt_trial():
+    """Send interrupt signal to Oríon worker"""
+    sys.exit(config.worker.interrupt_signal_code)
+
+
+def report_objective(objective, name='objective'):
+    """Report only the objective at the end of execution
+
+    To send more data (statistic, constraint, gradient), use ``report_results``.
+
+    .. warning::
+
+       To be called only once in order to report a final evaluation of a particular trial.
+
+    .. warning::
+
+       Oríon is only minimizing. Make sure to report a metric that you seek to minimize.
+
+    .. note::
+
+       In case that user's script is not running in a orion's context,
+       this function will act as a Python `print` function.
+
+    Parameters
+    ----------
+    objective: float
+        Objective the return to Oríon for the current trial.
+    name: str, optional
+        Name of the objective. Default is 'objective'.
+
+    """
+    report_results([dict(name=name, type='objective', value=objective)])
+
+
+def report_bad_trial(objective=1e10, name='objective', data=None):
+    """Report a bad trial with large objective to Oríon.
+
+    This is especially useful if some parameter values lead to exceptions such as out of memory.
+    Reporting a large objective from such trials will push algorithms towards valid
+    configurations.
+
+    .. warning::
+
+       To be called only once in order to report a final evaluation of a particular trial.
+
+    .. warning::
+
+       Oríon is only minimizing. Make sure to report a metric that you seek to minimize.
+
+    .. note::
+
+       In case that user's script is not running in a orion's context,
+       this function will act as a Python `print` function.
+
+    Parameters
+    ----------
+    objective: float
+        Objective the return to Oríon for the current trial. The default objective is 1e10.
+        This may not be valid for some metrics and this value should be overrided accordingly. In
+        the case of error rates for instance, the value should be 1.0.
+    name: str, optional
+        Name of the objective. Default is 'objective'.
+    data: list of dict, optional
+        A list of dictionary representing the results in the form
+        dict(name=result_name, type='statistic', value=0). The types supported are
+        'contraint', 'gradient' and 'statistic'.
+
+    """
+    if data is None:
+        data = []
+    report_results([dict(name=name, type='objective', value=objective)] + data)
+
+
+def report_results(data):
+    """Facilitate the reporting of results for a user's script acting as a
+    black-box computation.
+
+    .. warning::
+
+       To be called only once in order to report a final evaluation of a particular trial.
+
+    .. warning::
+
+       Oríon is only minimizing. Make sure to report a metric that you seek to minimize.
+
+    .. note::
+
+       In case that user's script is not running in a orion's context,
+       this function will act as a Python `print` function.
+
+    Parameters
+    ----------
+    data: list of dict
+        A list of dictionary representing the results in the form
+        dict(name=result_name, type='statistic', value=0). The types supported are
+        'objective', 'contraint', 'gradient' and 'statistic'. The list should contain at least
+        one 'objective', which is the metric the algorithm will be minimizing.
+
+    """
+    global _HAS_REPORTED_RESULTS  # pylint:disable=global-statement
+    if _HAS_REPORTED_RESULTS:
+        raise RuntimeWarning("Has already reported evaluation results once.")
+    if IS_ORION_ON:
+        with open(RESULTS_FILENAME, 'w') as results_file:
+            json.dump(data, results_file)
+    else:
+        print(data)
+    _HAS_REPORTED_RESULTS = True

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -132,6 +132,8 @@ def define_worker_config(config):
         'max_broken', option_type=int, default=3)
     worker_config.add_option(
         'max_idle_time', option_type=int, default=60)
+    worker_config.add_option(
+        'interrupt_signal_code', option_type=int, default=130, env_var='ORION_INTERRUPT_CODE')
 
     config.worker = worker_config
 

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -10,11 +10,12 @@
 """
 import argparse
 import logging
+import sys
 import textwrap
 
 import orion
 from orion.core.io.database import DatabaseError
-from orion.core.utils.exceptions import NoConfigurationError
+from orion.core.utils.exceptions import MissingResultFile, NoConfigurationError
 
 
 CLI_DOC_HEADER = """
@@ -72,12 +73,17 @@ class OrionArgsParser:
         try:
             args, function = self.parse(argv)
             function(args)
-        except NoConfigurationError:
-            print("Error: No commandline configuration found for new experiment.")
+        except (NoConfigurationError, DatabaseError, MissingResultFile) as e:
+            print('Error:', e, file=sys.stderr)
+
+            if args.get('verbose', 0) >= 2:
+                raise e
+
             return 1
-        except DatabaseError as e:
-            print(e)
-            return 1
+
+        except KeyboardInterrupt:
+            print('Orion is interrupted.')
+            return 130
 
         return 0
 

--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -9,10 +9,16 @@
 """
 
 
+NO_CONFIGURATION_FOUND = """\
+No commandline configuration found for new experiment.
+"""
+
+
 class NoConfigurationError(Exception):
     """Raise when commandline configuration is empty."""
 
-    pass
+    def __init__(self, message=NO_CONFIGURATION_FOUND):
+        super().__init__(message)
 
 
 class CheckError(Exception):
@@ -25,3 +31,18 @@ class RaceCondition(Exception):
     """Raise when a race condition occured."""
 
     pass
+
+
+MISSING_RESULT_FILE = """
+Cannot parse result file.
+
+Make sure to report results in file `$ORION_RESULTS_PATH`.
+This can be done with `orion.client.cli.report_objective()`.
+"""
+
+
+class MissingResultFile(Exception):
+    """Raise when no result file (or empty) at end of trial execution."""
+
+    def __init__(self, message=MISSING_RESULT_FILE):
+        super().__init__(message)

--- a/src/orion/core/worker/__init__.py
+++ b/src/orion/core/worker/__init__.py
@@ -70,7 +70,7 @@ def workon(experiment, worker_trials=None):
     stats = experiment.stats
 
     if not stats:
-        log.info("No trials completed.")
+        print("No trials completed.")
         return
 
     best = get_storage().get_trial(uid=stats['best_trials_id'])
@@ -83,6 +83,8 @@ def workon(experiment, worker_trials=None):
     pprint.pprint(best.to_dict()['params'], stream=best_stream)
     best_string = best_stream.getvalue()
 
-    log.info("#####  Search finished successfully  #####")
-    log.info("\nRESULTS\n=======\n%s\n", stats_string)
-    log.info("\nBEST PARAMETERS\n===============\n%s", best_string)
+    print("#####  Search finished successfully  #####")
+    print("\nRESULTS\n=======\n")
+    print(stats_string)
+    print("\nBEST PARAMETERS\n===============")
+    print(best_string)

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -153,6 +153,7 @@ class Consumer(object):
 
         env['ORION_WORKING_DIR'] = str(trial.working_dir)
         env['ORION_RESULTS_PATH'] = str(results_file)
+        env['ORION_INTERRUPT_CODE'] = str(orion.core.config.worker.interrupt_signal_code)
 
         return env
 
@@ -193,6 +194,9 @@ class Consumer(object):
         process = subprocess.Popen(command, env=environ)
 
         return_code = process.wait()
-        if return_code != 0:
+
+        if return_code == orion.core.config.worker.interrupt_signal_code:
+            raise KeyboardInterrupt()
+        elif return_code != 0:
             raise ExecutionError("Something went wrong. Check logs. Process "
                                  "returned with code {} !".format(return_code))

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -9,12 +9,14 @@
 
 """
 import datetime
+import json
 import logging
 
 import orion.core
 from orion.core.io.convert import JSONConverter
 from orion.core.io.database import Database, OutdatedDatabaseError
 import orion.core.utils.backward as backward
+from orion.core.utils.exceptions import MissingResultFile
 from orion.storage.base import BaseStorageProtocol, FailedUpdate, MissingArguments
 
 log = logging.getLogger(__name__)
@@ -173,7 +175,10 @@ class Legacy(BaseStorageProtocol):
         if results_file is None:
             return trial
 
-        results = JSONConverter().parse(results_file.name)
+        try:
+            results = JSONConverter().parse(results_file.name)
+        except json.decoder.JSONDecodeError:
+            raise MissingResultFile()
 
         trial.results = [
             Trial.Result(

--- a/tests/functional/client/black_box.py
+++ b/tests/functional/client/black_box.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Script that will always interrupt trials."""
+import argparse
+
+from orion.client import interrupt_trial, report_bad_trial, report_objective  # noqa: F401
+
+
+def no_report():
+    """Do not report any result"""
+    return
+
+
+def execute():
+    """Execute a simple pipeline as an example."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('fct', type=str)
+    parser.add_argument('--name', type=str)
+    parser.add_argument('--objective', type=str)
+    parser.add_argument('--data', type=str)
+    parser.add_argument('-x', type=float)
+
+    inputs = parser.parse_args()
+
+    kwargs = {}
+
+    # Maybe its a float, maybe user made a mistake and report objective='name'
+    try:
+        inputs.objective = float(inputs.objective)
+    except (ValueError, TypeError):
+        pass
+
+    for key, value in vars(inputs).items():
+        if value is not None:
+            kwargs[key] = value
+
+    kwargs.pop('fct')
+    kwargs.pop('x')
+
+    if 'data' in kwargs:
+        kwargs['data'] = [dict(name=kwargs['data'], type='constraint', value=1.0)]
+
+    globals()[inputs.fct](**kwargs)
+
+
+if __name__ == "__main__":
+    execute()

--- a/tests/functional/client/orion_config.yaml
+++ b/tests/functional/client/orion_config.yaml
@@ -1,0 +1,14 @@
+name: voila_voici
+
+pool_size: 1
+max_trials: 100
+
+algorithms: random
+
+producer:
+    strategy: NoParallelStrategy
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/functional/client/test_cli_client.py
+++ b/tests/functional/client/test_cli_client.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test for client helper functions."""
+import os
+
+import pytest
+
+import orion.core.cli
+from orion.core.worker.consumer import Consumer
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_interrupt(database, monkeypatch, capsys):
+    """Test interruption from within user script."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    error_code = orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", "interrupt_trial"] + user_args)
+
+    assert error_code == 130
+
+    captured = capsys.readouterr()
+    assert captured.out == 'Orion is interrupted.\n'
+    assert captured.err == ''
+
+    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = exp[0]
+    exp_id = exp['_id']
+    trials = list(database.trials.find({'experiment': exp_id}))
+    assert len(trials) == 1
+    assert trials[0]['status'] == 'interrupted'
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_interrupt_diff_code(database, monkeypatch, capsys):
+    """Test interruption from within user script with custom int code"""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    # Set local to 200
+    orion.core.config.worker.interrupt_signal_code = 200
+
+    # But child won't be passed ORION_INTERRUPT_CODE and therefore will send default code 130
+    def empty_env(self, trial, results_file=None):
+        return os.environ
+
+    with monkeypatch.context() as m:
+        m.setattr(Consumer, 'get_execution_environment', empty_env)
+
+        # Interrupt won't be interpreted properly and trials will be marked as broken
+        error_code = orion.core.cli.main([
+            "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+            "python", "black_box.py", "interrupt_trial"] + user_args)
+
+        assert error_code == 0
+
+        exp = list(database.experiments.find({'name': 'voila_voici'}))
+        exp = exp[0]
+        exp_id = exp['_id']
+        trials = list(database.trials.find({'experiment': exp_id}))
+        assert len(trials) == 2
+        assert trials[0]['status'] == 'broken'
+
+    # This time we use true `get_execution_environment which pass properly int code to child.
+    error_code = orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", "interrupt_trial"] + user_args)
+
+    assert error_code == 130
+
+    captured = capsys.readouterr()
+    assert 'Orion is interrupted.\n' in captured.out
+    assert captured.err == ''
+
+    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = exp[0]
+    exp_id = exp['_id']
+    trials = list(database.trials.find({'experiment': exp_id}))
+    assert len(trials) == 3
+    assert trials[-1]['status'] == 'interrupted'
+
+
+# TODO:
+
+# test no call to any report
+
+# Add all this in DOC.
+
+
+@pytest.mark.parametrize('fct', ['report_bad_trial', 'report_objective'])
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_report_no_name(database, monkeypatch, fct):
+    """Test report helper functions with default names"""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", fct, "--objective", "1.0"] + user_args)
+
+    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = exp[0]
+    exp_id = exp['_id']
+    trials = list(database.trials.find({'experiment': exp_id}))
+    assert len(trials) == 2
+    assert trials[0]['status'] == 'completed'
+    assert trials[0]['results'][0]['name'] == 'objective'
+    assert trials[0]['results'][0]['type'] == 'objective'
+    assert trials[0]['results'][0]['value'] == 1.0
+
+
+@pytest.mark.parametrize('fct', ['report_bad_trial', 'report_objective'])
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_report_with_name(database, monkeypatch, fct):
+    """Test report helper functions with custom names"""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", fct, "--objective", "1.0", "--name", "metric"] + user_args)
+
+    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = exp[0]
+    exp_id = exp['_id']
+    trials = list(database.trials.find({'experiment': exp_id}))
+    assert len(trials) == 2
+    assert trials[0]['status'] == 'completed'
+    assert trials[0]['results'][0]['name'] == 'metric'
+    assert trials[0]['results'][0]['type'] == 'objective'
+    assert trials[0]['results'][0]['value'] == 1.0
+
+
+@pytest.mark.parametrize('fct', ['report_bad_trial', 'report_objective'])
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_report_with_bad_objective(database, monkeypatch, fct):
+    """Test report helper functions with bad objective types"""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    with pytest.raises(ValueError) as exc:
+        orion.core.cli.main([
+            "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+            "python", "black_box.py", fct, "--objective", "oh oh"] + user_args)
+
+    assert 'must contain a type `objective` with type float/int' in str(exc.value)
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_report_with_bad_trial_no_objective(database, monkeypatch):
+    """Test bad trial report helper function with default objective."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", "report_bad_trial"] + user_args)
+
+    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = exp[0]
+    exp_id = exp['_id']
+    trials = list(database.trials.find({'experiment': exp_id}))
+    assert len(trials) == 2
+    assert trials[0]['status'] == 'completed'
+    assert trials[0]['results'][0]['name'] == 'objective'
+    assert trials[0]['results'][0]['type'] == 'objective'
+    assert trials[0]['results'][0]['value'] == 1e10
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_report_with_bad_trial_with_data(database, monkeypatch):
+    """Test bad trial report helper function with additional data."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", "report_bad_trial", "--data", "another"] + user_args)
+
+    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = exp[0]
+    exp_id = exp['_id']
+    trials = list(database.trials.find({'experiment': exp_id}))
+    assert len(trials) == 2
+    assert trials[0]['status'] == 'completed'
+    assert trials[0]['results'][0]['name'] == 'objective'
+    assert trials[0]['results'][0]['type'] == 'objective'
+    assert trials[0]['results'][0]['value'] == 1e10
+
+    assert trials[0]['results'][1]['name'] == 'another'
+    assert trials[0]['results'][1]['type'] == 'constraint'
+    assert trials[0]['results'][1]['value'] == 1.0
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+def test_no_report(database, monkeypatch, capsys):
+    """Test script call without any results reported."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    user_args = [
+        "-x~uniform(-50, 50, precision=5)"]
+
+    errorcode = orion.core.cli.main([
+        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
+        "python", "black_box.py", 'no_report'] + user_args)
+
+    assert errorcode == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert 'Cannot parse result file' in captured.err

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -7,7 +7,8 @@ import json
 
 import pytest
 
-from orion import client
+import orion.client
+import orion.client.cli as cli
 import orion.core
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.pickleddb import PickledDB
@@ -18,8 +19,8 @@ from orion.storage.base import get_storage
 from orion.storage.legacy import Legacy
 
 
-create_experiment = client.create_experiment
-workon = client.workon
+create_experiment = orion.client.create_experiment
+workon = orion.client.workon
 
 
 config = dict(
@@ -72,7 +73,7 @@ class TestReportResults(object):
         Then: It should print `data` parameter instead to stdout.
         """
         monkeypatch.delenv('ORION_RESULTS_PATH', raising=False)
-        reloaded_client = reload(client)
+        reloaded_client = reload(cli)
 
         assert reloaded_client.IS_ORION_ON is False
         assert reloaded_client.RESULTS_FILENAME is None
@@ -92,7 +93,7 @@ class TestReportResults(object):
         with open(path, mode='w'):
             pass
         monkeypatch.setenv('ORION_RESULTS_PATH', path)
-        reloaded_client = reload(client)
+        reloaded_client = reload(cli)
 
         assert reloaded_client.IS_ORION_ON is True
         assert reloaded_client.RESULTS_FILENAME == path
@@ -116,7 +117,7 @@ class TestReportResults(object):
         monkeypatch.setenv('ORION_RESULTS_PATH', path)
 
         with pytest.raises(RuntimeWarning) as exc:
-            reload(client)
+            reload(cli)
 
         assert "existing file" in str(exc.value)
 
@@ -125,7 +126,7 @@ class TestReportResults(object):
         if function has already been called once.
         """
         monkeypatch.delenv('ORION_RESULTS_PATH', raising=False)
-        reloaded_client = reload(client)
+        reloaded_client = reload(cli)
 
         reloaded_client.report_results(data)
         with pytest.raises(RuntimeWarning) as exc:

--- a/tests/unittests/storage/test_legacy.py
+++ b/tests/unittests/storage/test_legacy.py
@@ -8,6 +8,7 @@ import tempfile
 
 import pytest
 
+from orion.core.utils.exceptions import MissingResultFile
 from orion.core.utils.tests import OrionState
 from orion.core.worker.trial import Trial
 from orion.storage.base import FailedUpdate
@@ -148,7 +149,7 @@ class TestLegacyStorage:
 
             trial = Trial(**base_trial)
 
-            with pytest.raises(json.decoder.JSONDecodeError) as exec:
+            with pytest.raises(MissingResultFile) as exec:
                 storage.retrieve_result(trial, results_file)
 
-        assert exec.match(r'Expecting value: line 1 column 1 \(char 0\)')
+        assert exec.match(r'Cannot parse result file')


### PR DESCRIPTION
Some users need a way to signal an interruption from within the script.
While KeyboardInterrupt in the shell where orion's worker is running
would catch the signal properly and interrupt the trial, raising
KeyboardInterrupt from within the script would only lead to a completed
script with error code > 0, hence the trial would be set to broken.

This commit adds a new helper function for this, `interrupt_trial`,
which terminates the process with a special code defined by Oríon, so
that the worker can detect that this is not a broken trial, but
an interrupted one.

Additional helper functions are added to simplify usage of Oríon:
`report_objective` and `report_bad_trials`.