### PR TITLE
Add comprehensive error message for branching err

### DIFF
--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -133,7 +133,7 @@ def create_experiment(
         means that different modifications occured during each race condition resolution. This is
         likely due to quick code change during experiment creation. Make sure your script is not
         generating files within your code repository.
-    `ValueError`
+    `orion.core.utils.exceptions.BranchingEvent`
         The configuration is different than the corresponding one in DB and the branching cannot be
         solved automatically. This usually happens if the version=x is specified but the experiment
         ``(name, x)`` already has a child ``(name, x+1)``. If you really need to branch from version

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -15,7 +15,7 @@ import textwrap
 
 import orion
 from orion.core.io.database import DatabaseError
-from orion.core.utils.exceptions import MissingResultFile, NoConfigurationError
+from orion.core.utils.exceptions import BranchingEvent, MissingResultFile, NoConfigurationError
 
 
 CLI_DOC_HEADER = """
@@ -73,7 +73,7 @@ class OrionArgsParser:
         try:
             args, function = self.parse(argv)
             function(args)
-        except (NoConfigurationError, DatabaseError, MissingResultFile) as e:
+        except (NoConfigurationError, DatabaseError, MissingResultFile, BranchingEvent) as e:
             print('Error:', e, file=sys.stderr)
 
             if args.get('verbose', 0) >= 2:

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -102,7 +102,7 @@ from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
 from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
 from orion.core.io.space_builder import SpaceBuilder
 import orion.core.utils.backward as backward
-from orion.core.utils.exceptions import NoConfigurationError, RaceCondition
+from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, RaceCondition
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import Strategy
@@ -449,9 +449,7 @@ def _branch_experiment(experiment, conflicts, version, branching_arguments):
         branching_prompt = BranchingPrompt(experiment_brancher)
 
         if not sys.__stdin__.isatty():
-            raise ValueError(
-                "Configuration is different and generates a branching event:\n{}".format(
-                    branching_prompt.get_status()))
+            raise BranchingEvent(branching_prompt.get_status())
 
         branching_prompt.cmdloop()
 

--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -46,3 +46,42 @@ class MissingResultFile(Exception):
 
     def __init__(self, message=MISSING_RESULT_FILE):
         super().__init__(message)
+
+
+BRANCHING_ERROR_MESSAGE = """\
+Configuration is different and generates a branching event:
+{}
+
+Hint
+----
+
+This error is typically caused by the following 2 reasons:
+  1) Commandline calls where arguments are different from one worker to another
+     (think of paths that are worker specific). There will be --cli-change-type
+     in the error message above if it is the case.
+  2) User script that writes to the repository of the script, causing changes in the code
+     and therefore leading to branching events. There will be --code-change-type
+     in the error message above if it is the case.
+
+For each case you should:
+  1) Use --non-monitored-arguments [ARGUMENT_NAME]
+     (where you argument would be --argument-name, note the lack of dashes at
+      the beginning and the underscores instead of dashes between words)
+     The commandline argument only support one entry. To ignore many arguments,
+     you can use the option in a local config file, or in the global config file:
+     ```
+     evc:
+         non_monitored_arguments: ['FIRST_ARG', 'ANOTHER_ARG']
+     ```
+
+  2) Avoid writing data in your repository. It should only be code anyway, right? :)
+     Otherwise, you can ignore code changes altogether with option --ignore-code-changes.
+
+"""
+
+
+class BranchingEvent(Exception):
+    """Raise when conflicts could not be automatically resolved."""
+
+    def __init__(self, status, message=BRANCHING_ERROR_MESSAGE):
+        super().__init__(message.format(status))

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -13,7 +13,7 @@ import orion.core
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.pickleddb import PickledDB
 from orion.core.utils import SingletonNotInstantiatedError
-from orion.core.utils.exceptions import NoConfigurationError, RaceCondition
+from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, RaceCondition
 from orion.core.utils.tests import OrionState, update_singletons
 from orion.storage.base import get_storage
 from orion.storage.legacy import Legacy
@@ -328,7 +328,7 @@ class TestCreateExperiment:
         with OrionState(experiments=[config]):
             create_experiment(config['name'], space=new_space)
 
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(BranchingEvent) as exc:
                 create_experiment(config['name'], version=1, space=new_space)
 
             assert "Configuration is different and generates" in str(exc.value)

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -11,7 +11,7 @@ from orion.algo.space import Space
 from orion.core.evc.adapters import BaseAdapter
 import orion.core.io.experiment_builder as experiment_builder
 import orion.core.utils.backward as backward
-from orion.core.utils.exceptions import NoConfigurationError, RaceCondition
+from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, RaceCondition
 from orion.core.utils.tests import OrionState
 from orion.storage.base import get_storage
 
@@ -681,7 +681,7 @@ class TestBuild(object):
             assert parent.version == 1
             assert child.version == 2
 
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(BranchingEvent) as exc_info:
                 experiment_builder.build(name=name, version=1, space={'x': 'loguniform(1,10)'})
             assert 'Configuration is different and generates a branching' in str(exc_info.value)
 
@@ -803,7 +803,7 @@ class TestBuild(object):
             monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
                                 insert_race_condition_1)
 
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(BranchingEvent) as exc_info:
                 experiment_builder.build(name=name, version=1, space={'x': 'loguniform(1,10)'})
             assert 'Configuration is different and generates' in str(exc_info.value)
 


### PR DESCRIPTION
Why:

Users are confused when there is an error because of branching events.
Most of branching events are handled automatically, but when commandline
arguments are different for each workers or user scripts writes in code
repo there is a race condition between the version increments and it
fails.

How:

Write a clear message to explain what are the typical causes for these
issues and give hints on how to solve it.