### PR TITLE
Use EVC tree trials in producer

### DIFF
--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -104,7 +104,7 @@ class Producer(object):
         """Pull all trials to update model with completed ones and naive model with non completed
         ones.
         """
-        trials = self.experiment.fetch_trials()
+        trials = self.experiment.fetch_trials(with_evc_tree=True)
 
         self._update_algorithm([trial for trial in trials if trial.status == 'completed'])
         self._update_naive_algorithm([trial for trial in trials if trial.status != 'completed'])

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -16,6 +16,7 @@ import time
 import orion.core
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils import format_trials
+from orion.core.worker.trial import Trial
 from orion.core.worker.trials_history import TrialsHistory
 
 log = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ class Producer(object):
         # TODO: Move trials_history into PrimaryAlgo during the refactoring of Algorithm with
         #       Strategist and Scheduler.
         self.trials_history = TrialsHistory()
+        self.params_hashes = set()
         self.naive_trials_history = None
 
     @property
@@ -78,7 +80,6 @@ class Producer(object):
                         self.max_idle_time))
 
             log.debug("### Algorithm suggests new points.")
-
             new_points = self.naive_algorithm.suggest(self.pool_size)
             # Sync state of original algo so that state continues evolving.
             self.algorithm.set_state(self.naive_algorithm.state_dict)
@@ -91,14 +92,27 @@ class Producer(object):
                 log.debug("#### Convert point to `Trial` object.")
                 new_trial = format_trials.tuple_to_trial(new_point, self.space)
                 try:
+                    self._prevalidate_trial(new_trial)
                     new_trial.parents = self.naive_trials_history.children
                     log.debug("#### Register new trial to database: %s", new_trial)
                     self.experiment.register_trial(new_trial)
+                    self._update_params_hashes([new_trial])
                     sampled_points += 1
                 except DuplicateKeyError:
                     log.debug("#### Duplicate sample.")
                     self.backoff()
                     break
+
+    def _prevalidate_trial(self, new_trial):
+        """Verify if trial is not in parent history"""
+        if Trial.compute_trial_hash(new_trial, ignore_experiment=True) in self.params_hashes:
+            raise DuplicateKeyError
+
+    def _update_params_hashes(self, trials):
+        """Register locally all param hashes of trials"""
+        for trial in trials:
+            self.params_hashes.add(
+                Trial.compute_trial_hash(trial, ignore_experiment=True, ignore_lie=True))
 
     def update(self):
         """Pull all trials to update model with completed ones and naive model with non completed
@@ -130,6 +144,7 @@ class Producer(object):
             self.trials_history.update(new_completed_trials)
             self.algorithm.observe(points, results)
             self.strategy.observe(points, results)
+            self._update_params_hashes(new_completed_trials)
 
     def _produce_lies(self, incomplete_trials):
         """Add fake objective results to incomplete trials
@@ -172,3 +187,4 @@ class Producer(object):
             log.debug("### Observe them.")
             self.naive_trials_history.update(lying_trials)
             self.naive_algorithm.observe(points, results)
+            self._update_params_hashes(lying_trials)

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -308,7 +308,7 @@ class Trial:
 
         .. note:: The params contributing to the hash do not include the fidelity.
         """
-        return self.compute_trial_hash(self, ignore_fidelity=True)
+        return self.compute_trial_hash(self, ignore_fidelity=True, ignore_lie=True)
 
     def __hash__(self):
         """Return the hashname for this trial"""
@@ -362,17 +362,21 @@ class Trial:
         return Trial.format_values(params, sep)
 
     @staticmethod
-    def compute_trial_hash(trial, ignore_fidelity=False):
+    def compute_trial_hash(trial, ignore_fidelity=False, ignore_experiment=False,
+                           ignore_lie=False):
         """Generate a unique param md5sum hash for a given `Trial`"""
         if not trial._params and not trial.experiment:
             raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "
                              "have not been set.")
 
         params = Trial.format_params(trial._params, ignore_fidelity=ignore_fidelity)
-        experiment_repr = str(trial.experiment)
+
+        experiment_repr = ""
+        if not ignore_experiment:
+            experiment_repr = str(trial.experiment)
 
         lie_repr = ""
-        if not ignore_fidelity and trial.lie:
+        if not ignore_lie and trial.lie:
             lie_repr = Trial.format_values([trial.lie])
 
         return hashlib.md5((params + experiment_repr + lie_repr).encode('utf-8')).hexdigest()

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -238,6 +238,29 @@ class TestTrial(object):
         assert t1.hash_name != t2.hash_name
         assert t1.hash_params == t2.hash_params
 
+    def test_hash_ignore_experiment(self, exp_config):
+        """Check property `Trial.compute_trial_hash(ignore_experiment=True)`."""
+        exp_config[1][1]['params'].append({'name': '/max_epoch', 'type': 'fidelity', 'value': '1'})
+        t1 = Trial(**exp_config[1][1])
+        exp_config[1][1]['experiment'] = 'test'  # changing the experiment name
+        t2 = Trial(**exp_config[1][1])
+        assert t1.hash_name != t2.hash_name
+        assert t1.hash_params != t2.hash_params
+        assert (Trial.compute_trial_hash(t1, ignore_experiment=True) ==
+                Trial.compute_trial_hash(t2, ignore_experiment=True))
+
+    def test_hash_ignore_lie(self, exp_config):
+        """Check property `Trial.compute_trial_hash(ignore_lie=True)`."""
+        exp_config[1][1]['params'].append({'name': '/max_epoch', 'type': 'fidelity', 'value': '1'})
+        t1 = Trial(**exp_config[1][1])
+        # Add a lie
+        exp_config[1][1]['results'].append({'name': 'lie', 'type': 'lie', 'value': 1})
+        t2 = Trial(**exp_config[1][1])
+        assert t1.hash_name != t2.hash_name
+        assert t1.hash_params == t2.hash_params
+        assert (Trial.compute_trial_hash(t1, ignore_lie=True) ==
+                Trial.compute_trial_hash(t2, ignore_lie=True))
+
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""
         t = Trial(**exp_config[1][1])


### PR DESCRIPTION
## Use EVC tree trials in producer 

Why:

It seams the EVC tree was not used inside the producer... Making the EVC
somewhat useless beside traceability between experiments.

## Add a check to avoid duplicates across EVC 

Why:

The check against duplicates relies on the trial id which is a hash
based on the experiment id and the params. Problem is, the trial of
different experiment in the EVC have different experiment id, thus
different hash for the same parameters. To avoid duplicates between two
experiments in the EVC, we need to rely on a check before the
registration of the trial. This can only work of there is no parallel
workers on the 2 different experiment at the same time. This should be
the case since experiments are typically run sequentially, and
parallelism occurs within a single experiment.

How:

Keep track of hash of trials based on params only (including fidelity)
inside the producer, and verify if a new trial already exist before
registering it. DuplicateKeyError may still be raised during
registration if 2 workers try to register the same trial simultaneously.