### PR TITLE
Make global, local and cmdline args coherent

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -21,6 +21,7 @@
    user/algorithms
    user/script
    user/evc
+   user/config
 
 .. toctree::
    :caption: Examples

--- a/docs/src/user/config.rst
+++ b/docs/src/user/config.rst
@@ -1,5 +1,5 @@
 .. _configuration:
-    
+
 **********************
 Advanced Configuration
 **********************
@@ -15,7 +15,7 @@ lower ones. The levels are the following:
 5. Local configuration
 6. Commandline arguments
 
-Where larger numbers have precedence over 
+Where larger numbers have precedence over
 the lower ones. We describe here further each
 type of configuration.
 
@@ -40,13 +40,13 @@ This list is an example and will likely be differ on your end.
 
 **3. Environment Variables**
 
-Most options are configurable through environment variables as well. 
-These are provided in the documented below at the **Env var** fields, 
+Most options are configurable through environment variables as well.
+These are provided in the documented below at the **Env var** fields,
 whenever configurable otherwise the field is left empty.
 
 **4. Experiment Configuration from Database**
 
-\*Experiment configuration from database is not configurable by the user per say, 
+\*Experiment configuration from database is not configurable by the user per say,
 but it is represented here because whenever something differs between the experiment's
 configuration and the levels below, the experiment's configuration will have precedence.
 For instance if ``experiment.max_trials`` is set to 10 in global configuration
@@ -287,7 +287,7 @@ worker_trials
 
 :Type: int
 :Default: 1000000000
-:Env var: 
+:Env var:
 :Description:
     (DEPRECATED) This argument will be removed in v0.3.
     See :ref:`worker: max_trials <config_worker_max_trials>` instead.
@@ -313,7 +313,7 @@ working_dir
 ~~~~~~~~~~~
 
 :Type: str
-:Default: 
+:Default:
 :Env var: ORION_WORKING_DIR
 :Description:
     Set working directory for running experiment.
@@ -331,7 +331,7 @@ pool_size
 
 :Type: int
 :Default: 1
-:Env var: 
+:Env var:
 :Description:
     (DEPRECATED) This argument will be removed in v0.3.
 
@@ -343,7 +343,7 @@ algorithms
 
 :Type: dict
 :Default: random
-:Env var: 
+:Env var:
 :Description:
     Algorithm configuration for the experiment.
 
@@ -356,7 +356,7 @@ strategy
 
 :Type: dict
 :Default: MaxParallelStrategy
-:Env var: 
+:Env var:
 :Description:
     Parallel strategy to use with the algorithm.
 
@@ -500,10 +500,11 @@ auto_resolution
 
 :Type: bool
 :Default: True
-:Env var: 
+:Env var:
 :Description:
     (DEPRECATED) This argument will be removed in v0.3. Conflicts are now resolved automatically by
-    default. See :ref:`evc: manual_resolution <config_evc_manual_resolution>` to avoid auto-resolution.
+    default. See :ref:`evc: manual_resolution <config_evc_manual_resolution>` to avoid
+    auto-resolution.
 
 
 .. _config_evc_manual_resolution:

--- a/docs/src/user/config.rst
+++ b/docs/src/user/config.rst
@@ -1,0 +1,617 @@
+.. _configuration:
+    
+**********************
+Advanced Configuration
+**********************
+
+Oríon supports different levels of configuration to provide flexibility.
+The configuration levels are hierchical with higher levels having precedence over the
+lower ones. The levels are the following:
+
+1. Default configuration
+2. Global configuration
+3. Environment variables
+4. Experiment configuration from database*
+5. Local configuration
+6. Commandline arguments
+
+Where larger numbers have precedence over 
+the lower ones. We describe here further each
+type of configuration.
+
+**1. Default Configuration**
+
+Default values defined in core code of Oríon  `here </_modules/orion/core.html>`_.
+
+**2. Global Configuration**
+
+Defined in a yaml file in global configuration folders of Oríon.
+On Linux systems, this is typically at ``$HOME/.config/orion.core``. You can get a list
+of these folders on your system with the following command.
+
+.. code-block:: bash
+
+   $ python -c 'import orion.core; print("\n".join(orion.core.DEF_CONFIG_FILES_PATHS))'
+   /usr/share/awesome/orion.core/orion_config.yaml.example
+   /etc/xdg/xdg-awesome/orion.core/orion_config.yaml
+   /home/user/.config/orion.core/orion_config.yaml
+
+This list is an example and will likely be differ on your end.
+
+**3. Environment Variables**
+
+Most options are configurable through environment variables as well. 
+These are provided in the documented below at the **Env var** fields, 
+whenever configurable otherwise the field is left empty.
+
+**4. Experiment Configuration from Database**
+
+\*Experiment configuration from database is not configurable by the user per say, 
+but it is represented here because whenever something differs between the experiment's
+configuration and the levels below, the experiment's configuration will have precedence.
+For instance if ``experiment.max_trials`` is set to 10 in global configuration
+and an experiment with ``max_trials`` set to 100 is resumed, then ``max_trials``
+will be 100, not 10.
+However, if ``experiment.max_trials`` is set to 10 in local configuration file
+(the file passed with ``--config`` to the hunt command) or with commandline argument
+``--exp-max-trials``, then the experiments ``max_trials`` will be updated to 10.
+This make it possible to resume experiments without specifying the whole configuration,
+because experiment configuration from database is reused, but it also makes it possble
+to create a new experiment based on a previous one by simply specifying what to change.
+
+**5. Local Configuration**
+
+Defined in a yaml file that is passed to commandline.
+
+.. code-block:: bash
+
+      orion [COMMAND] --config local.yaml
+
+Not to be confused with a configuration file that may be passed to the user's script.
+
+.. code-block:: bash
+
+      orion hunt --config local.yaml ./myscript.sh --config script.yaml
+
+Here ``script.yaml`` is the user's script configuration (passed to ``./myscript.sh``),
+and ``local.yaml`` is the local configuration script (passed to ``hunt``).
+
+The configuration passed through the python API is also considered as local configuration.
+
+**6. Commandline Arguments**
+
+All arguments of ``orion hunt``.
+
+Full Example of Global Configuration
+------------------------------------
+
+.. code-block:: yaml
+
+    database:
+        host: localhost
+        name: orion
+        port: 27017
+        type: mongodb
+
+    experiment:
+        algorithms:
+            random:
+                seed: None
+        max_broken: 3
+        max_trials: 1000000000
+        pool_size: 1
+        strategy:
+            MaxParallelStrategy
+        worker_trials: 1000000000
+        working_dir:
+
+    worker:
+        heartbeat: 120
+        interrupt_signal_code: 130
+        max_broken: 10
+        max_idle_time: 60
+        max_trials: 1000000000
+        user_script_config: config
+
+    evc:
+        algorithm_change: False
+        auto_resolution: True
+        cli_change_type: break
+        code_change_type: break
+        config_change_type: break
+        ignore_code_changes: False
+        manual_resolution: False
+        non_monitored_arguments: []
+
+
+----
+
+
+.. _config_database:
+
+Database
+--------
+
+.. code-block:: yaml
+
+    database:
+        host: localhost
+        name: orion
+        port: 27017
+        type: mongodb
+
+
+.. _config_database_name:
+
+name
+~~~~
+
+:Type: str
+:Default: orion
+:Env var: ORION_DB_NAME
+:Description:
+    Name of the database.
+
+
+
+.. _config_database_type:
+
+type
+~~~~
+
+:Type: str
+:Default: MongoDB
+:Env var: ORION_DB_TYPE
+:Description:
+    Type of database. Builtin backends are ``mongodb``, ``pickleddb`` and ``ephemeraldb``.
+
+
+
+.. _config_database_host:
+
+host
+~~~~
+
+:Type: str
+:Default: 127.0.1.1
+:Env var: ORION_DB_ADDRESS
+:Description:
+    URI for ``mongodb``, or file path for ``pickleddb``.
+
+
+
+.. _config_database_port:
+
+port
+~~~~
+
+:Type: int
+:Default: 27017
+:Env var: ORION_DB_PORT
+:Description:
+    Port address for ``mongodb``.
+
+
+
+----
+
+
+.. _config_experiment:
+
+Experiment
+----------
+
+.. code-block:: yaml
+
+    experiment:
+        algorithms:
+            random:
+                seed: None
+        max_broken: 3
+        max_trials: 1000000000
+        pool_size: 1
+        strategy:
+            MaxParallelStrategy
+        worker_trials: 1000000000
+        working_dir:
+
+
+
+.. _config_experiment_name:
+
+name
+~~~~
+
+.. note:: This option is only supported in local configuration.
+
+:Type: str
+:Default:
+:Env var:
+:Description:
+    Name of the experiment.
+
+
+.. _config_experiment_version:
+
+version
+~~~~~~~
+
+.. note:: This option is only supported in local configuration.
+
+
+:Type: int
+:Default: None
+:Env var:
+:Description:
+    Version of the experiment. If not defined, latest experiment for the given
+    name will be selected. Version is automatically incremented if there is any
+    modification detected in the experiment's configuration
+    (search space, algorithm configuration, code version, ...)
+
+
+user
+~~~~
+
+.. note:: This option is only supported in local configuration.
+
+:Type: str
+:Default: $USERNAME
+:Env var:
+:Description:
+    Name of the user to associate with the experiment.
+
+
+.. _config_experiment_max_trials:
+
+max_trials
+~~~~~~~~~~
+
+:Type: int
+:Default: 1000000000
+:Env var: ORION_EXP_MAX_TRIALS
+:Description:
+    number of trials to be completed for the experiment. This value will be saved within the
+    experiment configuration and reused across all workers to determine experiment's completion.
+
+
+
+.. _config_experiment_worker_trials:
+
+worker_trials
+~~~~~~~~~~~~~
+
+.. warning::
+
+   **DEPRECATED.** This argument will be removed in v0.3.
+   See :ref:`worker: max_trials <config_worker_max_trials>` instead.
+
+:Type: int
+:Default: 1000000000
+:Env var: 
+:Description:
+    (DEPRECATED) This argument will be removed in v0.3.
+    See :ref:`worker: max_trials <config_worker_max_trials>` instead.
+
+
+
+.. _config_experiment_max_broken:
+
+max_broken
+~~~~~~~~~~
+
+:Type: int
+:Default: 3
+:Env var: ORION_EXP_MAX_BROKEN
+:Description:
+    Maximum number of broken trials before experiment stops.
+
+
+
+.. _config_experiment_working_dir:
+
+working_dir
+~~~~~~~~~~~
+
+:Type: str
+:Default: 
+:Env var: ORION_WORKING_DIR
+:Description:
+    Set working directory for running experiment.
+
+
+
+.. _config_experiment_pool_size:
+
+pool_size
+~~~~~~~~~
+
+.. warning::
+
+   **DEPRECATED.** This argument will be removed in v0.3.
+
+:Type: int
+:Default: 1
+:Env var: 
+:Description:
+    (DEPRECATED) This argument will be removed in v0.3.
+
+
+.. _config_experiment_algorithms:
+
+algorithms
+~~~~~~~~~~
+
+:Type: dict
+:Default: random
+:Env var: 
+:Description:
+    Algorithm configuration for the experiment.
+
+
+
+.. _config_experiment_strategy:
+
+strategy
+~~~~~~~~
+
+:Type: dict
+:Default: MaxParallelStrategy
+:Env var: 
+:Description:
+    Parallel strategy to use with the algorithm.
+
+
+
+----
+
+
+.. _config_worker:
+
+Worker
+------
+
+.. code-block:: yaml
+
+    worker:
+        heartbeat: 120
+        interrupt_signal_code: 130
+        max_broken: 10
+        max_idle_time: 60
+        max_trials: 1000000000
+        user_script_config: config
+
+
+
+.. _config_worker_heartbeat:
+
+heartbeat
+~~~~~~~~~
+
+:Type: int
+:Default: 120
+:Env var: ORION_HEARTBEAT
+:Description:
+    Frequency (seconds) at which the heartbeat of the trial is updated. If the heartbeat of a
+    `reserved` trial is larger than twice the configured heartbeat, Oríon will reset the status of
+    the trial to `interrupted`. This allows restoring lost trials (ex: due to killed worker).
+
+
+
+.. _config_worker_max_trials:
+
+max_trials
+~~~~~~~~~~
+
+:Type: int
+:Default: 1000000000
+:Env var: ORION_WORKER_MAX_TRIALS
+:Description:
+    Number of trials to be completed for this worker. If the experiment is completed, the worker
+    will die even if it did not reach its maximum number of trials.
+
+
+
+.. _config_worker_max_broken:
+
+max_broken
+~~~~~~~~~~
+
+:Type: int
+:Default: 3
+:Env var: ORION_WORKER_MAX_BROKEN
+:Description:
+    Maximum number of broken trials before worker stops.
+
+
+
+.. _config_worker_max_idle_time:
+
+max_idle_time
+~~~~~~~~~~~~~
+
+:Type: int
+:Default: 60
+:Env var: ORION_MAX_IDLE_TIME
+:Description:
+    Maximum time the producer can spend trying to generate a new suggestion.Such timeout are
+    generally caused by slow database, large number of concurrent workers leading to many race
+    conditions or small search spaces with integer/categorical dimensions that may be fully
+    explored.
+
+
+
+.. _config_worker_interrupt_signal_code:
+
+interrupt_signal_code
+~~~~~~~~~~~~~~~~~~~~~
+
+:Type: int
+:Default: 130
+:Env var: ORION_INTERRUPT_CODE
+:Description:
+    Signal returned by user script to signal to Oríon that it was interrupted.
+
+
+
+.. _config_worker_user_script_config:
+
+user_script_config
+~~~~~~~~~~~~~~~~~~
+
+:Type: str
+:Default: config
+:Env var: ORION_USER_SCRIPT_CONFIG
+:Description:
+    Config argument name of user's script (--config).
+
+
+
+----
+
+
+.. _config_evc:
+
+Experiment Version Control
+--------------------------
+
+.. code-block:: yaml
+
+    evc:
+        algorithm_change: False
+        auto_resolution: True
+        cli_change_type: break
+        code_change_type: break
+        config_change_type: break
+        ignore_code_changes: False
+        manual_resolution: False
+        non_monitored_arguments: []
+
+
+
+.. _config_evc_auto_resolution:
+
+auto_resolution
+~~~~~~~~~~~~~~~
+
+.. warning::
+
+   **DEPRECATED.** This argument will be removed in v0.3.
+   See :ref:`evc: manual_resolution <config_evc_manual_resolution>` to avoid auto-resolution.
+
+:Type: bool
+:Default: True
+:Env var: 
+:Description:
+    (DEPRECATED) This argument will be removed in v0.3. Conflicts are now resolved automatically by
+    default. See :ref:`evc: manual_resolution <config_evc_manual_resolution>` to avoid auto-resolution.
+
+
+.. _config_evc_manual_resolution:
+
+manual_resolution
+~~~~~~~~~~~~~~~~~
+
+:Type: bool
+:Default: False
+:Env var: ORION_EVC_MANUAL_RESOLUTION
+:Description:
+    If ``True``, enter experiment version control conflict resolver for manual resolution on
+    branching events. Otherwise, auto-resolution is attempted.
+
+
+
+.. _config_evc_non_monitored_arguments:
+
+non_monitored_arguments
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: list
+:Default: []
+:Env var: ORION_EVC_NON_MONITORED_ARGUMENTS
+:Description:
+    Ignore these commandline arguments when looking for differences in user's commandline call.
+    Environment variable and commandline only supports one argument. Use global config or local
+    config to pass a list of arguments to ignore.
+
+
+
+.. _config_evc_ignore_code_changes:
+
+ignore_code_changes
+~~~~~~~~~~~~~~~~~~~
+
+:Type: bool
+:Default: False
+:Env var: ORION_EVC_IGNORE_CODE_CHANGES
+:Description:
+    If ``True``, ignore code changes when looking for differences.
+
+
+
+.. _config_evc_algorithm_change:
+
+algorithm_change
+~~~~~~~~~~~~~~~~
+
+:Type: bool
+:Default: False
+:Env var: ORION_EVC_ALGO_CHANGE
+:Description:
+    If ``True``, set algorithm change as resolved if a branching event occur. Child and parent
+    experiment have access to all trials from each other when the only difference between them is
+    the algorithm configuration.
+
+
+.. _config_evc_code_change_type:
+
+code_change_type
+~~~~~~~~~~~~~~~~
+
+:Type: str
+:Default: break
+:Env var: ORION_EVC_CODE_CHANGE
+:Description:
+    One of ``break``, ``unsure`` or ``noeffet``. Defines how trials should be filtered in Experiment
+    Version Control tree if there is a change in the user's code repository. If the effect of the
+    change is ``unsure``, the child experiment will access the trials of the parent but not the
+    other way around. This is to ensure parent experiment does not get corrupted with possibly
+    incompatible results. The child cannot access the trials from parent if ``code_change_type`` is
+    ``break``. The parent cannot access trials from child if ``code_change_type`` is ``unsure`` or
+    ``break``.
+
+
+
+.. _config_evc_cli_change_type:
+
+cli_change_type
+~~~~~~~~~~~~~~~
+
+:Type: str
+:Default: break
+:Env var: ORION_EVC_CMDLINE_CHANGE
+:Description:
+    One of ``break``, ``unsure`` or ``noeffet``. Defines how trials should be filtered in Experiment
+    Version Control tree if there is a change in the user's commandline call. If the effect of the
+    change is ``unsure``, the child experiment will access the trials of the parent but not the
+    other way around. This is to ensure parent experiment does not get corrupted with possibly
+    incompatible results. The child cannot access the trials from parent if ``cli_change_type`` is
+    ``break``. The parent cannot access trials from child if ``cli_change_type`` is ``unsure`` or
+    ``break``.
+
+
+
+.. _config_evc_config_change_type:
+
+config_change_type
+~~~~~~~~~~~~~~~~~~
+
+:Type: str
+:Default: break
+:Env var: ORION_EVC_CONFIG_CHANGE
+:Description:
+    One of ``break``, ``unsure`` or ``noeffet``. Defines how trials should be filtered in Experiment
+    Version Control tree if there is a change in the user's script. If the effect of the change is
+    ``unsure``, the child experiment will access the trials of the parent but not the other way
+    around. This is to ensure parent experiment does not get corrupted with possibly incompatible
+    results. The child cannot access the trials from parent if ``config_change_type`` is ``break``.
+    The parent cannot access trials from child if ``config_change_type`` is ``unsure`` or ``break``.

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -57,7 +57,8 @@ def define_config():
     define_evc_config(config)
 
     config.add_option(
-        'user_script_config', option_type=str, default='config')
+        'user_script_config', option_type=str, default='config',
+        deprecate=dict(version='v0.3', alternative='worker.user_script_config'))
 
     return config
 
@@ -72,7 +73,7 @@ def define_storage_config(config):
     config.storage = storage_config
 
     define_database_config(config.storage)
-    # Backward compatibility, should be removed in v0.2.0
+    # Backward compatibility, should be removed in v0.3.0, or not?
     config.database = config.storage.database
 
 
@@ -102,16 +103,29 @@ def define_experiment_config(config):
     experiment_config = Configuration()
 
     experiment_config.add_option(
-        'pool_size', option_type=int, default=1)
+        'max_trials', option_type=int, default=int(10e8), env_var='ORION_EXP_MAX_TRIALS',
+        help="number of trials to be completed for the experiment. This value "
+             "will be saved within the experiment configuration and reused "
+             "across all workers to determine experiment's completion. ")
 
     experiment_config.add_option(
-        'max_trials', option_type=int, default=int(10e8))
+        'worker_trials', option_type=int, default=int(10e8),
+        deprecate=dict(version='v0.3', alternative='worker.max_trials',
+                       name='experiment.worker_trials'),
+        help="This argument will be removed in v0.3. Use --exp-max-trials instead.")
 
     experiment_config.add_option(
-        'worker_trials', option_type=int, default=int(10e8))
+        'max_broken', option_type=int, default=3, env_var='ORION_EXP_MAX_BROKEN',
+        help=('Maximum number of broken trials before experiment stops.'))
 
     experiment_config.add_option(
-        'working_dir', option_type=str, default='')
+        'working_dir', option_type=str, default='', env_var='ORION_WORKING_DIR',
+        help="Set working directory for running experiment.")
+
+    experiment_config.add_option(
+        "pool_size", option_type=int, default=1,
+        deprecate=dict(version='v0.3', alternative=None, name='experiment.pool_size'),
+        help="This argument will be removed in v0.3.")
 
     experiment_config.add_option(
         'algorithms', option_type=dict, default={'random': {'seed': None}})
@@ -127,13 +141,38 @@ def define_worker_config(config):
     worker_config = Configuration()
 
     worker_config.add_option(
-        'heartbeat', option_type=int, default=120)
+        'heartbeat', option_type=int, default=120, env_var='ORION_HEARTBEAT',
+        help=('Frequency (seconds) at which the heartbeat of the trial is updated. '
+              'If the heartbeat of a `reserved` trial is larger than twice the configured '
+              'heartbeat, Oríon will reset the status of the trial to `interrupted`. '
+              'This allows restoring lost trials (ex: due to killed worker).'))
+
     worker_config.add_option(
-        'max_broken', option_type=int, default=3)
+        'max_trials', option_type=int, default=int(10e8), env_var='ORION_WORKER_MAX_TRIALS',
+        help="number of trials to be completed for this worker. "
+             "If the experiment is completed, the worker will die even if it "
+             "did not reach its maximum number of trials ")
+
     worker_config.add_option(
-        'max_idle_time', option_type=int, default=60)
+        'max_broken', option_type=int, default=3, env_var='ORION_WORKER_MAX_BROKEN',
+        help=('Maximum number of broken trials before experiment stops.'))
+
     worker_config.add_option(
-        'interrupt_signal_code', option_type=int, default=130, env_var='ORION_INTERRUPT_CODE')
+        'max_idle_time', option_type=int, default=60, env_var='ORION_MAX_IDLE_TIME',
+        help=('Maximum time the producer can spend trying to generate a new suggestion.'
+              'Such timeout are generally caused by slow database, large number of '
+              'concurrent workers leading to many race conditions or small search spaces '
+              'with integer/categorical dimensions that may be fully explored.'))
+
+    worker_config.add_option(
+        'interrupt_signal_code', option_type=int, default=130, env_var='ORION_INTERRUPT_CODE',
+        help='Signal returned by user script to signal to Oríon that it was interrupted.')
+
+    # TODO: Will this support -config as well, or only --config?
+    worker_config.add_option(
+        'user_script_config', option_type=str, default='config',
+        env_var='ORION_USER_SCRIPT_CONFIG',
+        help='Config argument name of user\'s script (--config).')
 
     config.worker = worker_config
 
@@ -142,22 +181,53 @@ def define_evc_config(config):
     """Create and define the fields of the evc configuration."""
     evc_config = Configuration()
 
+    # TODO: This should be built automatically like get_branching_args_group
+    #       After this, the cmdline parser should be built based on config.
+
     evc_config.add_option(
-        'auto_resolution', option_type=bool, default=True)
+        'auto_resolution', option_type=bool, default=True,
+        deprecate=dict(version='v0.3', alternative='evc.manual_resolution',
+                       name='evc.auto_resolution'),
+        help="This argument will be removed in v0.3. "
+             "Conflicts are now resolved automatically by default. "
+             "See --manual-resolution to avoid auto-resolution.")
+
     evc_config.add_option(
-        'manual_resolution', option_type=bool, default=False)
+        'manual_resolution', option_type=bool, default=False,
+        env_var='ORION_EVC_MANUAL_RESOLUTION',
+        help="Enter evc conflict resolver for manual resolution on branching events.")
+
     evc_config.add_option(
-        'non_monitored_arguments', option_type=list, default=[])
+        'non_monitored_arguments', option_type=list, default=[],
+        env_var='ORION_EVC_NON_MONITORED_ARGUMENTS',
+        help=("Ignore these arguments when looking for differences. "
+              "Environment variable and commandline only supports one argument. "
+              "Use global config or local config to pass a list of arguments to ignore."))
+
     evc_config.add_option(
-        'ignore_code_changes', option_type=bool, default=False)
+        'ignore_code_changes', option_type=bool, default=False,
+        env_var='ORION_EVC_IGNORE_CODE_CHANGES',
+        help=("Ignore code changes when looking for differences"))
+
     evc_config.add_option(
-        'algorithm_change', option_type=bool, default=False)
+        'algorithm_change', option_type=bool, default=False,
+        env_var='ORION_EVC_ALGO_CHANGE',
+        help="Set algorithm change as resolved if a branching event occur")
+
     evc_config.add_option(
-        'code_change_type', option_type=str, default='break')
+        'code_change_type', option_type=str, default='break',
+        env_var='ORION_EVC_CODE_CHANGE',
+        help="Set default code change type")
+
     evc_config.add_option(
-        'cli_change_type', option_type=str, default='break')
+        'cli_change_type', option_type=str, default='break',
+        env_var='ORION_EVC_CMDLINE_CHANGE',
+        help="Set default command line change type")
+
     evc_config.add_option(
-        'config_change_type', option_type=str, default='break')
+        'config_change_type', option_type=str, default='break',
+        env_var='ORION_EVC_CONFIG_CHANGE',
+        help="Set default user script config change type")
 
     config.evc = evc_config
 

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -88,11 +88,13 @@ class OrionArgsParser:
         return 0
 
 
-def get_basic_args_group(parser):
+def get_basic_args_group(
+        parser,
+        group_name="Oríon arguments",
+        group_help="These arguments determine orion's behaviour"):
     """Return the basic arguments for any command."""
     basic_args_group = parser.add_argument_group(
-        "Oríon arguments (optional)",
-        description="These arguments determine orion's behaviour")
+        group_name, description=group_help)
 
     basic_args_group.add_argument(
         '-n', '--name',

--- a/src/orion/core/cli/evc.py
+++ b/src/orion/core/cli/evc.py
@@ -36,7 +36,7 @@ def _add_ignore_code_changes_argument(parser):
     parser.add_argument(
         "--ignore-code-changes",
         action="store_true",
-        help="Ignore these arguments when looking for differences")
+        help="Ignore code changes when looking for differences")
 
 
 def _add_branch_from_argument(parser):

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -76,7 +76,9 @@ def _build_extended_user_args(config):
     """
     user_args = config['metadata']['user_args']
 
-    parser = OrionCmdlineParser(orion.core.config.user_script_config)
+    # No need to pass config_prefix because we have access to everything
+    # required in config[metadata][parser] (parsed data)
+    parser = OrionCmdlineParser()
     parser.set_state_dict(config['metadata']['parser'])
 
     return user_args + [standard_param_name(key) + value
@@ -326,7 +328,7 @@ class Conflict(object, metaclass=ABCMeta):
         return self._is_resolved or self.resolution is not None
 
     # pylint:disable=unused-argument,no-self-use
-    def get_marked_arguments(self, conflicts):
+    def get_marked_arguments(self, conflicts, **branching_kwargs):
         """Return arguments from marked resolutions in new configuration
 
         Some conflicts may be passed arguments with their marker to automate conflict resolution.
@@ -761,7 +763,7 @@ class MissingDimensionConflict(Conflict):
         self.dimension = dimension
         self.prior = prior
 
-    def get_marked_arguments(self, conflicts):
+    def get_marked_arguments(self, conflicts, **branching_kwargs):
         """Find and return marked arguments for remove or rename resolution
 
         .. seealso::
@@ -1113,7 +1115,7 @@ class CodeConflict(Conflict):
         if not ignore_code_changes and new_hash_commit and old_hash_commit != new_hash_commit:
             yield cls(old_config, new_config)
 
-    def get_marked_arguments(self, conflicts):
+    def get_marked_arguments(self, conflicts, code_change_type=None, **branching_kwargs):
         """Find and return marked arguments for code change conflict
 
         .. seealso::
@@ -1126,7 +1128,10 @@ class CodeConflict(Conflict):
         if change_type:
             return dict(change_type=change_type)
 
-        return dict(change_type=orion.core.config.evc.code_change_type)
+        if code_change_type is None:
+            code_change_type = orion.core.config.evc.code_change_type
+
+        return dict(change_type=code_change_type)
 
     def try_resolve(self, change_type=None):
         """Try to create a resolution CodeResolution
@@ -1261,7 +1266,7 @@ class CommandLineConflict(Conflict):
         if old_nameless_args != new_nameless_args:
             yield cls(old_config, new_config)
 
-    def get_marked_arguments(self, conflicts):
+    def get_marked_arguments(self, conflicts, cli_change_type=None, **branching_kwargs):
         """Find and return marked arguments for cli change conflict
 
         .. seealso::
@@ -1274,7 +1279,10 @@ class CommandLineConflict(Conflict):
         if change_type:
             return dict(change_type=change_type)
 
-        return dict(change_type=orion.core.config.evc.cli_change_type)
+        if cli_change_type is None:
+            cli_change_type = orion.core.config.evc.cli_change_type
+
+        return dict(change_type=cli_change_type)
 
     def try_resolve(self, change_type=None):
         """Try to create a resolution CommandLineResolution
@@ -1370,14 +1378,18 @@ class ScriptConfigConflict(Conflict):
 
     """
 
+    # pylint:disable=unused-argument
     @classmethod
-    def get_nameless_config(cls, config):
+    def get_nameless_config(cls, config, user_script_config=None, **branching_kwargs):
         """Get configuration dict of user's script without dimension definitions"""
         # Used python API
         if 'parser' not in config['metadata']:
             return ""
 
-        parser = OrionCmdlineParser(orion.core.config.user_script_config)
+        if user_script_config is None:
+            user_script_config = orion.core.config.user_script_config
+
+        parser = OrionCmdlineParser(user_script_config)
         parser.set_state_dict(config['metadata']['parser'])
 
         nameless_config = dict((key, value)
@@ -1391,13 +1403,16 @@ class ScriptConfigConflict(Conflict):
         """Detect if user's script's config file in `new_config` differs from `old_config`
         :param branching_config:
         """
-        old_script_config = cls.get_nameless_config(old_config)
-        new_script_config = cls.get_nameless_config(new_config)
+        if branching_config is None:
+            branching_config = {}
+
+        old_script_config = cls.get_nameless_config(old_config, **branching_config)
+        new_script_config = cls.get_nameless_config(new_config, **branching_config)
 
         if old_script_config != new_script_config:
             yield cls(old_config, new_config)
 
-    def get_marked_arguments(self, conflicts):
+    def get_marked_arguments(self, conflicts, config_change_type=None, **branching_kwargs):
         """Find and return marked arguments for user's script's config change conflict
 
         .. seealso::
@@ -1410,7 +1425,10 @@ class ScriptConfigConflict(Conflict):
         if change_type:
             return dict(change_type=change_type)
 
-        return dict(change_type=orion.core.config.evc.config_change_type)
+        if config_change_type is None:
+            config_change_type = orion.core.config.evc.config_change_type
+
+        return dict(change_type=config_change_type)
 
     def try_resolve(self, change_type=None):
         """Try to create a resolution ScriptConfigResolution
@@ -1514,7 +1532,7 @@ class ExperimentNameConflict(Conflict):
         """
         yield cls(old_config, new_config)
 
-    def get_marked_arguments(self, conflicts):
+    def get_marked_arguments(self, conflicts, **branching_kwargs):
         """Find and return marked arguments for experiment name conflict
 
         .. seealso::

--- a/src/orion/core/io/config.py
+++ b/src/orion/core/io/config.py
@@ -153,6 +153,7 @@ class Configuration:
             configuration object.
 
         """
+        key = self._curate(key)
         if key not in self.SPECIAL_KEYS and key in self._config:
             self._validate(key, value)
             self._config[key]['value'] = value
@@ -205,7 +206,7 @@ class Configuration:
             A general object to set an option.
 
         """
-        keys = key.split(".")
+        keys = list(map(self._curate, key.split(".")))
 
         # Set in current config for special keys
         if len(keys) == 2 and keys[-1] in self.SPECIAL_KEYS:
@@ -236,7 +237,9 @@ class Configuration:
             Ex: 'first.second.third'
 
         """
-        keys = key.split(".")
+        print(key)
+        keys = list(map(self._curate, key.split(".")))
+
         # Recursively in sub configurations
         if len(keys) > 1:
             subconfig = getattr(self, keys[0])
@@ -271,6 +274,7 @@ class Configuration:
             YAML configuration file.
 
         """
+        key = self._curate(key)
         if key in self._config or key in self._subconfigs:
             raise ValueError('Configuration already contains {}'.format(key))
         self._config[key] = {'type': option_type}
@@ -278,6 +282,9 @@ class Configuration:
             self._config[key]['env_var'] = env_var
         if default is not NOT_SET:
             self._config[key]['default'] = default
+
+    def _curate(self, key):
+        return key.replace('-', '_')
 
     def to_dict(self):
         """Return a dictionary representation of the configuration"""

--- a/src/orion/core/io/config.py
+++ b/src/orion/core/io/config.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-builtin
 """
 :mod:`orion.core.io.config` -- Configuration object
 ===================================================
@@ -29,6 +30,10 @@ class ConfigurationError(Exception):
     """Error raised when a configuration value is requested but not set."""
 
 
+def _curate(key):
+    return key.replace('-', '_')
+
+
 class Configuration:
     """Configuration object
 
@@ -56,7 +61,7 @@ class Configuration:
 
     """
 
-    SPECIAL_KEYS = ['_config', '_subconfigs', '_yaml', '_default', '_env_var']
+    SPECIAL_KEYS = ['_config', '_subconfigs', '_yaml', '_default', '_env_var', '_help']
 
     def __init__(self):
         self._config = {}
@@ -127,6 +132,9 @@ class Configuration:
             raise ConfigurationError("Configuration not set and no default "
                                      "provided: {}.".format(key))
 
+        if config_setting.get('deprecated'):
+            self._deprecate(key)
+
         return config_setting['type'](value)
 
     def __setattr__(self, key, value):
@@ -153,10 +161,12 @@ class Configuration:
             configuration object.
 
         """
-        key = self._curate(key)
+        key = _curate(key)
         if key not in self.SPECIAL_KEYS and key in self._config:
             self._validate(key, value)
             self._config[key]['value'] = value
+            if self._config[key].get('deprecated'):
+                self._deprecate(key, value)
 
         elif key in ['_config', '_subconfigs']:
             super(Configuration, self).__setattr__(key, value)
@@ -170,6 +180,16 @@ class Configuration:
         else:
             raise TypeError("Can only set {} as a Configuration, not {}. Use add_option to set a "
                             "new option.".format(key, type(value)))
+
+    # pylint: disable=unused-argument
+    def _deprecate(self, key, value=NOT_SET):
+        deprecate = self._config[key]['deprecated']
+        message = "(DEPRECATED) Option `%s` will be removed in %s."
+        args = [deprecate.get('name', key), deprecate['version']]
+        if 'alternative' in deprecate:
+            message += " Use `%s` instead."
+            args.append(deprecate['alternative'])
+        logger.warning(message, *args)
 
     def _validate(self, key, value):
         """Validate the (key, value) option
@@ -206,13 +226,15 @@ class Configuration:
             A general object to set an option.
 
         """
-        keys = list(map(self._curate, key.split(".")))
+        keys = list(map(_curate, key.split(".")))
 
         # Set in current config for special keys
         if len(keys) == 2 and keys[-1] in self.SPECIAL_KEYS:
             key, field = keys
             self._validate(key, value)
             self._config[key][field.lstrip('_')] = value
+            if self._config[key].get('deprecated'):
+                self._deprecate(key)
 
         # Set in current configuration
         elif len(keys) == 1:
@@ -237,11 +259,12 @@ class Configuration:
             Ex: 'first.second.third'
 
         """
-        print(key)
-        keys = list(map(self._curate, key.split(".")))
+        keys = list(map(_curate, key.split(".")))
 
         # Recursively in sub configurations
-        if len(keys) > 1:
+        if len(keys) == 2 and keys[1] in self.SPECIAL_KEYS:
+            return self._config[keys[0]][keys[1][1:]]
+        elif len(keys) > 1:
             subconfig = getattr(self, keys[0])
             if subconfig is None:
                 raise KeyError("'{}' is not defined in configuration.".format(keys[0]))
@@ -250,7 +273,8 @@ class Configuration:
         else:
             return getattr(self, keys[0])
 
-    def add_option(self, key, option_type, default=NOT_SET, env_var=None):
+    def add_option(self, key, option_type, default=NOT_SET, env_var=None, deprecate=None,
+                   help=None):
         """Add a configuration setting.
 
         Parameters
@@ -272,9 +296,20 @@ class Configuration:
             The environment variable name that holds this configuration
             value. If not given, this configuration can only be set in the
             YAML configuration file.
+        deprecate: `dict`, optional
+            Should define dict(version, alternative), version at which the deprecated option will be
+            removed and alternative to use. A deprecation warning will be logged each time this
+            option is set by user. The option `name` can be used in addition to `version` and
+            `alternative` to provide a different name then the key. This is useful if the key
+            is in a subconfiguration and we want the deprecation error message to include the full
+            path. This will add (DEPRECATED) at the beginning of the help message.
+        help : str, optionial
+            Documentation for the option. Can be reused to build documentation
+            or to build parsers with help messages.
+            Default help message is 'Undocumented'.
 
         """
-        key = self._curate(key)
+        key = _curate(key)
         if key in self._config or key in self._subconfigs:
             raise ValueError('Configuration already contains {}'.format(key))
         self._config[key] = {'type': option_type}
@@ -282,9 +317,56 @@ class Configuration:
             self._config[key]['env_var'] = env_var
         if default is not NOT_SET:
             self._config[key]['default'] = default
+        if deprecate is not None:
+            if 'version' not in deprecate:
+                raise ValueError(f'`version` is missing in deprecate option: {deprecate}')
+            self._config[key]['deprecated'] = deprecate
 
-    def _curate(self, key):
-        return key.replace('-', '_')
+        if help is None:
+            help = 'Undocumented'
+
+        if default is not NOT_SET:
+            help += ' (default: {})'.format(default)
+        if deprecate is not None:
+            help = '(DEPRECATED) ' + help
+        self._config[key]['help'] = help
+
+    def help(self, key):
+        """Return the help message for the given option."""
+        return self[key + '._help']
+
+    def add_arguments(self, parser, rename=None):
+        """Add arguments to an `argparse` parser based on configuration
+
+        This does not support subconfigurations. They will be ignored.
+
+        Parameters
+        ----------
+        parser: `argparse.ArgumentParser`
+            Parser to which this function will add arguments
+        rename: dict, optional
+            Mappings to provide different commandline names. Ex `{key: --my-arg}`
+
+        """
+        if rename is None:
+            rename = dict()
+
+        for key in self._config:
+            # TODO: Try with list and nargs='*', but it may case issues with
+            # nargs=argparse.REMAINDER.
+            if self._config[key]['type'] in (dict, list, tuple):
+                continue
+
+            # NOTE: Do not set default, if parser.parse_argv().options[key] is None, then code
+            # should look to config[key].
+            arg_name = rename.get(key, "--{}".format(key.replace('_', '-')))
+            parser.add_argument(
+                arg_name, type=self._config[key]['type'],
+                help=self._config[key].get('help'))
+
+    def __contains__(self, key):
+        """Return True if the option is defined."""
+        return key in self._config or key in self._subconfigs
 
     def to_dict(self):
         """Return a dictionary representation of the configuration"""

--- a/src/orion/core/io/experiment_branch_builder.py
+++ b/src/orion/core/io/experiment_branch_builder.py
@@ -66,8 +66,10 @@ class ExperimentBranchBuilder:
         self.conflicts = conflicts
 
         for key, value in branching_arguments.items():
-            if value is None:
+            if value is None and key in orion.core.config.evc:
                 branching_arguments[key] = orion.core.config.evc[key]
+
+        self.branching_arguments = branching_arguments
 
         self.conflicting_config.update(branching_arguments)
         self.resolve_conflicts()
@@ -93,7 +95,7 @@ class ExperimentBranchBuilder:
 
             resolution = self.conflicts.try_resolve(
                 conflict, silence_errors=silence_errors,
-                **conflict.get_marked_arguments(self.conflicts))
+                **conflict.get_marked_arguments(self.conflicts, **self.branching_arguments))
 
             if resolution and (self.manual_resolution and not resolution.is_marked):
                 self.conflicts.revert(resolution)

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -93,7 +93,6 @@ import sys
 
 from orion.algo.space import Space
 import orion.core
-from orion.core.cli.evc import fetch_branching_configuration
 from orion.core.evc.adapters import Adapter
 from orion.core.evc.conflicts import detect_conflicts, ExperimentNameConflict
 from orion.core.io import resolve_config
@@ -519,10 +518,10 @@ def setup_storage(storage=None):
     if storage is None:
         storage = orion.core.config.storage.to_dict()
 
-    if storage['type'] == 'legacy':
-
-        if 'database' not in storage:
-            storage['database'] = orion.core.config.storage.database.to_dict()
+    if storage.get('type') == 'legacy' and 'database' not in storage:
+        storage['database'] = orion.core.config.storage.database.to_dict()
+    elif storage.get('type') is None and 'database' in storage:
+        storage['type'] = 'legacy'
 
     storage_type = storage.pop('type')
 
@@ -554,8 +553,6 @@ def build_from_args(cmdargs):
 
     setup_storage(cmd_config['storage'])
 
-    cmd_config['branching'] = fetch_branching_configuration(cmd_config)
-
     return build(**cmd_config)
 
 
@@ -582,8 +579,8 @@ def get_cmd_config(cmdargs):
     """Fetch configuration defined by commandline and local configuration file.
 
     Arguments of commandline have priority over options in configuration file.
-
     """
+    cmdargs = resolve_config.fetch_config_from_cmdargs(cmdargs)
     cmd_config = resolve_config.fetch_config(cmdargs)
     cmd_config = resolve_config.merge_configs(cmd_config, cmdargs)
 
@@ -593,5 +590,8 @@ def get_cmd_config(cmdargs):
 
     backward.populate_space(cmd_config)
     backward.update_db_config(cmd_config)
+
+    cmd_config.update(cmd_config.pop('experiment'))
+    cmd_config['branching'] = cmd_config.pop('evc', {})
 
     return cmd_config

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -584,14 +584,14 @@ def get_cmd_config(cmdargs):
     cmd_config = resolve_config.fetch_config(cmdargs)
     cmd_config = resolve_config.merge_configs(cmd_config, cmdargs)
 
+    cmd_config.update(cmd_config.pop('experiment', {}))
+    cmd_config['branching'] = cmd_config.pop('evc', {})
+
     metadata = resolve_config.fetch_metadata(cmd_config.get('user'), cmd_config.get('user_args'))
     cmd_config['metadata'] = metadata
     cmd_config.pop('config', None)
 
     backward.populate_space(cmd_config)
     backward.update_db_config(cmd_config)
-
-    cmd_config.update(cmd_config.pop('experiment'))
-    cmd_config['branching'] = cmd_config.pop('evc', {})
 
     return cmd_config

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -130,11 +130,11 @@ def fetch_config_from_cmdargs(cmdargs):
 
     global_config = config.to_dict()
 
-    for key in ['config', 'user', 'user_args']:
+    for key in ['config', 'user_args']:
         if cmdargs.get(key) not in [False, None]:
             cmdargs_config[key] = cmdargs[key]
 
-    for key in ['name', 'version']:
+    for key in ['name', 'user', 'version']:
         if cmdargs.get(key) not in [False, None]:
             cmdargs_config[f'experiment.{key}'] = cmdargs[key]
 

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -45,14 +45,31 @@ class Consumer(object):
     has been defined in a special orion environmental variable which is set
     into the child process' environment.
 
+    Parameters
+    ----------
+    experiment: `orion.core.worker.experiment.Experiment`
+        Manager of this experiment, provides convenient interface for interacting with
+        the database.
+
+    heartbeat: int, optional
+        Frequency (seconds) at which the heartbeat of the trial is updated.
+        If the heartbeat of a `reserved` trial is larger than twice the configured
+        heartbeat, Oríon will reset the status of the trial to `interrupted`.
+        This allows restoring lost trials (ex: due to killed worker).
+        Defaults to `orion.core.config.worker.heartbeat`.
+
+    user_script_config: str, optional
+        Config argument name of user's script (--config).
+        Defaults to `orion.core.config.worker.user_script_config`.
+
+    interrupt_signal_code: int, optional
+        Signal returned by user script to signal to Oríon that it was interrupted.
+        Defaults to `orion.core.config.worker.interrupt_signal_code`.
+
     """
 
-    def __init__(self, experiment):
-        """Initialize a consumer.
-
-        :param experiment: Manager of this experiment, provides convenient
-           interface for interacting with the database.
-        """
+    def __init__(self, experiment, heartbeat=None, user_script_config=None,
+                 interrupt_signal_code=None):
         log.debug("Creating Consumer object.")
         self.experiment = experiment
         self.space = experiment.space
@@ -60,8 +77,20 @@ class Consumer(object):
             raise RuntimeError("Experiment object provided to Consumer has not yet completed"
                                " initialization.")
 
+        if heartbeat is None:
+            heartbeat = orion.core.config.worker.heartbeat
+
+        if user_script_config is None:
+            user_script_config = orion.core.config.user_script_config
+
+        if interrupt_signal_code is None:
+            interrupt_signal_code = orion.core.config.worker.interrupt_signal_code
+
+        self.heartbeat = heartbeat
+        self.interrupt_signal_code = interrupt_signal_code
+
         # Fetch space builder
-        self.template_builder = OrionCmdlineParser(orion.core.config.user_script_config)
+        self.template_builder = OrionCmdlineParser(user_script_config)
         self.template_builder.set_state_dict(experiment.metadata['parser'])
         # Get path to user's script and infer trial configuration directory
         if experiment.working_dir:
@@ -75,7 +104,15 @@ class Consumer(object):
         """Execute user's script as a block box using the options contained
         within `trial`.
 
-        :type trial: `orion.core.worker.trial.Trial`
+        Parameters
+        ----------
+        trial: `orion.core.worker.trial.Trial`
+            Orion trial to execute.
+
+        Returns
+        -------
+        bool
+            True if the trial was successfully executed. False if the trial is broken.
 
         """
         log.debug("### Create new directory at '%s':", self.working_dir)
@@ -94,6 +131,8 @@ class Consumer(object):
                 log.debug("## Parse results from file and fill corresponding Trial object.")
                 self.experiment.update_completed_trial(trial, results_file)
 
+            success = True
+
         except KeyboardInterrupt:
             log.debug("### Save %s as interrupted.", trial)
             self.experiment.set_trial_status(trial, status='interrupted')
@@ -102,6 +141,10 @@ class Consumer(object):
         except ExecutionError:
             log.debug("### Save %s as broken.", trial)
             self.experiment.set_trial_status(trial, status='broken')
+
+            success = False
+
+        return success
 
     def get_execution_environment(self, trial, results_file='results.log'):
         """Set a few environment variables to allow users and
@@ -153,7 +196,7 @@ class Consumer(object):
 
         env['ORION_WORKING_DIR'] = str(trial.working_dir)
         env['ORION_RESULTS_PATH'] = str(results_file)
-        env['ORION_INTERRUPT_CODE'] = str(orion.core.config.worker.interrupt_signal_code)
+        env['ORION_INTERRUPT_CODE'] = str(self.interrupt_signal_code)
 
         return env
 
@@ -175,7 +218,7 @@ class Consumer(object):
 
         log.debug("## Launch user's script as a subprocess and wait for finish.")
 
-        self.pacemaker = TrialPacemaker(trial)
+        self.pacemaker = TrialPacemaker(trial, self.heartbeat)
         self.pacemaker.start()
         try:
             self.execute_process(cmd_args, env)
@@ -195,7 +238,7 @@ class Consumer(object):
 
         return_code = process.wait()
 
-        if return_code == orion.core.config.worker.interrupt_signal_code:
+        if return_code == self.interrupt_signal_code:
             raise KeyboardInterrupt()
         elif return_code != 0:
             raise ExecutionError("Something went wrong. Check logs. Process "

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -134,9 +134,6 @@ class Experiment:
         """
         log.debug('reserving trial with (score: %s)', score_handle)
 
-        if score_handle is not None:
-            log.warning("Argument `score_handle` is deprecated")
-
         self.fix_lost_trials()
 
         selected_trial = self._storage.reserve_trial(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,21 @@ from orion.storage.base import Storage
 from orion.storage.legacy import Legacy
 
 
+@pytest.fixture(scope="session", autouse=True)
+def shield_from_user_config(request):
+    """Do not read user's yaml global config."""
+    _pop_out_yaml_from_config(orion.core.config)
+
+
+def _pop_out_yaml_from_config(config):
+    """Remove any configuration fetch from yaml file"""
+    for key in config._config.keys():
+        config._config[key].pop('yaml', None)
+
+    for key in config._subconfigs.keys():
+        _pop_out_yaml_from_config(config._subconfigs[key])
+
+
 class DumbAlgo(BaseAlgorithm):
     """Stab class for `BaseAlgorithm`."""
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -250,7 +250,7 @@ def test_workon():
     with OrionState():
         experiment = experiment_builder.build_from_args(config)
 
-        workon(experiment)
+        workon(experiment, 100, 100, 100, 100, 100)
 
         storage = get_storage()
 

--- a/tests/unittests/core/io/orion_config.yaml
+++ b/tests/unittests/core/io/orion_config.yaml
@@ -1,11 +1,10 @@
-name: voila_voici
+experiment:
+    name: voila_voici
+    pool_size: 1
+    max_trials: 100
 
-pool_size: 1
-max_trials: 100
+    algorithms: 'random'
 
-algorithms: 'random'
-
-producer:
     strategy: NoParallelStrategy
 
 database:

--- a/tests/unittests/core/io/test_config.py
+++ b/tests/unittests/core/io/test_config.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.core.io.config`."""
 
+import argparse
+import logging
 import os
 
 import pytest
@@ -310,3 +312,183 @@ def test_nested_key_curation():
 
     config['nested']['test-with-underscores'] = 'labas'
     assert config.nested.test_with_underscores == 'labas'
+
+
+def test_help_option():
+    """Verify adding documentation to options."""
+    config = Configuration()
+    config.add_option('option', option_type=str, help='A useless option!')
+
+    assert config.help('option') == 'A useless option!'
+
+
+def test_help_nested_option():
+    """Verify adding documentation to a nested option."""
+    config = Configuration()
+    config.add_option('option', option_type=str, help='A useless option!')
+    config.nested = Configuration()
+    config.nested.add_option('option', option_type=str, help='A useless nested option!')
+
+    assert config.help('nested.option') == 'A useless nested option!'
+    assert config.nested.help('option') == 'A useless nested option!'
+
+
+def test_help_option_with_default():
+    """Verify adding documentation to options with default value."""
+    config = Configuration()
+    config.add_option('option', option_type=str, default='a', help='A useless option!')
+
+    assert config.help('option') == 'A useless option! (default: a)'
+
+
+def test_no_help_option():
+    """Verify not adding documentation to options."""
+    config = Configuration()
+    config.add_option('option', option_type=str)
+
+    assert config.help('option') == 'Undocumented'
+
+
+def test_argument_parser():
+    """Verify the argument parser built based on config."""
+    config = Configuration()
+    config.add_option('option', option_type=str)
+
+    parser = argparse.ArgumentParser()
+    config.add_arguments(parser)
+
+    options = parser.parse_args(['--option', 'a'])
+
+    assert options.option == 'a'
+
+
+def test_argument_parser_ignore_default():
+    """Verify the argument parser does not get default values."""
+    config = Configuration()
+    config.add_option('option', option_type=str, default='b')
+
+    parser = argparse.ArgumentParser()
+    config.add_arguments(parser)
+
+    options = parser.parse_args([])
+
+    assert options.option is None
+
+
+def test_argument_parser_rename():
+    """Verify the argument parser built based on config with some options renamed."""
+    config = Configuration()
+    config.add_option('option', option_type=str)
+
+    parser = argparse.ArgumentParser()
+    config.add_arguments(parser, rename=dict(option='--new-option'))
+
+    with pytest.raises(SystemExit) as exc:
+        options = parser.parse_args(['--option', 'a'])
+
+    assert exc.match('2')
+
+    options = parser.parse_args(['--new-option', 'a'])
+
+    assert options.new_option == 'a'
+
+
+def test_argument_parser_dict_list_tuple():
+    """Verify the argument parser does not contain options of type dict/list/tuple in config."""
+    config = Configuration()
+    config.add_option('st', option_type=str)
+    config.add_option('di', option_type=dict)
+    config.add_option('li', option_type=list)
+    config.add_option('tu', option_type=tuple)
+
+    parser = argparse.ArgumentParser()
+    config.add_arguments(parser)
+
+    options = parser.parse_args([])
+    assert vars(options) == {'st': None}
+
+    with pytest.raises(SystemExit) as exc:
+        options = parser.parse_args(['--di', 'ct'])
+
+    assert exc.match('2')
+
+
+def test_deprecate_option(caplog):
+    """Test deprecating an option."""
+    config = Configuration()
+    config.add_option(
+        'option', option_type=str, default='hello',
+        deprecate=dict(version='v1.0', alternative='None! T_T'))
+
+    config.add_option(
+        'ok', option_type=str, default='hillo')
+
+    # Access the deprecated option and trigger a warning.
+    with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
+        assert config.option == 'hello'
+
+    assert caplog.record_tuples == [(
+        'orion.core.io.config', logging.WARNING,
+        '(DEPRECATED) Option `option` will be removed in v1.0. Use `None! T_T` instead.')]
+
+    caplog.clear()
+
+    # Access the non-deprecated option and trigger no warnings.
+    with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
+        assert config.ok == 'hillo'
+
+    assert caplog.record_tuples == []
+
+
+def test_deprecate_option_missing_version():
+    """Verify option deprecation if version is missing."""
+    config = Configuration()
+    with pytest.raises(ValueError) as exc:
+        config.add_option(
+            'option', option_type=str,
+            deprecate=dict(alternative='None! T_T'))
+
+    assert exc.match('`version` is missing in deprecate option')
+
+
+def test_deprecate_option_no_alternative(caplog):
+    """Verify option deprecation when there is no alternative."""
+    config = Configuration()
+    config.add_option(
+        'option', option_type=str, default='hello',
+        deprecate=dict(version='v1.0'))
+
+    # Access the deprecated option and trigger a warning.
+    with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
+        assert config.option == 'hello'
+
+    assert caplog.record_tuples == [(
+        'orion.core.io.config', logging.WARNING,
+        '(DEPRECATED) Option `option` will be removed in v1.0.')]
+
+
+def test_deprecate_option_help():
+    """Verify help message of a deprecated option."""
+    config = Configuration()
+    config.add_option(
+        'option', option_type=str,
+        deprecate=dict(version='v1.0', alternative='None! T_T'),
+        help='A useless option!')
+
+    assert config.help('option') == '(DEPRECATED) A useless option!'
+
+
+def test_deprecate_option_print_with_different_name(caplog):
+    """Verify deprecation warning with different name (for nested options)."""
+    config = Configuration()
+    config.add_option(
+        'option', option_type=str, default='hello',
+        deprecate=dict(version='v1.0', alternative='None! T_T', name='nested.option'))
+
+    # Access the deprecated option and trigger a warning.
+    with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
+        assert config.option == 'hello'
+
+    assert caplog.record_tuples == [(
+        'orion.core.io.config', logging.WARNING,
+        '(DEPRECATED) Option `nested.option` will be removed in v1.0. Use `None! T_T` instead.')]

--- a/tests/unittests/core/io/test_config.py
+++ b/tests/unittests/core/io/test_config.py
@@ -273,3 +273,40 @@ def test_to_dict():
         'test': 'hello',
         'nested': {
             'test2': 'labas'}}
+
+
+def test_key_curation():
+    """Test that both - and _ maps to same options"""
+    config = Configuration()
+    config.add_option('test-with-dashes', option_type=int, default=1)
+    config.add_option('test_with_underscores', option_type=int, default=2)
+    config.add_option('test-all_mixedup', option_type=int, default=3)
+
+    assert config['test-with-dashes'] == 1
+    assert config['test_with_underscores'] == 2
+    assert config['test-all_mixedup'] == 3
+
+    assert config['test_with_dashes'] == 1
+    assert config['test-with-underscores'] == 2
+    assert config['test_all-mixedup'] == 3
+
+    assert config.test_with_dashes == 1
+    assert config.test_with_underscores == 2
+    assert config.test_all_mixedup == 3
+
+    config['test_with_dashes'] = 4
+    assert config['test-with-dashes'] == 4
+
+
+def test_nested_key_curation():
+    """Test that both - and _ maps to same options in nested configs as well"""
+    config = Configuration()
+    config.add_option('test-with-dashes', option_type=str, default="voici_voila")
+    config.nested = Configuration()
+    config.nested.add_option('test_with_underscores', option_type=str, default="zici")
+
+    assert config['nested']['test_with_underscores'] == 'zici'
+    assert config['nested']['test-with-underscores'] == 'zici'
+
+    config['nested']['test-with-underscores'] = 'labas'
+    assert config.nested.test_with_underscores == 'labas'

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -142,12 +142,11 @@ def test_get_cmd_config(config_file):
     local_config = experiment_builder.get_cmd_config(cmdargs)
 
     assert local_config['algorithms'] == 'random'
-    assert local_config['producer'] == {'strategy': 'NoParallelStrategy'}
+    assert local_config['strategy'] == 'NoParallelStrategy'
     assert local_config['max_trials'] == 100
     assert local_config['name'] == 'voila_voici'
     assert local_config['pool_size'] == 1
     assert local_config['storage'] == {
-        'type': 'legacy',
         'database': {
             'host': 'mongodb://user:pass@localhost',
             'name': 'orion_test',

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -161,12 +161,12 @@ def test_fetch_config_from_cmdargs():
 
     config = resolve_config.fetch_config_from_cmdargs(cmdargs)
 
-    assert config.pop('config') is None
-    assert config.pop('user') == 'me'
+    assert config.pop('config', None) is None
 
     exp_config = config.pop('experiment')
     assert exp_config.pop('name') == 'test'
     assert exp_config.pop('version') == 1
+    assert exp_config.pop('user') == 'me'
     assert exp_config.pop('max_trials') == 'exp_max_trials'
     assert exp_config.pop('max_broken') == 'exp_max_broken'
     assert exp_config.pop('working_dir') == 'working_dir'
@@ -217,7 +217,7 @@ def test_fetch_config_from_cmdargs_no_empty(argument):
 
     config = resolve_config.fetch_config_from_cmdargs({argument: 1})
 
-    if argument in ['name', 'version']:
+    if argument in ['name', 'user', 'version']:
         assert config == {'experiment': {argument: 1}}
     elif argument in ['branch_from', 'branch_to']:
         assert config == {'evc': {argument: 1}}

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -129,6 +129,102 @@ def test_fetch_metadata():
     len(metadata) == 4
 
 
+def test_fetch_config_from_cmdargs():
+    """Verify fetch_config returns empty dict on no config file path"""
+    cmdargs = {
+        'name': 'test',
+        'user': 'me',
+        'version': 1,
+        'config': None,
+        'exp_max_trials': 'exp_max_trials',
+        'worker_trials': 'worker_trials',
+        'exp_max_broken': 'exp_max_broken',
+        'working_dir': 'working_dir',
+        'pool_size': 'pool_size',
+        'max_trials': 'max_trials',
+        'heartbeat': 'heartbeat',
+        'worker_max_trials': 'worker_max_trials',
+        'worker_max_broken': 'worker_max_broken',
+        'max_idle_time': 'max_idle_time',
+        'interrupt_signal_code': 'interrupt_signal_code',
+        'user_script_config': 'user_script_config',
+        'manual_resolution': 'manual_resolution',
+        'non_monitored_arguments': 'non_monitored_arguments',
+        'ignore_code_changes': 'ignore_code_changes',
+        'auto_resolution': 'auto_resolution',
+        'branch_from': 'branch_from',
+        'algorithm_change': 'algorithm_change',
+        'code_change_type': 'code_change_type',
+        'cli_change_type': 'cli_change_type',
+        'branch_to': 'branch_to',
+        'config_change_type': 'config_change_type'}
+
+    config = resolve_config.fetch_config_from_cmdargs(cmdargs)
+
+    assert config.pop('config') is None
+    assert config.pop('user') == 'me'
+
+    exp_config = config.pop('experiment')
+    assert exp_config.pop('name') == 'test'
+    assert exp_config.pop('version') == 1
+    assert exp_config.pop('max_trials') == 'exp_max_trials'
+    assert exp_config.pop('max_broken') == 'exp_max_broken'
+    assert exp_config.pop('working_dir') == 'working_dir'
+    assert exp_config.pop('pool_size') == 'pool_size'
+
+    assert exp_config == {}
+
+    worker_config = config.pop('worker')
+    assert worker_config.pop('heartbeat') == 'heartbeat'
+    assert worker_config.pop('max_trials') == 'worker_max_trials'
+    assert worker_config.pop('max_broken') == 'worker_max_broken'
+    assert worker_config.pop('max_idle_time') == 'max_idle_time'
+    assert worker_config.pop('interrupt_signal_code') == 'interrupt_signal_code'
+    assert worker_config.pop('user_script_config') == 'user_script_config'
+
+    assert worker_config == {}
+
+    evc_config = config.pop('evc')
+    assert evc_config.pop('manual_resolution') == 'manual_resolution'
+    assert evc_config.pop('non_monitored_arguments') == 'non_monitored_arguments'
+    assert evc_config.pop('ignore_code_changes') == 'ignore_code_changes'
+    assert evc_config.pop('auto_resolution') == 'auto_resolution'
+    assert evc_config.pop('branch_from') == 'branch_from'
+    assert evc_config.pop('algorithm_change') == 'algorithm_change'
+    assert evc_config.pop('code_change_type') == 'code_change_type'
+    assert evc_config.pop('cli_change_type') == 'cli_change_type'
+    assert evc_config.pop('branch_to') == 'branch_to'
+    assert evc_config.pop('config_change_type') == 'config_change_type'
+
+    assert evc_config == {}
+
+    assert config == {}
+
+
+@pytest.mark.parametrize(
+    "argument",
+    ['config', 'user', 'user_args', 'name', 'version', 'branch_from', 'branch_to'])
+def test_fetch_config_from_cmdargs_no_empty(argument):
+    """Verify fetch_config returns only defined arguments."""
+    config = resolve_config.fetch_config_from_cmdargs({})
+    assert config == {}
+
+    config = resolve_config.fetch_config_from_cmdargs({argument: None})
+    assert config == {}
+
+    config = resolve_config.fetch_config_from_cmdargs({argument: False})
+    assert config == {}
+
+    config = resolve_config.fetch_config_from_cmdargs({argument: 1})
+
+    if argument in ['name', 'version']:
+        assert config == {'experiment': {argument: 1}}
+    elif argument in ['branch_from', 'branch_to']:
+        assert config == {'evc': {argument: 1}}
+    else:
+        assert config == {argument: 1}
+
+
 def test_fetch_config_no_hit():
     """Verify fetch_config returns empty dict on no config file path"""
     config = resolve_config.fetch_config({"config": ""})
@@ -139,14 +235,139 @@ def test_fetch_config(config_file):
     """Verify fetch_config returns valid dictionnary"""
     config = resolve_config.fetch_config({"config": config_file})
 
-    assert config['algorithms'] == 'random'
-    assert config['database']['host'] == 'mongodb://user:pass@localhost'
-    assert config['database']['name'] == 'orion_test'
-    assert config['database']['type'] == 'mongodb'
+    assert config.pop('storage') == {
+        'database': {
+            'host': 'mongodb://user:pass@localhost',
+            'name': 'orion_test',
+            'type': 'mongodb'}}
 
-    assert config['max_trials'] == 100
-    assert config['name'] == 'voila_voici'
-    assert config['pool_size'] == 1
+    assert config.pop('experiment') == {
+        'max_trials': 100,
+        'name': 'voila_voici',
+        'pool_size': 1,
+        'algorithms': 'random',
+        'strategy': 'NoParallelStrategy'}
+
+    assert config == {}
+
+
+def test_fetch_config_global_local_coherence(monkeypatch, config_file):
+    """Verify fetch_config parses local config according to global config structure."""
+    def mocked_config(file_object):
+        return orion.core.config.to_dict()
+    monkeypatch.setattr('yaml.safe_load', mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    # Test storage subconfig
+    storage_config = config.pop('storage')
+    database_config = storage_config.pop('database')
+    assert storage_config.pop('type') == orion.core.config.storage.type
+    assert storage_config == {}
+
+    assert database_config.pop('host') == orion.core.config.storage.database.host
+    assert database_config.pop('name') == orion.core.config.storage.database.name
+    assert database_config.pop('port') == orion.core.config.storage.database.port
+    assert database_config.pop('type') == orion.core.config.storage.database.type
+
+    assert database_config == {}
+
+    # Test experiment subconfig
+    exp_config = config.pop('experiment')
+    assert exp_config.pop('max_trials') == orion.core.config.experiment.max_trials
+    assert exp_config.pop('max_broken') == orion.core.config.experiment.max_broken
+    assert exp_config.pop('working_dir') == orion.core.config.experiment.working_dir
+    assert exp_config.pop('pool_size') == orion.core.config.experiment.pool_size
+    assert exp_config.pop('algorithms') == orion.core.config.experiment.algorithms
+    assert exp_config.pop('strategy') == orion.core.config.experiment.strategy
+
+    assert exp_config == {}
+
+    # Test worker subconfig
+    worker_config = config.pop('worker')
+    assert worker_config.pop('heartbeat') == orion.core.config.worker.heartbeat
+    assert worker_config.pop('max_trials') == orion.core.config.worker.max_trials
+    assert worker_config.pop('max_broken') == orion.core.config.worker.max_broken
+    assert worker_config.pop('max_idle_time') == orion.core.config.worker.max_idle_time
+    assert (worker_config.pop('interrupt_signal_code') ==
+            orion.core.config.worker.interrupt_signal_code)
+    assert (worker_config.pop('user_script_config') ==
+            orion.core.config.worker.user_script_config)
+
+    assert worker_config == {}
+
+    # Test evc subconfig
+    evc_config = config.pop('evc')
+    assert evc_config.pop('auto_resolution') == orion.core.config.evc.auto_resolution
+    assert evc_config.pop('manual_resolution') == orion.core.config.evc.manual_resolution
+    assert (evc_config.pop('non_monitored_arguments') ==
+            orion.core.config.evc.non_monitored_arguments)
+    assert evc_config.pop('ignore_code_changes') == orion.core.config.evc.ignore_code_changes
+    assert evc_config.pop('algorithm_change') == orion.core.config.evc.algorithm_change
+    assert evc_config.pop('code_change_type') == orion.core.config.evc.code_change_type
+    assert evc_config.pop('cli_change_type') == orion.core.config.evc.cli_change_type
+    assert evc_config.pop('config_change_type') == orion.core.config.evc.config_change_type
+
+    assert evc_config == {}
+
+    # Confirm that all fields were tested.
+    assert config == {}
+
+
+def test_fetch_config_dash(monkeypatch, config_file):
+    """Verify fetch_config supports dash."""
+    def mocked_config(file_object):
+        return {'experiment': {'max-broken': 10, 'algorithms': {'dont-change': 'me'}}}
+    monkeypatch.setattr('yaml.safe_load', mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {'experiment': {'max_broken': 10, 'algorithms': {'dont-change': 'me'}}}
+
+
+def test_fetch_config_underscore(monkeypatch, config_file):
+    """Verify fetch_config supports underscore as well."""
+    def mocked_config(file_object):
+        return {'experiment': {'max_broken': 10, 'algorithms': {'dont-change': 'me'}}}
+    monkeypatch.setattr('yaml.safe_load', mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {'experiment': {'max_broken': 10, 'algorithms': {'dont-change': 'me'}}}
+
+
+def test_fetch_config_deprecated_max_trials(monkeypatch, config_file):
+    """Verify fetch_config will overwrite deprecated value if also properly defined."""
+    def mocked_config(file_object):
+        return {'experiment': {'max_trials': 10}, 'max_trials': 20}
+    monkeypatch.setattr('yaml.safe_load', mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {'experiment': {'max_trials': 10}}
+
+
+def test_fetch_config_deprecate_tricky_names(monkeypatch, config_file):
+    """Verify fetch_config assigns values properly for the similar names."""
+    def mocked_config(file_object):
+        return {
+            'experiment': {
+                'worker_trials': 'should_be_ignored'},
+            'max_trials': 'exp_max_trials',
+            'max_broken': 'exp_max_broken',
+            'worker_trials': 'worker_max_trials',
+            'name': 'exp_name'
+        }
+    monkeypatch.setattr('yaml.safe_load', mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {
+        'experiment': {
+            'name': 'exp_name',
+            'max_trials': 'exp_max_trials',
+            'max_broken': 'exp_max_broken'},
+        'worker': {'max_trials': 'worker_max_trials'}}
 
 
 def test_merge_configs_update_two():

--- a/tox.ini
+++ b/tox.ini
@@ -204,7 +204,7 @@ deps =
     -rdocs/requirements.txt
 commands =
     sphinx-build -W --color -c docs/src/ -b html docs/src/ docs/build/html
-    sphinx-build -W --color -c docs/src/ -b man docs/src/ docs/build/man
+# sphinx-build -W --color -c docs/src/ -b man docs/src/ docs/build/man
 
 [testenv:serve-docs]
 description = Host project's documentation and API reference in localhost


### PR DESCRIPTION
## Make global, local and cmdline args coherent
Why:

So far some arguments were supported either in global, local or cmdline,
sometimes in the same format, sometimes in different format. This
was horribly confusing for users.

How:

Force the local config to use the same format as global config by using
the latter as a reference point while parsing local config. The cmdline
arguments are processed and turned into a dictionary following the
structure of the global config.

## Add help and deprecation to Configuration

Why:

The help message for options is scattered and duplicated all over the code.
We should use the configuration as a common ground, where help messages
are globally defined. Also, there is many modifications coming to make
global, local and commandline options more coherent, which will require
many deprecation. Adding the deprecation inside the configuration makes
it possible to centralize all (most) deprecation warnings.

## Make configuration insensitive to - or _

Why:

It is very confusing for user if the configuration does recognize only
dash or underscore in option names.

How:

Convert to underscore any dash so that config is insensitive to both.
This means however that to_dict will return all keys with underscores.