### PR TITLE
Enabling localized testing via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     coverage
 commands =
     pip install -U {toxinidir}/tests/functional/gradient_descent_algo
-    coverage run --parallel-mode -m pytest -vv --ignore tests/functional/backward_compatibility --timeout=180
+    coverage run --parallel-mode -m pytest -vv --ignore tests/functional/backward_compatibility --timeout=180 {posargs}
     coverage combine
     coverage report -m
 


### PR DESCRIPTION
Why:
Best practice is to use **tox** as the facade to launch all the coverage, packaging and testing taks. It is often necessary to test specific, localized tests or modules during development using the command `$ tox -e devel -- path/to/your/tests`.

However, the latter command isn't used by the CI which rely on a regular `tox` call which will internally call **tox** on different environments. The developer can emulate this behaviour using `$ tox -e py36` to test the Python 3.6 environment. Unfortunately, this will run the **entire** test suite which can take a significant portion of the developer time.

This PR proposes to add the option for the developer to run specific tests instead of the entire environment test suite, enabling him to quickly verify that his changes will not break in CI and see the localized coverage.

How:
Adding {posargs} at the end of the command invoking pytest allows developers to specify additional arguments such as which tests to run. Example:
`$ tox -e py36 -- tests/unittests/core/test_branch_config.py`