### PR TITLE
Contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,13 @@ Hi there 👋. Thank you for considering contributing to Oríon 🎉. We're exci
 We present the guidelines for contributing to the project. They are not hard rules, use your best judgment, and feel free to propose changes to this document in a pull request. If you havn't already, it's a good idea to quickly passthrough our [code of conduct](https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md) to ensure everyone has a good time.
 
 ## Where do I go from here?
-If you have a question, found a bug or have a feature request, you're welcome to open a new issue! It's generally best if you get confirmation of your bug or approval for your feature request before starting to code.
+If you have a question, found a bug or have a feature request, you're welcome to open a new issue at https://github.com/Epistimio/orion/issues. It's generally best if you get confirmation of your bug or approval for your feature request before starting to code.
+
+Depending on what you want to do, we're suggesting you read the respective guidelines:
+- [Asking a question](###how-to-ask-a-question)
+- [Reporting a bug](###how-to-report-a-bug)
+- [Proposing enhancements](###how-to-propose-enhancements)
+- [Submitting changes](###how-to-submit-changes)
 
 In some cases, you might want to add a new algorithm for Oríon, make sure to check out the [plugin documentation](https://orion.readthedocs.io/en/latest/plugins/base.html).
 
@@ -13,6 +19,7 @@ TODO
 
 ### How to report a bug
 TODO
+### How to propose enhancements
 
 ### How to submit changes
 Short and sweet message, giving an overview of our process (Such as how to make a PR).Refer to the developer documentation in the docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,20 @@ When suggesting enhancements, it is a good idea to:
 - Add as much details as possible!
 
 ### How to submit changes
-Short and sweet message, giving an overview of our process (Such as how to make a PR).Refer to the developer documentation in the docs.
+We're grateful you're considering making changes to Oríon! To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes. Once you implemented the changes, submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests>). All changes to Oríon are done through PRs, where they will be peer-reviewed and checked against our continuous integration system to ensure the quality of the code base.
+
+During this processs keep in mind to:
+- Set a descriptive and short branch name
+- Create a descriptive and clear title for the PR
+- Motivate the *why* and *how* of the PR (get inspiration from current or past PRs!)
+- Write [good commits](https://chris.beams.io/posts/git-commit/)
+
+Next, you need to get familiar with the developer documentation. You will find the instructions to set up your development environment, including how to use the test suite and verify you changes will pass the CI as well as our style guides for source code and documentation.
+
+-> https://orion.readthedocs.io/en/latest/developer/overview.html
+
+#### Your first contribution
+If you are not sure about what to work on first, we suggest you take a look on the [help wanted](https://github.com/Epistimio/orion/labels/help%20wanted) and [good first issues](https://github.com/Epistimio/orion/labels/good%20first%20issue) opened. They are great places to start!
 
 ---
 Thank you for contributing! We really appreciate it!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to Oríon
+Hi there 👋. Thank you for considering contributing to Oríon 🎉. We're excited to have you here!
+
+We present the guidelines for contributing to the project. They are not hard rules, use your best judgment, and feel free to propose changes to this document in a pull request. If you havn't already, it's a good idea to quickly passthrough our [code of conduct](https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md) to ensure everyone has a good time.
+
+## Where do I go from here?
+If you have a question, found a bug or have a feature request, you're welcome to open a new issue! It's generally best if you get confirmation of your bug or approval for your feature request before starting to code.
+
+In some cases, you might want to add a new algorithm for Oríon, make sure to check out the [plugin documentation](https://orion.readthedocs.io/en/latest/plugins/base.html).
+
+### How to ask a question
+TODO
+
+### How to report a bug
+TODO
+
+### How to submit changes
+Short and sweet message, giving an overview of our process. Refer to the developer documentation in the docs.
+
+---
+Thank you for contributing! We really appreciate it!
+
+-- The Oríon team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Depending on what you want to do, we're suggesting you read the respective guide
 In some cases, you might want to add a new algorithm for Oríon, make sure to check out the [plugin documentation](https://orion.readthedocs.io/en/latest/plugins/base.html).
 
 ### How to ask a question
-TODO
+Asking a question is also a contribution to the project! We'll be happy to help you if you have any question. Before opening a new issue, make sure to do a quick search. It's possible your question has already been answered! Otherwise, go ahead. We're looking forward to help you.
 
 ### How to report a bug
 TODO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,8 @@ During this processs keep in mind to:
 - Create a descriptive and clear title for the PR
 - Motivate the *why* and *how* of the PR (get inspiration from current or past PRs!)
 - Write [good commits](https://chris.beams.io/posts/git-commit/)
+- Include tests for new features or bug fixes
+- Update the source code documentation (docstring) and, if applicable, the [general documentation](https://orion.readthedocs.io/en/latest/index.html)
 
 Next, you need to get familiar with the developer documentation. You will find the instructions to set up your development environment, including how to use the test suite and verify you changes will pass the CI as well as our style guides for source code and documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,15 @@ When reporting a bug, please include:
 - Extra details about your setup that might help us to reproduce the bug if not included previously
 
 ### How to propose enhancements
+We're thrilled to hear you found a way to make Oríon better through minor improvements to completely new features! 
+Before creating enhancement suggestions, please check that your idea is not already present in the list of issues. You might find that you don't need to create one and can just join in the discussion directly and give your opinion!
+
+When suggesting enhancements, it is a good idea to:
+- A clear and descriptive title for the issue
+- Motivate why this feature is relevant regarding [Oríon's mission](https://github.com/Epistimio/orion).
+- Explain in detail how it would work.
+- Keep the scope as narrow as possible, to make it easier to implement.
+- Add as much details as possible!
 
 ### How to submit changes
 Short and sweet message, giving an overview of our process (Such as how to make a PR).Refer to the developer documentation in the docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,16 @@ In some cases, you might want to add a new algorithm for Oríon, make sure to ch
 Asking a question is also a contribution to the project! We'll be happy to help you if you have any question. Before opening a new issue, make sure to do a quick search. It's possible your question has already been answered! Otherwise, go ahead. We're looking forward to help you.
 
 ### How to report a bug
-TODO
+You found a bug? Great! Before submitting, make sure you're experiencing the bug on the latest version of Oríon and that it's not already opened in our issue tracker.
+
+When reporting a bug, please include: 
+- A clear and descriptive title for the issue
+- Your operating system and its version
+- The version of Oríon (even if you're using the latest!)
+- A description of the bug
+- The steps to reproduce the bug
+- Extra details about your setup that might help us to reproduce the bug if not included previously
+
 ### How to propose enhancements
 
 ### How to submit changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ When reporting a bug, please include:
 - The version of Oríon (even if you're using the latest!)
 - A description of the bug
 - The steps to reproduce the bug
-- Extra details about your setup that might help us to reproduce the bug if not included previously
+- Extra details (e.g., database, algortihm, configuration) about your setup that might help us to reproduce the bug if not included previously
 
 ### How to propose enhancements
 We're thrilled to hear you found a way to make Oríon better through minor improvements to completely new features! 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ We're thrilled to hear you found a way to make Oríon better through minor impro
 Before creating enhancement suggestions, please check that your idea is not already present in the list of issues. You might find that you don't need to create one and can just join in the discussion directly and give your opinion!
 
 When suggesting enhancements, it is a good idea to:
-- A clear and descriptive title for the issue
+- Write a clear and descriptive title for the issue
 - Motivate why this feature is relevant regarding [Oríon's mission](https://github.com/Epistimio/orion).
 - Explain in detail how it would work.
 - Keep the scope as narrow as possible, to make it easier to implement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Oríon
 Hi there 👋. Thank you for considering contributing to Oríon 🎉. We're excited to have you here!
 
-We present the guidelines for contributing to the project. They are not hard rules, use your best judgment, and feel free to propose changes to this document in a pull request. If you havn't already, it's a good idea to quickly passthrough our [code of conduct](https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md) to ensure everyone has a good time.
+We present the guidelines for contributing to the project. They are not hard rules, use your best judgment, and feel free to propose changes to this document in a pull request. If you havn't already, it's a good idea to quickly pass through our [code of conduct](https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md) to ensure everyone has a good time.
 
 ## Where do I go from here?
 If you have a question, found a bug or have a feature request, you're welcome to open a new issue at https://github.com/Epistimio/orion/issues. It's generally best if you get confirmation of your bug or approval for your feature request before starting to code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ TODO
 TODO
 
 ### How to submit changes
-Short and sweet message, giving an overview of our process. Refer to the developer documentation in the docs.
+Short and sweet message, giving an overview of our process (Such as how to make a PR).Refer to the developer documentation in the docs.
 
 ---
 Thank you for contributing! We really appreciate it!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ When suggesting enhancements, it is a good idea to:
 - Add as much details as possible!
 
 ### How to submit changes
-We're grateful you're considering making changes to Oríon! To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes. Once you implemented the changes, submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests>). All changes to Oríon are done through PRs, where they will be peer-reviewed and checked against our continuous integration system to ensure the quality of the code base.
+We're grateful you're considering making changes to Oríon! To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes. Once you implemented the changes, submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). All changes to Oríon are done through PRs, where they will be peer-reviewed and checked against our continuous integration system to ensure the quality of the code base.
 
 During this processs keep in mind to:
 - Set a descriptive and short branch name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,5 +59,3 @@ If you are not sure about what to work on first, we suggest you take a look on t
 
 ---
 Thank you for contributing! We really appreciate it!
-
--- The Oríon team

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 include LICENSE
 include *.rst
 include ROADMAP.md
+include CONTRIBUTING.md
 exclude RESEARCH.md
 
 # Control and setup helpers

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Contribute or Ask
 
 Do you have a question or issues?
 Do you want to report a bug or suggest a feature? Name it!
-Please contact us by opening an issue in our repository below:
+Please contact us by opening an issue in our repository below and checkout our `contribution guidelines <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_:
 
 - Issue Tracker: `<https://github.com/epistimio/orion/issues>`_
 - Source Code: `<https://github.com/epistimio/orion>`_

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -1,6 +1,6 @@
 Welcome to the project. We're excited you decided to improve Oríon!
 
-Hopefully, by then you should be familiar with our `contribution guide <>`_ and `code of conduct <>`_. We can jump straight into getting you started for your first contribution.
+Hopefully, by then you should be familiar with our `contribution guide <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_ and `code of conduct <https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md>`_. We can jump straight into getting you started for your first contribution.
 
 - Dev installation instructions
 - Check everything is ready for some dev (Run the test suite!)

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -1,0 +1,10 @@
+Welcome to the project. We're excited you decided to improve Oríon!
+
+Hopefully, by then you should be familiar with our `contribution guide <>`_ and `code of conduct <>`_. We can jump straight into getting you started for your first contribution.
+
+- Dev installation instructions
+- Check everything is ready for some dev (Run the test suite!)
+- Coding Conventions
+- Testing
+- Documenting
+- Packaging

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -4,11 +4,14 @@ Overview
 
 Welcome to the project. We're excited you decided to improve Oríon!
 
-Hopefully, by then you should be familiar with our `contribution guide <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_ and `code of conduct <https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md>`_. We can jump straight into getting you started for your first contribution.
+Hopefully, by then you should be familiar with our `contribution guide <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_ and `code of conduct <https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md>`_.
+We can jump straight into getting you started for your first contribution.
 
-- Dev installation instructions
-- Check everything is ready for some dev (Run the test suite!)
-- Coding Conventions
-- Testing
-- Documenting
-- Packaging
+The steps are:
+
+#. :doc:`Installing the development environment <../install/core>`.
+#. Checking everything is ready by running the test suite using ``$ tox``
+#. Get familiar with the :doc:`coding conventions <standards>`
+#. Implement your changes and :doc:`testing <testing>`
+#. :doc:`Document your changes <documenting>`
+#. Submit a `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -1,3 +1,7 @@
+********
+Overview
+********
+
 Welcome to the project. We're excited you decided to improve Oríon!
 
 Hopefully, by then you should be familiar with our `contribution guide <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_ and `code of conduct <https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md>`_. We can jump straight into getting you started for your first contribution.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -57,6 +57,7 @@
    :caption: Developer's Guide
    :maxdepth: 1
 
+   developer/overview
    developer/testing
    developer/documenting
    developer/standards


### PR DESCRIPTION
Adds the contribution guidelines for the project in the recommended CONTRIBUTING.md open-source standard. The goal of this file is to provide a short and sweet introduction to contributing to the project. 

The developer documentation will contain the main information about setting up the development environment, testing, documenting, and packaging.

I drew inspirations from the following sources:
- https://mozillascience.github.io/working-open-workshop/contributing/
- https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md
- https://github.com/atom/atom/blob/master/CONTRIBUTING.md
- https://github.com/mila-iqia/cookiecutter-pypackage/blob/master/CONTRIBUTING.rst