### PR TITLE
Add max_trials to algorithm.is_done

### DIFF
--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -205,6 +205,10 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
         """
         if len(self._trials_info) >= self.space.cardinality:
             return True
+
+        if len(self._trials_info) >= getattr(self, 'max_trials', float('inf')):
+            return True
+
         return False
 
     def score(self, point):  # pylint:disable=no-self-use,unused-argument

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ class DumbAlgo(BaseAlgorithm):
         self._num = 0
         self._index = 0
         self._points = []
+        self._suggested = None
         self._results = []
         self._score_point = None
         self._judge_point = None

--- a/tests/unittests/algo/test_base.py
+++ b/tests/unittests/algo/test_base.py
@@ -87,7 +87,7 @@ def test_state_dict(dumbalgo):
     assert len(algo.state_dict['_trials_info']) == 1
 
 
-def test_is_done(monkeypatch, dumbalgo):
+def test_is_done_cardinality(monkeypatch, dumbalgo):
     """Check whether algorithm will stop with base algorithm cardinality check"""
     monkeypatch.delattr(dumbalgo, 'is_done')
 
@@ -112,3 +112,22 @@ def test_is_done(monkeypatch, dumbalgo):
 
     assert len(algo.state_dict['_trials_info']) == 4
     assert not algo.is_done
+
+
+def test_is_done_max_trials(monkeypatch, dumbalgo):
+    """Check whether algorithm will stop with base algorithm max_trials check"""
+    monkeypatch.delattr(dumbalgo, 'is_done')
+
+    space = Space()
+    space.register(Real('yolo1', 'uniform', 1, 4))
+
+    algo = dumbalgo(space)
+    algo.suggest()
+    for i in range(1, 5):
+        algo.observe([[i]], [{'objective': 3}])
+
+    assert len(algo.state_dict['_trials_info']) == 4
+    assert not algo.is_done
+
+    dumbalgo.max_trials = 4
+    assert algo.is_done


### PR DESCRIPTION
Why:

We need to be able to discern when experiment is completed and no more
trials should be executed, and when algorithm is completed and no more
trials should be created. With current experiment.is_done, we sample
more than `max_trials`. Adding `max_trials` to termination criterion of
algo makes it possible for the algo to flag when it should not sample
new points, but still experiment.is_done is False because there is
pending trials.

How:

Add max_trials to algo in `Producer`. This is somewhat hacky but
`max_trials` is tightly integrated to `Experiment` so moving it to
algorithms would be complicated. Maybe something we should consider
doing later on.

In experiment.is_done, it now return True if number of completed trials
is greater than or equal to `max_trials`, or if `algorithm.is_done` and
there is no more pending trials.