### PR TITLE
Handle timeout in DBs (PickledDB in particular)

### DIFF
--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -305,6 +305,12 @@ class DuplicateKeyError(DatabaseError):
     pass
 
 
+class DatabaseTimeout(DatabaseError):
+    """Exception type used when there is a timeout during database operations."""
+
+    pass
+
+
 class OutdatedDatabaseError(DatabaseError):
     """Exception type used when the database is outdated."""
 

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -13,7 +13,7 @@ import functools
 import pymongo
 
 from orion.core.io.database import (
-    AbstractDB, DatabaseError, DuplicateKeyError)
+    AbstractDB, DatabaseError, DatabaseTimeout, DuplicateKeyError)
 
 
 AUTH_FAILED_MESSAGES = [
@@ -42,6 +42,20 @@ def mongodb_exception_wrapper(method):
 
         try:
             rval = method(self, *args, **kwargs)
+        except pymongo.errors.ExecutionTimeout as e:
+            # Raised when a database operation times out, exceeding the $maxTimeMS set in
+            # the query or command option.
+            raise DatabaseTimeout() from e
+        except pymongo.errors.NetworkTimeout as e:
+            # An operation on an open connection exceeded socketTimeoutMS.
+            #
+            # The remaining connections in the pool stay open. In the case of a
+            # write operation, you cannot know whether it succeeded or failed.
+            raise DatabaseTimeout() from e
+        except pymongo.errors.WTimeoutError as e:
+            # Raised when a database operation times out (i.e. wtimeout expires)
+            # before replication completes.
+            raise DatabaseTimeout() from e
         except pymongo.errors.DuplicateKeyError as e:
             raise DuplicateKeyError(str(e)) from e
         except pymongo.errors.BulkWriteError as e:

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -15,15 +15,37 @@ import os
 import pickle
 from pickle import PicklingError
 
-from filelock import FileLock
+from filelock import FileLock, Timeout
 
 import orion.core
-from orion.core.io.database import AbstractDB
+from orion.core.io.database import AbstractDB, DatabaseTimeout
 from orion.core.io.database.ephemeraldb import EphemeralDB
 
 log = logging.getLogger(__name__)
 
 DEFAULT_HOST = os.path.join(orion.core.DIRS.user_data_dir, 'orion', 'orion_db.pkl')
+
+TIMEOUT_ERROR_MESSAGE = """\
+Could not acquire lock for PickledDB after {} seconds.
+
+This is likely due to one or many of the following scenarios:
+
+1. There is a large amount of workers and many simultaneous queries. This typically occurs
+   when the task to optimize is short (few minutes). Try to reduce the amount of workers
+   at least below 50.
+
+2. The database is growing large with thousands of trials and many experiments.
+   If so, you can use a different PickleDB (different file, that is, different `host`)
+   for each experiment seperately to alleviate this issue.
+
+3. The filesystem is slow. Parallel filesystems on HPC often suffer from
+   large pool of users generating frequent I/O. In this case try using a separate
+   partition that may be less affected.
+
+If you cannot solve the issues listed above that are causing timeouts, you
+may need to setup the MongoDB backend for better performance.
+See https://orion.readthedocs.io/en/latest/install/database.html
+"""
 
 
 def find_unpickable_doc(dict_of_dict):
@@ -69,12 +91,17 @@ class PickledDB(AbstractDB):
     host: str
         File path to save pickled ephemeraldb.  Default is {user data dir}/orion/orion_db.pkl ex:
         $HOME/.local/share/orion/orion_db.pkl
+    timeout: int
+        Maximum number of seconds to wait for the lock before raising DatabaseTimeout.
+        Default is 60.
 
     """
 
     # pylint: disable=unused-argument
-    def __init__(self, host=DEFAULT_HOST, *args, **kwargs):
+    def __init__(self, host=DEFAULT_HOST, timeout=60, *args, **kwargs):
         super(PickledDB, self).__init__(host)
+
+        self.timeout = timeout
 
         if os.path.dirname(host):
             os.makedirs(os.path.dirname(host), exist_ok=True)
@@ -198,10 +225,13 @@ class PickledDB(AbstractDB):
         """Lock database file during wrapped operation call."""
         lock = FileLock(self.host + '.lock')
 
-        with lock.acquire(timeout=60):
-            database = self._get_database()
+        try:
+            with lock.acquire(timeout=self.timeout):
+                database = self._get_database()
 
-            yield database
+                yield database
 
-            if write:
-                self._dump_database(database)
+                if write:
+                    self._dump_database(database)
+        except Timeout as e:
+            raise DatabaseTimeout(TIMEOUT_ERROR_MESSAGE.format(self.timeout)) from e


### PR DESCRIPTION
Why:

When there are timeouts, the errors are not handled and
python leaves with scary stack-traces in terminal for users.
There is typical issues causing timeouts in PickledDB, the error message
should explain these to the users so they learn what to do to fix it.

Note:

They timeouts never occurred for MongoDB during the stress test and it
is not clear what message should be provided to users, given there is no
obvious root problems as of now. So I leave this as empty reraise, and
do not test...