### PR TITLE
Update developer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,12 @@ When suggesting enhancements, it is a good idea to:
 - Add as much details as possible!
 
 ### How to submit changes
-We're grateful you're considering making changes to Oríon! To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes. Once you implemented the changes, submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). All changes to Oríon are done through PRs, where they will be peer-reviewed and checked against our continuous integration system to ensure the quality of the code base.
+We're grateful you're considering making changes to Oríon!
+ 
+To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes. 
+
+Once you implemented the changes, make sure to [rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) your branch on the latest Oríon's *develop* branch and finally submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). 
+All changes to Oríon are done through PRs, where they will be peer-reviewed and checked against our continuous integration system to ensure the quality of the code base.
 
 During this processs keep in mind to:
 - Set a descriptive and short branch name

--- a/docs/src/developer/ci.rst
+++ b/docs/src/developer/ci.rst
@@ -10,11 +10,23 @@ Continuous Integration
 We use travis-ci_ and codecov_ for continuous integration and tox_ to automate the process at
 the repository level.
 
-When a commit is pushed in a pull request, a call to ``$ tox`` will be made by
-TravisCI which will trigger a call to multiple contexts. *py35*, *py36*, *py37*, ... for running all
-the tests and checking coverage; *flake8*, *pylint*, *doc8*, *packaging* for linting code,
-documentation and Python packaging-related files; finally *docs* for
-building the Sphinx documentation.
+When a commit is pushed in a pull request, a call to ``$ tox`` is made by
+TravisCI which triggers the following chain of events:
+
+#. A test environment is spun up for each version of python tested (definined in ``tox.ini``).
+#. Code styles verifications, and quality checks are run (``flake8``, ``pylint``, ``doc8``). The
+   documentation is also built at this time (``docs``).
+#. The test suite is run completely with coverage, including the dedicated backward
+   compatibility tests.
+#. The structure of the repository is validated by ``check-manifest`` and ``readme_renderer``.
+#. The results of the coverage check are reported directly in the pull request.
+
+The coverage results show the difference of coverage introduced by the changes. We always aim to
+have changes that improve coverage.
+
+If a step fails at any point in any environment, the build will be immediatly stopped, marked as
+failed and reported to the pull requestion and repository. In such case, the maintainers and
+relevant contributors will be alerted.
 
 .. _codecov: https://codecov.io/
 .. _travis-ci: https://travis-ci.com/

--- a/docs/src/developer/ci.rst
+++ b/docs/src/developer/ci.rst
@@ -8,10 +8,12 @@ Continuous Integration
    :target: https://codecov.io/gh/epistimio/orion
 
 We use travis-ci_ and codecov_ for continuous integration and tox_ to automate the process at
-the repository level. When a commit is pushed in a pull request, a call to ``$ tox`` will be made by
-TravisCI which will trigger a call to multiple contexts. *py35*, *py36*, *py37*, ... for running
-tests and checking coverage, *flake8*, *pylint*, *doc8*, *packaging* for linting code,
-documentation and Python packaging-related files, and finally *docs* for
+the repository level.
+
+When a commit is pushed in a pull request, a call to ``$ tox`` will be made by
+TravisCI which will trigger a call to multiple contexts. *py35*, *py36*, *py37*, ... for running all
+the tests and checking coverage; *flake8*, *pylint*, *doc8*, *packaging* for linting code,
+documentation and Python packaging-related files; finally *docs* for
 building the Sphinx documentation.
 
 .. _codecov: https://codecov.io/

--- a/docs/src/developer/ci.rst
+++ b/docs/src/developer/ci.rst
@@ -1,0 +1,19 @@
+**********************
+Continuous Integration
+**********************
+.. image:: https://travis-ci.org/epistimio/orion.svg?branch=master
+   :target: https://travis-ci.org/epistimio/orion
+
+.. image:: https://codecov.io/gh/epistimio/orion/branch/master/graphs/badge.svg?branch=master
+   :target: https://codecov.io/gh/epistimio/orion
+
+We use travis-ci_ and codecov_ for continuous integration and tox_ to automate the process at
+the repository level. When a commit is pushed in a pull request, a call to ``$ tox`` will be made by
+TravisCI which will trigger a call to multiple contexts. *py35*, *py36*, *py37*, ... for running
+tests and checking coverage, *flake8*, *pylint*, *doc8*, *packaging* for linting code,
+documentation and Python packaging-related files, and finally *docs* for
+building the Sphinx documentation.
+
+.. _codecov: https://codecov.io/
+.. _travis-ci: https://travis-ci.com/
+.. _tox: https://tox.readthedocs.io/en/latest/

--- a/docs/src/developer/documenting.rst
+++ b/docs/src/developer/documenting.rst
@@ -18,11 +18,5 @@ Also by executing::
 
 the page under ``/docs/build/html`` is hosted by *localhost*.
 
-Use also command::
-
-   tox -e doc8
-
-to ensure that documentation standards are being followed.
-
 .. _Read The Docs: https://sphinx-rtd-theme.readthedocs.io/en/latest/
 .. _Sphinx: http://www.sphinx-doc.org/en/master/

--- a/docs/src/developer/documenting.rst
+++ b/docs/src/developer/documenting.rst
@@ -1,22 +1,16 @@
-.. contents:: Developer's Guide 102: Documenting
-
 ***********
 Documenting
 ***********
+The documentation is built using Sphinx_ with the `Read The Docs`_ theme.
 
-We are using `Read The Docs`_ theme for Sphinx_.
+To generate the *html* and *man* pages of the documentation, run:
 
-Run tox command::
+.. code-block:: sh
 
    tox -e docs
 
-to build *html* and *man* pages for documentation
-
-Also by executing::
-
-   tox -e serve-docs
-
-the page under ``/docs/build/html`` is hosted by *localhost*.
+When writing, you can also run ``$ tox -e serve-docs`` to host the content of
+``/docs/build/html`` on http://localhost:8000.
 
 .. _Read The Docs: https://sphinx-rtd-theme.readthedocs.io/en/latest/
 .. _Sphinx: http://www.sphinx-doc.org/en/master/

--- a/docs/src/developer/documenting.rst
+++ b/docs/src/developer/documenting.rst
@@ -1,8 +1,8 @@
 .. contents:: Developer's Guide 102: Documenting
 
-********
-Document
-********
+***********
+Documenting
+***********
 
 We are using `Read The Docs`_ theme for Sphinx_.
 

--- a/docs/src/developer/documenting.rst
+++ b/docs/src/developer/documenting.rst
@@ -3,13 +3,22 @@ Documenting
 ***********
 The documentation is built using Sphinx_ with the `Read The Docs`_ theme.
 
+We try to write the documentation at only one place and reuse it as much as possible. For instance,
+the home page of this documentation (https://orion.readthedocs.io/en/latest/) is actually pulled
+from the README.md and appended with a table of content of the documentation generated
+automatically. The advantage of having a single source of truth is that it's vastly easier to find
+information and keep it up to date.
+
+Building documentation
+======================
+
 To generate the *html* and *man* pages of the documentation, run:
 
 .. code-block:: sh
 
    tox -e docs
 
-When writing, you can also run ``$ tox -e serve-docs`` to host the content of
+When writing, you can run ``$ tox -e serve-docs`` to host the content of
 ``/docs/build/html`` on http://localhost:8000.
 
 .. _Read The Docs: https://sphinx-rtd-theme.readthedocs.io/en/latest/

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -44,6 +44,8 @@ for linting as we will see in a next chapter.
 Check everything is ready by running the test suite using ``$ tox`` (this will take some time).
 If the tests can't be run to completion, contact us by opening a `new issue <https://github.com/Epistimio/orion/issues/new>`_. We'll do our best to help you!
 
+About tox
+=========
 tox_ is an automation tool that execute tasks in virtual environments. We automate all our testing,
 verification, and release macros with it. All contexts are defined in
 `tox.ini <https://github.com/epistimio/orion/blob/master/tox.ini>`_. They can be executed using

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -1,12 +1,12 @@
+***************
 Getting started
-===============
-
+***************
 In this section, we'll guide you to install the dependencies and environment to develop on Oríon.
 We made our best to automate most of the process using Python's ecosystem goodness to facilitate
 your onboarding. Let us know how we can improve!
 
 Oríon
-----------------
+=====
 The first step is to clone your remote repository from Github (if not already done, make sure to
 fork our repository_ first).
 
@@ -30,12 +30,11 @@ Then, you need to deploy the project in `development mode`_ by invoking the ``se
    $ python setup.py develop --optimize=1
 
 Database
------------------------
-
+========
 Follow the same instructions as to install the :ref:`install_database` regularly.
 
 Verifying the installation
---------------------------
+==========================
 For developer's convenience the packages enlisted in the requirements file
 ``dev-requirements.txt`` are meant to facilitate the development process.
 Packages include `tox <https://tox.readthedocs.io/en/latest/>`_ for defining
@@ -51,7 +50,7 @@ verification, and release macros with it. All contexts are defined in
 ``$ tox -e <context name>``.
 
 Continuous Integration
-----------------------
+======================
 .. image:: https://travis-ci.org/epistimio/orion.svg?branch=master
    :target: https://travis-ci.org/epistimio/orion
 

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -49,24 +49,7 @@ verification, and release macros with it. All contexts are defined in
 `tox.ini <https://github.com/epistimio/orion/blob/master/tox.ini>`_. They can be executed using
 ``$ tox -e <context name>``.
 
-Continuous Integration
-======================
-.. image:: https://travis-ci.org/epistimio/orion.svg?branch=master
-   :target: https://travis-ci.org/epistimio/orion
-
-.. image:: https://codecov.io/gh/epistimio/orion/branch/master/graphs/badge.svg?branch=master
-   :target: https://codecov.io/gh/epistimio/orion
-
-We use travis-ci_ and codecov_ for continuous integration and tox_ to automate the process at
-the repository level. When a commit is pushed in a pull request, a call to ``$ tox`` will be made by
-TravisCI which will trigger a call to multiple contexts. *py35*, *py36*, *py37*, ... for running
-tests and checking coverage, *flake8*, *pylint*, *doc8*, *packaging* for linting code,
-documentation and Python packaging-related files, and finally *docs* for
-building the Sphinx documentation.
-
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _repository: https://github.com/epistimio/orion
 .. _virtual environment: https://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html#mkvirtualenv
 .. _development mode: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode
-.. _codecov: https://codecov.io/
-.. _travis-ci: https://travis-ci.com/

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -1,5 +1,5 @@
-Development environment
-=======================
+Getting started
+===============
 
 In this section, we'll guide you to install the dependencies and environment to develop on Oríon.
 We made our best to automate most of the process using Python's ecosystem goodness to facilitate

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -5,14 +5,14 @@ In this section, we'll guide you to install the dependencies and environment to 
 We made our best to automate most of the process using Python's ecosystem goodness to facilitate
 your onboarding. Let us know how we can improve!
 
-Installing Oríon
+Oríon
 ----------------
 The first step is to clone your remote repository from Github (if not already done, make sure to
 fork our repository_ first).
 
 .. code-block:: sh
 
-   git clone https://github.com/epistimio/orion.git --branch develop
+   $ git clone https://github.com/epistimio/orion.git --branch develop
 
 .. tip::
 
@@ -20,26 +20,54 @@ fork our repository_ first).
 
    .. code-block:: sh
 
-      mkvirtualenv -a $PWD/orion orion
+      $ mkvirtualenv -a $PWD/orion orion
 
 Then, you need to deploy the project in `development mode`_ by invoking the ``setup.py`` script with
 ``develop`` argument or by using ``pip install --editable``.
 
 .. code-block:: sh
 
-   python setup.py develop --optimize=1
+   $ python setup.py develop --optimize=1
 
-Setting up the database
+Database
 -----------------------
 
 Follow the same instructions as to install the :ref:`install_database` regularly.
 
 Verifying the installation
 --------------------------
+For developer's convenience the packages enlisted in the requirements file
+``dev-requirements.txt`` are meant to facilitate the development process.
+Packages include `tox <https://tox.readthedocs.io/en/latest/>`_ for defining
+and organizing macros of sh commands in virtual environments, and packages
+for linting as we will see in a next chapter.
 
 Check everything is ready by running the test suite using ``$ tox`` (this will take some time).
 If the tests can't be run to completion, contact us by opening a `new issue <https://github.com/Epistimio/orion/issues/new>`_. We'll do our best to help you!
 
+tox_ is an automation tool that execute tasks in virtual environments. We automate all our testing,
+verification, and release macros with it. All contexts are defined in
+`tox.ini <https://github.com/epistimio/orion/blob/master/tox.ini>`_. They can be executed using
+``$ tox -e <context name>``.
+
+Continuous Integration
+----------------------
+.. image:: https://travis-ci.org/epistimio/orion.svg?branch=master
+   :target: https://travis-ci.org/epistimio/orion
+
+.. image:: https://codecov.io/gh/epistimio/orion/branch/master/graphs/badge.svg?branch=master
+   :target: https://codecov.io/gh/epistimio/orion
+
+We use travis-ci_ and codecov_ for continuous integration and tox_ to automate the process at
+the repository level. When a commit is pushed in a pull request, a call to ``$ tox`` will be made by
+TravisCI which will trigger a call to multiple contexts. *py35*, *py36*, *py37*, ... for running
+tests and checking coverage, *flake8*, *pylint*, *doc8*, *packaging* for linting code,
+documentation and Python packaging-related files, and finally *docs* for
+building the Sphinx documentation.
+
+.. _tox: https://tox.readthedocs.io/en/latest/
 .. _repository: https://github.com/epistimio/orion
 .. _virtual environment: https://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html#mkvirtualenv
 .. _development mode: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode
+.. _codecov: https://codecov.io/
+.. _travis-ci: https://travis-ci.com/

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -31,7 +31,7 @@ Then, you need to deploy the project in `development mode`_ by invoking the ``se
 
 Database
 ========
-Follow the same instructions as to install the :ref:`install_database` regularly.
+Follow the same instructions as to install the :ref:`install_database` locally.
 
 Verifying the installation
 ==========================

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -1,0 +1,45 @@
+Development environment
+=======================
+
+In this section, we'll guide you to install the dependencies and environment to develop on Oríon.
+We made our best to automate most of the process using Python's ecosystem goodness to facilitate
+your onboarding. Let us know how we can improve!
+
+Installing Oríon
+----------------
+The first step is to clone your remote repository from Github (if not already done, make sure to
+fork our repository_ first).
+
+.. code-block:: sh
+
+   git clone https://github.com/epistimio/orion.git --branch develop
+
+.. tip::
+
+   The usage of a `virtual environment`_ is recommended, but not necessary.
+
+   .. code-block:: sh
+
+      mkvirtualenv -a $PWD/orion orion
+
+Then, you need to deploy the project in `development mode`_ by invoking the ``setup.py`` script with
+``develop`` argument or by using ``pip install --editable``.
+
+.. code-block:: sh
+
+   python setup.py develop --optimize=1
+
+Setting up the database
+-----------------------
+
+Follow the same instructions as to install the :ref:`install_database` regularly.
+
+Verifying the installation
+--------------------------
+
+Check everything is ready by running the test suite using ``$ tox`` (this will take some time).
+If the tests can't be run to completion, contact us by opening a `new issue <https://github.com/Epistimio/orion/issues/new>`_. We'll do our best to help you!
+
+.. _repository: https://github.com/epistimio/orion
+.. _virtual environment: https://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html#mkvirtualenv
+.. _development mode: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode

--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -41,8 +41,9 @@ Packages include `tox <https://tox.readthedocs.io/en/latest/>`_ for defining
 and organizing macros of sh commands in virtual environments, and packages
 for linting as we will see in a next chapter.
 
-Check everything is ready by running the test suite using ``$ tox`` (this will take some time).
-If the tests can't be run to completion, contact us by opening a `new issue <https://github.com/Epistimio/orion/issues/new>`_. We'll do our best to help you!
+Check everything is ready by running python 3.6 the test suite using ``$ tox -e py36`` (this will
+take some time). If the tests can't be run to completion, contact us by opening a `new issue
+<https://github.com/Epistimio/orion/issues/new>`_. We'll do our best to help you!
 
 About tox
 =========

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -5,12 +5,11 @@ Overview
 Welcome to the project. We're excited you decided to improve Oríon!
 
 Hopefully, by then you should be familiar with our `contribution guide <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_ and `code of conduct <https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md>`_.
-We can jump straight into getting you started for your first contribution.
+The documentation for developers is organized in the following, easy to read, sections:
 
-The steps are:
+* :doc:`Getting Started <installing>`. Installing the development environment
+* :doc:`Conventions <standards>`. Get familiar with the project's standards and guidelines
+* :doc:`Testing <testing>`. Implementing your changes and how to test your code
+* :doc:`Documenting <documenting>`. Documenting your changes and updating the documentation
 
-#. :doc:`Installing the development environment <installing>`.
-#. Get familiar with the :doc:`project's standards and guidelines <standards>`
-#. Implement your changes and :doc:`testing <testing>`
-#. :doc:`Document your changes <documenting>`
-#. Submit a `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.
+When you're done, don't forget to submit your `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -10,7 +10,7 @@ We can jump straight into getting you started for your first contribution.
 The steps are:
 
 #. :doc:`Installing the development environment <installing>`.
-#. Get familiar with the :doc:`coding conventions <standards>`
+#. Get familiar with the :doc:`project's standards and guidelines <standards>`
 #. Implement your changes and :doc:`testing <testing>`
 #. :doc:`Document your changes <documenting>`
 #. Submit a `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -11,5 +11,6 @@ The documentation for developers is organized in the following, easy to read, se
 * :doc:`Conventions <standards>`. Get familiar with the project's standards and guidelines
 * :doc:`Testing <testing>`. Implementing your changes and how to test your code
 * :doc:`Documenting <documenting>`. Documenting your changes and updating the documentation
+* :doc:`Continuous Integration <ci>`. Get familiar with our continuous integration setup
 
 When you're done, don't forget to submit your `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -14,3 +14,5 @@ The documentation for developers is organized in the following, easy to read, se
 * :doc:`Continuous Integration <ci>`. Get familiar with our continuous integration setup
 
 When you're done, don't forget to submit your `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.
+
+If you have any question or suggestion feel free to reach out to us by email or by `opening an issue <https://github.com/Epistimio/orion/issues>`_.

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -9,8 +9,7 @@ We can jump straight into getting you started for your first contribution.
 
 The steps are:
 
-#. :doc:`Installing the development environment <../install/core>`.
-#. Checking everything is ready by running the test suite using ``$ tox``
+#. :doc:`Installing the development environment <installing>`.
 #. Get familiar with the :doc:`coding conventions <standards>`
 #. Implement your changes and :doc:`testing <testing>`
 #. :doc:`Document your changes <documenting>`

--- a/docs/src/developer/overview.rst
+++ b/docs/src/developer/overview.rst
@@ -13,6 +13,8 @@ The documentation for developers is organized in the following, easy to read, se
 * :doc:`Documenting <documenting>`. Documenting your changes and updating the documentation
 * :doc:`Continuous Integration <ci>`. Get familiar with our continuous integration setup
 
-When you're done, don't forget to submit your `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.
+When you're done, don't forget to `rebase <https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase>`_
+your changes to the latest version of the *develop* branch of https://github.com/Epistimio/orion.
+Then, submit your `pull request <https://github.com/epistimio/orion/pulls>`_ and ask for a review when the build is passing in the CI.
 
 If you have any question or suggestion feel free to reach out to us by email or by `opening an issue <https://github.com/Epistimio/orion/issues>`_.

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -36,7 +36,7 @@ at the start of the branch name, after the prefix. For example the branch name f
 by issue 225 would be ``fix/225-short-bug-description``.
 
 When creating a release, we use the pattern *release-{version}rc*. This branch represent the release
-candidate that will be merge in the master branch when the changes are ready to be launched in
+candidate that will be merged in the master branch when the changes are ready to be launched in
 production.
 
 Synchronization

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -50,9 +50,10 @@ such cases, we recommend that you merge the changes from develop to your branch 
 approves your pull request and then the maintainer will merge your branch to develop, closing your
 pull request.
 
-We discourage rebases after the PR has been submitted as it can cause problems in GitHub's review
-system. On another note, merges are always done with the creation of a merge commit, also known as a
-*non fast-forward merge*.
+We discourage rebases after the pull resquest has been submitted as it can cause problems in
+GitHub's review system which makes it loose track of the comments on the pull request. On another
+note, merges are always done with the creation of a merge commit, also known as a *non fast-forward
+merge*.
 
 In some cases where the PR has small and focused changes contained in one or two commits,
 the contribution may be integrated to the development branch using `squash and merge <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits>`_ to avoid clutter.

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -1,6 +1,6 @@
-************************
-Standards and guidelines
-************************
+***********
+Conventions
+***********
 
 In this chapter, we present the different standards we use throughout the project. The coding and
 documentation standards are enforced during the PR process automatically.

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -2,8 +2,8 @@
 Conventions
 ***********
 
-In this chapter, we present the different standards we use throughout the project. The coding and
-documentation standards are enforced during the PR process automatically.
+In this chapter, we present the different standards and guidelines we use throughout the project.
+All the conventions are enforced automatically during the PR process.
 
 You can verify if your code will pass the checks locally beforehand using:
 
@@ -39,6 +39,8 @@ When creating a release, we use the pattern *release-{version}rc*. This branch r
 candidate that will be merge in the master branch when the changes are ready to be launched in
 production.
 
+Synchronization
+---------------
 Regarding merges, we recommend you keep your changes in your forked repository for as long as
 possible and rebase your branch to Oríon's develop branch before submitting a PR.
 Most probably, the develop branch will have changed by the time your PR is approved. In such cases,
@@ -46,6 +48,11 @@ we recommend to merge the changes from develop to your branch and then merge you
 We discourage rebases after the PR has been submitted as it can cause problems in GitHub's review
 system. On another note, merges are always done with the creation of a merge commit, also known
 as a *non fast-forward merge*.
+
+In some cases where the PR has small and focused changes contained in one or two commits,
+the contribution may be integrated to the development branch using `squash and merge <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits>`_ to avoid clutter.
+It is strongly encouraged to make small pull requests.
+They are simpler to implement, easier to integrate and faster to review.
 
 .. _standard-documenting:
 

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -43,12 +43,16 @@ production.
 Synchronization
 ---------------
 Regarding merges, we recommend you keep your changes in your forked repository for as long as
-possible and rebase your branch to Oríon's develop branch before submitting a PR.
-Most probably, the develop branch will have changed by the time your PR is approved. In such cases,
-we recommend to merge the changes from develop to your branch and then merge your branch to develop.
+possible and rebase your branch to Oríon's develop branch before submitting a pull request.
+
+Most probably, the develop branch will have changed by the time your pull request is approved. In
+such cases, we recommend that you merge the changes from develop to your branch when the reviewer
+approves your pull request and then the maintainer will merge your branch to develop, closing your
+pull request.
+
 We discourage rebases after the PR has been submitted as it can cause problems in GitHub's review
-system. On another note, merges are always done with the creation of a merge commit, also known
-as a *non fast-forward merge*.
+system. On another note, merges are always done with the creation of a merge commit, also known as a
+*non fast-forward merge*.
 
 In some cases where the PR has small and focused changes contained in one or two commits,
 the contribution may be integrated to the development branch using `squash and merge <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits>`_ to avoid clutter.

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -55,10 +55,11 @@ GitHub's review system which makes it loose track of the comments on the pull re
 note, merges are always done with the creation of a merge commit, also known as a *non fast-forward
 merge*.
 
-In some cases where the PR has small and focused changes contained in one or two commits,
-the contribution may be integrated to the development branch using `squash and merge <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits>`_ to avoid clutter.
-It is strongly encouraged to make small pull requests.
-They are simpler to implement, easier to integrate and faster to review.
+In some cases where the pull request embodies contributions which are scattered across multiple
+commits containing incremental changes (e.g., ``fix pep8``, ``update based on feedback``), the pull
+request may be integrated to the development branch using `squash and merge <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits>`_
+to avoid clutter. It is strongly encouraged to make small pull requests. They are simpler to
+implement, easier to integrate and faster to review.
 
 .. _standard-documenting:
 

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -31,10 +31,10 @@ To collaborate through VCS, we follow the
 workflow. The *develop* and *master* branches are protected and can only be changed with pull
 requests.
 
-For branch names, we recommend prefixing the name of the branch with *feature/*, *fix/*, et
+For branch names, we recommend prefixing the name of the branch with *feature/*, *fix/*, and
 *doc/* depending on the change you're implementing. Additionally, we encourage adding the issue's id
-at the start of the branch name, after the prefix. For example the branch name for a bug represented
-by issue 225 would be ``fix/225-short-bug-description``.
+(if there is one) at the start of the branch name, after the prefix. For example the branch name for
+a bug represented by issue 225 would be ``fix/225-short-bug-description``.
 
 When creating a release, we use the pattern *release-{version}rc*. This branch represent the release
 candidate that will be merged in the master branch when the changes are ready to be launched in

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -5,11 +5,8 @@ Conventions
 In this chapter, we present the different standards and guidelines we use throughout the project.
 All the conventions are enforced automatically during the PR process.
 
-You can verify if your code will pass the checks locally beforehand using:
-
-.. code-block:: sh
-
-   tox -e lint
+You can verify if your code will pass the checks locally beforehand using ``$ tox -e lint`` (which
+is the equivalent of ``$ tox -e flake8,pylint,doc8,packaging``).
 
 .. _standard-coding:
 

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -1,47 +1,79 @@
-.. contents:: Developer's Guide 103: Contribution Standards
+************************
+Standards and guidelines
+************************
 
-**********
-Contribute
-**********
+In this chapter, we present the different standards we use throughout the project. The coding and
+documentation standards are enforced during the PR process automatically.
 
-Coding and Repository Standards
-===============================
-
-We are using flake8_ (along with some of its plugins) and pylint_.
-Their styles are provided in ``/tox.ini`` and ``/.pylintrc`` respectively.
+You can verify if your code will pass the checks locally beforehand using:
 
 .. code-block:: sh
-
-   tox -e flake8
-   tox -e pylint
-
-Also, we are using a check-manifest_ which compares ``/MANIFEST.in`` and git
-structure of the source repository, and finally readme_renderer_ which
-checks whether ``/README.rst`` can be
-actually rendered in PyPI_ website page for Oríon.
-
-.. code-block:: sh
-
-   tox -e packaging
-
-To run all of expected linters execute::
 
    tox -e lint
 
+.. _standard-coding:
+
+Coding standard
+===============
+
+Our coding standards are specified via flake8_ and pylint_. Their configurations are provided in
+``tox.ini`` and ``.pylintrc`` respectively. You can verify the conformity of your changes locally
+by running ``$ tox -e flake8`` and ``$ tox -e pylint``.
+
+.. _standard-vcs:
+
+Version Control Guidelines
+==========================
+
+To collaborate through VCS, we follow the
+`gitflow <https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow>`_
+workflow. The *develop* and *master* branches are protected and can only be changed with pull
+requests.
+
+For branch names, we recommend prefixing the name of the branch with *feature/*, *fix/*, et
+*doc/* depending on the change you're implementing. Additionally, we encourage adding the issue's id
+at the start of the branch name, after the prefix. For example the branch name for a bug represented
+by issue 225 would be ``fix/225-short-bug-description``.
+
+When creating a release, we use the pattern *release-{version}rc*. This branch represent the release
+candidate that will be merge in the master branch when the changes are ready to be launched in
+production.
+
+Regarding merges, we recommend you keep your changes in your forked repository for as long as
+possible and rebase your branch to Oríon's develop branch before submitting a PR.
+Most probably, the develop branch will have changed by the time your PR is approved. In such cases,
+we recommend to merge the changes from develop to your branch and then merge your branch to develop.
+We discourage rebases after the PR has been submitted as it can cause problems in GitHub's review
+system. On another note, merges are always done with the creation of a merge commit, also known
+as a *non fast-forward merge*.
+
+.. _standard-documenting:
+
+Documenting standard
+====================
+
+Our documentation standard is upheld via doc8_. You can verify your documentation modifications
+by running ``$ tox -e doc8``.
+
+.. _standard-repository:
+
+Repository standard
+===================
+
+We are using check-manifest_ to ensure no file is missing when we distribute our application and we
+also use readme_renderer_ which checks whether ``/README.rst`` can be rendered in PyPI_.
+You can verify these locally by running ``$ tox -e packaging``.
+
+Versioning standard
+===================
+
+We follow the `semantic versioning <https://semver.org/>`_ convention to name the versions of Oríon.
+While in beta, we prepend a ``0`` on the left of the major version.
+
+.. _Github: https://github.com
 .. _flake8: http://flake8.pycqa.org/en/latest/
+.. _doc8: https://pypi.org/project/doc8/
 .. _pylint: https://www.pylint.org/
 .. _check-manifest: https://pypi.org/project/check-manifest/
 .. _readme_renderer: https://pypi.org/project/readme_renderer/
 .. _PyPI: https://pypi.org/
-
-Fork and Pull Request
-=====================
-
-Fork Oríon remotely to your Github_ account now, and start by submitting a
-`Pull Request <https://github.com/epistimio/orion/pulls>`_ to us or by
-discussing an `issue <https://github.com/epistimio/orion/issues>`_ with us.
-
-.. image:: https://img.shields.io/github/forks/epistimio/orion.svg?style=social&label=Fork
-   :target: https://github.com/epistimio/orion/network
-
-.. _Github: https://github.com

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -66,8 +66,9 @@ implement, easier to integrate and faster to review.
 Documenting standard
 ====================
 
-Our documentation standard is upheld via doc8_. You can verify your documentation modifications
-by running ``$ tox -e doc8``.
+Our documentation standard is upheld via doc8_. You can verify your documentation modifications by
+running ``$ tox -e doc8``. The information about writing and generating documentation is available
+in the :doc:`documenting` chapter.
 
 .. _standard-repository:
 

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -58,8 +58,8 @@ merge*.
 In some cases where the pull request embodies contributions which are scattered across multiple
 commits containing incremental changes (e.g., ``fix pep8``, ``update based on feedback``), the pull
 request may be integrated to the development branch using `squash and merge <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits>`_
-to avoid clutter. It is strongly encouraged to make small pull requests. They are simpler to
-implement, easier to integrate and faster to review.
+by the maintainer to avoid clutter. It is strongly encouraged to make small pull requests. They are
+simpler to implement, easier to integrate and faster to review.
 
 .. _standard-documenting:
 

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -17,6 +17,10 @@ Our coding standards are specified via flake8_ and pylint_. Their configurations
 ``tox.ini`` and ``.pylintrc`` respectively. You can verify the conformity of your changes locally
 by running ``$ tox -e flake8`` and ``$ tox -e pylint``.
 
+In addition, we follow `Numpy's docstring standards
+<https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ to ensure a good
+quality of documentation for the project.
+
 .. _standard-vcs:
 
 Version Control Guidelines

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -31,23 +31,29 @@ This will call tests for the particular shell's environment Python's executable.
 If the tests are successful, then a code **coverage** summary will be printed
 on shell's screen.
 
-However, during development we recommend using
+However, during development consider using
 
 .. code-block:: sh
 
    $ tox -e devel
 
 This will run in the background and run the tests on a code change event (e.g., you save a file)
-automatically run the tests when you make a change. It's particularly useful when you
-specify a location of the tests:
+automatically run the tests when you make a change. It's particularly useful when you also
+specify the location of the tests:
 
 .. code-block:: sh
 
    $ tox -e devel -- 'path/to/your/tests/'
+
+.. code-block:: sh
+
    $ tox -e devel -- 'path/to/your/tests/file.py'
+
+.. code-block:: sh
+
    $ tox -e devel -- 'path/to/your/tests/file.py::test_name'
 
-This way, the tests will be ran automatically every time you make a change in the specified path,
-file or specific test. This option is also avalable for ``$ tox -e py``.
+This way, the tests will be ran automatically every time you make a change in the specified folder,
+file, or test respectively. This option is also avalable for ``$ tox -e py``.
 
 .. _pytest: https://docs.pytest.org/en/latest/

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -16,7 +16,7 @@ tests:
 The tests are made with pytest_. We highly recommend you check it out and take a look at the
 existing tests in the ``tests`` folder.
 
-We recommend invoking the tests using *tox* as this will be the path used by the CI system.
+We recommend invoking the tests using ``tox`` as this will be the method used by the CI system.
 It will avoid you headaches when trying to run tests and nasty surprises when submitting PRs.
 
 Running tests

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -1,79 +1,52 @@
-.. contents:: Developer's Guide 101: Tools & Testing
-
 *******
 Testing
 *******
 
-For developer's convenience the packages enlisted in the requirements file
-``dev-requirements.txt`` are meant to facilitate the development process.
-Packages include `tox <https://tox.readthedocs.io/en/latest/>`_ for defining
-and organizing macros of sh commands in virtual environments, and packages
-for linting as we will see in a next chapter.
+All the tests for our software are located and organized in the directory
+``/tests`` relative to the root of the code repository. There are three kinds of
+tests:
 
+#. Unit tests, located under ``/tests/unittests``.
+   They test individual features, often at the class granularity.
+#. Functional tests, located under ``/tests/functional``.
+   They test end to end functionality, invoking Oríon's executable from shell.
+#. Stress tests, located under ``/tests/stress``.
+   They test the resilience and performance.
 
-Continuous Integration
-======================
+The tests are made with pytest_. We highly recommend you check it out and take a look at the
+existing tests in the *tests* folder.
 
-We use **TravisCI** and **CodeCov**.
+We recommend invoking the tests using *tox* as this will be the path used by the CI system.
+It will avoid you headaches when trying to run tests and nasty surprises when submitting PRs.
 
-.. image:: https://travis-ci.org/epistimio/orion.svg?branch=master
-   :target: https://travis-ci.org/epistimio/orion
-
-.. image:: https://codecov.io/gh/epistimio/orion/branch/master/graphs/badge.svg?branch=master
-   :target: https://codecov.io/gh/epistimio/orion
-
-Continuous Testing
-==================
-
-Using ``tox`` we can automate many processes of continuous testing into macros.
-All contexts are defined in `/tox.ini <https://github.com/epistimio/orion/blob/master/tox.ini>`_.
-
-By calling::
-
-   tox
-
-one attempts to call all contexts that matter for our Continuous Integration in
-the same call. Those are *py35*, *py36*, *py37* for running tests and
-checking coverage, *flake8*, *pylint*, *doc8*, *packaging* for linting code,
-documentation and Python packaging-related files, and finally *docs* for
-building the Sphinx documentation.
+Running tests
+=============
+To run the complete test suite, you can use
 
 .. code-block:: sh
 
-   tox -e py
+   $ tox -e py
 
 This will call tests for the particular shell's environment Python's executable.
 If the tests are successful, then a code **coverage** summary will be printed
 on shell's screen.
 
+However, during development we recommend using
+
 .. code-block:: sh
 
-   tox -e devel
+   $ tox -e devel
 
-This will finally always run the tests on background and on a code change event,
-it automatically performs **regression testing**.
+This will run in the background and run the tests on a code change event (e.g., you save a file)
+automatically run the tests when you make a change. It's particularly useful when you
+specify a location of the tests:
 
-Test
-====
+.. code-block:: sh
 
-All the tests for our software are located and organized in the directory
-``/tests`` relative to the root of the code repository. There are two kinds of
-tests: Unit tests are located under ``/tests/unittests`` and functional tests
-(tests which invoke Oríon's executable from shell) under ``/tests/functional``.
+   $ tox -e devel -- 'path/to/your/tests/'
 
-Our software requires pytest_ ``>=3.0.0`` for automated testing.
-Also, it requires the particular database setup described in
-:doc:`/install/database` to have been followed.
-
-Hence the tests can be invoked with::
-
-   python setup.py test
-
-For instance::
-
-   python setup.py test --addopts 'tests/unittests'
-
-will only execute tests located under ``/tests/unittests``, this is all unit
-tests.
+This way, the tests will be ran automatically everytime you make a change in the specified path.
+You can specify a folder, a file or a specific test.
+This option is also avalable for ``$ tox -e py``.
 
 .. _pytest: https://docs.pytest.org/en/latest/

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -14,7 +14,7 @@ tests:
    They test the resilience and performance.
 
 The tests are made with pytest_. We highly recommend you check it out and take a look at the
-existing tests in the *tests* folder.
+existing tests in the ``tests`` folder.
 
 We recommend invoking the tests using *tox* as this will be the path used by the CI system.
 It will avoid you headaches when trying to run tests and nasty surprises when submitting PRs.

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -44,9 +44,10 @@ specify a location of the tests:
 .. code-block:: sh
 
    $ tox -e devel -- 'path/to/your/tests/'
+   $ tox -e devel -- 'path/to/your/tests/file.py'
+   $ tox -e devel -- 'path/to/your/tests/file.py::test_name'
 
-This way, the tests will be ran automatically everytime you make a change in the specified path.
-You can specify a folder, a file or a specific test.
-This option is also avalable for ``$ tox -e py``.
+This way, the tests will be ran automatically every time you make a change in the specified path,
+file or specific test. This option is also avalable for ``$ tox -e py``.
 
 .. _pytest: https://docs.pytest.org/en/latest/

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -60,8 +60,8 @@
    :maxdepth: 1
 
    developer/overview
+   developer/standards
    developer/testing
    developer/documenting
-   developer/standards
 
 .. Don't fetch reference/viz

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -64,5 +64,6 @@
    developer/standards
    developer/testing
    developer/documenting
+   developer/ci
 
 .. Don't fetch reference/viz

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -60,6 +60,7 @@
    :maxdepth: 1
 
    developer/overview
+   developer/installing
    developer/standards
    developer/testing
    developer/documenting

--- a/docs/src/install/core.rst
+++ b/docs/src/install/core.rst
@@ -24,36 +24,9 @@ Via Git
 This way is recommended if you want to work with the bleeding edge version
 of Oríon.
 
-Recommended for users
----------------------
-
 .. code-block:: sh
 
    pip install git+https://github.com/epistimio/orion.git@develop
 
 Note that the bleeding-edge branch is develop. The master branch is the same as the latest version
 on PyPI.
-
-Recommended for developers of Oríon
------------------------------------
-
-Clone remote repository_ from Github, using *https* or *ssh*, and then
-deploy the project in `development mode`_, by invoking the ``setup.py`` script
-with ``develop`` argument
-or by using ``pip install --editable``. Usage of a `virtual environment`_ is
-also recommended, but not necessary. Example:
-
-.. code-block:: sh
-
-   <Create and navigate to the directory where local repo will reside>
-   git clone https://github.com/epistimio/orion.git --branch develop
-   mkvirtualenv -a $PWD/orion orion
-   python setup.py develop --optimize=1
-   <Do your job>
-   deactivate
-
-Begin reading instructions for developing it in :doc:`/developer/testing`.
-
-.. _repository: https://github.com/epistimio/orion
-.. _virtual environment: https://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html#mkvirtualenv
-.. _development mode: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode

--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -23,10 +23,6 @@ not intending to use an already existing one, is necessary.
 We are going to follow an example of installing and setting up a minimal
 database locally.
 
-.. note::
-
-   This is the same database required to be setup in order to run the tests.
-
 Local MongoDB Installation
 ==========================
 


### PR DESCRIPTION
In this pull request, we refresh, update and reorganize the documentation for developers. The objective is to have a simple, easy to read and exhaustive place where developers come to guide them to developing for Oríon.

Please note, this documentation doesn't have the same role as CONTRIBUTING.md. Its role is to give developers all the information they need build and modify Oríon by themselves (and then do a PR :)).