### PR TITLE
Fix broken-link in monitoring

### DIFF
--- a/docs/src/user/library/evc_results.rst
+++ b/docs/src/user/library/evc_results.rst
@@ -1,7 +1,7 @@
 Iterative Results with EVC
 --------------------------
 
-When using the experiment version control (described :doc:`here <../../user/evc>`),
+When using the experiment version control (described :doc:`here </user/evc>`),
 the experiments are connected in a tree structure which we call the EVC tree.
 You can retrieve results from different experiments with the EVC tree similarly
 as described in previous section. All trials of the tree can be fetched

--- a/docs/src/user/library/evc_results.rst
+++ b/docs/src/user/library/evc_results.rst
@@ -1,7 +1,7 @@
 Iterative Results with EVC
 --------------------------
 
-When using the experiment version control (described `here <user/evc>`_),
+When using the experiment version control (described :doc:`here <../../user/evc>`),
 the experiments are connected in a tree structure which we call the EVC tree.
 You can retrieve results from different experiments with the EVC tree similarly
 as described in previous section. All trials of the tree can be fetched


### PR DESCRIPTION
Why:
There is a broken link in the monitoring section when referencing the EVC. https://trello.com/c/HWp2LH8J

How:
I replaced the broken external link with a valid internal link. This way, if the linked document is moved, the build system will throw an error.
