### PR TITLE
Add link to cookiecutter template

### DIFF
--- a/docs/src/plugins/base.rst
+++ b/docs/src/plugins/base.rst
@@ -1,5 +1,9 @@
-************************************
-How to setup and distribute a plugin
-************************************
+********
+Overview
+********
+Developing plugins for Oríon is easy. We offer a plugin template powered by cookiecutter_. The
+instructions are on the `template's page <https://github.com/Epistimio/cookiecutter-orion.algo>`_.
 
-Checkout how the gradient descent algorithm is setup `here <https://github.com/epistimio/orion/blob/master/tests/functional/gradient_descent_algo/setup.py>`_.
+We encourage you to checkout our gradient descent algorithm plugin for some inspiration: https://github.com/epistimio/orion/blob/master/tests/functional/gradient_descent_algo/.
+
+.. _cookiecutter: https://github.com/cookiecutter/cookiecutter


### PR DESCRIPTION
These changes update the landing page for plugin development.
- The title is changed to reflect the true nature of the page.
- Add link to the cookiecutter template.
- Integrate the link to gradient descent algorithm plugin as an example of cookiecutter template.