### PR TITLE
Handle trials with corrupted status 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Software License Agreement (BSD License)
 
- Copyright (c) 2017-2018, Epistímio.
+ Copyright (c) 2017-2020, Epistímio.
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/docs/src/code/storage.rst
+++ b/docs/src/code/storage.rst
@@ -1,0 +1,11 @@
+****************
+Storage Protocol
+****************
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Modules
+
+   storage/base
+   storage/legacy
+   storage/track

--- a/docs/src/code/storage/base.rst
+++ b/docs/src/code/storage/base.rst
@@ -1,0 +1,5 @@
+Base
+====
+
+.. automodule:: orion.storage.base
+   :members:

--- a/docs/src/code/storage/legacy.rst
+++ b/docs/src/code/storage/legacy.rst
@@ -1,0 +1,5 @@
+Legacy Database
+===============
+
+.. automodule:: orion.storage.legacy
+   :members:

--- a/docs/src/code/storage/track.rst
+++ b/docs/src/code/storage/track.rst
@@ -1,0 +1,5 @@
+Track
+=====
+
+.. automodule:: orion.storage.track
+   :members:

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -21,6 +21,7 @@
    user/algorithms
    user/script
    user/evc
+   user/storage
    user/config
 
 .. toctree::
@@ -51,9 +52,10 @@
    :maxdepth: 2
    :caption: Code Reference
 
-   code/core
    code/algo
    code/client
+   code/core
+   code/storage
 
 .. toctree::
    :caption: Developer's Guide

--- a/docs/src/user/api.rst
+++ b/docs/src/user/api.rst
@@ -89,7 +89,8 @@ Service API
 -----------
 
 Experiments are created using the helper function
-:py:func:`orion.client.create_experiment`. You can then sample new trials with
+:py:func:`orion.client.create_experiment`.
+You can then sample new trials with
 :py:meth:`experiment.suggest() <orion.client.experiment.ExperimentClient.suggest>`.
 The parameters of the trials are provided as a dictionary with
 :py:meth:`trial.params <orion.core.worker.trial.Trial.params>`.

--- a/docs/src/user/storage.rst
+++ b/docs/src/user/storage.rst
@@ -1,0 +1,325 @@
+.. role:: hidden
+    :class: hidden-section
+
+
+.. _storage:
+
+*******
+Storage
+*******
+
+In short, users are expected to only use the
+:py:class:`ExperimentClient <orion.client.experiment.ExperimentClient>` to interact
+with the storage client, to fetch and register trials. Creation of experiments
+should always be done through
+:py:func:`create_experiment() <orion.client.create_experiment>`.
+
+If you need to access the storage with more flexibility, you can do
+so using the methods of the storage client directly. See :ref:`storage_backend` section
+for more details.
+
+Finally, legacy databases supported by Oríon can also be accessed directly in last
+resort if the storage backend is not flexible enough. See :ref:`database_backend` section
+for more details.
+
+.. _experiment_client:
+
+ExperimentClient
+================
+
+The experiment client must be created with the helper function
+:py:func:`create_experiment() <orion.client.create_experiment>` which will take care of
+initiating the storage backend and create a new experiment if non-existant or simply load
+the corresponding experiment from the storage.
+
+There is a small subset of methods to fetch trials or create new ones. We focus here
+on the methods for loading or creation of trials in particular, see
+:py:class:`ExperimentClient <orion.client.experiment.ExperimentClient>` for documentation
+of all methods.
+
+Here is a short example to fetch trials or insert a new one.
+
+.. code-block:: python
+
+   from orion.client import create_experiment
+
+   # Create the ExperimentClient
+   experiment = create_experiment('exp-name', space=dict(x='uniform(0, 1)'))
+
+   # To fetch all trials from an experiment
+   trials = experiment.fetch_trials()
+
+   # Insert a new trial in storage
+   experiment.insert(dict(x=0.5))
+
+   # Insert a new trial and reserve to execute
+   trial = experiment.insert(dict(x=0.6), reserve=True)
+
+:hidden:`fetch_trials`
+----------------------
+
+.. automethod:: orion.client.experiment.ExperimentClient.fetch_trials
+   :noindex:
+
+:hidden:`fetch_trials_by_status`
+--------------------------------
+
+.. automethod:: orion.client.experiment.ExperimentClient.fetch_trials_by_status
+   :noindex:
+
+:hidden:`fetch_noncompleted_trials`
+-----------------------------------
+
+.. automethod:: orion.client.experiment.ExperimentClient.fetch_noncompleted_trials
+   :noindex:
+
+:hidden:`get_trial`
+-------------------
+
+.. automethod:: orion.client.experiment.ExperimentClient.get_trial
+   :noindex:
+
+:hidden:`insert`
+----------------
+
+.. automethod:: orion.client.experiment.ExperimentClient.insert
+   :noindex:
+
+
+
+.. _storage_backend:
+
+Storage
+=======
+
+.. warning::
+
+   The storage backends are not meant to be used directly by users.
+   Be careful if you use any method which modifies the data in storage or
+   you may break your experiment or trials.
+
+The storage backend is used by the
+:py:class:`ExperimentClient <orion.client.experiment.ExperimentClient>`
+to read and write persistant records of the experiment and trials.
+Although we recommand using the experiment client,
+we document the storage backend here for users who may need
+more flexibility.
+
+There is two ways for creating the storage client. If you
+already created an experiment client, the storage
+was already created during the process of creating the
+experiment client and you can get it with
+:py:func:`orion.storage.base.get_storage`.
+Otherwise, you can create the storage client with
+:py:func:`orion.storage.base.setup_storage` before
+fetching it with
+:py:func:`get_storage() <orion.storage.base.get_storage>`.
+To recap, you can create it indirectly with
+:py:func:`create_experiment() <orion.client.create_experiment>`
+or directly with
+:py:func:`setup_storage() <orion.storage.base.setup_storage>`.
+In both case, you can access it with
+:py:func:`get_storage() <orion.storage.base.get_storage>`.
+
+.. code-block:: python
+
+   from orion.client import create_experiment
+   from orion.storage.base import get_storage, setup_storage
+
+   # Create the ExperimentClient and storage implicitly
+   experiment = create_experiment('exp-name', space=dict(x='uniform(0, 1)'))
+
+   # Or create storage explicitly using setup_storage
+   setup_storage(dict(
+       type='legacy',
+       database=dict(
+           type='pickleddb',
+           host='db.pkl')
+           )
+       )
+   )
+
+   # Get the storage client
+   storage = get_storage()
+
+   # fetch trials
+   trials = storage.fetch_trials(uid=experiment.id)
+
+   # Update trial status
+   storage.set_trial_status(trials[0], 'interrupted')
+
+.. note::
+
+   The function :py:func:`setup_storage() <orion.storage.base.setup_storage>`
+   reads the global configuration like
+   :py:func:`create_experiment() <orion.client.create_experiment>`
+   does if there is missing information. Therefore, it is possible
+   to call it without any argument the same way it is possible
+   to call
+   :py:func:`create_experiment() <orion.client.create_experiment>`
+   without specifying storage configuration.
+
+:hidden:`update_experiment`
+---------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.update_experiment
+   :noindex:
+
+:hidden:`fetch_experiment`
+--------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.fetch_experiments
+   :noindex:
+
+:hidden:`register_trial`
+------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.register_trial
+   :noindex:
+
+:hidden:`reserve_trial`
+-----------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.reserve_trial
+   :noindex:
+
+:hidden:`fetch_trials`
+----------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.fetch_trials
+   :noindex:
+
+:hidden:`get_trial`
+-------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.get_trial
+   :noindex:
+
+:hidden:`fetch_lost_trials`
+---------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.fetch_lost_trials
+   :noindex:
+
+:hidden:`fetch_pending_trials`
+------------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.fetch_pending_trials
+   :noindex:
+
+:hidden:`fetch_noncompleted_trials`
+-----------------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.fetch_noncompleted_trials
+   :noindex:
+
+:hidden:`fetch_trials_by_status`
+--------------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.fetch_trials_by_status
+   :noindex:
+
+:hidden:`count_completed_trials`
+--------------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.count_completed_trials
+   :noindex:
+
+:hidden:`count_broken_trials`
+-----------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.count_broken_trials
+   :noindex:
+
+:hidden:`set_trial_status`
+--------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.set_trial_status
+   :noindex:
+
+
+.. _database_backend:
+
+Database
+========
+
+.. warning::
+
+   The database backends are not meant to be used directly by users.
+   Be careful if you use any method which modifies the data in database or
+   you may break your experiment or trials.
+
+The database backend used to be the sole database support
+initially. An additional abstraction layer, the storage protocol,
+has been added with the goal to support various storage types
+such as third-party experiment management platforms which
+could not be supported using the basic methods ``read``
+and ``write``.
+This is why the database backend has been turned into
+a legacy storage procotol. Because it is the default
+storage protocol, we document it here for users
+who may need even more flexibility than what the
+storage protocol provides.
+
+There is two ways for creating the database client. If you
+already created an experiment client, the database
+was already created during the process of creating the
+experiment client and you can get it with
+:py:func:`orion.storage.legacy.get_database`.
+Otherwise, you can create the database client with
+:py:func:`orion.storage.legacy.setup_database` before
+fetching it with
+:py:func:`get_database() <orion.storage.legacy.get_database>`.
+To recap, you can create it indirectly with
+:py:func:`create_experiment() <orion.client.create_experiment>`
+or directly with
+:py:func:`setup_database() <orion.storage.legacy.setup_database>`.
+In both case, you can access it with
+:py:func:`get_database() <orion.storage.legacy.get_database>`.
+
+Here's an example on how you could remove an experiment
+
+.. code-block:: python
+
+   from orion.client import create_experiment
+   from orion.storage.legacy import get_database, setup_database
+
+   # Create the ExperimentClient and database implicitly
+   experiment = create_experiment('exp-name', space=dict(x='uniform(0, 1)'))
+
+   # Or create database explicitly using setup_database
+   setup_database(dict(
+       type='pickleddb',
+       host='db.pkl'
+       )
+   )
+
+   # This gets the db singleton that was already instantiated within the experiment object.
+   db = get_database()
+
+   # To remove all trials of an experiment
+   db.remove('trials', dict(experiment=experiment.id))
+
+   # To remove the experiment
+   db.remove('experiments', dict(_id=experiment.id))
+
+
+:hidden:`read`
+--------------
+
+.. automethod:: orion.core.io.database.Database.read
+
+:hidden:`write`
+---------------
+
+.. automethod:: orion.core.io.database.Database.write
+
+:hidden:`remove`
+----------------
+
+.. automethod:: orion.core.io.database.Database.remove
+
+:hidden:`read_and_write`
+------------------------
+
+.. automethod:: orion.core.io.database.Database.read_and_write

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -17,7 +17,8 @@ from orion.core.utils.tests import update_singletons
 from orion.core.worker.producer import Producer
 
 
-__all__ = ['interrupt_trial', 'report_bad_trial', 'report_objective', 'report_results']
+__all__ = ['interrupt_trial', 'report_bad_trial', 'report_objective', 'report_results',
+           'create_experiment', 'workon']
 
 
 # pylint: disable=too-many-arguments

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -35,7 +35,7 @@ __license__ = 'BSD-3-Clause'
 __author__ = u'Epistímio'
 __author_short__ = u'Epistímio'
 __author_email__ = 'xavier.bouthillier@umontreal.ca'
-__copyright__ = u'2017-2019, Epistímio'
+__copyright__ = u'2017-2020, Epistímio'
 __url__ = 'https://github.com/epistimio/orion'
 
 DIRS = AppDirs(__name__, __author_short__)

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -105,7 +105,7 @@ from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, Ra
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import Strategy
-from orion.storage.base import get_storage, Storage
+from orion.storage.base import get_storage, setup_storage
 
 
 log = logging.getLogger(__name__)
@@ -504,33 +504,6 @@ def _fetch_config_version(configs, version=None):
     configs = filter(lambda exp: exp.get('version', 1) == version, configs)
 
     return next(iter(configs))
-
-
-def setup_storage(storage=None):
-    """Create the storage instance from a configuration.
-
-    Parameters
-    ----------
-    config: dict
-        Configuration for the storage backend.
-
-    """
-    if storage is None:
-        storage = orion.core.config.storage.to_dict()
-
-    if storage.get('type') == 'legacy' and 'database' not in storage:
-        storage['database'] = orion.core.config.storage.database.to_dict()
-    elif storage.get('type') is None and 'database' in storage:
-        storage['type'] = 'legacy'
-
-    storage_type = storage.pop('type')
-
-    log.debug("Creating %s storage client with args: %s", storage_type, storage)
-    try:
-        Storage(of_type=storage_type, **storage)
-    except ValueError:
-        if Storage().__class__.__name__.lower() != storage_type.lower():
-            raise
 
 
 ###

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -242,7 +242,7 @@ class Experiment:
 
         :return: list of `Trial` objects
         """
-        return self._select_evc_call(with_evc_tree, 'fetch_trial_by_status', status)
+        return self._select_evc_call(with_evc_tree, 'fetch_trials_by_status', status)
 
     def fetch_noncompleted_trials(self, with_evc_tree=False):
         """Fetch non-completed trials of this `Experiment` instance.

--- a/src/orion/core/worker/strategy.py
+++ b/src/orion/core/worker/strategy.py
@@ -17,6 +17,17 @@ from orion.core.worker.trial import Trial
 log = logging.getLogger(__name__)
 
 
+CORRUPTED_DB_WARNING = """\
+Trial `%s` has an objective but status is not completed.
+This is likely due to a corrupted database, possibly because of
+database timeouts. Try setting manually status to `completed`.
+You can find documention to do this at
+https://orion.readthedocs.io/en/latest/user/storage.html#storage-backend.
+
+If you encounter this issue often, please consider reporting it to
+https://github.com/Epistimio/orion/issues."""
+
+
 def get_objective(trial):
     """Get the value for the objective, if it exists, for this trial
 
@@ -57,15 +68,33 @@ class BaseParallelStrategy(object, metaclass=ABCMeta):
         # converted to expect trials instead of lists and dictionaries.
         pass
 
-    @abstractmethod
+    # pylint: disable=no-self-use
     def lie(self, trial):
         """Construct a fake result for an incomplete trial
 
-        :param trial: `orion.core.worker.trial.Trial`
-        :return: Float or None
-            The fake objective result corresponding to the trial given
+        Parameters
+        ----------
+        trial: `orion.core.worker.trial.Trial`
+            A trial object which is not supposed to be completed.
+
+        Returns
+        -------
+        ``orion.core.worker.trial.Trial.Result``
+            The fake objective result corresponding to the trial given.
+
+        Notes
+        -----
+        If the trial has an objective even if not completed, a warning is printed to user
+        with a pointer to documentation to resolve the database corruption. The result returned is
+        the corresponding objective instead of the lie.
+
         """
-        pass
+        objective = get_objective(trial)
+        if objective:
+            log.warning(CORRUPTED_DB_WARNING, trial.id)
+            return Trial.Result(name='lie', type='lie', value=objective)
+
+        return None
 
     @property
     def configuration(self):
@@ -83,7 +112,11 @@ class NoParallelStrategy(BaseParallelStrategy):
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
-        pass
+        result = super(NoParallelStrategy, self).lie(trial)
+        if result:
+            return result
+
+        return None
 
 
 class MaxParallelStrategy(BaseParallelStrategy):
@@ -101,8 +134,9 @@ class MaxParallelStrategy(BaseParallelStrategy):
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
-        if get_objective(trial):
-            raise RuntimeError("Trial {} is completed but should not be.".format(trial.id))
+        result = super(MaxParallelStrategy, self).lie(trial)
+        if result:
+            return result
 
         return Trial.Result(name='lie', type='lie', value=self.max_result)
 
@@ -123,8 +157,9 @@ class MeanParallelStrategy(BaseParallelStrategy):
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
-        if get_objective(trial):
-            raise RuntimeError("Trial {} is completed but should not be.".format(trial.id))
+        result = super(MeanParallelStrategy, self).lie(trial)
+        if result:
+            return result
 
         return Trial.Result(name='lie', type='lie', value=self.mean_result)
 
@@ -142,8 +177,9 @@ class StubParallelStrategy(BaseParallelStrategy):
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
-        if get_objective(trial):
-            raise RuntimeError("Trial {} is completed but should not be.".format(trial.id))
+        result = super(StubParallelStrategy, self).lie(trial)
+        if result:
+            return result
 
         return Trial.Result(name='lie', type='lie', value=self.stub_value)
 

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -198,7 +198,7 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         """Fetch all non completed trials"""
         raise NotImplementedError()
 
-    def fetch_trial_by_status(self, experiment, status):
+    def fetch_trials_by_status(self, experiment, status):
         """Fetch all trials with the given status"""
         raise NotImplementedError()
 
@@ -302,7 +302,7 @@ class ReadOnlyStorageProtocol(object):
         'fetch_noncompleted_trials',
         'fetch_pending_trials',
         'fetch_lost_trials',
-        'fetch_trial_by_status'
+        'fetch_trials_by_status'
     }
 
     def __init__(self, protocol):

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 :mod:`orion.storage.legacy` -- Legacy storage
-=============================================================================
+=============================================
 
 .. module:: legacy
    :platform: Unix
@@ -22,7 +22,27 @@ from orion.storage.base import BaseStorageProtocol, FailedUpdate, MissingArgumen
 log = logging.getLogger(__name__)
 
 
-def setup_database(config):
+def get_database():
+    """Return current database
+
+    This is a wrapper around the Database Singleton object to provide
+    better error message when it is used without being initialized.
+
+    Raises
+    ------
+    RuntimeError
+        If the underlying database was not initialized prior to calling this function
+
+    Notes
+    -----
+    To initialize the underlying database you must first call `Database(...)`
+    with the appropriate arguments for the chosen backend
+
+    """
+    return Database()
+
+
+def setup_database(config=None):
     """Create the Database instance from a configuration.
 
     Parameters
@@ -31,6 +51,10 @@ def setup_database(config):
         Configuration for the database.
 
     """
+    if config is None:
+        # TODO: How could we support orion.core.config.storage.database as well?
+        config = orion.core.config.database.to_dict()
+
     db_opts = config
     dbtype = db_opts.pop('type')
 

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -340,8 +340,8 @@ class Legacy(BaseStorageProtocol):
         """Update trial's heartbeat"""
         return self._update_trial(trial, heartbeat=datetime.datetime.utcnow(), status='reserved')
 
-    def fetch_trial_by_status(self, experiment, status):
-        """See :func:`~orion.storage.BaseStorageProtocol.fetch_trial_by_status`"""
+    def fetch_trials_by_status(self, experiment, status):
+        """See :func:`~orion.storage.BaseStorageProtocol.fetch_trials_by_status`"""
         query = dict(
             experiment=experiment._id,
             status=status

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -723,7 +723,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
         )
         return self.backend.fetch_trials(query)
 
-    def fetch_trial_by_status(self, experiment, status):
+    def fetch_trials_by_status(self, experiment, status):
         """Fetch all trials with the given status"""
         trials = self._fetch_trials(dict(status=status, group_id=experiment.id))
         return trials

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.storage.legacy -- Track Storage Protocol
+:mod:`orion.storage.track` -- Track Storage Protocol
 ====================================================
 
 .. module:: base

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -502,7 +502,7 @@ class TestStorage:
 
             assert len(trials) == count
 
-    def test_fetch_trial_by_status(self, storage):
+    def test_fetch_trials_by_status(self, storage):
         """Test fetch completed trials"""
         with OrionState(
                 experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
@@ -513,7 +513,7 @@ class TestStorage:
 
             storage = cfg.storage()
             experiment = cfg.get_experiment('default_name', version=None)
-            trials = storage.fetch_trial_by_status(experiment, 'completed')
+            trials = storage.fetch_trials_by_status(experiment, 'completed')
 
             assert len(trials) == count
             for trial in trials:
@@ -558,7 +558,7 @@ class TestStorage:
             storage = cfg.storage()
 
             exp = cfg.get_experiment('default_name')
-            trial1 = storage.fetch_trial_by_status(exp, status='reserved')[0]
+            trial1 = storage.fetch_trials_by_status(exp, status='reserved')[0]
             trial1b = copy.deepcopy(trial1)
 
             storage.update_heartbeat(trial1)
@@ -575,7 +575,7 @@ class TestStorage:
             assert trial2.heartbeat < datetime.datetime.utcnow()
 
             if storage_name is None:
-                trial3 = storage.fetch_trial_by_status(exp, status='completed')[0]
+                trial3 = storage.fetch_trials_by_status(exp, status='completed')[0]
                 storage.update_heartbeat(trial3)
 
                 assert trial3.heartbeat is None, \


### PR DESCRIPTION
Why:

Database corruption occurs when there is Timeouts in PickledDB. The objective is saved but status is not set to completed.

How:

We catch non-completed trials with objective and log a warning with a pointer to documentation to manually fix corrupted trials.

Note:

Also add substantial documentation on storage which was required to document what the user can do to fix the database corruption.