### PR TITLE
Cite latest version of Oríon by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,8 +134,8 @@ If you use Oríon for published work, please cite our work using the following b
      year         = 2019,
      publisher    = {Zenodo},
      version      = {v0.1.7},
-     doi          = {10.5281/zenodo.3478593},
-     url          = {https://doi.org/10.5281/zenodo.3478593}
+     doi          = {10.5281/zenodo.3478592},
+     url          = {https://doi.org/10.5281/zenodo.3478592}
    }
 
 License


### PR DESCRIPTION
Why:
The current DOI (10.5281/zenodo.3478593) represent Oríon v0.1.7. When a new version will be released, this DOI will change and will need to be updated. Often, researchers do not want to cite a specific version but rather the software as a whole. The advantage is that there is only one way to reference the software instead of having one citation for each version which is tedious and undermines the referencing of Oríon and its discoverability among peers.

How:
Replace the references to the DOI for the current version with a DOI that represents all versions. [Learn more](https://help.zenodo.org/#versioning).