### PR TITLE
Changing the default branch to develop

### DIFF
--- a/docs/src/developer/installing.rst
+++ b/docs/src/developer/installing.rst
@@ -12,7 +12,7 @@ fork our repository_ first).
 
 .. code-block:: sh
 
-   $ git clone https://github.com/epistimio/orion.git --branch develop
+   $ git clone https://github.com/epistimio/orion.git
 
 .. tip::
 


### PR DESCRIPTION
Currently, _master_ is the default branch. It is not a problem per say except that developers need to switch branch when they make a PR.

However, switching to _develop_ would bring a lot of advantages and no drawbacks.
- New users arriving on the page will see an active project
- Nothing changes for users except that they now have to specify to clone on master when installing via Git. This installation method is not recommended (prefer using PyPI) and represent a small portion of installs from advanced users.
- Developers cloning the projects automatically work on the right branch (_develop_)

The only modification related to the project is to remove the specification to clone the develop branch for new developers.

When this PR is accepted, we can switch the default branch on the project's option on GitHub.