### PR TITLE
Documentation guidelines for internal links on the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Oríon
 Hi there 👋. Thank you for considering contributing to Oríon 🎉. We're excited to have you here!
 
-We present the guidelines for contributing to the project. They are not hard rules, use your best judgment, and feel free to propose changes to this document in a pull request. If you havn't already, it's a good idea to quickly pass through our [code of conduct](https://github.com/Epistimio/orion/blob/master/CODE_OF_CONDUCT.md) to ensure everyone has a good time.
+We present the guidelines for contributing to the project. They are not hard rules, use your best judgment, and feel free to propose changes to this document in a pull request. If you havn't already, it's a good idea to quickly pass through our [code of conduct](https://github.com/Epistimio/orion/blob/develop/CODE_OF_CONDUCT.md) to ensure everyone has a good time.
 
 ## Where do I go from here?
 If you have a question, found a bug or have a feature request, you're welcome to open a new issue at https://github.com/Epistimio/orion/issues. It's generally best if you get confirmation of your bug or approval for your feature request before starting to code.
@@ -20,7 +20,7 @@ Asking a question is also a contribution to the project! We'll be happy to help 
 ### How to report a bug
 You found a bug? Great! Before submitting, make sure you're experiencing the bug on the latest version of Oríon and that it's not already opened in our issue tracker.
 
-When reporting a bug, please include: 
+When reporting a bug, please include:
 - A clear and descriptive title for the issue
 - Your operating system and its version
 - The version of Oríon (even if you're using the latest!)
@@ -29,7 +29,7 @@ When reporting a bug, please include:
 - Extra details (e.g., database, algortihm, configuration) about your setup that might help us to reproduce the bug if not included previously
 
 ### How to propose enhancements
-We're thrilled to hear you found a way to make Oríon better through minor improvements to completely new features! 
+We're thrilled to hear you found a way to make Oríon better through minor improvements to completely new features!
 Before creating enhancement suggestions, please check that your idea is not already present in the list of issues. You might find that you don't need to create one and can just join in the discussion directly and give your opinion!
 
 When suggesting enhancements, it is a good idea to:
@@ -41,10 +41,10 @@ When suggesting enhancements, it is a good idea to:
 
 ### How to submit changes
 We're grateful you're considering making changes to Oríon!
- 
-To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes. 
 
-Once you implemented the changes, make sure to [rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) your branch on the latest Oríon's *develop* branch and finally submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). 
+To get started, you need to first fork the repository and then create a new branch on your fork where you'll do your changes.
+
+Once you implemented the changes, make sure to [rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) your branch on the latest Oríon's *develop* branch and finally submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
 All changes to Oríon are done through PRs, where they will be peer-reviewed and checked against our continuous integration system to ensure the quality of the code base.
 
 During this processs keep in mind to:

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,6 @@ Why Oríon?
 - Comprehensive `configuration <https://orion.readthedocs.io/en/latest/user/config.html>`_ system with smart defaults
 - Transparent persistence in local or remote `database <https://orion.readthedocs.io/en/stable/install/database.html>`_
 - `Integrate seamlessly <https://orion.readthedocs.io/en/stable/plugins/base.html>`_ your own hyper-optimization algorithms
-
 Installation
 ============
 
@@ -73,7 +72,7 @@ Install Oríon by running:
 
 For more information read the `full installation docs`_.
 
-.. _full installation docs: https://orion.readthedocs.io/en/latest/install/core.html
+.. _full installation docs: https://orion.readthedocs.io/en/stable/install/core.html
 
 Contribute or Ask
 =================

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Contribute or Ask
 
 Do you have a question or issues?
 Do you want to report a bug or suggest a feature? Name it!
-Please contact us by opening an issue in our repository below and checkout our `contribution guidelines <https://github.com/Epistimio/orion/blob/master/CONTRIBUTING.md>`_:
+Please contact us by opening an issue in our repository below and checkout our `contribution guidelines <https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md>`_:
 
 - Issue Tracker: `<https://github.com/epistimio/orion/issues>`_
 - Source Code: `<https://github.com/epistimio/orion>`_
@@ -91,7 +91,7 @@ Thanks for the support!
 Roadmap
 ========
 
-You can find our roadmap here: `<https://github.com/Epistimio/orion/blob/master/ROADMAP.md>`_
+Our current roadmap is available here: `<https://github.com/Epistimio/orion/blob/develop/ROADMAP.md>`_
 
 Citation
 ========

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,9 @@ Why Oríon?
 - Elegant and rich `search-space definitions <https://orion.readthedocs.io/en/stable/user/searchspace.html>`_
 - Comprehensive `configuration <https://orion.readthedocs.io/en/latest/user/config.html>`_ system with smart defaults
 - Transparent persistence in local or remote `database <https://orion.readthedocs.io/en/stable/install/database.html>`_
-- `Integrate seamlessly <https://orion.readthedocs.io/en/stable/plugins/base.html>`_ your own hyper-optimization algorithms
+- `Integrate seamlessly <https://orion.readthedocs.io/en/stable/plugins/base.html>`_ your own
+  hyper-optimization algorithms
+
 Installation
 ============
 

--- a/docs/src/developer/documenting.rst
+++ b/docs/src/developer/documenting.rst
@@ -4,10 +4,20 @@ Documenting
 The documentation is built using Sphinx_ with the `Read The Docs`_ theme.
 
 We try to write the documentation at only one place and reuse it as much as possible. For instance,
-the home page of this documentation (https://orion.readthedocs.io/en/latest/) is actually pulled
+the home page of this documentation (https://orion.readthedocs.io/) is actually pulled
 from the README.rst and appended with a table of content of the documentation generated
 automatically. The advantage of having a single source of truth is that it's vastly easier to find
 information and keep it up to date.
+
+Updating README.rst
+===================
+
+When you need to reference a page from the documentation on the README.rst, make sure to always
+point to the **stable** channel in readthedocs (https://orion.readthedocs.io/en/stable/).
+
+If you need to add a link to a specific page in the documentation that is not yet on the stable
+channel, make the link to the **latest** channel (https://orion.readthedocs.io/en/latest/). During
+the :doc:`release process </developer/release>` the link will be updated to the stable channel.
 
 Building documentation
 ======================

--- a/docs/src/developer/documenting.rst
+++ b/docs/src/developer/documenting.rst
@@ -5,7 +5,7 @@ The documentation is built using Sphinx_ with the `Read The Docs`_ theme.
 
 We try to write the documentation at only one place and reuse it as much as possible. For instance,
 the home page of this documentation (https://orion.readthedocs.io/en/latest/) is actually pulled
-from the README.md and appended with a table of content of the documentation generated
+from the README.rst and appended with a table of content of the documentation generated
 automatically. The advantage of having a single source of truth is that it's vastly easier to find
 information and keep it up to date.
 

--- a/docs/src/developer/release.rst
+++ b/docs/src/developer/release.rst
@@ -16,6 +16,8 @@ such as the README.rst.
    ``{version}`` is replaced by the number of the new version (e.g., ``1.2.0``). This effectively
    freezes the feature set for this new version, while allowing regular development to continue take
    place in the *develop* branch. More information is available in :ref:`standard-vcs`.
+#. In README.rst, replace any link pointing to ``https://orion.readthedocs.io/en/latest/**`` to
+   ``https://orion.readthedocs.io/en/stable/**``.
 #. Create a new pull request for the branch created in the last step and list all the changes by
    category. Example: https://github.com/Epistimio/orion/pull/283.
 #. Run the stress tests according to the instructions in stress test's documentation.

--- a/docs/src/developer/release.rst
+++ b/docs/src/developer/release.rst
@@ -10,7 +10,7 @@ Creating a release candidate
 The first step in releasing a new version is to create a release candidate. A release candidate
 allows us to thoroughly test the new version and iron out the remaining bugs. Additionally, it's
 also at this time that we make sure to change the version number and update related documentation
-such as the README.md.
+such as the README.rst.
 
 #. Create a new branch from the *develop* branch named ``release-{version}rc``, where
    ``{version}`` is replaced by the number of the new version (e.g., ``1.2.0``). This effectively
@@ -19,7 +19,7 @@ such as the README.md.
 #. Create a new pull request for the branch created in the last step and list all the changes by
    category. Example: https://github.com/Epistimio/orion/pull/283.
 #. Run the stress tests according to the instructions in stress test's documentation.
-#. Update the **Citation** section in the project's README.md with the latest version of Oríon.
+#. Update the **Citation** section in the project's README.rst with the latest version of Oríon.
 
 .. _release-make:
 


### PR DESCRIPTION
I updated the **latest** and **stable** channels in https://readthedocs.org/ to respectively build from the branch develop and master. When linking our Sphinx documentation to the README, we can encounter problems when making a release where the documentation pointing to latest is not updated to stable, sending visitors to 404 error pages.

This content of this  PR defines how such links are to be used on the README and how to migrate them during a release to integrate them to the legacy release documentation.