### PR TITLE
Show proper yaml syntax in resolve_config deprecation warnings containing None

### DIFF
--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -243,8 +243,8 @@ def fetch_config(args):
                 if backward_value is not None:
                     log.warning(
                         '(DEPRECATED) Option `%s` and will be removed in v0.3. '
-                        'Use instead the option' '\n%s:\n  %s: %s',
-                        subkey, key, subkey, repr(backward_value))
+                        'Use instead the option' '\n%s:\n  %s:\n    %s',
+                        subkey, key, subkey, yaml.dump(backward_value, indent=6))
                 value = tmp_config.get(key, {}).pop(subkey, backward_value)
                 if value is not None:
                     local_config.setdefault(key, {})


### PR DESCRIPTION
# Description
Fix #390

# Changes
Instead of printing the `repr()`, the suggested change is now passed through `yaml.dump()`

# Checklist
* [ ] does the chosen indentation fit all/most use cases?

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)