### PR TITLE
ASHA now also filters out trials with objective inf

### DIFF
--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -338,7 +338,7 @@ class Bracket():
         next_rung = self.rungs[rung_id + 1][1]
 
         rung = list(sorted((objective, point) for objective, point in rung.values()
-                           if objective is not None))
+                           if objective not in (None, float('inf'))))
         k = len(rung) // self.reduction_factor
         k = min(k, len(rung))
 


### PR DESCRIPTION
Fixes #395

# Description of Changes
ASHA now also filters out trials with objective inf. The code before only filtered trials with objective `None`. During debugging if found that running trials had objective value `inf` not `None`.

# Checklist
* [ ] Make sure that this is not just treating symptoms, i.e. that the objective being set to `inf` instead of `None` for running trials is not a bug itself.

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/) (not sure)
- [ ] My code follows the style guidelines (`$ tox -e lint`) (not sure)