### PR TITLE
Add doc about label categories

### DIFF
--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -98,55 +98,88 @@ Topic
 
 Specifies an area in the software or meta concerns.
 
-* ``documentation``
-* ``tests``
+* |documentation|_
+* |tests|_
+
+.. |documentation| replace:: ``documentation``
+.. |tests| replace:: ``tests``
+.. _documentation: https://github.com/Epistimio/orion/labels/documentation
+.. _tests: https://github.com/Epistimio/orion/labels/tests
 
 Addition
 --------
 
 Specifies a new feature.
 
-* ``feature``
+* |feature|_
+
+.. |feature| replace:: ``feature``
+.. _feature: https://github.com/Epistimio/orion/labels/feature
 
 Improvement
 -----------
 
 Improves a feature or non-functional aspects (e.g., optimization, prettify, technical debt)
 
-* ``enhancement``
+* |enhancement|_
+
+.. |enhancement| replace:: ``enhancement``
+.. _enhancement: https://github.com/Epistimio/orion/labels/enhancement
 
 Problems
 --------
 
 Indicates an unexpected problem or unintended behavior
 
-* ``bug``
+* |bug|_
+
+.. |bug| replace:: ``bug``
+.. _bug: https://github.com/Epistimio/orion/labels/bug
 
 Status
 ------
 
 Status of the issue or Priority
 
-* ``blocked``
-* ``in progress``
-* ``in review``
+* |blocked|_
+* |in progress|_
+* |in review|_
+
+.. |blocked| replace:: ``blocked``
+.. _blocked: https://github.com/Epistimio/orion/labels/blocked
+.. |in progress| replace:: ``in progress``
+.. _in progress: https://github.com/Epistimio/orion/labels/in%20progress
+.. |in review| replace:: ``in review``
+.. _in review: https://github.com/Epistimio/orion/labels/in%20review
 
 Discussion
 ----------
 
 Questions or feedback about the project
 
-* ``user question``
-* ``dev question``
-* ``feedback``
+* |user question|_
+* |dev question|_
+* |feedback|_
+
+.. |user question| replace:: ``user question``
+.. _user question: https://github.com/Epistimio/orion/labels/user%20question
+.. |dev question| replace:: ``dev question``
+.. _dev question: https://github.com/Epistimio/orion/labels/dev%20question
+.. |feedback| replace:: ``feedback``
+.. _feedback: https://github.com/Epistimio/orion/labels/feedback
 
 Community
 ---------
 
 Related to the community, calls to application
 
-* ``help wanted``
-* ``good first issue``
+* |help wanted|_
+* |good first issue|_
+
+.. |help wanted| replace:: ``help wanted``
+.. _help wanted: https://github.com/Epistimio/orion/labels/help%20wanted
+.. |good first issue| replace:: ``good first issue``
+.. _good first issue: https://github.com/Epistimio/orion/labels/good%20first%20issue
 
 Priority
 --------
@@ -155,20 +188,38 @@ Qualifies priority bugs and features.
 This category enables the maintainers to identify which issues should be done in priority.
 Each label has a different shade based on the priority.
 
-* ``critical``
-* ``high``
-* ``medium``
-* ``low``
+* |critical|_
+* |high|_
+* |medium|_
+* |low|_
+
+.. |critical| replace:: ``critical``
+.. _critical: https://github.com/Epistimio/orion/labels/critical
+.. |high| replace:: ``high``
+.. _high: https://github.com/Epistimio/orion/labels/high
+.. |medium| replace:: ``medium``
+.. _medium: https://github.com/Epistimio/orion/labels/medium
+.. |low| replace:: ``low``
+.. _low: https://github.com/Epistimio/orion/labels/low
 
 Inactive
 --------
 
 No action needed or possible. The issue is either fixed, addressed
 
-* ``on hold``
-* ``wont fix``
-* ``duplicate``
-* ``invalid``
+* |on hold|_
+* |wont fix|_
+* |duplicate|_
+* |invalid|_
+
+.. |on hold| replace:: ``on hold``
+.. _on hold: https://github.com/Epistimio/orion/labels/on%20hold
+.. |wont fix| replace:: ``wont fix``
+.. _wont fix: https://github.com/Epistimio/orion/labels/wont%20fix
+.. |duplicate| replace:: ``duplicate``
+.. _duplicate: https://github.com/Epistimio/orion/labels/duplicate
+.. |invalid| replace:: ``invalid``
+.. _invalid: https://github.com/Epistimio/orion/labels/invalid
 
 .. _Github: https://github.com
 .. _flake8: http://flake8.pycqa.org/en/latest/

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -85,6 +85,28 @@ Versioning standard
 We follow the `semantic versioning <https://semver.org/>`_ convention to name the versions of Oríon.
 While in beta, we prepend a ``0`` on the left of the major version.
 
+GitHub labels
+=============
+
+The labels are divided in a few categories. The objective is to have precise labels while staying lean.
+Each category is identified with a color. Bold colors should be used for tags that should be easily findable when looking at the issues.
+
+===========  ===========================================================================================  ==================================================
+Category     Description                                                                                  Labels
+===========  ===========================================================================================  ==================================================
+Topic        Specify an area in the software or meta concerns.                                            ``documentation`` ``tests``
+Addition     New feature                                                                                  ``feature``
+Improvement  Improves a feature or non-functional aspects (e.g., optimization, prettify, technical debt)  ``enhancement``
+problems     Indicates an unexpected problem or unintended behavior                                       ``bug``
+Status       Status of the issue or PR                                                                    ``blocked`` ``in progress`` ``in review``
+Discussion   Questions or feedback about the project                                                      ``user question`` ``dev question`` ``feedback``
+Community    Related to the community, calls to action                                                    ``help wanted`` ``good first issue``
+Priority     Qualifies priority bugs and features                                                         ``critical`` ``high`` ``medium`` ``low``
+Inactive     No action needed or possible. The issue is either fixed, addressed                           ``on hold`` ``wont fix`` ``duplicate`` ``invalid``
+===========  ===========================================================================================  ==================================================
+
+The priority category enables the maintainers to identify which issues should be done in priority. Each label has a different shade based on the priority.
+
 .. _Github: https://github.com
 .. _flake8: http://flake8.pycqa.org/en/latest/
 .. _doc8: https://pypi.org/project/doc8/

--- a/docs/src/developer/standards.rst
+++ b/docs/src/developer/standards.rst
@@ -88,24 +88,87 @@ While in beta, we prepend a ``0`` on the left of the major version.
 GitHub labels
 =============
 
-The labels are divided in a few categories. The objective is to have precise labels while staying lean.
-Each category is identified with a color. Bold colors should be used for tags that should be easily findable when looking at the issues.
+The labels are divided in a few categories.
+The objective is to have precise labels while staying lean.
+Each category is identified with a color.
+Bold colors should be used for tags that should be easily findable when looking at the issues.
 
-===========  ===========================================================================================  ==================================================
-Category     Description                                                                                  Labels
-===========  ===========================================================================================  ==================================================
-Topic        Specify an area in the software or meta concerns.                                            ``documentation`` ``tests``
-Addition     New feature                                                                                  ``feature``
-Improvement  Improves a feature or non-functional aspects (e.g., optimization, prettify, technical debt)  ``enhancement``
-problems     Indicates an unexpected problem or unintended behavior                                       ``bug``
-Status       Status of the issue or PR                                                                    ``blocked`` ``in progress`` ``in review``
-Discussion   Questions or feedback about the project                                                      ``user question`` ``dev question`` ``feedback``
-Community    Related to the community, calls to action                                                    ``help wanted`` ``good first issue``
-Priority     Qualifies priority bugs and features                                                         ``critical`` ``high`` ``medium`` ``low``
-Inactive     No action needed or possible. The issue is either fixed, addressed                           ``on hold`` ``wont fix`` ``duplicate`` ``invalid``
-===========  ===========================================================================================  ==================================================
+Topic
+-----
 
-The priority category enables the maintainers to identify which issues should be done in priority. Each label has a different shade based on the priority.
+Specifies an area in the software or meta concerns.
+
+* ``documentation``
+* ``tests``
+
+Addition
+--------
+
+Specifies a new feature.
+
+* ``feature``
+
+Improvement
+-----------
+
+Improves a feature or non-functional aspects (e.g., optimization, prettify, technical debt)
+
+* ``enhancement``
+
+Problems
+--------
+
+Indicates an unexpected problem or unintended behavior
+
+* ``bug``
+
+Status
+------
+
+Status of the issue or Priority
+
+* ``blocked``
+* ``in progress``
+* ``in review``
+
+Discussion
+----------
+
+Questions or feedback about the project
+
+* ``user question``
+* ``dev question``
+* ``feedback``
+
+Community
+---------
+
+Related to the community, calls to application
+
+* ``help wanted``
+* ``good first issue``
+
+Priority
+--------
+
+Qualifies priority bugs and features.
+This category enables the maintainers to identify which issues should be done in priority.
+Each label has a different shade based on the priority.
+
+* ``critical``
+* ``high``
+* ``medium``
+* ``low``
+
+Inactive
+--------
+
+No action needed or possible. The issue is either fixed, addressed
+
+* ``on hold``
+* ``wont fix``
+* ``duplicate``
+* ``invalid``
 
 .. _Github: https://github.com
 .. _flake8: http://flake8.pycqa.org/en/latest/


### PR DESCRIPTION
# Description
Add the documentation describing the label categories and convention we use on Github.

# Changes
Existing labels are formally grouped in a handful of extensible categories. *Priority* and *Status* categories are introduced.

# Checklist
## Tests
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)