### PR TITLE
Update TOX configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,43 @@
+[flake8]
+count = True
+show-source = True
+doctests = True
+
+ignore =
+    # Missing docstring in __init__
+    D107
+    # blank-line after doc summaries (annoying for modules' doc)
+    D205
+    # conflicts with D211: No blank lines allowed before class docstring
+    D203
+    # do not enforce first-line-period at module docs
+    D400
+    # conflicts with E133: closing bracket is missing indentation
+    E123
+
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    docs,
+    config,
+    build,
+    dist,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs,
+    src/orion/core/_version.py,
+    src/orion/core/utils/_appdirs.py
+
+# Line length
+max-line-length = 100
+
+# McCabe complexity checker
+max-complexity = 20
+
+# flake8-import-order: style
+import-order-style = google
+
+# flake8-import-order: local module name checker
+application-import-names = orion, versioneer

--- a/.flake8
+++ b/.flake8
@@ -6,14 +6,30 @@ doctests = True
 ignore =
     # Missing docstring in __init__
     D107
+
     # blank-line after doc summaries (annoying for modules' doc)
     D205
+
     # conflicts with D211: No blank lines allowed before class docstring
     D203
+
     # do not enforce first-line-period at module docs
     D400
+
     # conflicts with E133: closing bracket is missing indentation
     E123
+
+    # Line break after binary operator
+    W504
+
+    # Invalid escape sequence
+    W605
+
+    # Local variable never used
+    F841
+
+    # Use of == / != to compare constant literals
+    F632
 
 exclude =
     .tox,

--- a/.flake8
+++ b/.flake8
@@ -31,6 +31,18 @@ ignore =
     # Use of == / != to compare constant literals
     F632
 
+    # First line should be imperative mood
+    D401
+
+    # Do not perform function calls in argument defaults.
+    B008
+
+    # Do not call getattr with a constant attribute value, it is not any safer than normal property access
+    B009
+
+    # Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
+    B011
+
 exclude =
     .tox,
     .git,

--- a/.pylintrc
+++ b/.pylintrc
@@ -51,7 +51,8 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=abstract-class-instantiated,useless-super-delegation,no-member,keyword-arg-before-vararg,unidiomatic-typecheck,redefined-outer-name,fixme,F0401,intern-builtin,wrong-import-position,wrong-import-order
+disable=abstract-class-instantiated,useless-super-delegation,no-member,keyword-arg-before-vararg,unidiomatic-typecheck,redefined-outer-name,fixme,F0401,intern-builtin,wrong-import-position,wrong-import-order,
+        C0415, F0010, R0205, R1705, R1711, R1720, W0106, W0107, W0127, W0706
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ exclude .travis.yml
 exclude tox.ini
 exclude *-requirements.txt
 exclude .pylintrc
+exclude .flake8
 exclude codecov.yml
 exclude .mailmap
 prune conda/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,2 @@
+# The only dev package necessary is `tox` in order to run the different environments used for testing, linting and releasing.
 tox
-flake8 == 3.5.0
-flake8-import-order == 0.15
-flake8-docstrings == 1.1.0
-flake8-bugbear == 17.4.0
-pylint == 1.8.1
-doc8 == 0.8.0
-check-manifest
-readme_renderer

--- a/docs/src/developer/release.rst
+++ b/docs/src/developer/release.rst
@@ -20,8 +20,10 @@ such as the README.rst.
    ``https://orion.readthedocs.io/en/stable/**``.
 #. Create a new pull request for the branch created in the last step and list all the changes by
    category. Example: https://github.com/Epistimio/orion/pull/283.
-#. Run the stress tests according to the instructions in stress test's documentation.
 #. Update the **Citation** section in the project's README.rst with the latest version of Oríon.
+#. Update the linters ``flake8``, ``pylint``, and ``doc8`` to their latest versions in ``tox.ini``,
+   and address any new error.
+#. Run the stress tests according to the instructions in stress test's documentation.
 
 .. _release-make:
 

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ basepython = python3
 skip_install = true
 deps =
     -rdocs/requirements.txt
-    doc8 == 0.8.0
+    doc8 == 0.8.*
 commands =
     doc8 docs/src/
 

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands = codecov --required
 # Linting & Verification environments
 [testenv:lint]
 description = Lint code and docs against some standard standards
-basepython = python3.6
+basepython = python3
 skip_install = false
 deps =
     {[testenv:flake8]deps}
@@ -90,7 +90,7 @@ commands =
 
 [testenv:flake8] # Will use the configuration file `.flake8` automatically
 description = Use flake8 linter to impose standards on the project
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
     pydocstyle == 3.0.0
@@ -103,7 +103,7 @@ commands =
 
 [testenv:pylint] # Will use the configuration file `.pylintrc` automatically
 description = Perform static analysis and output code metrics
-basepython = python3.6
+basepython = python3
 skip_install = false
 deps =
     pylint == 1.8.1
@@ -112,7 +112,7 @@ commands =
 
 [testenv:doc8]
 description = Impose standards on *.rst documentation files
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
     -rdocs/requirements.txt
@@ -122,7 +122,7 @@ commands =
 
 [testenv:packaging]
 description = Check whether README.rst is reST and missing from MANIFEST.in
-basepython = python3.6
+basepython = python3
 deps =
     check-manifest
     readme_renderer
@@ -144,7 +144,7 @@ commands =
 # Documentation environments
 [testenv:docs]
 description = Invoke sphinx to build documentation and API reference
-basepython = python3.6
+basepython = python3
 deps =
     -rdocs/requirements.txt
 commands =
@@ -153,7 +153,7 @@ commands =
 
 [testenv:serve-docs]
 description = Host the documentation of the project and API reference in localhost
-basepython = python3.6
+basepython = python3
 skip_install = true
 changedir = docs/build/html
 deps =
@@ -162,7 +162,7 @@ commands =
 
 # Release environments (to be removed in favor of CI with CD)
 [testenv:build]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
     wheel
@@ -171,7 +171,7 @@ commands =
     python setup.py -q sdist bdist_wheel
 
 [testenv:release]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
     {[testenv:build]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -2,29 +2,9 @@
 envlist = py36,py37,py38,flake8,pylint,doc8,packaging,docs
 minversion = 2.7.0
 
-## Configure test + coverage process
-
-[pytest]
-addopts = -ra -q --color=yes
-norecursedirs = .* *.egg* config docs dist build
-xfail_strict = True
-rsyncdirs = src tests
-looponfailroots = src tests examples
-
-[coverage:run]
-branch = True
-source =
-    src
-    tests
-omit = **/_[a-zA-Z0-9]*.py
-
-[coverage:report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    # Don't complain if tests don't hit defensive assertion code:
-    pass
-    raise AssertionError
-    raise NotImplementedError
+#########################################################
+# Tox environments
+#########################################################
 
 [testenv]
 description = Run tests with coverage with pytest under current Python env
@@ -71,6 +51,7 @@ commands =
     coverage combine
     coverage report -m
 
+# Coverage environments
 [testenv:final-coverage]
 description = Combine coverage data across environments (run after tests)
 skip_install = True
@@ -91,23 +72,23 @@ passenv = {[testenv]passenv}
 deps = codecov
 commands = codecov --required
 
-## Setup development process
-
-[testenv:devel]
-description = Incremental devel env command, defaults to running tests
+# Linting & Verification environments
+[testenv:lint]
+description = Lint code and docs against some standard standards
+basepython = python3.6
+skip_install = false
 deps =
-    -rtests/requirements.txt
-    -rexamples/scikitlearn-iris/requirements.txt
-usedevelop = True
+    {[testenv:flake8]deps}
+    {[testenv:pylint]deps}
+    {[testenv:doc8]deps}
+    {[testenv:packaging]deps}
 commands =
-    pip install -U {toxinidir}/tests/functional/gradient_descent_algo
-    python setup.py test --addopts '-vvv --exitfirst --looponfail {posargs}'
+    {[testenv:flake8]commands}
+    {[testenv:pylint]commands}
+    {[testenv:doc8]commands}
+    {[testenv:packaging]commands}
 
-## Configure linters
-
-[testenv:flake8]
-# Will use the configuration file `.flake8` automatically
-
+[testenv:flake8] # Will use the configuration file `.flake8` automatically
 description = Use flake8 linter to impose standards on the project
 basepython = python3.6
 skip_install = true
@@ -120,9 +101,7 @@ deps =
 commands =
     flake8 docs/ src/orion/ tests/ setup.py
 
-[testenv:pylint]
-# Will use the configuration file `.pylintrc` automatically
-
+[testenv:pylint] # Will use the configuration file `.pylintrc` automatically
 description = Perform static analysis and output code metrics
 basepython = python3.6
 skip_install = false
@@ -130,10 +109,6 @@ deps =
     pylint == 1.8.1
 commands =
     pylint src/orion/core src/orion/client src/orion/algo
-
-[doc8]
-max-line-length = 100
-file-encoding = utf-8
 
 [testenv:doc8]
 description = Impose standards on *.rst documentation files
@@ -155,23 +130,18 @@ commands =
     check-manifest
     python setup.py check -r -s
 
-[testenv:lint]
-description = Lint code and docs against some standard standards
-basepython = python3.6
-skip_install = false
+## Development environments
+[testenv:devel]
+description = Incremental devel env command, defaults to running tests
 deps =
-    {[testenv:flake8]deps}
-    {[testenv:pylint]deps}
-    {[testenv:doc8]deps}
-    {[testenv:packaging]deps}
+    -rtests/requirements.txt
+    -rexamples/scikitlearn-iris/requirements.txt
+usedevelop = True
 commands =
-    {[testenv:flake8]commands}
-    {[testenv:pylint]commands}
-    {[testenv:doc8]commands}
-    {[testenv:packaging]commands}
+    pip install -U {toxinidir}/tests/functional/gradient_descent_algo
+    python setup.py test --addopts '-vvv --exitfirst --looponfail {posargs}'
 
-## Documentation macros
-
+# Documentation environments
 [testenv:docs]
 description = Invoke sphinx to build documentation and API reference
 basepython = python3.6
@@ -182,7 +152,7 @@ commands =
 # sphinx-build -W --color -c docs/src/ -b man docs/src/ docs/build/man
 
 [testenv:serve-docs]
-description = Host project's documentation and API reference in localhost
+description = Host the documentation of the project and API reference in localhost
 basepython = python3.6
 skip_install = true
 changedir = docs/build/html
@@ -190,8 +160,7 @@ deps =
 commands =
     python -m http.server 8000 --bind 127.0.0.1
 
-## Release tooling (to be removed in favor of CI with CD)
-
+# Release environments (to be removed in favor of CI with CD)
 [testenv:build]
 basepython = python3.6
 skip_install = true
@@ -210,3 +179,35 @@ deps =
 commands =
     {[testenv:build]commands}
     twine upload --skip-existing dist/*
+
+#########################################################
+# Packages & Tools configuration
+#########################################################
+
+# Pytest configuration
+[pytest]
+addopts = -ra -q --color=yes
+norecursedirs = .* *.egg* config docs dist build
+xfail_strict = True
+rsyncdirs = src tests
+looponfailroots = src tests examples
+
+# Coverage configuration
+[coverage:run]
+branch = True
+source =
+    src
+    tests
+omit = **/_[a-zA-Z0-9]*.py
+
+[coverage:report]
+exclude_lines =
+    # Don't complain if tests don't hit defensive assertion code:
+    pass
+    raise AssertionError
+    raise NotImplementedError
+
+# Doc8 configuration
+[doc8]
+max-line-length = 100
+file-encoding = utf-8

--- a/tox.ini
+++ b/tox.ini
@@ -106,6 +106,8 @@ commands =
 ## Configure linters
 
 [testenv:flake8]
+# Will use the configuration file `.flake8` automatically
+
 description = Use flake8 linter to impose standards on the project
 basepython = python3.6
 skip_install = true
@@ -119,6 +121,8 @@ commands =
     flake8 docs/ src/orion/ tests/ setup.py
 
 [testenv:pylint]
+# Will use the configuration file `.pylintrc` automatically
+
 description = Perform static analysis and output code metrics
 basepython = python3.6
 skip_install = false

--- a/tox.ini
+++ b/tox.ini
@@ -105,44 +105,6 @@ commands =
 
 ## Configure linters
 
-[flake8]
-count = True
-show-source = True
-doctests = True
-# select = E, F, W, C90, I, D, B, B902
-ignore =
-    # Missing docstring in __init__
-    D107
-    # blank-line after doc summaries (annoying for modules' doc)
-    D205
-    # conflicts with D211: No blank lines allowed before class docstring
-    D203
-    # do not enforce first-line-period at module docs
-    D400
-    # conflicts with E133: closing bracket is missing indentation
-    E123
-exclude =
-    .tox,
-    .git,
-    __pycache__,
-    docs,
-    config,
-    build,
-    dist,
-    *.pyc,
-    *.egg-info,
-    .cache,
-    .eggs,
-    src/orion/core/_version.py,
-    src/orion/core/utils/_appdirs.py
-max-line-length = 100
-# McCabe complexity checker
-max-complexity = 20
-# flake8-import-order: style
-import-order-style = google
-# flake8-import-order: local module name checker
-application-import-names = orion, versioneer
-
 [testenv:flake8]
 description = Use flake8 linter to impose standards on the project
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ basepython = python3
 skip_install = true
 deps =
     pydocstyle == 3.0.0
-    flake8 == 3.5.0
+    flake8 == 3.8.*
     flake8-import-order == 0.15
     flake8-docstrings == 1.1.0
     flake8-bugbear == 17.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -93,11 +93,10 @@ description = Use flake8 linter to impose standards on the project
 basepython = python3
 skip_install = true
 deps =
-    pydocstyle == 3.0.0
     flake8 == 3.8.*
-    flake8-import-order == 0.15
-    flake8-docstrings == 1.1.0
-    flake8-bugbear == 17.4.0
+    flake8-import-order == 0.18.*
+    flake8-docstrings == 1.5.*
+    flake8-bugbear == 20.1.*
 commands =
     flake8 docs/ src/orion/ tests/ setup.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ description = Perform static analysis and output code metrics
 basepython = python3
 skip_install = false
 deps =
-    pylint == 1.8.1
+    pylint == 2.5.*
 commands =
     pylint src/orion/core src/orion/client src/orion/algo
 


### PR DESCRIPTION
# Description
These changes are refreshing `tox.ini` to increase the maintainability of the project and the good practices, and updating the linting packages.

# Changes
- `tox.ini` is now sorted by environment first. The misc package configs are moved at the end.
- The `flake8` configuration is moved to a standalone `.flake8` file  to improve linting compatibility with IDEs, and unclutter `tox.ini`.
- `dev-requirement.txt` now contains only the package `tox`. Since it's the only package required for developing. The other dependencies were duplicates of the environments dependencies specified in `tox.ini`.
- Versions for linters `pylint`, `flake8`, and `doc8` have been updated to their latest version*.
- New rules introduced by the update to the linters have been **disabled for now** **.
- Relaxed `basepython` property in `tox.ini` from `python3.6` to `python3` since the CI already specifies which minor python version to use.

# Checklist
## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
## * Linter version
We specify the major and minor version for the linter so our build system do not break the whole codebase when a linter adds a rule.

## ** Ignored new linting rules
The following rules are ignored for now; we have to schedule a maintenance task to fix them before accepting this PR.

 **Each rule was triggered at least once in the current code base.**

### flake8
- W504 (Line break after binary operator)
- W605 (Invalid escape sequence)
- F841 (Local variable never used)
- F632 (Use of == / != to compare constant literals)
- D401 (First line should be imperative mood)
- B008 (Do not perform function calls in argument defaults.)
- B009 (Do not call getattr with a constant attribute value, it is not any safer than normal property access)
- B011 (Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().)

### pylint
- C0415 (Used when an import statement is used anywhere other than the module top-level.)
- F0010 (Used when a `__init__.py` module file is missing.)
- R0205 (Used when a class inherit from object, which under python3 is implicit)
- R1705 (Used in order to highlight an unnecessary block of code following an if containing a return statement)
- R1711 (Emitted when a single "return" or "return None" statement is found at the end of function or method definition)
- R1720 (Used in order to highlight an unnecessary block of code following an if containing a raise statement)
- W0106 (Used when an expression that is not a function call is assigned to nothing)
- W0107 (Used when a "pass" statement that can be avoided is encountered.)
- W0127 (Emitted when we detect that a variable is assigned to itself)
- W0706 (Used when an except handler uses raise as its first or only operator. This is useless because it raises back the exception immediately)