### PR TITLE
Validate provided status before updating trial

### DIFF
--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -18,6 +18,13 @@ from orion.core.utils.flatten import unflatten
 log = logging.getLogger(__name__)
 
 
+def validate_status(status):
+    """Verify if given status is valid."""
+    if status is not None and status not in Trial.allowed_stati:
+        raise ValueError("Given status `{0}` not one of: {1}".format(
+            status, Trial.allowed_stati))
+
+
 class Trial:
     """Represents an entry in database/trials collection.
 
@@ -258,9 +265,7 @@ class Trial:
 
     @status.setter
     def status(self, status):
-        if status is not None and status not in self.allowed_stati:
-            raise ValueError("Given status, {0}, not one of: {1}".format(
-                status, self.allowed_stati))
+        validate_status(status)
         self._status = status
 
     @property

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -19,6 +19,7 @@ import warnings
 
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.flatten import flatten, unflatten
+from orion.core.worker.trial import Trial as OrionTrial, validate_status
 from orion.storage.base import BaseStorageProtocol, FailedUpdate, MissingArguments
 
 log = logging.getLogger(__name__)
@@ -168,8 +169,6 @@ class TrialAdapter:
     @property
     def _params(self):
         """See `~orion.core.worker.trial.Trial`"""
-        from orion.core.worker.trial import Trial as OrionTrial
-
         if self.memory is not None:
             return self.memory._params
 
@@ -224,8 +223,6 @@ class TrialAdapter:
     @property
     def objective(self):
         """See `~orion.core.worker.trial.Trial`"""
-        from orion.core.worker.trial import Trial as OrionTrial
-
         def result(val):
             return OrionTrial.Result(name=self.objective_key, value=val, type='objective')
 
@@ -256,8 +253,6 @@ class TrialAdapter:
     @property
     def results(self):
         """See `~orion.core.worker.trial.Trial`"""
-        from orion.core.worker.trial import Trial as OrionTrial
-
         self._results = []
 
         for k, values in self.storage.metrics.items():
@@ -279,7 +274,6 @@ class TrialAdapter:
     @property
     def hash_params(self):
         """See `~orion.core.worker.trial.Trial`"""
-        from orion.core.worker.trial import Trial as OrionTrial
         return OrionTrial.compute_trial_hash(self, ignore_fidelity=True)
 
     @results.setter
@@ -621,6 +615,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
             does not match the status in the database
 
         """
+        validate_status(status)
         try:
             result_trial = self.backend.fetch_and_update_trial({
                 'uid': trial.id,

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -384,6 +384,16 @@ class TestRelease:
             assert trial.id not in client._pacemakers
             assert not pacemaker.is_alive()
 
+    def test_release_invalid_status(self):
+        """Test releasing with a specific status"""
+        with create_experiment() as (cfg, experiment, client):
+            trial = experiment.get_trial(uid=cfg.trials[1]['_id'])
+            client.reserve(trial)
+            with pytest.raises(ValueError) as exc:
+                client.release(trial, 'mouf mouf')
+
+            assert exc.match('Given status `mouf mouf` not one of')
+
     def test_release_dont_exist(self, monkeypatch):
         """Verify that unregistered trials cannot be released"""
         with create_experiment() as (cfg, experiment, client):

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -440,6 +440,19 @@ class TestStorage:
         check_status_change('suspended')
         check_status_change('new')
 
+    def test_change_status_invalid(self, storage):
+        """Attempt to change the status of a Trial with an invalid one"""
+        with OrionState(
+                experiments=[base_experiment],
+                trials=generate_trials(), storage=storage) as cfg:
+            trial = get_storage().get_trial(cfg.get_trial(0))
+            assert trial is not None, 'Was not able to retrieve trial for test'
+
+            with pytest.raises(ValueError) as exc:
+                get_storage().set_trial_status(trial, status='moo')
+
+            assert exc.match('Given status `moo` not one of')
+
     def test_change_status_failed_update(self, storage):
         """Change the status of a Trial"""
         def check_status_change(new_status):


### PR DESCRIPTION
# Description

With the user interface it is possible that users try to set trials with
invalid status. We should verify the validity of the status before
potentially corrupting the database.

# Changes

Add validity checks in storage.set_trial_status to make sure status is valid.

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)