### PR TITLE
Catch keyboard interrupt in Python API

### DIFF
--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -11,6 +11,7 @@
 import atexit
 import functools
 import logging
+import sys
 
 from numpy import inf as infinity
 
@@ -29,12 +30,17 @@ log = logging.getLogger(__name__)
 
 def set_broken_trials(client):
     """Release all trials with status broken if the process exits without releasing them."""
+    if sys.exc_info()[0] is KeyboardInterrupt:
+        status = 'interrupted'
+    else:
+        status = 'broken'
+
     for trial_id in list(client._pacemakers.keys()):  # pylint: disable=protected-access
         trial = client.get_trial(uid=trial_id)
         if trial is None:
             log.warning('Trial {} was not found in storage, could not set status to `broken`.')
             continue
-        client.release(trial, status='broken')
+        client.release(trial, status=status)
 
 
 # pylint: disable=too-many-public-methods

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -549,6 +549,20 @@ class TestBroken:
                 assert client1.get_trial(trial1).status == 'broken'
                 assert client2.get_trial(trial2).status == 'interrupted'
 
+    def test_interrupted_trial(self):
+        """Test that interrupted trials are not set to broken"""
+        with create_experiment() as (cfg, experiment, client):
+            trial = client.suggest()
+            assert trial.status == 'reserved'
+
+            try:
+                raise KeyboardInterrupt
+            except KeyboardInterrupt as e:
+                atexit._run_exitfuncs()
+
+            assert client._pacemakers == {}
+            assert client.get_trial(trial).status == 'interrupted'
+
 
 class TestSuggest:
     """Tests for ExperimentClient.suggest"""


### PR DESCRIPTION
# Description

Exceptions during python execution leads to end of program, executing
`atexit` which marks reserved trials as broken. The special case of
KeyboardInterruption however should be handled differently, with the
trials set to interrupted instead.

# Changes

During `atexit` execution, the `sys.exc_info()` is looked up to decide
whether the trials should be set at `interrupted` or `broken`.

# Checklist
## Tests
- [ x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x ] I have updated the relevant documentation related to my changes

## Quality
- [x ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x ] My code follows the style guidelines (`$ tox -e lint`)