### PR TITLE
Round ASHA budget properly

### DIFF
--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -43,7 +43,8 @@ def compute_budgets(min_resources, max_resources, reduction_factor, num_rungs):
     budgets = numpy.logspace(
         numpy.log(min_resources) / numpy.log(reduction_factor),
         numpy.log(max_resources) / numpy.log(reduction_factor),
-        num_rungs, base=reduction_factor).astype(int)
+        num_rungs, base=reduction_factor)
+    budgets = (budgets + 0.5).astype(int)
 
     for i in range(num_rungs - 1):
         if budgets[i] >= budgets[i + 1]:

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -27,7 +27,7 @@ Params: {params}
 """
 
 SPACE_ERROR = """
-ASHA cannot be used if space does contain a fidelity dimension.
+ASHA can only be used if there is one fidelity dimension.
 For more information on the configuration and usage of ASHA, see
 https://orion.readthedocs.io/en/develop/user/algorithms.html#asha
 """

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -72,6 +72,8 @@ def test_compute_budgets():
     assert compute_budgets(1, 16, 4, 3) == [1, 4, 16]
     # Check rounding (max_resources is not a multiple of reduction_factor)
     assert compute_budgets(1, 30, 4, 3) == [1, 5, 30]
+    # Check rounding (min_resources may be rounded below its actual value)
+    assert compute_budgets(25, 1000, 2, 6) == [25, 52, 109, 229, 478, 1000]
     # Check min_resources
     assert compute_budgets(5, 125, 5, 3) == [5, 25, 125]
     # Check num_rungs
@@ -82,7 +84,7 @@ def test_compute_compressed_budgets():
     """Verify proper computation of budgets when scale is small and integer rounding creates
     duplicates
     """
-    assert compute_budgets(1, 16, 2, 10) == [1, 2, 3, 4, 5, 6, 7, 8, 11, 16]
+    assert compute_budgets(1, 16, 2, 10) == [1, 2, 3, 4, 5, 6, 7, 9, 12, 16]
 
     with pytest.raises(ValueError) as exc:
         compute_budgets(1, 2, 2, 10)


### PR DESCRIPTION
# Description

It was currently rounded taking the floor value. This lead to budgets
which were below the actual fidelity dimension.

# Further comments

Fixed #393 & #392 