### PR TITLE
Promote Oríon's agnosticity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Why Oríon?
 - Transparent persistence in local or remote `database <https://orion.readthedocs.io/en/stable/install/database.html>`_
 - `Integrate seamlessly <https://orion.readthedocs.io/en/stable/plugins/base.html>`_ your own
   hyper-optimization algorithms
-- Language and configuration file agnostic
+- Language and `configuration file <https://orion.readthedocs.io/en/latest/user/searchspace.html#configuration-file>`_ agnostic
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,8 @@ Why Oríon?
 - Transparent persistence in local or remote `database <https://orion.readthedocs.io/en/stable/install/database.html>`_
 - `Integrate seamlessly <https://orion.readthedocs.io/en/stable/plugins/base.html>`_ your own
   hyper-optimization algorithms
-- Language and `configuration file <https://orion.readthedocs.io/en/latest/user/searchspace.html#configuration-file>`_ agnostic
+- `Language <https://orion.readthedocs.io/en/latest/user/script.html#language-compatibility>`_
+  and `configuration file <https://orion.readthedocs.io/en/latest/user/searchspace.html#configuration-file>`_ agnostic
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Why Oríon?
 - Transparent persistence in local or remote `database <https://orion.readthedocs.io/en/stable/install/database.html>`_
 - `Integrate seamlessly <https://orion.readthedocs.io/en/stable/plugins/base.html>`_ your own
   hyper-optimization algorithms
+- Language and configuration file agnostic
 
 Installation
 ============

--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -54,6 +54,8 @@ the local one passed to
 created. To access the particular working directory of a trial, see next sections
 :ref:`commandline_templates` and :ref:`env_vars`.
 
+.. _language_compatibility:
+
 Language compatibility
 ======================
 The command line works for scripts and programs in any language.

--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -61,6 +61,21 @@ Language compatibility
 The command line works for scripts and programs in any language.
 The only requirement is that the executed script returns a JSON string with the objective value.
 
+The format is
+
+.. code-block:: json
+
+   [
+      {
+         "name": "some-objective",
+         "type": "objective",
+         "value": 1
+      }
+   ]
+
+
+See :meth:`orion.client.report_results` for more details.
+
 .. _commandline_templates:
 
 Command-line templating

--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -54,6 +54,11 @@ the local one passed to
 created. To access the particular working directory of a trial, see next sections
 :ref:`commandline_templates` and :ref:`env_vars`.
 
+Language compatibility
+======================
+The command line works for scripts and programs in any language.
+The only requirement is that the executed script returns a JSON string with the objective value.
+
 .. _commandline_templates:
 
 Command-line templating


### PR DESCRIPTION
# Description
Adds a line to promote the ability of Oríon to work with any language and support for any configuration file.

# Checklist
## Tests
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)