### PR TITLE
Handle producer config in experiment section

### DIFF
--- a/docs/src/plugins/install.rst
+++ b/docs/src/plugins/install.rst
@@ -34,8 +34,9 @@ Next we define the file ``bayes.yaml`` as this
 
 .. code-block:: yaml
 
-     name: orion-with-bayes
-     algorithms: BayesianOptimizer
+    experiment:
+        name: orion-with-bayes
+        algorithms: BayesianOptimizer
 
 Then call ``orion hunt`` with the configuration file.
 

--- a/docs/src/user/algorithms.rst
+++ b/docs/src/user/algorithms.rst
@@ -18,9 +18,10 @@ In a Oríon configuration YAML, define:
 
 .. code-block:: yaml
 
-   algorithms:
-     gradient_descent:
-       learning_rate: 0.1
+   experiment:
+       algorithms:
+           gradient_descent:
+               learning_rate: 0.1
 
 In this particular example, the name of the algorithm extension class to be
 imported and instantiated is ``Gradient_Descent``, so the lower-case identifier
@@ -49,9 +50,10 @@ Configuration
 
 .. code-block:: yaml
 
-     algorithms:
-        random:
-           seed: null
+    experiment:
+        algorithms:
+            random:
+                seed: null
 
 
 ``seed``
@@ -94,10 +96,19 @@ Configuration
 
 .. code-block:: yaml
 
-    algorithms:
-       hyperband:
-          seed: null
-          repetitions: 1
+    experiment:
+        algorithms:
+            hyperband:
+                seed: null
+                repetitions: 1
+
+        strategy: StubParallelStrategy
+
+
+.. note::
+
+   Notice the additional ``strategy`` in configuration which is not mandatory for most other
+   algorithms. See :ref:`StubParallelStrategy` for more information.
 
 
 ``seed``
@@ -152,19 +163,19 @@ Configuration
 
 .. code-block:: yaml
 
-    algorithms:
-       asha:
-          seed: null
-          num_rungs: null
-          num_brackets: 1
+    experiment:
+        algorithms:
+            asha:
+                seed: null
+                num_rungs: null
+                num_brackets: 1
 
-    producer:
-      strategy: StubParallelStrategy
+        strategy: StubParallelStrategy
 
 
 .. note::
 
-   Notice the additional ``producer.strategy`` in configuration which is not mandatory for other
+   Notice the additional ``strategy`` in configuration which is not mandatory for most other
    algorithms. See :ref:`StubParallelStrategy` for more information.
 
 
@@ -220,15 +231,16 @@ Configuration
 
 .. code-block:: yaml
 
-    algorithms:
-       tpe:
-          seed: null
-          n_initial_points: 20
-          n_ei_candidates: 25
-          gamma: 0.25
-          equal_weight: False
-          prior_weight: 1.0
-          full_weight_num: 25
+    experiment:
+        algorithms:
+            tpe:
+                seed: null
+                n_initial_points: 20
+                n_ei_candidates: 25
+                gamma: 0.25
+                equal_weight: False
+                prior_weight: 1.0
+                full_weight_num: 25
 
 
 ``seed``
@@ -288,15 +300,16 @@ Configuration
 
 .. code-block:: yaml
 
-     algorithms:
-        BayesianOptimizer:
-           seed: null
-           n_initial_points: 10
-           acq_func: gp_hedge
-           alpha: 1.0e-10
-           n_restarts_optimizer: 0
-           noise: "gaussian"
-           normalize_y: False
+    experiment:
+        algorithms:
+            BayesianOptimizer:
+                seed: null
+                n_initial_points: 10
+                acq_func: gp_hedge
+                alpha: 1.0e-10
+                n_restarts_optimizer: 0
+                noise: "gaussian"
+                normalize_y: False
 
 ``seed``
 
@@ -388,10 +401,10 @@ The value of the objective is customizable with ``stub_value``.
 
 .. code-block:: yaml
 
-    producer:
-      strategy:
-         StubParallelStrategy:
-            stub_value: 'custom value'
+    experiment:
+        strategy:
+            StubParallelStrategy:
+                stub_value: 'custom value'
 
 .. _MaxParallelStrategy:
 
@@ -406,10 +419,10 @@ is ``float('inf')`` by default.
 
 .. code-block:: yaml
 
-    producer:
-      strategy:
-         MaxParallelStrategy:
-            default_result: 10000
+    experiment:
+        strategy:
+            MaxParallelStrategy:
+                default_result: 10000
 
 
 MeanParallelStrategy
@@ -423,7 +436,7 @@ is ``float('inf')`` by default.
 
 .. code-block:: yaml
 
-    producer:
-      strategy:
-         MeanParallelStrategy:
-            default_result: 0.5
+    experiment:
+        strategy:
+            MeanParallelStrategy:
+                default_result: 0.5

--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -23,7 +23,8 @@ this:
 
 .. code-block:: yaml
 
-    user_script_config: configuration
+    worker:
+        user_script_config: configuration
 
 It is then possible to run ``orion hunt`` like here:
 

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -196,7 +196,7 @@ def fetch_config(args):
         max_trials = tmp_config.pop('max_trials', None)
         if max_trials is not None:
             log.warning(
-                '(DEPRECATED) Option `max_trials` is deprecated'
+                '(DEPRECATED) Option `max_trials` is deprecated '
                 'and will be removed in v0.3. Use instead the option'
                 '\nexperiment:\n  max_trials: %s', max_trials)
             local_config['experiment.max_trials'] = max_trials
@@ -204,7 +204,7 @@ def fetch_config(args):
         worker_trials = tmp_config.get('experiment', {}).pop('worker_trials', None)
         if worker_trials is not None:
             log.warning(
-                '(DEPRECATED) Option `experiment.worker_trials` is deprecated'
+                '(DEPRECATED) Option `experiment.worker_trials` is deprecated '
                 'and will be removed in v0.3. Use instead the option'
                 '\nworker:\n  max_trials: %s', worker_trials)
             local_config['worker.max_trials'] = worker_trials
@@ -212,7 +212,7 @@ def fetch_config(args):
         worker_trials = tmp_config.pop('worker_trials', None)
         if worker_trials is not None:
             log.warning(
-                '(DEPRECATED) Option `worker_trials` is deprecated'
+                '(DEPRECATED) Option `worker_trials` is deprecated '
                 'and will be removed in v0.3. Use instead the option'
                 '\nworker:\n  max_trials: %s', worker_trials)
             local_config['worker.max_trials'] = worker_trials
@@ -220,7 +220,15 @@ def fetch_config(args):
         producer = tmp_config.pop('producer', None)
         if producer is not None:
             log.warning(
-                '(DEPRECATED) Option `producer` is deprecated'
+                '(DEPRECATED) Option `producer` is deprecated '
+                'and will be removed in v0.3. Use instead the option'
+                '\nexperiment:\n  strategy: %s', producer['strategy'])
+            local_config['experiment.strategy'] = producer['strategy']
+
+        producer = tmp_config.get('experiment', {}).pop('producer', None)
+        if producer is not None:
+            log.warning(
+                '(DEPRECATED) Option `experiment.producer` is deprecated '
                 'and will be removed in v0.3. Use instead the option'
                 '\nexperiment:\n  strategy: %s', producer['strategy'])
             local_config['experiment.strategy'] = producer['strategy']


### PR DESCRIPTION

# Description
The user may (it happened, see #395 ) simply transfer the producer config
to experiment section, in which case it will ignored.

# Changes

Verify if producer is defined in experiment section of config and handle it.

Update docs according to new config format