### PR TITLE
Fix mongodb count for v < 3.7

### DIFF
--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -267,7 +267,7 @@ class MongoDB(AbstractDB):
 
         """
         dbcollection = self._db[collection_name]
-        if hasattr(dbcollection, 'count_documents'):
+        if not isinstance(getattr(dbcollection, 'count_documents'), pymongo.collection.Collection):
             return dbcollection.count_documents(filter=query if query else {})
 
         return dbcollection.count(filter=query)


### PR DESCRIPTION
# Description

Using hasattr(db, 'count_document') will always be True, but will return
a collection if the method does not exist (new in version 3.7).

# Changes

Test if attribute is a collection, if it is then used old count().