### PR TITLE
Print help when calling `orion` alone

### DIFF
--- a/src/orion/core/cli/__init__.py
+++ b/src/orion/core/cli/__init__.py
@@ -40,4 +40,6 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
-    main()
+    returncode = main()
+    if returncode > 0:
+        raise SystemExit(returncode)

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -15,7 +15,8 @@ import textwrap
 
 import orion
 from orion.core.io.database import DatabaseError
-from orion.core.utils.exceptions import BranchingEvent, MissingResultFile, NoConfigurationError
+from orion.core.utils.exceptions import (
+    BranchingEvent, MissingResultFile, NoConfigurationError, NoNameError)
 
 
 CLI_DOC_HEADER = """
@@ -77,7 +78,8 @@ class OrionArgsParser:
         try:
             args, function = self.parse(argv)
             function(args)
-        except (NoConfigurationError, DatabaseError, MissingResultFile, BranchingEvent) as e:
+        except (NoConfigurationError, NoNameError, DatabaseError, MissingResultFile,
+                BranchingEvent) as e:
             print('Error:', e, file=sys.stderr)
 
             if args.get('verbose', 0) >= 2:

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -50,7 +50,7 @@ class OrionArgsParser:
             '-d', '--debug', action='store_true',
             help="Use debugging mode with EphemeralDB.")
 
-        self.subparsers = self.parser.add_subparsers(help='sub-command help')
+        self.subparsers = self.parser.add_subparsers(dest='command', help='sub-command help')
 
     def get_subparsers(self):
         """Return the subparser object for this parser."""
@@ -66,10 +66,12 @@ class OrionArgsParser:
                   2: logging.DEBUG}
         logging.basicConfig(level=levels.get(verbose, logging.DEBUG))
 
-        function = args.pop('func', None)
-
-        if function is None:
+        if args['command'] is None:
             self.parser.parse_args(['--help'])
+
+        function = args.pop('func', None)
+        if function is None:
+            self.parser.parse_args([args['command'], '--help'])
 
         return args, function
 

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -70,7 +70,8 @@ class OrionArgsParser:
             self.parser.parse_args(['--help'])
 
         function = args.pop('func', None)
-        if function is None:
+        empty_command = (argv[-1] if argv else sys.argv[-1]) == args['command']
+        if function is None or (empty_command and args.pop('help_empty', False)):
             self.parser.parse_args([args['command'], '--help'])
 
         return args, function

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -65,7 +65,11 @@ class OrionArgsParser:
                   2: logging.DEBUG}
         logging.basicConfig(level=levels.get(verbose, logging.DEBUG))
 
-        function = args.pop('func')
+        function = args.pop('func', None)
+
+        if function is None:
+            self.parser.parse_args(['--help'])
+
         return args, function
 
     def execute(self, argv):

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -49,6 +49,7 @@ def add_subparser(parser):
     cli.get_user_args_group(hunt_parser)
 
     hunt_parser.set_defaults(func=main)
+    hunt_parser.set_defaults(help_empty=True)  # Print help if command is empty
 
     return hunt_parser
 

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -39,6 +39,7 @@ def add_subparser(parser):
     cli.get_user_args_group(init_only_parser)
 
     init_only_parser.set_defaults(func=main)
+    init_only_parser.set_defaults(help_empty=True)  # Print help if command is empty
 
     return init_only_parser
 

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -11,6 +11,7 @@
 
 import logging
 
+import orion.core
 from orion.core.cli import base as cli
 from orion.core.cli import evc as evc_cli
 import orion.core.io.experiment_builder as experiment_builder
@@ -22,7 +23,16 @@ def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
     init_only_parser = parser.add_parser('init_only', help='init_only help')
 
-    cli.get_basic_args_group(init_only_parser)
+    orion_group = cli.get_basic_args_group(
+        init_only_parser, group_name='init_only arguments', group_help='')
+
+    orion.core.config.experiment.add_arguments(
+        orion_group,
+        rename=dict(max_broken='--exp-max-broken', max_trials='--exp-max-trials'))
+
+    orion_group.add_argument(
+        '--max-trials', type=int, metavar='#',
+        help="(DEPRECATED) This argument will be removed in v0.3. Use --exp-max-trials instead")
 
     evc_cli.get_branching_args_group(init_only_parser)
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -32,6 +32,7 @@ def add_subparser(parser):
     cli.get_user_args_group(insert_parser)
 
     insert_parser.set_defaults(func=main)
+    insert_parser.set_defaults(help_empty=True)  # Print help if command is empty
 
     return insert_parser
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -101,7 +101,8 @@ from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
 from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
 from orion.core.io.space_builder import SpaceBuilder
 import orion.core.utils.backward as backward
-from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, RaceCondition
+from orion.core.utils.exceptions import (
+    BranchingEvent, NoConfigurationError, NoNameError, RaceCondition)
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import Strategy
@@ -527,6 +528,9 @@ def build_from_args(cmdargs):
     """
     cmd_config = get_cmd_config(cmdargs)
 
+    if 'name' not in cmd_config:
+        raise NoNameError()
+
     setup_storage(cmd_config['storage'], debug=cmd_config.get('debug'))
 
     return build(**cmd_config)
@@ -542,6 +546,9 @@ def build_view_from_args(cmdargs):
 
     """
     cmd_config = get_cmd_config(cmdargs)
+
+    if 'name' not in cmd_config:
+        raise NoNameError()
 
     setup_storage(cmd_config['storage'], debug=cmd_config.get('debug'))
 

--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -10,14 +10,24 @@
 
 
 NO_CONFIGURATION_FOUND = """\
-No commandline configuration found for new experiment.
-"""
+No commandline configuration found for new experiment."""
+
+
+NO_EXP_NAME_PROVIDED = """\
+No name provided for the experiment."""
 
 
 class NoConfigurationError(Exception):
     """Raise when commandline configuration is empty."""
 
     def __init__(self, message=NO_CONFIGURATION_FOUND):
+        super().__init__(message)
+
+
+class NoNameError(Exception):
+    """Raise when no name is provided for an experiment."""
+
+    def __init__(self, message=NO_EXP_NAME_PROVIDED):
         super().__init__(message)
 
 

--- a/tests/functional/commands/test_db_commands.py
+++ b/tests/functional/commands/test_db_commands.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test of the db commands."""
+import pytest
+
+import orion.core.cli
+
+
+def test_no_args(capsys):
+    """Test that help is printed when no args are given."""
+    with pytest.raises(SystemExit):
+        orion.core.cli.main(['db'])
+
+    captured = capsys.readouterr().out
+
+    assert 'usage:' in captured
+    assert 'Traceback' not in captured

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the hunt command."""
+import pytest
+
 import orion.core.cli
 
 
 def test_no_args(capsys):
-    """Try to run the command without any arguments"""
-    returncode = orion.core.cli.main(["hunt"])
+    """Test that help is printed when no args are given."""
+    with pytest.raises(SystemExit):
+        orion.core.cli.main(['hunt'])
+
+    captured = capsys.readouterr().out
+
+    assert 'usage:' in captured
+    assert 'Traceback' not in captured
+
+
+def test_no_name(capsys):
+    """Try to run the command without providing an experiment name"""
+    returncode = orion.core.cli.main(["hunt", "--exp-max-trials", "10"])
     assert returncode == 1
 
     captured = capsys.readouterr().err

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test of the hunt command."""
+import pytest
+
+import orion.core.cli
+
+
+def test_no_args(capsys):
+    """Try to run the command without any arguments"""
+    returncode = orion.core.cli.main(["hunt"])
+    assert returncode == 1
+
+    captured = capsys.readouterr().err
+
+    assert captured == 'Error: No name provided for the experiment.\n'

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the hunt command."""
-import pytest
-
 import orion.core.cli
 
 

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -67,3 +67,13 @@ def test_info_cmdline_api(clean_db, with_experiment_using_python_api, capsys):
 
     assert 'test_single_exp' in captured
     assert 'Commandline' in captured
+
+
+def test_no_args(capsys):
+    """Try to run the command without any arguments"""
+    returncode = orion.core.cli.main(["info"])
+    assert returncode == 1
+
+    captured = capsys.readouterr().err
+
+    assert captured == 'Error: No name provided for the experiment.\n'

--- a/tests/functional/commands/test_init_only_command.py
+++ b/tests/functional/commands/test_init_only_command.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test of the init_only command."""
+import pytest
+
+import orion.core.cli
+
+
+def test_no_args(capsys):
+    """Try to run the command without any arguments"""
+    returncode = orion.core.cli.main(["init_only"])
+    assert returncode == 1
+
+    captured = capsys.readouterr().err
+
+    assert captured == 'Error: No name provided for the experiment.\n'

--- a/tests/functional/commands/test_init_only_command.py
+++ b/tests/functional/commands/test_init_only_command.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the init_only command."""
-import pytest
-
 import orion.core.cli
 
 

--- a/tests/functional/commands/test_init_only_command.py
+++ b/tests/functional/commands/test_init_only_command.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the init_only command."""
+import pytest
+
 import orion.core.cli
 
 
 def test_no_args(capsys):
-    """Try to run the command without any arguments"""
-    returncode = orion.core.cli.main(["init_only"])
+    """Test that help is printed when no args are given."""
+    with pytest.raises(SystemExit):
+        orion.core.cli.main(['init_only'])
+
+    captured = capsys.readouterr().out
+
+    assert 'usage:' in captured
+    assert 'Traceback' not in captured
+
+
+def test_no_name(capsys):
+    """Try to run the command without providing an experiment name"""
+    returncode = orion.core.cli.main(["init_only", "--exp-max-trials", "10"])
     assert returncode == 1
 
     captured = capsys.readouterr().err

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -174,8 +174,19 @@ def test_insert_with_version(create_db_instance, monkeypatch, script_path):
 
 
 def test_no_args(capsys):
-    """Try to run the command without any arguments"""
-    returncode = orion.core.cli.main(["init_only"])
+    """Test that help is printed when no args are given."""
+    with pytest.raises(SystemExit):
+        orion.core.cli.main(['insert'])
+
+    captured = capsys.readouterr().out
+
+    assert 'usage:' in captured
+    assert 'Traceback' not in captured
+
+
+def test_no_name(capsys):
+    """Try to run the command without providing an experiment name"""
+    returncode = orion.core.cli.main(["insert", "--version", "1"])
     assert returncode == 1
 
     captured = capsys.readouterr().err

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -171,3 +171,13 @@ def test_insert_with_version(create_db_instance, monkeypatch, script_path):
     trials = list(get_storage().fetch_trials(uid=exp['_id']))
 
     assert len(trials) == 1
+
+
+def test_no_args(capsys):
+    """Try to run the command without any arguments"""
+    returncode = orion.core.cli.main(["init_only"])
+    assert returncode == 1
+
+    captured = capsys.readouterr().err
+
+    assert captured == 'Error: No name provided for the experiment.\n'

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -624,3 +624,14 @@ def test_debug_mode(monkeypatch):
 
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, EphemeralDB)
+
+
+def test_no_args(capsys):
+    """Test that help is printed when no args are given."""
+    with pytest.raises(SystemExit):
+        orion.core.cli.main([])
+
+    captured = capsys.readouterr().out
+
+    assert 'usage:' in captured
+    assert 'Traceback' not in captured


### PR DESCRIPTION
Why:

Orion was crashing with a confusing error message.

How:

Detect if no command is defined, if so print help message and exit.