### PR TITLE
Document Windows compatibility

### DIFF
--- a/docs/src/install/core.rst
+++ b/docs/src/install/core.rst
@@ -2,8 +2,9 @@
 Installing Oríon
 ****************
 
-Oríon is compatible with most Linux distributions and Mac OS X. It is tested on Ubuntu 16.04 LTS and
-Mac OS X 10.13. We do not support Windows and there is no short term plan to do so.
+Oríon is compatible with most Linux distributions and Mac OS X.
+Windows 10 is also supported through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/about>`_.
+Oríon is tested on Ubuntu 16.04 LTS and Mac OS X 10.13.
 
 The easiest way to install the latest version of Oríon is through the Python package manager. Oríon
 is registered on PyPI_ under `orion`. Use the following command to install Oríon:


### PR DESCRIPTION
# Description
Updates the compatibility status of Oríon on Windows.

# Changes
Oríon can be used on Windows 10 using the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about).

# Checklist
## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)