### PR TITLE
Raise exception when no prior is provided

### DIFF
--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -59,10 +59,6 @@ def main(args):
     args['leafs'] = []
     # TODO: simplify when parameter parsing is refactored
     experiment = experiment_builder.build_from_args(args)
-
-    if len(experiment.space) == 0:
-        raise ValueError("No prior found. Please include at least one.")
-
     config = experiment_builder.get_cmd_config(args)
     worker_config = orion.core.config.worker.to_dict()
     if config.get('worker'):

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -59,6 +59,10 @@ def main(args):
     args['leafs'] = []
     # TODO: simplify when parameter parsing is refactored
     experiment = experiment_builder.build_from_args(args)
+
+    if len(experiment.space) == 0:
+        raise ValueError("No prior found. Please include at least one.")
+
     config = experiment_builder.get_cmd_config(args)
     worker_config = orion.core.config.worker.to_dict()
     if config.get('worker'):

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -203,6 +203,9 @@ def build(name, version=None, branching=None, **config):
         raise NoConfigurationError(
             'Experiment {} does not exist in DB and space was not defined.'.format(name))
 
+    if len(config['space']) == 0:
+        raise ValueError("No prior found. Please include at least one.")
+
     experiment = create_experiment(**copy.deepcopy(config))
     if experiment.id is None:
         try:

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -205,7 +205,7 @@ def build(name, version=None, branching=None, **config):
             'Experiment {} does not exist in DB and space was not defined.'.format(name))
 
     if len(config['space']) == 0:
-        raise ValueError("No prior found. Please include at least one.")
+        raise NoConfigurationError("No prior found. Please include at least one.")
 
     experiment = create_experiment(**copy.deepcopy(config))
     if experiment.id is None:

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -12,7 +12,8 @@ def test_hunt_no_prior(clean_db, one_experiment):
         orion.core.cli.main(["hunt", "-n", "test", "./black_box.py"])
 
     assert "No prior found" in str(exception.value)
-    
+
+
 def test_no_args(capsys):
     """Test that help is printed when no args are given."""
     with pytest.raises(SystemExit):

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -1,0 +1,12 @@
+"""Perform a functional test of the hunt command."""
+import pytest
+
+import orion.core.cli
+
+
+def test_hunt_no_prior(clean_db, one_experiment):
+    """Test at least one prior is specified"""
+    with(pytest.raises(ValueError)) as exception:
+        orion.core.cli.main(["hunt", "-n", "test", "./black_box.py"])
+
+    assert "No prior found" in str(exception.value)

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -6,12 +6,14 @@ import pytest
 import orion.core.cli
 
 
-def test_hunt_no_prior(clean_db, one_experiment):
+def test_hunt_no_prior(clean_db, one_experiment, capsys):
     """Test at least one prior is specified"""
-    with(pytest.raises(ValueError)) as exception:
-        orion.core.cli.main(["hunt", "-n", "test", "./black_box.py"])
+    orion.core.cli.main(["hunt", "-n", "test", "./black_box.py"])
 
-    assert "No prior found" in str(exception.value)
+    captured = capsys.readouterr().err
+
+    assert "No prior found" in captured
+    assert 'Traceback' not in captured
 
 
 def test_no_args(capsys):

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -296,7 +296,7 @@ def test_build_from_args_debug_mode(script_path):
     """Try building experiment in debug mode"""
     update_singletons()
     experiment_builder.build_from_args(
-        {'name': 'whatever', 'user_args': [script_path]})
+        {'name': 'whatever', 'user_args': [script_path, '--mini-batch~uniform(32, 256)']})
 
     storage = get_storage()
 
@@ -306,7 +306,7 @@ def test_build_from_args_debug_mode(script_path):
     update_singletons()
 
     experiment_builder.build_from_args(
-        {'name': 'whatever', 'user_args': [script_path], 'debug': True})
+        {'name': 'whatever', 'user_args': [script_path, '--mini-batch~uniform(32, 256)'], 'debug': True})
     storage = get_storage()
 
     assert isinstance(storage, Legacy)

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -296,7 +296,8 @@ def test_build_from_args_debug_mode(script_path):
     """Try building experiment in debug mode"""
     update_singletons()
     experiment_builder.build_from_args(
-        {'name': 'whatever', 'user_args': [script_path, '--mini-batch~uniform(32, 256)']})
+        {'name': 'whatever',
+         'user_args': [script_path, '--mini-batch~uniform(32, 256)']})
 
     storage = get_storage()
 
@@ -306,7 +307,9 @@ def test_build_from_args_debug_mode(script_path):
     update_singletons()
 
     experiment_builder.build_from_args(
-        {'name': 'whatever', 'user_args': [script_path, '--mini-batch~uniform(32, 256)'], 'debug': True})
+        {'name': 'whatever',
+         'user_args': [script_path, '--mini-batch~uniform(32, 256)'],
+         'debug': True})
     storage = get_storage()
 
     assert isinstance(storage, Legacy)


### PR DESCRIPTION
# Description
When a user execute `orion hunt` without any prior the application raises an unrelated exception without any explanation to the user.

# Changes
The number of priors is verified during the parsing and inform the user that the command requires at least one prior.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)
