### PR TITLE
Add command `orion db rm`

### DIFF
--- a/docs/src/install/database.rst
+++ b/docs/src/install/database.rst
@@ -61,6 +61,8 @@ As described above, local configuration file can be used in combination with glo
 variable definitions. Local configuration values will overwrite configuration from both other
 methods.
 
+.. _Test Connection:
+
 Testing the configuration
 -------------------------
 

--- a/docs/src/user/cli/status.rst
+++ b/docs/src/user/cli/status.rst
@@ -205,9 +205,10 @@ versions: version `1`, `2` and `3`. Then running status as usual will only outpu
 
 The ``--version`` argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-The `--version` argument allows you to specify a version to print instead of getting the latest one.
-Suppose we have the same setup as above with three experiments named `test` but with different
-versions. Then running the following command will output the second version instead of the latest.
+The ``--version`` argument allows you to specify a version to print instead of getting the latest
+one.  Suppose we have the same setup as above with three experiments named ``test`` but with
+different versions. Then running the following command will output the second version instead of the
+latest.
 
 .. code-block:: console
 
@@ -219,13 +220,13 @@ versions. Then running the following command will output the second version inst
     =======
     empty
 
-It should be noted that using `--version` with any of `--collapse` or `--expand-versions` will lead
-to a `RuntimeError`.
+It should be noted that using ``--version`` with any of ``--collapse`` or ``--expand-versions``
+will lead to a ``RuntimeError``.
 
-The `--expand-versions` argument
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``--expand-versions`` argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 As specified above, if there are no children of a root experiment with a different name then the
-experiment tree will not be printed in its entirety. The `--expand-versions` allows you to get the
+experiment tree will not be printed in its entirety. The ``--expand-versions`` allows you to get the
 full output of the experiment tree, regardless if it only contains different versions. Once again,
 suppose we have the same setup with experiment `test`, then running the following command will print
 the experiment tree.

--- a/docs/src/user/storage.rst
+++ b/docs/src/user/storage.rst
@@ -8,6 +8,107 @@
 Storage
 *******
 
+Commands are available to help
+:ref:`configure <storage_setup>`,
+:ref:`test <storage_test>` and
+:ref:`upgrade <storage_upgrade>` the storage of Oríon.
+There is additionally commands to :ref:`delete <storage_rm>` experiment and trials
+or :ref:`update <storage_set>` values in the storage.
+
+For more flexibility, there is the :ref:`storage_python_apis`.
+
+.. _storage_commands:
+
+Commands
+========
+
+.. _storage_setup:
+
+``setup`` Storage configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``setup`` command helps creating a global configuration file
+for the configuration of Oríon's storage. For more details on its usage
+see :ref:`Database Configuration` in the database
+installation and configuration section.
+
+.. _storage_test:
+
+``test`` Test storage configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``test`` command provides a simple and efficient way of testing the storage configuration. For
+more details on its usage see :ref:`Test Connection` in the database installation and configuration
+section.
+
+.. _storage_rm:
+
+``rm`` Delete data from storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Command to delete experiments and trials.
+
+To delete an experiment and its trials, simply give the experiment's name.
+
+.. code-block:: sh
+
+   orion db rm my-exp-name
+
+To delete only trials that are broken, simply add ``--status`` broken.
+Note that the experiment will not be deleted, only the trials.
+
+.. code-block:: sh
+
+   orion db rm my-exp-name --status broken
+
+Or ``--status *`` to delete all trials of the experiment.
+
+.. code-block:: sh
+
+   orion db rm my-exp-name --status *
+
+By default, the last version of the experiment is deleted. Add ``--version``
+to select a prior version. Note that all child of the selected version
+will be deleted as well. You cannot delete a parent experiment without
+deleting the child experiments.
+
+.. code-block:: sh
+
+   orion db rm my-exp-name --version 1
+
+
+.. _storage_set:
+
+``set`` Change value of data in storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Coming soon
+
+.. _storage_upgrade:
+
+``upgrade`` Upgrade database scheme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Database scheme may change from one version of Oríon to another. If such change happens, you will
+get the following error after upgrading Oríon.
+
+.. code-block:: sh
+
+   The database is outdated. You can upgrade it with the command `orion db upgrade`.
+
+Make sure to create a backup of your database before upgrading it. You should also make sure that no
+process writes to the database during the upgrade otherwise the latter could fail. When ready,
+simply run the upgrade command.
+
+.. code-block:: sh
+
+   orion db upgrade
+
+.. _storage_python_apis:
+
+Python APIs
+===========
+
 In short, users are expected to only use the
 :py:class:`ExperimentClient <orion.client.experiment.ExperimentClient>` to interact
 with the storage client, to fetch and register trials. Creation of experiments
@@ -22,10 +123,12 @@ Finally, legacy databases supported by Oríon can also be accessed directly in l
 resort if the storage backend is not flexible enough. See :ref:`database_backend` section
 for more details.
 
+
+
 .. _experiment_client:
 
 ExperimentClient
-================
+~~~~~~~~~~~~~~~~
 
 The experiment client must be created with the helper function
 :py:func:`create_experiment() <orion.client.create_experiment>` which will take care of
@@ -90,7 +193,7 @@ Here is a short example to fetch trials or insert a new one.
 .. _storage_backend:
 
 Storage
-=======
+~~~~~~~
 
 .. warning::
 
@@ -165,10 +268,16 @@ In both case, you can access it with
 .. automethod:: orion.storage.base.BaseStorageProtocol.update_experiment
    :noindex:
 
-:hidden:`fetch_experiment`
---------------------------
+:hidden:`fetch_experiments`
+---------------------------
 
 .. automethod:: orion.storage.base.BaseStorageProtocol.fetch_experiments
+   :noindex:
+
+:hidden:`delete_experiment`
+---------------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.delete_experiment
    :noindex:
 
 :hidden:`register_trial`
@@ -187,6 +296,12 @@ In both case, you can access it with
 ----------------------
 
 .. automethod:: orion.storage.base.BaseStorageProtocol.fetch_trials
+   :noindex:
+
+:hidden:`delete_trials`
+-----------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.delete_trials
    :noindex:
 
 :hidden:`get_trial`
@@ -241,7 +356,7 @@ In both case, you can access it with
 .. _database_backend:
 
 Database
-========
+~~~~~~~~
 
 .. warning::
 

--- a/src/orion/core/cli/db/rm.py
+++ b/src/orion/core/cli/db/rm.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.rm` -- Module running the rm command
+============================================================
+
+.. module:: setup
+   :platform: Unix
+   :synopsis: Delete experiments and trials from the database
+"""
+import argparse
+import logging
+import sys
+
+import orion.core.io.experiment_builder as experiment_builder
+from orion.core.utils.pptree import print_tree
+from orion.storage.base import get_storage
+
+
+logger = logging.getLogger(__name__)
+
+
+EXP_RM_MESSAGE = """
+All experiments above and their corresponding trials will be deleted.
+To select a specific version use --version <VERSION>. Note that all
+children of a given version will be deleted. Oríon cannot delete a
+parent experiment without deleting the children.
+To delete trials only, use --status <STATUS>.
+
+Make sure to stop any worker currently executing one of these experiment.
+
+To proceed, type again the name of the experiment: """
+
+
+TRIALS_RM_MESSAGE = """
+Matching trials of all experiments above will be deleted.
+To select a specific version use --version <VERSION>.
+Note that trials of all children of a given version will be deleted.
+
+Make sure to stop any worker currently executing one of these experiment.
+
+To proceed, type again the name of the experiment: """
+
+
+DESCRIPTION = """
+Command to delete experiments and trials.
+
+To delete an experiment and its trials, simply give the experiment's name.
+$ orion db rm my-exp-name
+
+To delete only trials that are broken, simply add --status broken.
+Note that the experiment will not be deleted, only the trials.
+$ orion db rm my-exp-name --status broken
+
+Or --status * to delete all trials of the experiment.
+$ orion db rm my-exp-name --status *
+
+By default, the last version of the experiment is deleted. Add --version
+to select a prior version. Note that all child of the selected version
+will be deleted as well. You cannot delete a parent experiment without
+deleting the child experiments.
+$ orion db rm my-exp-name --version 1
+"""
+
+
+def add_subparser(parser):
+    """Return the parser that needs to be used for this command"""
+    rm_parser = parser.add_parser(
+        'rm',
+        description=DESCRIPTION,
+        help='rm help',
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    rm_parser.set_defaults(func=main)
+
+    rm_parser.add_argument(
+        'name',
+        help='Name of the experiment to delete.')
+
+    rm_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
+                           metavar='path-to-config', help="user provided "
+                           "orion configuration file")
+
+    rm_parser.add_argument(
+        '-v', '--version', type=int, default=None,
+        help="specific version of experiment to fetch; "
+             "(default: last version matching.)")
+
+    rm_parser.add_argument(
+        '-s', '--status',
+        help='Remove all trials of the experiment with the given status '
+             '(Will not delete the experiment). '
+             'Also supports --status=* to delete all trials of a given experiment.')
+
+    rm_parser.add_argument(
+        '-f', '--force', action='store_true',
+        help='Force delete without asking to enter experiment name twice.')
+
+    return rm_parser
+
+
+def confirm_name(message, name, force=False):
+    """Ask the user to confirm the name.
+
+    Parameters
+    ----------
+    message: str
+        The message to be printed.
+    name: str
+        The string that the user must enter.
+    force: bool
+        Override confirmation and return True. Default: False.
+
+    Returns
+    -------
+    bool
+        True if confirmed, False otherwise.
+
+    """
+    if force:
+        print(message)
+        print('FORCED')
+        return True
+
+    answer = input(message)
+
+    return answer.strip() == name
+
+
+def process_trial_rm(storage, root, status):
+    """Delete the matching trials of the given experiment."""
+    trials_total = 0
+    for node in root:
+        if status == '*':
+            query = {}
+        else:
+            query = {'status': status}
+
+        count = storage.delete_trials(uid=node.item.id, where=query)
+        logger.debug('%d trials deleted in experiment %s-v%d',
+                     count, node.item.name, node.item.version)
+        trials_total += count
+
+    print(f'{trials_total} trials deleted')
+
+
+def process_exp_rm(storage, root):
+    """Delete the given experiment node and all its children."""
+    trials_total = 0
+    exp_total = 0
+    for node in root:
+        count = storage.delete_trials(uid=node.item.id)
+        trials_total += count
+        logger.debug('%d trials deleted in experiment %s-v%d',
+                     count, node.item.name, node.item.version)
+        count = storage.delete_experiment(uid=node.item.id)
+        logger.debug('%s experiment %s-v%d deleted',
+                     count, node.item.name, node.item.version)
+        exp_total += count
+
+    print(f'{trials_total} trials deleted')
+    print(f'{exp_total} experiments deleted')
+
+
+def delete_experiments(storage, root, name, force):
+    """Delete matching experiments after user confirmation."""
+    confirmed = confirm_name(EXP_RM_MESSAGE, name, force)
+
+    if not confirmed:
+        print('Confirmation failed, aborting operation.')
+        sys.exit(1)
+
+    process_exp_rm(storage, root)
+
+
+def delete_trials(storage, root, name, status, force):
+    """Delete all matching trials after user confirmation."""
+    confirmed = confirm_name(TRIALS_RM_MESSAGE, name, force)
+
+    if not confirmed:
+        print('Confirmation failed, aborting operation.')
+        sys.exit(1)
+
+    process_trial_rm(storage, root, status)
+
+
+def main(args):
+    """Remove the experiment(s) or trial(s)."""
+    config = experiment_builder.get_cmd_config(args)
+    experiment_builder.setup_storage(config.get('storage'))
+
+    # Find root experiment
+    root = experiment_builder.build_view(name=args['name'],
+                                         version=args.get('version', None)).node
+
+    # List all experiments with children
+    print_tree(root, nameattr='tree_name')
+
+    storage = get_storage()
+
+    if args['status']:
+        delete_trials(storage, root, args['name'], args['status'], args['force'])
+    else:
+        delete_experiments(storage, root, args['name'], args['force'])

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -251,7 +251,7 @@ def build_view(name, version=None):
     if not db_config:
         message = ("No experiment with given name '%s' and version '%s' inside database, "
                    "no view can be created." % (name, version if version else '*'))
-        raise ValueError(message)
+        raise NoConfigurationError(message)
 
     db_config.setdefault('version', 1)
 

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -19,6 +19,42 @@ from orion.core.utils import (AbstractSingletonType, SingletonFactory)
 log = logging.getLogger(__name__)
 
 
+def get_experiment_uid(experiment=None, uid=None, force_uid=True):
+    """Return experiment uid either from `experiment` or directly uid.
+
+    Delete matching experiments from the database
+
+    Parameters
+    ----------
+    experiment: Experiment, optional
+       experiment object to retrieve from the database
+
+    uid: str, optional
+        experiment id used to retrieve the trial object
+
+    force_uid: bool, optional
+        If True, at least one of experiment or uid must be passed.
+
+    Raises
+    ------
+    UndefinedCall
+        if both experiment and uid are not set and force_uid is True
+
+    AssertionError
+        if both experiment and uid are provided and they do not match
+    """
+    if experiment is not None and uid is not None:
+        assert experiment.id == uid
+
+    if uid is None:
+        if experiment is None and force_uid:
+            raise MissingArguments('Either `experiment` or `uid` should be set')
+        elif experiment is not None:
+            uid = experiment.id
+
+    return uid
+
+
 class FailedUpdate(Exception):
     """Exception raised when we are unable to update a trial' status"""
 
@@ -39,6 +75,31 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
 
     def create_experiment(self, config):
         """Insert a new experiment inside the database"""
+        raise NotImplementedError()
+
+    def delete_experiment(self, experiment=None, uid=None):
+        """Delete matching experiments from the database
+
+        Parameters
+        ----------
+        experiment: Experiment, optional
+           experiment object to retrieve from the database
+
+        uid: str, optional
+            experiment id used to retrieve the trial object
+
+        Returns
+        -------
+        Number of experiments deleted.
+
+        Raises
+        ------
+        UndefinedCall
+            if both experiment and uid are not set
+
+        AssertionError
+            if both experiment and uid are provided and they do not match
+        """
         raise NotImplementedError()
 
     def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
@@ -95,6 +156,34 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         trial: `Trial` object
             Fake trial to register in the database
 
+        """
+        raise NotImplementedError()
+
+    def delete_trials(self, experiment=None, uid=None, where=None):
+        """Delete matching trials from the database
+
+        Parameters
+        ----------
+        experiment: Experiment, optional
+           experiment object to retrieve from the database
+
+        uid: str, optional
+            experiment id used to retrieve the trial object
+
+        where: Optional[dict]
+            constraint trials must respect
+
+        Returns
+        -------
+        Number of trials deleted.
+
+        Raises
+        ------
+        UndefinedCall
+            if both experiment and uid are not set
+
+        AssertionError
+            if both experiment and uid are provided and they do not match
         """
         raise NotImplementedError()
 

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -20,7 +20,8 @@ import warnings
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.flatten import flatten, unflatten
 from orion.core.worker.trial import Trial as OrionTrial, validate_status
-from orion.storage.base import BaseStorageProtocol, FailedUpdate, MissingArguments
+from orion.storage.base import (
+    BaseStorageProtocol, FailedUpdate, get_experiment_uid, MissingArguments)
 
 log = logging.getLogger(__name__)
 
@@ -392,14 +393,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
     def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_experiment`"""
-        if uid and experiment:
-            assert experiment._id == uid
-
-        if uid is None:
-            if experiment is None:
-                raise MissingArguments('experiment or uid need to be defined')
-            else:
-                uid = experiment._id
+        uid = get_experiment_uid(experiment, uid)
 
         self.group = self.backend.fetch_and_update_group({
             '_uid': uid

--- a/tests/functional/commands/test_db_rm.py
+++ b/tests/functional/commands/test_db_rm.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform functional tests for db rm."""
+import pytest
+
+import orion.core.cli
+from orion.storage.base import get_storage
+
+
+def execute(command, assert_code=0):
+    """Execute orion command and return returncode"""
+    returncode = orion.core.cli.main(command.split(' '))
+    assert returncode == assert_code
+
+
+def test_no_exp(clean_db, capsys):
+    """Test that rm non-existing exp exits gracefully"""
+    execute('db rm i-dont-exist', assert_code=1)
+
+    captured = capsys.readouterr()
+
+    assert captured.err.startswith("Error: No experiment with given name 'i-dont-exist'")
+
+
+def test_confirm_name(monkeypatch, clean_db, single_with_trials):
+    """Test name must be confirmed for deletion"""
+    def incorrect_name(*args):
+        return 'oops'
+
+    monkeypatch.setattr('builtins.input', incorrect_name)
+
+    with pytest.raises(SystemExit):
+        execute('db rm test_single_exp')
+
+    def correct_name(*args):
+        return 'test_single_exp'
+
+    monkeypatch.setattr('builtins.input', correct_name)
+
+    assert len(get_storage().fetch_experiments({})) == 1
+    execute('db rm test_single_exp')
+    assert len(get_storage().fetch_experiments({})) == 0
+
+
+def test_one_exp(clean_db, single_with_trials):
+    """Test that one exp is deleted properly"""
+    assert len(get_storage().fetch_experiments({})) == 1
+    assert len(get_storage()._fetch_trials({})) > 0
+    execute('db rm -f test_single_exp')
+    assert len(get_storage().fetch_experiments({})) == 0
+    assert len(get_storage()._fetch_trials({})) == 0
+
+
+def test_rm_all_evc(clean_db, three_family_branch_with_trials):
+    """Test that deleting root removes all experiments"""
+    assert len(get_storage().fetch_experiments({})) == 3
+    assert len(get_storage()._fetch_trials({})) > 0
+    execute('db rm -f test_double_exp --version 1')
+    assert len(get_storage().fetch_experiments({})) == 0
+    assert len(get_storage()._fetch_trials({})) == 0
+
+
+def test_rm_under_evc(clean_db, three_family_branch_with_trials):
+    """Test that deleting an experiment removes all children"""
+    assert len(get_storage().fetch_experiments({})) == 3
+    assert len(get_storage()._fetch_trials({})) > 0
+    execute('db rm -f test_double_exp_child --version 1')
+    assert len(get_storage().fetch_experiments({})) == 1
+    assert len(get_storage()._fetch_trials({})) > 0
+    # TODO: Test that the correct trials were deleted
+
+
+def test_rm_default_leaf(clean_db, three_experiments_same_name):
+    """Test that deleting an experiment removes the leaf by default"""
+    assert len(get_storage().fetch_experiments({})) == 3
+    execute('db rm -f test_single_exp')
+    assert len(get_storage().fetch_experiments({})) == 2
+
+
+def test_rm_trials_by_status(clean_db, single_with_trials):
+    """Test that trials can be deleted by status"""
+    trials = get_storage()._fetch_trials({})
+    n_broken = sum(trial.status == 'broken' for trial in trials)
+    assert n_broken > 0
+    execute('db rm -f test_single_exp --status broken')
+    assert len(get_storage()._fetch_trials({})) == len(trials) - n_broken
+
+
+def test_rm_trials_all(clean_db, single_with_trials):
+    """Test that trials all be deleted with '*'"""
+    assert len(get_storage()._fetch_trials({})) > 0
+    execute('db rm -f test_single_exp --status *')
+    assert len(get_storage()._fetch_trials({})) == 0
+
+
+def test_rm_trials_in_evc(clean_db, three_family_branch_with_trials):
+    """Test that trials of parent experiment are not deleted"""
+    assert len(get_storage().fetch_experiments({})) == 3
+    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_1'})) > 0
+    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_child_1'})) > 0
+    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_grand_child_1'})) > 0
+    execute('db rm -f test_double_exp_child --status *')
+    # Make sure no experiments were deleted
+    assert len(get_storage().fetch_experiments({})) == 3
+    # Make sure only trials of given experiment were deleted
+    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_1'})) > 0
+    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_child_1'})) == 0
+    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_grand_child_1'})) == 0

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the info command."""
-import pytest
-
 import orion.core.cli
 import orion.core.io.resolve_config
 
 
 def test_info_no_hit(clean_db, one_experiment, capsys):
     """Test info if no experiment with given name."""
-    with pytest.raises(SystemExit) as exc:
-        orion.core.cli.main(['info', '--name', 'i do not exist'])
+    returncode = orion.core.cli.main(['info', '--name', 'i do not exist'])
 
-    assert str(exc.value) == '1'
+    assert returncode == 1
 
-    captured = capsys.readouterr().out
+    captured = capsys.readouterr().err
 
-    assert captured == 'Experiment i do not exist not found in db.\n'
+    assert captured.startswith('Error: No experiment with given name \'i do not exist\'')
 
 
 def test_info_hit(clean_db, one_experiment, capsys):

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -16,17 +16,20 @@ def get_user_corneau():
 
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.usefixtures("null_db_instances")
-def test_insert_invalid_experiment(database, monkeypatch):
+def test_insert_invalid_experiment(database, monkeypatch, capsys):
     """Test the insertion of an invalid experiment"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
-    with pytest.raises(ValueError) as exc_info:
-        orion.core.cli.main(["insert", "-n", "dumb_experiment",
-                             "-c", "./orion_config_random.yaml", "./black_box.py", "-x=1"])
+    returncode = orion.core.cli.main(
+        ["insert", "-n", "dumb_experiment",
+         "-c", "./orion_config_random.yaml", "./black_box.py", "-x=1"])
 
-    assert ("No experiment with given name 'dumb_experiment' and version '*'"
-            in str(exc_info.value))
+    assert returncode == 1
+
+    captured = capsys.readouterr().err
+
+    assert ("Error: No experiment with given name 'dumb_experiment'")
 
 
 @pytest.mark.usefixtures("only_experiments_db")

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -210,7 +210,7 @@ def test_build_view_from_args_no_hit(config_file):
     cmdargs = {'name': 'supernaekei', 'config': config_file}
 
     with OrionState(experiments=[], trials=[]):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(NoConfigurationError) as exc_info:
             experiment_builder.build_view_from_args(cmdargs)
         assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
 
@@ -240,7 +240,7 @@ def test_build_from_args_no_hit(config_file, random_dt, script_path, new_config)
                              'x~uniform(0,10)']}
 
     with OrionState(experiments=[], trials=[]):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(NoConfigurationError) as exc_info:
             experiment_builder.build_view_from_args(cmdargs)
         assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
 
@@ -322,7 +322,7 @@ def test_build_view_from_args_debug_mode(script_path):
     update_singletons()
 
     # Can't build view if none exist. It's fine we only want to test the storage creation.
-    with pytest.raises(ValueError):
+    with pytest.raises(NoConfigurationError):
         experiment_builder.build_view_from_args({'name': 'whatever'})
 
     storage = get_storage()
@@ -333,7 +333,7 @@ def test_build_view_from_args_debug_mode(script_path):
     update_singletons()
 
     # Can't build view if none exist. It's fine we only want to test the storage creation.
-    with pytest.raises(ValueError):
+    with pytest.raises(NoConfigurationError):
         experiment_builder.build_view_from_args({'name': 'whatever', 'debug': True})
 
     storage = get_storage()
@@ -351,7 +351,7 @@ def test_build_no_hit(config_file, random_dt, script_path):
 
     with OrionState(experiments=[], trials=[]):
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(NoConfigurationError) as exc_info:
             experiment_builder.build_view(name)
         assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
 
@@ -890,7 +890,7 @@ class TestInitExperimentView(object):
     def test_empty_experiment_view(self):
         """Hit user name, but exp_name does not hit the db."""
         with OrionState(experiments=[], trials=[]):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(NoConfigurationError) as exc_info:
                 experiment_builder.build_view('supernaekei')
             assert ("No experiment with given name 'supernaekei' and version '*'"
                     in str(exc_info.value))

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -269,7 +269,7 @@ class TestStorage:
 
             experiment = cfg.experiments[0]
             mocked_experiment = _Dummy()
-            mocked_experiment._id = experiment['_id']
+            mocked_experiment.id = experiment['_id']
 
             storage.update_experiment(mocked_experiment, test=True)
             experiments = storage.fetch_experiments({'_id': experiment['_id']})
@@ -289,6 +289,20 @@ class TestStorage:
 
             with pytest.raises(AssertionError):
                 storage.update_experiment(experiment=mocked_experiment, uid='123')
+
+    def test_delete_experiment(self, storage):
+        """Test delete one experiment"""
+        if storage and storage['type'] == 'track':
+            pytest.xfail("Track does not support deletion yet.")
+
+        with OrionState(experiments=generate_experiments(), storage=storage) as cfg:
+            storage = cfg.storage()
+
+            n_experiments = len(storage.fetch_experiments({}))
+            storage.delete_experiment(uid=cfg.experiments[0]['_id'])
+            experiments = storage.fetch_experiments({})
+            assert len(experiments) == n_experiments - 1
+            assert cfg.experiments[0]['_id'] not in [exp['_id'] for exp in experiments]
 
     def test_register_trial(self, storage):
         """Test register trial"""
@@ -365,6 +379,60 @@ class TestStorage:
 
             assert len(trials1) == len(cfg.trials), 'trial count should match'
             assert len(trials2) == len(cfg.trials), 'trial count should match'
+
+    def test_delete_all_trials(self, storage):
+        """Test delete all trials of an experiment"""
+        if storage and storage['type'] == 'track':
+            pytest.xfail("Track does not support deletion yet.")
+
+        trials = generate_trials()
+        trial_from_other_exp = copy.deepcopy(trials[0])
+        trial_from_other_exp['experiment'] = 'other'
+        trials.append(trial_from_other_exp)
+        with OrionState(
+                experiments=[base_experiment], trials=trials, storage=storage) as cfg:
+            storage = cfg.storage()
+
+            # Make sure we have sufficient trials to test deletion
+            trials = storage.fetch_trials(uid='default_name')
+            assert len(trials) > 2
+
+            count = storage.delete_trials(uid='default_name')
+            assert count == len(trials)
+            assert storage.fetch_trials(uid='default_name') == []
+
+            # Make sure trials from other experiments were not deleted
+            assert len(storage.fetch_trials(uid='other')) == 1
+
+    def test_delete_trials_with_query(self, storage):
+        """Test delete experiment trials matching a query"""
+        if storage and storage['type'] == 'track':
+            pytest.xfail("Track does not support deletion yet.")
+
+        trials = generate_trials()
+        trial_from_other_exp = copy.deepcopy(trials[0])
+        trial_from_other_exp['experiment'] = 'other'
+        trials.append(trial_from_other_exp)
+        with OrionState(
+                experiments=[base_experiment], trials=trials, storage=storage) as cfg:
+            storage = cfg.storage()
+            experiment = cfg.get_experiment('default_name')
+
+            # Make sure we have sufficient trials to test deletion
+            status = trials[0]['status']
+            trials = storage.fetch_trials(experiment)
+            trials_with_status = storage.fetch_trials_by_status(experiment, status)
+            assert len(trials_with_status) > 0
+            assert len(trials) > len(trials_with_status)
+
+            # Test deletion
+            count = storage.delete_trials(uid='default_name', where={'status': status})
+            assert count == len(trials_with_status)
+            assert storage.fetch_trials_by_status(experiment, status) == []
+            assert len(storage.fetch_trials(experiment)) == len(trials) - len(trials_with_status)
+
+            # Make sure trials from other experiments were not deleted
+            assert len(storage.fetch_trials(uid='other')) == 1
 
     def test_get_trial(self, storage):
         """Test get trial"""


### PR DESCRIPTION

# Description

Add a command to delete experiments based on name and version number, as well as trials based on status.

The format of the command is ```orion db rm <exp name> [--version VERSION] [--status STATUS]```.

Executing ```orion db rm <exp name>``` will remove the experiment, its children and all corresponding trials.

Specifying the ```--status``` will result in deleting the trials only.

# Changes

Methods `delete_experiment` and `delete_trials` are added to the storage interface and implemented for the Legacy backend. For now the Track backend does not support it.

To avoid coupling the experiment builder, the EVC and the storagte, the method `delete_experiment` removes the given experiment only, not the children. The implementation of the hierarchical deletion is done in the CLI module (orion.core.cli.db.rm). The same applies for deletion of trials.

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)