### PR TITLE
Fix test using 'in' to assert equality

### DIFF
--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -156,7 +156,7 @@ class TestDimension(object):
         dim = Dimension('yolo', None)
         print(dim._prior_name)
         assert dim.prior is None
-        assert dim._prior_name is 'None'
+        assert dim._prior_name == 'None'
 
     @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_get_prior_string(self):


### PR DESCRIPTION
# Description
The test `test_no_prior` is using the operation `in` to test for string equality which is generally ambiguous semantically and wrong in this case since we compare two string for equality.

# Changes
The pull request replaces `in` by `==`.

# Checklist
## Tests
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)