### PR TITLE
Add command `orion db set`

### DIFF
--- a/docs/src/user/storage.rst
+++ b/docs/src/user/storage.rst
@@ -82,7 +82,35 @@ deleting the child experiments.
 ``set`` Change value of data in storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Coming soon
+Command to update trial attributes.
+
+To change a trial status, simply give the experiment name,
+trial id and status. (use `orion status --all` to get trial ids)
+
+.. code-block:: sh
+
+   orion db set my-exp-name id=3cc91e851e13281ca2152c19d888e937 status=interrupted
+
+To change all trials from a given status to another, simply give the two status
+
+.. code-block:: sh
+
+   orion db set my-exp-name status=broken status=interrupted
+
+Or `*` to apply the change to all trials
+
+.. code-block:: sh
+
+   orion db set my-exp-name '*' status=interrupted
+
+By default, trials of the last version of the experiment are selected.
+Add --version to select a prior version. Note that the modification
+is applied recursively to all child experiment, but not to the parents.
+
+.. code-block:: sh
+
+   orion db set my-exp-name --version 1 status=broken status=interrupted
+
 
 .. _storage_upgrade:
 

--- a/docs/src/user/storage.rst
+++ b/docs/src/user/storage.rst
@@ -338,6 +338,18 @@ In both case, you can access it with
 .. automethod:: orion.storage.base.BaseStorageProtocol.get_trial
    :noindex:
 
+:hidden:`update_trials`
+-----------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.update_trials
+   :noindex:
+
+:hidden:`update_trial`
+-----------------------
+
+.. automethod:: orion.storage.base.BaseStorageProtocol.update_trial
+   :noindex:
+
 :hidden:`fetch_lost_trials`
 ---------------------------
 

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -80,7 +80,7 @@ class OrionArgsParser:
         """Execute main function of the subparser"""
         try:
             args, function = self.parse(argv)
-            function(args)
+            returncode = function(args)
         except (NoConfigurationError, NoNameError, DatabaseError, MissingResultFile,
                 BranchingEvent) as e:
             print('Error:', e, file=sys.stderr)
@@ -94,7 +94,7 @@ class OrionArgsParser:
             print('Orion is interrupted.')
             return 130
 
-        return 0
+        return 0 if returncode is None else returncode
 
 
 def get_basic_args_group(

--- a/src/orion/core/cli/db/rm.py
+++ b/src/orion/core/cli/db/rm.py
@@ -14,6 +14,7 @@ import sys
 
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.pptree import print_tree
+from orion.core.utils.terminal import confirm_name
 from orion.storage.base import get_storage
 
 
@@ -97,34 +98,6 @@ def add_subparser(parser):
         help='Force delete without asking to enter experiment name twice.')
 
     return rm_parser
-
-
-def confirm_name(message, name, force=False):
-    """Ask the user to confirm the name.
-
-    Parameters
-    ----------
-    message: str
-        The message to be printed.
-    name: str
-        The string that the user must enter.
-    force: bool
-        Override confirmation and return True. Default: False.
-
-    Returns
-    -------
-    bool
-        True if confirmed, False otherwise.
-
-    """
-    if force:
-        print(message)
-        print('FORCED')
-        return True
-
-    answer = input(message)
-
-    return answer.strip() == name
 
 
 def process_trial_rm(storage, root, status):

--- a/src/orion/core/cli/db/set.py
+++ b/src/orion/core/cli/db/set.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli.db.set` -- Module running the set command
+==============================================================
+
+.. module:: setup
+   :platform: Unix
+   :synopsis: Update data of experiments and trials in the storage
+"""
+import argparse
+import logging
+import sys
+
+import orion.core.io.experiment_builder as experiment_builder
+from orion.core.utils.pptree import print_tree
+from orion.core.utils.terminal import confirm_name
+from orion.storage.base import get_storage
+
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION = """
+Command to update trial attributes.
+
+To change a trial status, simply give the experiment name,
+trial id and status. (use `orion status --all` to get trial ids)
+$ orion db set my-exp-name id=3cc91e851e13281ca2152c19d888e937 status=interrupted
+
+To change all trials from a given status to another, simply give the two status
+$ orion db set my-exp-name status=broken status=interrupted
+
+Or `*` to apply the change to all trials
+$ orion db set my-exp-name '*' status=interrupted
+
+By default, trials of the last version of the experiment are selected.
+Add --version to select a prior version. Note that the modification
+is applied recursively to all child experiment, but not to the parents.
+$ orion db set my-exp-name --version 1 status=broken status=interrupted
+"""
+
+
+CONFIRM_MESSAGE = """
+Trials matching the query `{query}` for all experiments listed above
+will be modified with `{update}`.
+To select a specific version use --version <VERSION>.
+
+Make sure to stop any worker currently executing one of these experiment.
+
+To proceed, type again the name of the experiment: """
+
+
+def add_subparser(parser):
+    """Return the parser that needs to be used for this command"""
+    set_parser = parser.add_parser(
+        'set',
+        description=DESCRIPTION,
+        help='set help',
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    set_parser.set_defaults(func=main)
+
+    set_parser.add_argument(
+        'name',
+        help='Name of the experiment to delete.')
+
+    set_parser.add_argument(
+        '-c', '--config', type=argparse.FileType('r'), metavar='path-to-config',
+        help="user provided orion configuration file")
+
+    set_parser.add_argument(
+        '-v', '--version', type=int, default=None,
+        help="specific version of experiment to fetch; "
+             "(default: last version matching.)")
+
+    set_parser.add_argument(
+        '-f', '--force', action='store_true',
+        help='Force modify without asking to enter experiment name twice.')
+
+    set_parser.add_argument(
+        'query',
+        help=(f'Query for trials to update. Can be `*` to update all trials. '
+              f'Otherwise format must be <attribute>=<value>. Ex: status=broken. '
+              f'Supported attributes are {VALID_QUERY_ATTRS}'))
+
+    set_parser.add_argument(
+        'update',
+        help=(f'Update for trials. Format must be <attribute>=<value>. '
+              f'Ex: status=interrupted. '
+              f'Supported attributes are {VALID_UPDATE_ATTRS}'))
+
+    return set_parser
+
+
+def process_updates(storage, root, query, update):
+    """Update the matching trials of the given experiment and its children."""
+    trials_total = 0
+    for node in root:
+        count = storage.update_trials(node.item, where=query, **update)
+        logger.debug('%d trials modified in experiment %s-v%d',
+                     count, node.item.name, node.item.version)
+        trials_total += count
+
+    print(f'{trials_total} trials modified')
+
+
+VALID_QUERY_ATTRS = ['status', 'id']
+VALID_UPDATE_ATTRS = ['status']
+
+
+def build_query(query):
+    """Convert query string to dict format
+
+    String format must be <attr name>=<value>
+    """
+    if query.strip() == '*':
+        return {}
+
+    attribute, value = query.split('=')
+
+    if attribute not in VALID_QUERY_ATTRS:
+        raise ValueError(
+            f'Invalid query attribute `{attribute}`. Must be one of {VALID_QUERY_ATTRS}')
+
+    if attribute == 'id':
+        attribute = '_id'
+
+    return {attribute: value}
+
+
+def build_update(update):
+    """Convert update string to dict format
+
+    String format must be <attr name>=<value>
+    """
+    attribute, value = update.split('=')
+
+    if attribute not in VALID_UPDATE_ATTRS:
+        raise ValueError(
+            f'Invalid update attribute `{attribute}`. Must be one of {VALID_UPDATE_ATTRS}')
+
+    return {attribute: value}
+
+
+def main(args):
+    """Remove the experiment(s) or trial(s)."""
+    config = experiment_builder.get_cmd_config(args)
+    experiment_builder.setup_storage(config.get('storage'))
+
+    # Find root experiment
+    root = experiment_builder.build_view(name=args['name'],
+                                         version=args.get('version', None)).node
+
+    try:
+        query = build_query(args['query'])
+        update = build_update(args['update'])
+    except ValueError as e:
+        print(f'Error: {e}', file=sys.stderr)
+        return 1
+
+    # List all experiments with children
+    print_tree(root, nameattr='tree_name')
+
+    confirmed = confirm_name(
+        CONFIRM_MESSAGE.format(query=args['query'], update=args['update']),
+        args['name'], args['force'])
+
+    if not confirmed:
+        print('Confirmation failed, aborting operation.')
+        return 1
+
+    storage = get_storage()
+
+    process_updates(storage, root, query, update)
+
+    return 0

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -15,6 +15,7 @@ import os
 import yaml
 
 import orion.core
+from orion.core.utils.terminal import ask_question
 
 log = logging.getLogger(__name__)
 
@@ -26,33 +27,6 @@ def add_subparser(parser):
     setup_parser.set_defaults(func=main)
 
     return setup_parser
-
-
-def ask_question(question, default=None):
-    """Ask a question to the user and receive an answer.
-
-    Parameters
-    ----------
-    question: str
-        The question to be asked.
-    default: str
-        The default value to use if the user enters nothing.
-
-    Returns
-    -------
-    str
-        The answer provided by the user.
-
-    """
-    if default is not None:
-        question = question + " (default: {}) ".format(default)
-
-    answer = input(question)
-
-    if answer.strip() == "":
-        return default
-
-    return answer
 
 
 # pylint: disable = unused-argument

--- a/src/orion/core/cli/status.py
+++ b/src/orion/core/cli/status.py
@@ -189,7 +189,7 @@ def print_summary(trials, offset=0):
 
         if c_trials[0].objective:
             headers.append('min {}'.format(c_trials[0].objective.name))
-            line.append(min(trial.objective.value for trial in c_trials))
+            line.append(min(trial.objective.value for trial in c_trials if trial.objective))
 
         lines.append(line)
 

--- a/src/orion/core/utils/terminal.py
+++ b/src/orion/core/utils/terminal.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.utils.terminal` -- Helper functions for terminal i/o
+=====================================================================
+
+.. module:: setup
+   :platform: Unix
+   :synopsis: Helper functions for interaction with user on terminal
+"""
+
+
+def ask_question(question, default=None):
+    """Ask a question to the user and receive an answer.
+
+    Parameters
+    ----------
+    question: str
+        The question to be asked.
+    default: str
+        The default value to use if the user enters nothing.
+
+    Returns
+    -------
+    str
+        The answer provided by the user.
+
+    """
+    if default is not None:
+        question = question + " (default: {}) ".format(default)
+
+    answer = input(question)
+
+    if answer.strip() == "":
+        return default
+
+    return answer
+
+
+def confirm_name(message, name, force=False):
+    """Ask the user to confirm the name.
+
+    Parameters
+    ----------
+    message: str
+        The message to be printed.
+    name: str
+        The string that the user must enter.
+    force: bool
+        Override confirmation and return True. Default: False.
+
+    Returns
+    -------
+    bool
+        True if confirmed, False otherwise.
+
+    """
+    if force:
+        print(message)
+        print('FORCED')
+        return True
+
+    answer = input(message)
+
+    return answer.strip() == name

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -19,38 +19,36 @@ from orion.core.utils import (AbstractSingletonType, SingletonFactory)
 log = logging.getLogger(__name__)
 
 
-def get_experiment_uid(experiment=None, uid=None, force_uid=True):
-    """Return experiment uid either from `experiment` or directly uid.
-
-    Delete matching experiments from the database
+def get_uid(item=None, uid=None, force_uid=True):
+    """Return uid either from `item` or directly uid.
 
     Parameters
     ----------
-    experiment: Experiment, optional
-       experiment object to retrieve from the database
+    item: Experiment or Trial, optional
+       Object with .id attribute
 
     uid: str, optional
-        experiment id used to retrieve the trial object
+        str id representation
 
     force_uid: bool, optional
-        If True, at least one of experiment or uid must be passed.
+        If True, at least one of item or uid must be passed.
 
     Raises
     ------
     UndefinedCall
-        if both experiment and uid are not set and force_uid is True
+        if both item and uid are not set and force_uid is True
 
     AssertionError
-        if both experiment and uid are provided and they do not match
+        if both item and uid are provided and they do not match
     """
-    if experiment is not None and uid is not None:
-        assert experiment.id == uid
+    if item is not None and uid is not None:
+        assert item.id == uid
 
     if uid is None:
-        if experiment is None and force_uid:
-            raise MissingArguments('Either `experiment` or `uid` should be set')
-        elif experiment is not None:
-            uid = experiment.id
+        if item is None and force_uid:
+            raise MissingArguments('Either `item` or `uid` should be set')
+        elif item is not None:
+            uid = item.id
 
     return uid
 
@@ -103,7 +101,7 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         raise NotImplementedError()
 
     def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
-        """Update a the fields of a given trials
+        """Update the fields of a given experiment
 
         Parameters
         ----------
@@ -219,6 +217,62 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
 
         AssertionError
             if both experiment and uid are provided and they do not match
+
+        """
+        raise NotImplementedError()
+
+    def update_trials(self, experiment=None, uid=None, where=None, **kwargs):
+        """Update trials of a given experiment matching a query
+
+        Parameters
+        ----------
+        experiment: Experiment, optional
+           experiment object to retrieve from the database
+
+        uid: str, optional
+            experiment id used to retrieve the trial object
+
+        where: Optional[dict]
+            constraint trials must respect
+
+        **kwargs: dict
+            a dictionary of fields to update
+
+        Raises
+        ------
+        UndefinedCall
+            if both experiment and uid are not set
+
+        AssertionError
+            if both experiment and uid are provided and they do not match
+
+        """
+        raise NotImplementedError()
+
+    def update_trial(self, trial=None, uid=None, where=None, **kwargs):
+        """Update fields of a given trial
+
+        Parameters
+        ----------
+        trial: Trial, optional
+           trial object to update in the database
+
+        uid: str, optional
+            id of the trial to update in the database
+
+        where: Optional[dict]
+            constraint trials must respect. Note: useful to handle race conditions.
+
+        **kwargs: dict
+            a dictionary of fields to update
+
+        Raises
+        ------
+        UndefinedCall
+            if both trial and uid are not set
+
+        AssertionError
+            if both trial and uid are provided and they do not match
 
         """
         raise NotImplementedError()

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -20,8 +20,7 @@ import warnings
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.flatten import flatten, unflatten
 from orion.core.worker.trial import Trial as OrionTrial, validate_status
-from orion.storage.base import (
-    BaseStorageProtocol, FailedUpdate, get_experiment_uid, MissingArguments)
+from orion.storage.base import BaseStorageProtocol, FailedUpdate, get_uid, MissingArguments
 
 log = logging.getLogger(__name__)
 
@@ -393,7 +392,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
     def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_experiment`"""
-        uid = get_experiment_uid(experiment, uid)
+        uid = get_uid(experiment, uid)
 
         self.group = self.backend.fetch_and_update_group({
             '_uid': uid
@@ -534,44 +533,6 @@ class Track(BaseStorageProtocol):   # noqa: F811
         trials.sort(key=sort_key)
         return trials
 
-    _ignore_updates_for = {'results', 'params', '_id'}
-
-    def _update_trial(self, trial, **kwargs):
-        """Update the fields of a given trials
-
-        Parameters
-        ----------
-        trial: Trial
-            Trial object to update
-
-        where: Optional[dict]
-            constraint trial must respect
-
-        kwargs: dict
-            a dictionary of fields to update
-
-        Returns
-        -------
-        returns true if the underlying storage was updated
-
-        """
-        try:
-            if isinstance(trial, TrialAdapter):
-                trial = trial.storage
-
-            for key, value in kwargs.items():
-                if key == 'status':
-                    self.backend.set_trial_status(trial, get_track_status(value))
-                elif key in self._ignore_updates_for:
-                    continue
-                else:
-                    pair = {key: to_json(value)}
-                    self.backend.log_trial_metadata(trial, **pair)
-
-            return True
-        except ConcurrentWrite:
-            return False
-
     def retrieve_result(self, trial, *args, **kwargs):
         """Fetch the result from a given medium (file, db, socket, etc..) for a given trial and
         insert it into the trial object
@@ -624,14 +585,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
     def fetch_trials(self, experiment=None, uid=None):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_trials`"""
-        if uid and experiment:
-            assert experiment.id == uid
-
-        if uid is None:
-            if experiment is None:
-                raise MissingArguments('experiment or uid need to be defined')
-
-            uid = experiment.id
+        uid = get_uid(experiment, uid)
 
         return self._fetch_trials(dict(group_id=uid))
 
@@ -683,6 +637,64 @@ class Track(BaseStorageProtocol):   # noqa: F811
             return None
 
         return TrialAdapter(trial, objective=self.objective)
+
+    def update_trials(self, experiment=None, uid=None, where=None, **kwargs):
+        """See :func:`~orion.storage.BaseStorageProtocol.update_trials`"""
+        uid = get_uid(experiment, uid)
+
+        if where is None:
+            where = dict()
+
+        where['group_id'] = uid
+
+        count = 0
+        for trial in self._fetch_trials(where):
+            count += self.update_trial(trial, **kwargs)
+
+        return count
+
+    _ignore_updates_for = {'results', 'params', '_id'}
+
+    def update_trial(self, trial=None, uid=None, **kwargs):
+        """Update the fields of a given trials
+
+        Parameters
+        ----------
+        trial: Trial
+            Trial object to update
+
+        where: Optional[dict]
+            constraint trial must respect
+
+        kwargs: dict
+            a dictionary of fields to update
+
+        Returns
+        -------
+        returns 1 if the underlying storage was updated else 0
+
+        """
+        uid = get_uid(trial, uid)
+
+        if trial is None:
+            trial = self.get_trial(uid)
+
+        try:
+            if isinstance(trial, TrialAdapter):
+                trial = trial.storage
+
+            for key, value in kwargs.items():
+                if key == 'status':
+                    self.backend.set_trial_status(trial, get_track_status(value))
+                elif key in self._ignore_updates_for:
+                    continue
+                else:
+                    pair = {key: to_json(value)}
+                    self.backend.log_trial_metadata(trial, **pair)
+
+            return 1
+        except ConcurrentWrite:
+            return 0
 
     def fetch_lost_trials(self, experiment):
         """Fetch all trials that have a heartbeat older than

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -20,7 +20,7 @@ import warnings
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.flatten import flatten, unflatten
 from orion.core.worker.trial import Trial as OrionTrial, validate_status
-from orion.storage.base import BaseStorageProtocol, FailedUpdate, get_uid, MissingArguments
+from orion.storage.base import BaseStorageProtocol, FailedUpdate, get_uid
 
 log = logging.getLogger(__name__)
 
@@ -591,14 +591,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
     def get_trial(self, trial=None, uid=None):
         """See :func:`~orion.storage.BaseStorageProtocol.get_trials`"""
-        if trial is not None and uid is not None:
-            assert trial.id == uid
-
-        if uid is None:
-            if trial is None:
-                raise MissingArguments('trial or uid argument should be populated')
-
-            uid = trial.id
+        uid = get_uid(trial, uid)
 
         _hash, _rev = 0, 0
         data = uid.split('_', maxsplit=1)
@@ -674,10 +667,8 @@ class Track(BaseStorageProtocol):   # noqa: F811
         returns 1 if the underlying storage was updated else 0
 
         """
-        uid = get_uid(trial, uid)
-
-        if trial is None:
-            trial = self.get_trial(uid)
+        # Get a TrialAdapter
+        trial = self.get_trial(trial=trial, uid=uid)
 
         try:
             if isinstance(trial, TrialAdapter):

--- a/tests/functional/commands/test_db_set.py
+++ b/tests/functional/commands/test_db_set.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform functional tests for db set."""
+import orion.core.cli
+import orion.core.io.experiment_builder as experiment_builder
+from orion.storage.base import get_storage
+
+
+def execute(command, assert_code=0):
+    """Execute orion command and return returncode"""
+    returncode = orion.core.cli.main(command.split(' '))
+    assert returncode == assert_code
+
+
+def test_no_exp(clean_db, capsys):
+    """Test that set non-existing exp exits gracefully"""
+    execute('db set i-dont-exist whatever=1 idontcare=2', assert_code=1)
+
+    captured = capsys.readouterr()
+
+    assert captured.err.startswith("Error: No experiment with given name 'i-dont-exist'")
+
+
+def test_confirm_name(monkeypatch, clean_db, single_with_trials):
+    """Test name must be confirmed for update"""
+    def incorrect_name(*args):
+        return 'oops'
+
+    monkeypatch.setattr('builtins.input', incorrect_name)
+
+    execute('db set test_single_exp status=broken status=interrupted', assert_code=1)
+
+    def correct_name(*args):
+        return 'test_single_exp'
+
+    monkeypatch.setattr('builtins.input', correct_name)
+
+    assert len(get_storage()._fetch_trials({'status': 'broken'})) > 0
+    execute('db set test_single_exp status=broken status=interrupted')
+    assert len(get_storage()._fetch_trials({'status': 'broken'})) == 0
+
+
+def test_invalid_query(clean_db, single_with_trials, capsys):
+    """Test error message when query is invalid"""
+    execute('db set -f test_single_exp whatever=1 idontcare=2', assert_code=1)
+
+    captured = capsys.readouterr()
+
+    assert captured.err.startswith("Error: Invalid query attribute `whatever`.")
+
+
+def test_invalid_update(clean_db, single_with_trials, capsys):
+    """Test error message when update attribute is invalid"""
+    execute('db set -f test_single_exp status=new yoopidoo=2', assert_code=1)
+
+    captured = capsys.readouterr()
+
+    assert captured.err.startswith("Error: Invalid update attribute `yoopidoo`.")
+
+
+def test_update_trial(clean_db, single_with_trials, capsys):
+    """Test that trial is updated properly"""
+    trials = get_storage()._fetch_trials({})
+    assert sum(trial.status == 'broken' for trial in trials) > 0
+    trials = dict(zip((trial.id for trial in trials), trials))
+    execute('db set -f test_single_exp status=broken status=interrupted')
+    for trial in get_storage()._fetch_trials({}):
+        if trials[trial.id].status == 'broken':
+            assert trial.status == 'interrupted', 'status not changed properly'
+        else:
+            assert trials[trial.id].status == trial.status, 'status should not have been changed'
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith("1 trials modified\n")
+
+
+def test_update_trial_with_id(clean_db, single_with_trials, capsys):
+    """Test that trial is updated properly when querying with the id"""
+    trials = get_storage()._fetch_trials({})
+    trials = dict(zip((trial.id for trial in trials), trials))
+    trial = get_storage()._fetch_trials({'status': 'broken'})[0]
+    execute(f'db set -f test_single_exp id={trial.id} status=interrupted')
+    for new_trial in get_storage()._fetch_trials({}):
+        if new_trial.id == trial.id:
+            assert new_trial.status == 'interrupted', 'status not changed properly'
+        else:
+            status_unchanged = trials[new_trial.id].status == new_trial.status
+            assert status_unchanged, 'status should not have been changed'
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith("1 trials modified\n")
+
+
+def test_update_no_match_query(clean_db, single_with_trials, capsys):
+    """Test that no trials are updated when there is no match"""
+    trials = get_storage()._fetch_trials({})
+    trials = dict(zip((trial.id for trial in trials), trials))
+    execute('db set -f test_single_exp status=invalid status=interrupted')
+    for trial in get_storage()._fetch_trials({}):
+        assert trials[trial.id].status == trial.status, 'status should not have been changed'
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith("0 trials modified\n")
+
+
+def test_update_child_only(clean_db, three_experiments_same_name_with_trials, capsys):
+    """Test trials of the parent experiment are not updated"""
+    exp1 = experiment_builder.build_view(name='test_single_exp', version=1)
+    exp2 = experiment_builder.build_view(name='test_single_exp', version=2)
+    exp3 = experiment_builder.build_view(name='test_single_exp', version=3)
+    execute('db set -f test_single_exp --version 2 status=broken status=interrupted')
+    assert len(exp1.fetch_trials_by_status('broken')) > 0
+    assert len(exp2.fetch_trials_by_status('broken')) == 0
+    assert len(exp3.fetch_trials_by_status('broken')) == 0
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith("2 trials modified\n")
+
+
+def test_update_default_leaf(clean_db, three_experiments_same_name_with_trials, capsys):
+    """Test trials of the parent experiment are not updated"""
+    exp1 = experiment_builder.build_view(name='test_single_exp', version=1)
+    exp2 = experiment_builder.build_view(name='test_single_exp', version=2)
+    exp3 = experiment_builder.build_view(name='test_single_exp', version=3)
+    execute('db set -f test_single_exp status=broken status=interrupted')
+    assert len(exp1.fetch_trials_by_status('broken')) > 0
+    assert len(exp2.fetch_trials_by_status('broken')) > 0
+    assert len(exp3.fetch_trials_by_status('broken')) == 0
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith("1 trials modified\n")
+
+
+def test_no_update_id_from_parent(clean_db, three_experiments_same_name_with_trials, capsys):
+    """Test trials of the parent experiment are not updated"""
+    exp1 = experiment_builder.build_view(name='test_single_exp', version=1)
+    exp2 = experiment_builder.build_view(name='test_single_exp', version=2)
+    exp3 = experiment_builder.build_view(name='test_single_exp', version=3)
+    trial = exp1.fetch_trials_by_status('broken')[0]
+    execute(f'db set -f test_single_exp id={trial.id} status=shouldnothappen')
+    assert len(exp1.fetch_trials_by_status('shouldnothappen')) == 0
+    assert len(exp2.fetch_trials_by_status('shouldnothappen')) == 0
+    assert len(exp3.fetch_trials_by_status('shouldnothappen')) == 0
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith("0 trials modified\n")

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -347,13 +347,15 @@ class TestStorage:
             class _Dummy:
                 pass
 
-            trials = storage.fetch_trials(uid='default_name')
+            experiment = cfg.get_experiment('default_name', version=None)
+            trials = storage.fetch_trials(experiment)
             assert sum(trial.status == 'reserved' for trial in trials) == 2
-            storage.update_trials(
-                uid='default_name',
+            count = storage.update_trials(
+                experiment,
                 where={'status': 'reserved'},
                 status='interrupted')
-            trials = storage.fetch_trials(uid='default_name')
+            assert count == 2
+            trials = storage.fetch_trials(experiment)
             assert sum(trial.status == 'interrupted' for trial in trials) == 2
 
     def test_update_trial(self, storage):
@@ -400,7 +402,7 @@ class TestStorage:
             experiment = cfg.get_experiment('default_name', version=None)
 
             trials1 = storage.fetch_trials(experiment=experiment)
-            trials2 = storage.fetch_trials(uid=experiment._id)
+            trials2 = storage.fetch_trials(uid=experiment.id)
 
             with pytest.raises(MissingArguments):
                 storage.fetch_trials()

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -336,6 +336,37 @@ class TestStorage:
             with pytest.raises(DuplicateKeyError):
                 storage.register_lie(Trial(**cfg.lies[0]))
 
+    def test_update_trials(self, storage):
+        """Test update many trials"""
+        with OrionState(
+                experiments=[base_experiment],
+                trials=generate_trials(status=['completed', 'reserved', 'reserved']),
+                storage=storage) as cfg:
+            storage = cfg.storage()
+
+            class _Dummy:
+                pass
+
+            trials = storage.fetch_trials(uid='default_name')
+            assert sum(trial.status == 'reserved' for trial in trials) == 2
+            storage.update_trials(
+                uid='default_name',
+                where={'status': 'reserved'},
+                status='interrupted')
+            trials = storage.fetch_trials(uid='default_name')
+            assert sum(trial.status == 'interrupted' for trial in trials) == 2
+
+    def test_update_trial(self, storage):
+        """Test update one trial"""
+        with OrionState(experiments=[base_experiment], trials=[base_trial], storage=storage) as cfg:
+            storage = cfg.storage()
+
+            trial = Trial(**cfg.trials[0])
+
+            assert trial.status != 'interrupted'
+            storage.update_trial(trial, status='interrupted')
+            assert storage.get_trial(trial).status == 'interrupted'
+
     def test_reserve_trial_success(self, storage):
         """Test reserve trial"""
         with OrionState(


### PR DESCRIPTION
## Why:

Users need a way to change values of some fields of the trials, namely
the status.

## How:

A command orion db set is added. It supports query for a single
attribute (ex: status=completed) and update for single attributes as
well (ex: status=interrupted). So far only `status` and `id` are
supported for queries and `status` for updates. These are likely to be
sufficient for the majority of use cases.

As for orion db rm, the updates are recursive in children experiments.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
Depends on #425 