### PR TITLE
Quit if code changed between two trials execution

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -563,6 +563,7 @@ def get_cmd_config(cmdargs):
     cmd_config.update(cmd_config.pop('experiment', {}))
     cmd_config['branching'] = cmd_config.pop('evc', {})
 
+    # TODO: user_args won't be defined if reading from DB only (`orion hunt -n <exp> ` alone)
     metadata = resolve_config.fetch_metadata(cmd_config.get('user'), cmd_config.get('user_args'))
     cmd_config['metadata'] = metadata
     cmd_config.pop('config', None)


### PR DESCRIPTION
Why:

We test the code version at beginning of experiment but it could change
during an execution, leading to trials ran with different code versions.

How:

Validate before the execution of the trial that code version did not
change. If so, raise BranchingEvent().

Note:

There may be race conditions between the validation and the execution of the trial.
The only solution for this would be to test the code version at
beginning of trial execution but that would require reimplementation for
all languages of users' scripts...