### PR TITLE
added info about working_dir when using orion info CLI

### DIFF
--- a/src/orion/core/utils/format_terminal.py
+++ b/src/orion/core/utils/format_terminal.py
@@ -258,6 +258,7 @@ CONFIG_TEMPLATE = """\
 {title}
 pool size: {experiment.pool_size}
 max trials: {experiment.max_trials}
+working dir: {experiment.working_dir}
 """
 
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -409,7 +409,7 @@ class ExperimentView(object):
 
     #                     Attributes
     valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials",
-                         "version", "space"] +
+                         "version", "space", "working_dir"] +
                         # Properties
                         ["id", "node", "is_done", "algorithms", "stats", "configuration"] +
                         # Methods

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -395,11 +395,13 @@ def test_format_config(monkeypatch):
     experiment = DummyExperiment()
     experiment.pool_size = 10
     experiment.max_trials = 100
+    experiment.working_dir = "working_dir"
     assert format_config(experiment) == """\
 Config
 ======
 pool size: 10
 max trials: 100
+working dir: working_dir
 """
 
 
@@ -574,6 +576,7 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment.metadata = {'user_args': commandline}
     experiment.pool_size = 10
     experiment.max_trials = 100
+    experiment.working_dir = "working_dir"
     experiment.configuration = {'algorithms': algorithm_dict}
 
     space = SpaceBuilder().build(
@@ -636,6 +639,7 @@ Config
 ======
 pool size: 10
 max trials: 100
+working dir: working_dir
 
 
 Algorithm


### PR DESCRIPTION
# Description
When using the CLI command `orion info`, it will now print the working_dir variable.

E.g.,

Config
======
pool size: 1
max trials: 2
working dir: orion_working_dir

# Changes
Just added working_dir to the list of variables printed under "Config"

# Checklist

## Tests
- [x ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x ] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x ] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
