### PR TITLE
Enable `is_broken` for ExperimentView

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -411,7 +411,8 @@ class ExperimentView(object):
     valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials",
                          "version", "space"] +
                         # Properties
-                        ["id", "node", "is_done", "algorithms", "stats", "configuration"] +
+                        ["id", "node", "is_done", "is_broken", "algorithms", "stats",
+                         "configuration"] +
                         # Methods
                         ["fetch_trials", "fetch_trials_by_status", "get_trial"])
 

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -583,3 +583,16 @@ def test_experiment_view_protocol_read_only():
 
         with pytest.raises(AttributeError):
             exp_view._experiment._storage.set_trial_status
+
+
+def test_view_is_broken():
+    """Tests that property ``is_broken`` is accessible in an experiment's view"""
+    broken = ['broken'] * 5
+    with OrionState(trials=generate_trials(broken)) as cfg:
+        exp = Experiment('test-experiment')
+        exp._id = cfg.trials[0]['experiment']
+
+        assert exp.is_broken
+
+        exp_view = ExperimentView(exp)
+        assert exp_view.is_broken


### PR DESCRIPTION
# Description
`is_broken` is a property defined in `Experiment`. Since it's a read-only property with no side effects. It should be included in the authorized attributes for instances of `ExperimentView`.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)