### PR TITLE
Specialized properties for Trials

### DIFF
--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -310,7 +310,6 @@ class Trial:
         """
         return self._fetch_results('constraint', self.results)
 
-
     @property
     def statistics(self):
         """

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -310,6 +310,18 @@ class Trial:
         """
         return self._fetch_results('constraint')
 
+
+    @property
+    def statistics(self):
+        """
+        Return this trial's statistics
+
+        Returns
+        -------
+        A list of ``Trial.Result`` de type 'statistic'
+        """
+        return self._fetch_results('statistic')
+
     @property
     def hash_name(self):
         """Generate a unique name with an md5sum hash for this `Trial`.

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -308,7 +308,7 @@ class Trial:
         -------
         A list of ``Trial.Result`` of type 'constraint'
         """
-        return self._fetch_results('constraint')
+        return self._fetch_results('constraint', self.results)
 
 
     @property
@@ -320,7 +320,7 @@ class Trial:
         -------
         A list of ``Trial.Result`` de type 'statistic'
         """
-        return self._fetch_results('statistic')
+        return self._fetch_results('statistic', self.results)
 
     @property
     def hash_name(self):
@@ -350,17 +350,15 @@ class Trial:
                              "have not been set.")
         return self.format_values(self._params, sep='-').replace('/', '.')
 
-    def _fetch_results(self, type):
+    def _fetch_results(self, type, results):
         """Fetch results for the given type"""
-        results = [result for result in self.results if result.type == type]
-
-        return results
+        return [result for result in results if result.type == type]
 
     def _fetch_one_result_of_type(self, result_type, results=None):
         if results is None:
             results = self.results
 
-        value = [result for result in results if result.type == result_type]
+        value = self._fetch_results(result_type, results)
 
         if not value:
             return None

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -300,6 +300,17 @@ class Trial:
         return self._fetch_one_result_of_type('gradient')
 
     @property
+    def constraints(self):
+        """
+        Return this trial's constraints
+
+        Returns
+        -------
+        A list of ``Trial.Result`` of type 'constraint'
+        """
+        return self._fetch_results('constraint')
+
+    @property
     def hash_name(self):
         """Generate a unique name with an md5sum hash for this `Trial`.
 
@@ -326,6 +337,12 @@ class Trial:
             raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "
                              "have not been set.")
         return self.format_values(self._params, sep='-').replace('/', '.')
+
+    def _fetch_results(self, type):
+        """Fetch results for the given type"""
+        results = [result for result in self.results if result.type == type]
+
+        return results
 
     def _fetch_one_result_of_type(self, result_type, results=None):
         if results is None:

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -242,6 +242,38 @@ class TestTrial(object):
 
         assert expected == trial.constraints
 
+    def test_statistics_property(self, exp_config):
+        """Tests the property for accessing statistics"""
+        # 0 result of type 'statistic' exist
+        t = Trial(**exp_config[1][1])
+        assert t.statistics == []
+
+        # 1 result of type 'statistic' exist
+        expected = [
+            Trial.Result(name='a', type='statistic', value=5),
+        ]
+
+        exp_config[1][1]['results'].append(dict(name='a',
+                                                type='statistic',
+                                                value=5))
+
+        trial = Trial(**exp_config[1][1])
+
+        assert expected == trial.statistics
+
+        # > 1 results of type 'statistic' exist
+        expected = [
+            Trial.Result(name='a', type='statistic', value=5),
+            Trial.Result(name='b', type='statistic', value=20)
+        ]
+
+        exp_config[1][1]['results'].append(dict(name='b',
+                                                type='statistic',
+                                                value=20))
+        trial = Trial(**exp_config[1][1])
+
+        assert expected == trial.statistics
+
     def test_params_repr_property(self, exp_config):
         """Check property `Trial.params_repr`."""
         t = Trial(**exp_config[1][1])

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -208,6 +208,40 @@ class TestTrial(object):
         assert t.gradient.value == [5, 3]
         tmp = exp_config[1][1]['results'].pop()
 
+    def test_constraints_property(self, exp_config):
+        """Tests the property for accessing constraints"""
+        # 0 result of type 'constraints' exist
+        tmp = exp_config[1][1]['results'].pop(1)
+        t = Trial(**exp_config[1][1])
+        assert t.constraints == []
+        exp_config[1][1]['results'].append(tmp)
+
+        # 1 result of type 'constraint' exist
+        expected = [
+            Trial.Result(name='contra', type='constraint', value=1.2)
+        ]
+
+        trial = Trial(**exp_config[1][1])
+
+        assert expected == trial.constraints
+
+        # > 1 results of type 'constraint' exist
+        expected = [
+            Trial.Result(name='contra', type='constraint', value=1.2),
+            Trial.Result(name='a', type='constraint', value=5),
+            Trial.Result(name='b', type='constraint', value=20)
+        ]
+
+        exp_config[1][1]['results'].append(dict(name='a',
+                                                type='constraint',
+                                                value=5))
+        exp_config[1][1]['results'].append(dict(name='b',
+                                                type='constraint',
+                                                value=20))
+        trial = Trial(**exp_config[1][1])
+
+        assert expected == trial.constraints
+
     def test_params_repr_property(self, exp_config):
         """Check property `Trial.params_repr`."""
         t = Trial(**exp_config[1][1])


### PR DESCRIPTION
# Description
Trial supports results of type 'objective', 'constraint', 'gradient', and 'statistic'; it's not possible to fetch more than one result. For the results of type 'gradient' and 'objective' it's acceptable since multi-objective optimization is not yet supported. However, multiple results of type 'constraint' and 'statistic' can already be supported.

# Changes
This pull request adds properties to fetch the results of type 'constraint' and 'statistic'.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)