### PR TITLE
Add `completed` field to `info` cmd

### DIFF
--- a/src/orion/core/utils/format_terminal.py
+++ b/src/orion/core/utils/format_terminal.py
@@ -352,6 +352,7 @@ def format_refers(experiment):
 
 STATS_TEMPLATE = """\
 {title}
+completed: {is_done}
 trials completed: {stats[trials_completed]}
 best trial:
   id: {stats[best_trials_id]}
@@ -391,7 +392,8 @@ def format_stats(experiment):
     stats_string = STATS_TEMPLATE.format(
         title=format_title("Stats"),
         stats=stats,
-        best_params=format_dict(best_params, depth=2, width=2))
+        best_params=format_dict(best_params, depth=2, width=2),
+        is_done=experiment.is_done)
 
     return stats_string
 

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -549,9 +549,11 @@ def test_format_stats(dummy_trial):
         finish_time='now',
         duration='way too long')
     experiment.get_trial = lambda trial=None, uid=None: dummy_trial
+    experiment.is_done = False
     assert format_stats(experiment) == """\
 Stats
 =====
+completed: False
 trials completed: 10
 best trial:
   id: dummy
@@ -621,6 +623,7 @@ def test_format_info(algorithm_dict, dummy_trial):
         finish_time='now',
         duration='way too long')
     experiment.get_trial = lambda trial=None, uid=None: dummy_trial
+    experiment.is_done = False
 
     assert format_info(experiment) == """\
 Identification
@@ -682,6 +685,7 @@ adapter:
 
 Stats
 =====
+completed: False
 trials completed: 10
 best trial:
   id: dummy


### PR DESCRIPTION
Why:

The information whether an experiment is completed is important and
should be part of what `info` provides.