### PR TITLE
REST plotting endpoint with regret plots

### DIFF
--- a/src/orion/serving/plots_resources.py
+++ b/src/orion/serving/plots_resources.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.serving.plots_resources` -- Module responsible for the plots/ REST endpoint
+========================================================================================
+
+.. module:: plots_resources
+   :platform: Unix
+   :synopsis: Serves all the requests made to plots/ REST endpoint
+"""
+from falcon import Request, Response
+
+from orion.client import ExperimentClient
+from orion.serving.parameters import retrieve_experiment
+from orion.storage.base import get_storage
+
+
+class PlotsResource(object):
+    """Serves all the requests made to plots/ REST endpoint"""
+
+    def __init__(self):
+        self.storage = get_storage()
+
+    def on_get_regret(self, req: Request, resp: Response, experiment_name: str):
+        """
+        Handle GET requests for plotting regret plots on plots/regret/:experiment
+        where ``experiment`` is the user-defined name of the experiment.
+        """
+        experiment = ExperimentClient(retrieve_experiment(experiment_name), None)
+        resp.body = experiment.plot.regret().to_json()

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -12,6 +12,7 @@
 import falcon
 
 from orion.serving.experiments_resource import ExperimentsResource
+from orion.serving.plots_resources import PlotsResource
 from orion.serving.runtime import RuntimeResource
 from orion.serving.trials_resource import TrialsResource
 from orion.storage.base import setup_storage
@@ -33,6 +34,7 @@ class WebApi(falcon.API):
         root_resource = RuntimeResource()
         experiments_resource = ExperimentsResource()
         trials_resource = TrialsResource()
+        plots_resource = PlotsResource()
 
         # Build routes
         self.add_route('/', root_resource)
@@ -41,6 +43,7 @@ class WebApi(falcon.API):
         self.add_route('/trials/{experiment_name}', trials_resource, suffix='trials_in_experiment')
         self.add_route('/trials/{experiment_name}/{trial_id}',
                        trials_resource, suffix='trial_in_experiment')
+        self.add_route('/plots/regret/{experiment_name}', plots_resource, suffix='regret')
 
     def start(self):
         """A hook to when a Gunicorn worker calls run()."""

--- a/tests/functional/serving/test_plots_resource.py
+++ b/tests/functional/serving/test_plots_resource.py
@@ -1,0 +1,59 @@
+"""Perform tests for the REST endpoint `/plots`"""
+from orion.testing import create_experiment
+
+config = dict(
+    name='experiment-name',
+    space={'x': 'uniform(0, 200)'},
+    metadata={'user': 'test-user',
+              'orion_version': 'XYZ',
+              'VCS': {"type": "git",
+                      "is_dirty": False,
+                      "HEAD_sha": "test",
+                      "active_branch": None,
+                      "diff_sha": "diff"}},
+    version=1,
+    pool_size=1,
+    max_trials=10,
+    working_dir='',
+    algorithms={'random': {'seed': 1}},
+    producer={'strategy': 'NoParallelStrategy'},
+)
+
+trial_config = {
+    'experiment': 0,
+    'status': 'completed',
+    'worker': None,
+    'start_time': None,
+    'end_time': None,
+    'heartbeat': None,
+    'results': [],
+    'params': []
+}
+
+
+def test_root_not_available(client):
+    """Tests that plots/regret is not available"""
+    response = client.simulate_get('/plots/regret')
+
+    assert response.status == "404 Not Found"
+
+
+class TestRegretPlots:
+    """Tests regret plots"""
+
+    def test_unknown_experiment(self, client):
+        """Tests that the API returns a 404 Not Found when an unknown experiment is queried."""
+        response = client.simulate_get('/plots/regret/unknown-experiment')
+
+        assert response.status == "404 Not Found"
+        assert response.json == {'title': 'Experiment not found',
+                                 'description': 'Experiment "unknown-experiment" does not exist'}
+
+    def test_plot(self, client):
+        """Tests that the API returns the plot in json format."""
+        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+            response = client.simulate_get('/plots/regret/experiment-name')
+
+        assert response.status == "200 OK"
+        assert response.json
+        assert list(response.json.keys()) == ['data', 'layout']


### PR DESCRIPTION
# Description
This is the last foundational pull request for the REST API. It adds the `/plots` endpoint and serves regret plots as the first kind of plot available.

For more information, refer to #423.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)
