### PR TITLE
Add orion.client.get_experiment()

### DIFF
--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -206,7 +206,8 @@ def get_experiment(name, version=None):
 
     Raises
     ------
-    :class:`orion.core.utils.exceptions.NoConfigurationError` when no experiment is found.
+    `orion.core.utils.exceptions.NoConfigurationError`
+        The experiment is not in the database provided by the user.
     """
     return experiment_builder.build_view(name, version)
 

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -14,7 +14,6 @@ from orion.client.experiment import ExperimentClient
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.exceptions import RaceCondition
 from orion.core.utils.singleton import update_singletons
-from orion.core.worker.experiment import ExperimentView
 from orion.core.worker.producer import Producer
 from orion.storage.base import setup_storage
 

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -188,7 +188,7 @@ def create_experiment(
     return ExperimentClient(experiment, producer, heartbeat)
 
 
-def get_experiment(name, version=None):
+def get_experiment(name, version=None, storage=None):
     """
     Retrieve an existing experiment as :class:`orion.core.worker.experiment.ExperimentView`.
 
@@ -199,6 +199,8 @@ def get_experiment(name, version=None):
     version: int, optional
         Version to select. If None, last version will be selected. If version given is larger than
         largest version available, the largest version will be selected.
+    storage: dict, optional
+        Configuration of the storage backend.
 
     Returns
     -------
@@ -209,6 +211,7 @@ def get_experiment(name, version=None):
     `orion.core.utils.exceptions.NoConfigurationError`
         The experiment is not in the database provided by the user.
     """
+    setup_storage(storage)
     return experiment_builder.build_view(name, version)
 
 

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -14,11 +14,12 @@ from orion.client.experiment import ExperimentClient
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.exceptions import RaceCondition
 from orion.core.utils.singleton import update_singletons
+from orion.core.worker.experiment import ExperimentView
 from orion.core.worker.producer import Producer
 from orion.storage.base import setup_storage
 
 __all__ = ['interrupt_trial', 'report_bad_trial', 'report_objective', 'report_results',
-           'create_experiment', 'workon']
+           'create_experiment', 'get_experiment', 'workon']
 
 
 # pylint: disable=too-many-arguments
@@ -185,6 +186,29 @@ def create_experiment(
     producer = Producer(experiment, max_idle_time)
 
     return ExperimentClient(experiment, producer, heartbeat)
+
+
+def get_experiment(name: str, version: int = None) -> ExperimentView:
+    """
+    Retrieve an existing experiment as :class:`orion.core.worker.experiment.ExperimentView`.
+
+    Parameters
+    ----------
+    name: str
+        The name of the experiment.
+    version: int, optional
+        Version to select. If None, last version will be selected. If version given is larger than
+        largest version available, the largest version will be selected.
+
+    Returns
+    -------
+    An instance of :class:`orion.core.worker.experiment.ExperimentView` representing the experiment.
+
+    Raises
+    ------
+    :class:`orion.core.utils.exceptions.NoConfigurationError` when no experiment is found.
+    """
+    return experiment_builder.build_view(name, version)
 
 
 def workon(function, space, name='loop', algorithms=None, max_trials=None):

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -188,7 +188,7 @@ def create_experiment(
     return ExperimentClient(experiment, producer, heartbeat)
 
 
-def get_experiment(name: str, version: int = None) -> ExperimentView:
+def get_experiment(name, version=None):
     """
     Retrieve an existing experiment as :class:`orion.core.worker.experiment.ExperimentView`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from orion.core.utils.singleton import update_singletons
 from orion.core.worker.trial import Trial
 from orion.storage.base import Storage
 from orion.storage.legacy import Legacy
+from orion.testing import OrionState
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -205,6 +206,17 @@ def database():
     database = client.orion_test
     yield database
     client.close()
+
+
+@pytest.fixture()
+def mock_database():
+    """
+    Lightweight fixture for an empty, in-memory database using :class:`OrionState`.
+    The database is automatically discarded after each test method.
+    """
+    storage = {'type': 'legacy', 'database': {'type': 'EphemeralDB'}}
+    with OrionState(storage=storage) as state:
+        yield state
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description
`orion.client` is the public-facing API to work with experiments. However, there is currently no intuitive way to retrieve an experiment for the only viewing past results. Currently, the options are to either use `orion.client.create_experiment()` which is semantically opposed to what the user wants to do or use `orion.core.io.experiment_builder.build_view()` which is located in internal modules.

# Changes
This PR adds an intuitive method to retrieve existing experiments through `orion.client.get_experiment`. An instance of `orion.core.worker.experiment.ExperimentView` is returned to ensure a read-only experience.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)