### PR TITLE
CLI documentation improvements

### DIFF
--- a/docs/src/code/core/cli.rst
+++ b/docs/src/code/core/cli.rst
@@ -1,5 +1,5 @@
-Command lines
-=============
+Command line
+============
 
 .. automodule:: orion.core.cli
    :members:

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -46,7 +46,7 @@ class OrionArgsParser:
             '-d', '--debug', action='store_true',
             help="Use debugging mode with EphemeralDB.")
 
-        self.subparsers = self.parser.add_subparsers(dest='command', help='sub-command help')
+        self.subparsers = self.parser.add_subparsers(dest='command')
 
     def get_subparsers(self):
         """Return the subparser object for this parser."""

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -19,11 +19,7 @@ from orion.core.utils.exceptions import (
     BranchingEvent, MissingResultFile, NoConfigurationError, NoNameError)
 
 
-CLI_DOC_HEADER = """
-orion:
-  Orion cli script for asynchronous distributed optimization
-
-"""
+CLI_DOC_HEADER = "Oríon CLI for asynchronous distributed optimization"
 
 
 class OrionArgsParser:

--- a/src/orion/core/cli/db/rm.py
+++ b/src/orion/core/cli/db/rm.py
@@ -69,7 +69,7 @@ def add_subparser(parser):
     rm_parser = parser.add_parser(
         'rm',
         description=DESCRIPTION,
-        help='rm help',
+        help='Deletes experiments and trials',
         formatter_class=argparse.RawTextHelpFormatter)
 
     rm_parser.set_defaults(func=main)

--- a/src/orion/core/cli/db/set.py
+++ b/src/orion/core/cli/db/set.py
@@ -56,7 +56,7 @@ def add_subparser(parser):
     set_parser = parser.add_parser(
         'set',
         description=DESCRIPTION,
-        help='set help',
+        help="Update trials' attributes",
         formatter_class=argparse.RawTextHelpFormatter)
 
     set_parser.set_defaults(func=main)

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -18,11 +18,16 @@ import orion.core
 from orion.core.utils.terminal import ask_question
 
 log = logging.getLogger(__name__)
+SHORT_DESCRIPTION = 'Starts the database configuration wizard'
+DESCRIPTION = """
+This command starts the database configuration wizard and creates a configuration file for the
+database.
+"""
 
 
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
-    setup_parser = parser.add_parser('setup', help='setup help')
+    setup_parser = parser.add_parser('setup', help=SHORT_DESCRIPTION, description=DESCRIPTION)
 
     setup_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/db/test.py
+++ b/src/orion/core/cli/db/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.core.cli.db.test` -- Module to check if the DB worrks
+:mod:`orion.core.cli.db.test` -- Module to check if the DB works
 =================================================================
 
 .. module:: test_db
@@ -18,11 +18,13 @@ from orion.core.cli.checks.presence import PresenceStage
 from orion.core.utils.exceptions import CheckError
 
 log = logging.getLogger(__name__)
+SHORT_DESCRIPTION = 'Verifies that the database is correctly configured'
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    test_db_parser = parser.add_parser('test', help='test_db help')
+    test_db_parser = parser.add_parser('test', help=SHORT_DESCRIPTION,
+                                       description=SHORT_DESCRIPTION)
 
     test_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
                                 metavar='path-to-config', help="user provided "

--- a/src/orion/core/cli/db/upgrade.py
+++ b/src/orion/core/cli/db/upgrade.py
@@ -23,6 +23,7 @@ from orion.storage.legacy import Legacy
 
 
 log = logging.getLogger(__name__)
+SHORT_DESCRIPTION = 'Upgrade the database scheme'
 
 
 # TODO: Move somewhere else to share with `db setup`.
@@ -55,7 +56,8 @@ def ask_question(question, default=None):
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    upgrade_db_parser = parser.add_parser('upgrade', help='Upgrade the database scheme')
+    upgrade_db_parser = parser.add_parser('upgrade', help=SHORT_DESCRIPTION,
+                                          description=SHORT_DESCRIPTION)
 
     upgrade_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
                                    metavar='path-to-config', help="user provided "

--- a/src/orion/core/cli/db_main.py
+++ b/src/orion/core/cli/db_main.py
@@ -26,7 +26,7 @@ def add_subparser(parser):
     # Use `-h` option to show help
 
     db_parser = parser.add_parser('db', help=SHORT_DESCRIPTION, description=DESCRIPTION)
-    subparsers = db_parser.add_subparsers(help='sub-command help')
+    subparsers = db_parser.add_subparsers()
 
     load_modules_parser(subparsers)
 

--- a/src/orion/core/cli/db_main.py
+++ b/src/orion/core/cli/db_main.py
@@ -14,6 +14,10 @@ import logging
 from orion.core.utils import module_import
 
 log = logging.getLogger(__name__)
+SHORT_DESCRIPTION = 'Database initialization, upgrade, verification, and edition'
+DESCRIPTION = """
+Root command for database operations.
+"""
 
 
 def add_subparser(parser):
@@ -21,7 +25,7 @@ def add_subparser(parser):
     # Fetch experiment name, user's script path and command line arguments
     # Use `-h` option to show help
 
-    db_parser = parser.add_parser('db', help='test_db help')
+    db_parser = parser.add_parser('db', help=SHORT_DESCRIPTION, description=DESCRIPTION)
     subparsers = db_parser.add_subparsers(help='sub-command help')
 
     load_modules_parser(subparsers)

--- a/src/orion/core/cli/db_main.py
+++ b/src/orion/core/cli/db_main.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.core.cli.test_db` -- Module to check if the DB worrks
-=================================================================
+:mod:`orion.core.cli.db_main` -- Module containing database related operations
+==============================================================================
 
-.. module:: test_db
+.. module:: db_main
    :platform: Unix
-   :synopsis: Runs multiple checks to see if the database was correctly setup.
+   :synopsis: Root command for database operations
 
 """
 import logging

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -22,8 +22,9 @@ log = logging.getLogger(__name__)
 SHORT_DESCRIPTION = 'Conducts hyperparameter optimization'
 DESCRIPTION = """
 This command starts hyperparameter optimization process for the user-provided model using the
-configured optimization algorithm and search space. 
+configured optimization algorithm and search space.
 """
+
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -19,11 +19,15 @@ import orion.core.io.experiment_builder as experiment_builder
 from orion.core.worker import workon
 
 log = logging.getLogger(__name__)
-
+SHORT_DESCRIPTION = 'Conducts hyperparameter optimization'
+DESCRIPTION = """
+This command starts hyperparameter optimization process for the user-provided model using the
+configured optimization algorithm and search space. 
+"""
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    hunt_parser = parser.add_parser('hunt', help='hunt help')
+    hunt_parser = parser.add_parser('hunt', help=SHORT_DESCRIPTION, description=DESCRIPTION)
 
     orion_group = cli.get_basic_args_group(
         hunt_parser, group_name='Hunt arguments', group_help='')

--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -17,11 +17,12 @@ import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.format_terminal import format_info
 
 log = logging.getLogger(__name__)
+SHORT_DESCRIPTION = 'Gives detailed information about experiments'
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    info_parser = parser.add_parser('info', help='info help')
+    info_parser = parser.add_parser('info', help=SHORT_DESCRIPTION, description=SHORT_DESCRIPTION)
     get_basic_args_group(info_parser)
 
     info_parser.set_defaults(func=main)

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -17,11 +17,12 @@ from orion.core.cli import evc as evc_cli
 import orion.core.io.experiment_builder as experiment_builder
 
 log = logging.getLogger(__name__)
+DESCRIPTION = '(DEPRECATED) Use command `orion hunt --init_only` instead'
 
 
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
-    init_only_parser = parser.add_parser('init_only', help='init_only help')
+    init_only_parser = parser.add_parser('init_only', help=DESCRIPTION, description=DESCRIPTION)
 
     orion_group = cli.get_basic_args_group(
         init_only_parser, group_name='init_only arguments', group_help='')

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -22,10 +22,13 @@ from orion.core.utils.format_trials import tuple_to_trial
 
 log = logging.getLogger(__name__)
 
+SHORT_DESCRIPTION = 'Inserts new trials in an existing experiment'
+DESCRIPTION = 'Insert new trials for a given experiment with fixed values'
+
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    insert_parser = parser.add_parser('insert', help='insert help')
+    insert_parser = parser.add_parser('insert', help=SHORT_DESCRIPTION, description=DESCRIPTION)
 
     cli.get_basic_args_group(insert_parser)
 

--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -15,11 +15,15 @@ from orion.core.utils.pptree import print_tree
 from orion.storage.base import get_storage
 
 log = logging.getLogger(__name__)
+SHORT_DESCRIPTION = 'Gives a list of experiments'
+DESCRIPTION = """
+This command gives a list of your experiments in a easy-to-read tree-like structure.
+"""
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    list_parser = parser.add_parser('list', help='list help')
+    list_parser = parser.add_parser('list', help=SHORT_DESCRIPTION, description=DESCRIPTION)
 
     cli.get_basic_args_group(list_parser)
 

--- a/src/orion/core/cli/serve.py
+++ b/src/orion/core/cli/serve.py
@@ -19,13 +19,12 @@ from orion.serving.webapi import WebApi
 
 
 log = logging.getLogger(__name__)
-
-DESCRIPTION = "Starts HTTP endpoints"
+DESCRIPTION = "Starts Oríon's REST API server"
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    serve_parser = parser.add_parser('serve', help='serve help', description=DESCRIPTION)
+    serve_parser = parser.add_parser('serve', help=DESCRIPTION, description=DESCRIPTION)
 
     serve_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
                               metavar='path-to-config', help="user provided "

--- a/src/orion/core/cli/setup.py
+++ b/src/orion/core/cli/setup.py
@@ -15,11 +15,12 @@ from orion.core.cli.db.setup import main
 
 
 log = logging.getLogger(__name__)
+DESCRIPTION = '(DEPRECATED) Use command `orion db setup` instead'
 
 
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
-    setup_parser = parser.add_parser('setup', help='setup help')
+    setup_parser = parser.add_parser('setup', help=DESCRIPTION, description=DESCRIPTION)
 
     setup_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/status.py
+++ b/src/orion/core/cli/status.py
@@ -21,11 +21,12 @@ from orion.storage.base import get_storage
 log = logging.getLogger(__name__)
 SHORT_DESCRIPTION = "Gives an overview of experiments' trials"
 DESCRIPTION = """
-This command outputs the status of the different trials inside every experiment or a 
-specific EVC tree. It can either give you an overview of the different trials status, i.e., 
-the number of currently completed trials and so on, or, it can give you a deeper view of the 
+This command outputs the status of the different trials inside every experiment or a
+specific EVC tree. It can either give you an overview of the different trials status, i.e.,
+the number of currently completed trials and so on, or, it can give you a deeper view of the
 experiments by outlining every single trial, its status and its objective.
 """
+
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""

--- a/src/orion/core/cli/status.py
+++ b/src/orion/core/cli/status.py
@@ -19,11 +19,17 @@ import orion.core.io.experiment_builder as experiment_builder
 from orion.storage.base import get_storage
 
 log = logging.getLogger(__name__)
-
+SHORT_DESCRIPTION = "Gives an overview of experiments' trials"
+DESCRIPTION = """
+This command outputs the status of the different trials inside every experiment or a 
+specific EVC tree. It can either give you an overview of the different trials status, i.e., 
+the number of currently completed trials and so on, or, it can give you a deeper view of the 
+experiments by outlining every single trial, its status and its objective.
+"""
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    status_parser = parser.add_parser('status', help='status help')
+    status_parser = parser.add_parser('status', help=SHORT_DESCRIPTION, description=DESCRIPTION)
 
     cli.get_basic_args_group(status_parser)
 

--- a/src/orion/core/cli/test_db.py
+++ b/src/orion/core/cli/test_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-:mod:`orion.core.cli.test_db` -- Module to check if the DB worrks
+:mod:`orion.core.cli.test_db` -- Module to check if the DB works
 =================================================================
 
 .. module:: test_db
@@ -16,11 +16,12 @@ from orion.core.cli.db.test import main
 
 
 log = logging.getLogger(__name__)
+DESCRIPTION = '(DEPRECATED) Use command `orion db test` instead'
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    test_db_parser = parser.add_parser('test-db', help='test_db help')
+    test_db_parser = parser.add_parser('test-db', help=DESCRIPTION, description=DESCRIPTION)
 
     test_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
                                 metavar='path-to-config', help="user provided "


### PR DESCRIPTION
# Description
The command line subcommands do not have descriptions that make it hard to use Oríon without looking at the documentation.

# Changes
This PR fixes a few documentation problems and adds a short and long description for each subcommand, indicating what are their purposes.

# Checklist
## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)