### PR TITLE
Remove outdated `branch_from` parameter documentation in `experiment_builder.build()`

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -131,9 +131,6 @@ def build(name, version=None, branching=None, **config):
     version: int, optional
         Version to select. If None, last version will be selected. If version given is larger than
         largest version available, the largest version will be selected.
-    branch_from: str, optional
-        Name of the experiment to branch from. The new experiment will have access to all trials
-        from the parent experiment it has been branched from.
     space: dict, optional
         Optimization space of the algorithm. Should have the form `dict(name='<prior>(args)')`.
     algorithms: str or dict, optional


### PR DESCRIPTION
# Description
Remove the outdated root parameter documentation `branch_from` from `experiment_builder.build()`.

# Checklist
## Tests
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
➡️ https://trello.com/c/BAoRdVCK
