### PR TITLE
Sort modules and extensions alphabetically

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,12 +33,12 @@ requirements:
 
 test:
   import:
-    - orion.core
-    - orion.core.cli
     - orion.algo
     - orion.client
-    - orion.storage
+    - orion.core
+    - orion.core.cli
     - orion.serving
+    - orion.storage
     - orion.testing
   commands:
     - orion --help

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -40,21 +40,17 @@ import orion.core as orion  # noqa
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#
 # needs_sphinx = '1.0'
 
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.autosummary',
+extensions = [  # Extensions must be sorted alphabetically to ease maintenance and merges.
     'numpydoc',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
 ]
 
 # General information about the project.

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,14 @@ tests_require = [
     ]
 
 
-packages = [
-    'orion.core',
-    'orion.client',
+packages = [  # Packages must be sorted alphabetically to ease maintenance and merges.
     'orion.algo',
-    'orion.storage',
-    'orion.plotting',
     'orion.analysis',
+    'orion.client',
+    'orion.core',
+    'orion.plotting',
     'orion.serving',
+    'orion.storage',
     'orion.testing'
     ]
 


### PR DESCRIPTION
# Description
Unsorted extensions and modules list makes it hard to maintain and can cause merge conflicts when merged to develop.

# Changes
This pull request sorts alphabetically:
- The list of Sphinx extensions
- The list of orion modules in setup.py
- The list of orion modules in conda/meta.yaml

# Checklist
## Tests
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)