### PR TITLE
Avoid side effects in setup_storage

### DIFF
--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -9,7 +9,7 @@
               different storage backend
 
 """
-
+import copy
 import logging
 
 import orion.core
@@ -413,6 +413,8 @@ def setup_storage(storage=None, debug=False):
     """
     if storage is None:
         storage = orion.core.config.storage.to_dict()
+
+    storage = copy.deepcopy(storage)
 
     if storage.get('type') == 'legacy' and 'database' not in storage:
         storage['database'] = orion.core.config.storage.database.to_dict()

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -202,6 +202,15 @@ def test_setup_storage_bad_config_override():
         setup_storage({'database': {'type': 'mongodb'}})
 
 
+def test_setup_storage_stateless():
+    """Test that passed configuration dictionary is not modified by the fonction"""
+    update_singletons()
+    config = {'database': {'type': 'pickleddb', 'host': 'test.pkl'}}
+    passed_config = copy.deepcopy(config)
+    setup_storage(passed_config)
+    assert config == passed_config
+
+
 def test_get_storage_uninitiated():
     """Test that get storage fails if no storage singleton exist"""
     update_singletons()


### PR DESCRIPTION
Why:

The function was modifying the configuration dictionary, causing
side-effects if the user intended to reuse the configuration dictionary
later on.