### PR TITLE
Print user friendly err msg if script inexecutable

### DIFF
--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -16,7 +16,7 @@ import textwrap
 import orion
 from orion.core.io.database import DatabaseError
 from orion.core.utils.exceptions import (
-    BranchingEvent, MissingResultFile, NoConfigurationError, NoNameError)
+    BranchingEvent, InexecutableUserScript, MissingResultFile, NoConfigurationError, NoNameError)
 
 
 CLI_DOC_HEADER = "Oríon CLI for asynchronous distributed optimization"
@@ -78,7 +78,7 @@ class OrionArgsParser:
             args, function = self.parse(argv)
             returncode = function(args)
         except (NoConfigurationError, NoNameError, DatabaseError, MissingResultFile,
-                BranchingEvent) as e:
+                BranchingEvent, InexecutableUserScript) as e:
             print('Error:', e, file=sys.stderr)
 
             if args.get('verbose', 0) >= 2:

--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -115,3 +115,21 @@ class BrokenExperiment(Exception):
     """Raised when too many trials failed in an experiment and it is now considered broken"""
 
     pass
+
+
+INEXECUTABLE_USER_SCRIPT_ERROR_MESSAGE = """\
+User script is not executable:
+{}
+
+Use chmod +x <your script> to make it executable.
+If your script is written in python, you can otherwise
+use `python <your script>` instead of `./<your script>`.
+
+"""
+
+
+class InexecutableUserScript(PermissionError):
+    """Raised during consumption when user script is not executable"""
+
+    def __init__(self, cmdline, message=INEXECUTABLE_USER_SCRIPT_ERROR_MESSAGE):
+        super().__init__(message.format(cmdline))

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -18,7 +18,7 @@ import tempfile
 import orion.core
 from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.io.resolve_config import infer_versioning_metadata
-from orion.core.utils.exceptions import BranchingEvent
+from orion.core.utils.exceptions import BranchingEvent, InexecutableUserScript
 from orion.core.utils.working_dir import WorkingDir
 from orion.core.worker.trial_pacemaker import TrialPacemaker
 
@@ -251,7 +251,12 @@ class Consumer(object):
         command = cmd_args
 
         signal.signal(signal.SIGTERM, _handler)
-        process = subprocess.Popen(command, env=environ)
+
+        try:
+            process = subprocess.Popen(command, env=environ)
+        except PermissionError:
+            log.debug("### Script is not executable")
+            raise InexecutableUserScript(' '.join(cmd_args))
 
         return_code = process.wait()
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -192,6 +192,18 @@ def test_demo_with_python_and_script(database, monkeypatch):
 
 
 @pytest.mark.usefixtures("clean_db")
+def test_demo_inexecutable_script(database, monkeypatch, capsys):
+    """Test error message when user script is not executable."""
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+    script = tempfile.NamedTemporaryFile()
+    orion.core.cli.main(["hunt", "--config", "./orion_config.yaml",
+                         script.name, "--config", "script_config.yaml"])
+
+    captured = capsys.readouterr().err
+    assert 'User script is not executable' in captured
+
+
+@pytest.mark.usefixtures("clean_db")
 def test_demo_two_workers(database, monkeypatch):
     """Test a simple usage scenario."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Why:

A common error is to try running orion on a script that is not
executable. Orion currently prints the whole stack trace to user which
is unclear and somehow scary for users. We should give a clear error
message instead.

How:

Catch PermissionError in Popen and then raise a custom
InexecutableUserScript with a clear error message.
Add InexecutableUserScript to the list of errors that are catched by the
base argparse to print user friendly error messages.