### PR TITLE
changed variable name in docs to reflect the correct name

### DIFF
--- a/docs/src/user/script.rst
+++ b/docs/src/user/script.rst
@@ -149,7 +149,7 @@ We list them below.
 
    Current trial id that is currently being executed in this process.
 
-.. envvar:: ORION_WORKING_DIRECTORY
+.. envvar:: ORION_WORKING_DIR
 
    Trial's current working directory.
 


### PR DESCRIPTION
# Description
The correct name for this orion working directoy variable seems to be ORION_WORKING_DIR.
In the docs instead there is ORION_WORKING_DIRECTORY.
