### PR TITLE
Adjust OneHotEncoding interval shape

### DIFF
--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -380,10 +380,13 @@ class OneHotEncode(Transformer):
     # pylint:disable=unused-argument
     def interval(self, alpha=1.0):
         """Return the interval for the one-hot encoding in proper shape."""
-        low = numpy.zeros(self.num_cats)
-        high = numpy.ones(self.num_cats)
+        if self.num_cats == 2:
+            return 0, 1
+        else:
+            low = numpy.zeros(self.num_cats)
+            high = numpy.ones(self.num_cats)
 
-        return low, high
+            return low, high
 
     def infer_target_shape(self, shape):
         """Infer that transformed points will have one more tensor dimension,

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -437,6 +437,11 @@ class TestOneHotEncode(object):
         assert (low == numpy.zeros(3)).all()
         assert (high == numpy.ones(3)).all()
 
+        t = OneHotEncode(2)
+        low, high = t.interval()
+        assert (low == numpy.zeros(1)).all()
+        assert (high == numpy.ones(1)).all()
+
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
         t = OneHotEncode(3)


### PR DESCRIPTION
Why:

When the number of categories is only 2, we rely on (0, 1) encoding with
a threshold of 0.5. When number of categories is greater than 2, we rely
on a one-hot encoding. Previous implementation of interval was only
returning the one-hot encoding version, creating a mismatch with shape
when number of categories is 2.