### PR TITLE
Support non existing user script conf files 

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -323,7 +323,7 @@ def fetch_config_from_db(name, version=None):
         log.info("Many versions for experiment %s have been found. Using latest "
                  "version %s.", name, config['version'])
 
-    backward.populate_space(config)
+    backward.populate_space(config, force_update=False)
 
     return config
 

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -28,7 +28,7 @@ def populate_priors(metadata):
     update_user_args(metadata)
 
     parser = OrionCmdlineParser(orion.core.config.worker.user_script_config,
-                                allow_non_existing_user_script=True)
+                                allow_non_existing_files=True)
     parser.parse(metadata["user_args"])
     metadata["parser"] = parser.get_state_dict()
     metadata["priors"] = dict(parser.priors)

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -34,8 +34,11 @@ def populate_priors(metadata):
     metadata["priors"] = dict(parser.priors)
 
 
-def populate_space(config):
+def populate_space(config, force_update=True):
     """Add the space definition at the root of config."""
+    if 'space' in config and not force_update:
+        return
+
     populate_priors(config['metadata'])
     # Overwrite space to make sure to include changes from user_args
     if 'priors' in config['metadata']:

--- a/src/orion/core/utils/flatten.py
+++ b/src/orion/core/utils/flatten.py
@@ -22,16 +22,16 @@ def flatten(dictionary):
         key, value = dictionary.popitem()
         if not isinstance(value, dict) or not value:
             new_dictionary = {key: value}
-            new_dictionary.update(_flatten(dictionary))
+            new_dictionary.update(flatten(dictionary))
             return new_dictionary
 
-        flat_sub_dictionary = _flatten(value)
+        flat_sub_dictionary = flatten(value)
         for flat_sub_key in list(flat_sub_dictionary.keys()):
             flat_key = key + '.' + flat_sub_key
             flat_sub_dictionary[flat_key] = flat_sub_dictionary.pop(flat_sub_key)
 
         new_dictionary = flat_sub_dictionary
-        new_dictionary.update(_flatten(dictionary))
+        new_dictionary.update(flatten(dictionary))
         return new_dictionary
 
     return _flatten(copy.deepcopy(dictionary))

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -199,6 +199,18 @@ def with_experiment_using_python_api(monkeypatch, one_experiment):
 
 
 @pytest.fixture
+def with_experiment_missing_conf_file(monkeypatch, one_experiment):
+    """Create an experiment without trials."""
+    exp = experiment_builder.build(name='test_single_exp', version=1)
+    conf_file = 'idontexist.yaml'
+    exp.metadata['user_config'] = conf_file
+    exp.metadata['user_args'] += ['--config', conf_file]
+    Database().write('experiments', exp.configuration, query={'_id': exp.id})
+
+    return exp
+
+
+@pytest.fixture
 def broken_refers(one_experiment, db_instance):
     """Create an experiment with broken refers."""
     ensure_deterministic_id('test_single_exp', db_instance, update=dict(refers={'oups': 'broken'}))

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -56,6 +56,15 @@ def test_info_python_api(clean_db, with_experiment_using_python_api, capsys):
     assert 'Commandline' not in captured
 
 
+def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
+    """Test info can handle experiments when the user script config file is missing"""
+    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+
+    captured = capsys.readouterr().out
+
+    assert '--x~uniform(0,1)' in captured
+
+
 def test_info_cmdline_api(clean_db, with_experiment_using_python_api, capsys):
     """Test info if config built using cmdline api"""
     orion.core.cli.main(['info', '--name', 'test_single_exp'])

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -52,6 +52,15 @@ def test_python_api(clean_db, with_experiment_using_python_api, capsys):
     assert captured == " test_single_exp-v1\n from-python-api-v1\n"
 
 
+def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
+    """Test list can handle experiments when the user script config file is missing"""
+    orion.core.cli.main(['list'])
+
+    captured = capsys.readouterr().out
+
+    assert captured == " test_single_exp-v1\n"
+
+
 def test_two_exp(capsys, clean_db, two_experiments):
     """Test that experiment and child are printed."""
     orion.core.cli.main(['list'])

--- a/tests/functional/commands/test_status_command.py
+++ b/tests/functional/commands/test_status_command.py
@@ -55,6 +55,22 @@ empty
     assert captured == expected
 
 
+def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
+    """Test status can handle experiments when the user script config file is missing"""
+    orion.core.cli.main(['status'])
+
+    captured = capsys.readouterr().out
+
+    expected = """\
+test_single_exp-v1
+==================
+empty
+
+
+"""
+    assert captured == expected
+
+
 def test_experiment_without_trials_wout_ac(clean_db, one_experiment, capsys):
     """Test status with only one experiment and no trials."""
     orion.core.cli.main(['status'])

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -390,7 +390,7 @@ def test_tmpdir_is_deleted(database, monkeypatch, tmp_path):
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.usefixtures("null_db_instances")
 def test_working_dir_argument_config(database, monkeypatch):
-    """Check that a permanent directory is used instead of tmpdir"""
+    """Check that workning dir argument is handled properly"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     dir_path = os.path.join('orion', 'test')
     if os.path.exists(dir_path):

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -76,7 +76,9 @@ def new_config(random_dt, script_path):
                   'orion_version': 'XYZ',
                   'user_script': script_path,
                   'user_config': 'abs_path/hereitis.yaml',
-                  'user_args': [script_path, '--mini-batch~uniform(32, 256, discrete=True)'],
+                  'user_args': [
+                      script_path,
+                      '--mini-batch~uniform(32, 256, discrete=True)'],
                   'VCS': {"type": "git",
                           "is_dirty": False,
                           "HEAD_sha": "test",
@@ -222,6 +224,26 @@ def test_build_view_from_args_hit(config_file, random_dt, new_config):
     cmdargs = {'name': 'supernaekei', 'config': config_file}
 
     with OrionState(experiments=[new_config], trials=[]):
+        exp_view = experiment_builder.build_view_from_args(cmdargs)
+
+    assert exp_view._id == new_config['_id']
+    assert exp_view.name == new_config['name']
+    assert exp_view.configuration['refers'] == new_config['refers']
+    assert exp_view.metadata == new_config['metadata']
+    assert exp_view.pool_size == new_config['pool_size']
+    assert exp_view.max_trials == new_config['max_trials']
+    assert exp_view.algorithms.configuration == new_config['algorithms']
+
+
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_view_from_args_hit_no_conf_file(config_file, random_dt, new_config):
+    """Try building experiment view when in db, and local config file of user script does
+    not exist
+    """
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    new_config['metadata']['user_args'] += ['--config', new_config['metadata']['user_config']]
+
+    with OrionState(experiments=[new_config], trials=[]) as cfg:
         exp_view = experiment_builder.build_view_from_args(cmdargs)
 
     assert exp_view._id == new_config['_id']

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -11,6 +11,7 @@ from orion.core.worker.trial import Trial
 
 @pytest.fixture
 def script_path():
+    """Return existing script path for the command lines"""
     return os.path.dirname(os.path.abspath(__file__))
 
 

--- a/tests/unittests/core/utils/test_flatten.py
+++ b/tests/unittests/core/utils/test_flatten.py
@@ -1,0 +1,22 @@
+"""Example usage and tests for :mod:`orion.core.utils.flatten`."""
+from orion.core.utils.flatten import flatten, unflatten
+
+
+def test_basic():
+    """Test basic functionality of flatten"""
+    d = {'a': {'b': 2, 'c': 3}, 'c': {'d': 3, 'e': 4}}
+    assert flatten(d) == {'a.b': 2, 'a.c': 3, 'c.d': 3, 'c.e': 4}
+
+
+def test_handle_double_ref():
+    """Test proper handling of double references in dicts"""
+    a = {'b': 2, 'c': 3}
+    d = {'a': a, 'd': {'e': a}}
+    assert flatten(d) == {'a.b': 2, 'a.c': 3, 'd.e.b': 2, 'd.e.c': 3}
+
+
+def test_unflatten():
+    """Test than unflatten(flatten(x)) is idempotent"""
+    a = {'b': 2, 'c': 3}
+    d = {'a': a, 'd': {'e': a}}
+    assert unflatten(flatten(d)) == d


### PR DESCRIPTION
# Description

If the user pass script configs to experiments, the monitoring tools will fail to fetch the corresponding experiments if the script configs cannot be found. The information necessary for monitoring is already available in the database, so we can ignore the files if they cannot be found.

# Changes

- Extend orion cmdline parser to handle command lines with non existing configuration files
- Fix bug in flatten() to handle dictionaries containing double references.
- Add force_update option in backward.populate_space so that build_view can avoid loading the config files.

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)