### PR TITLE
Fix fetch_lost_trials

### DIFF
--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -251,7 +251,7 @@ class Legacy(BaseStorageProtocol):
     def fetch_lost_trials(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_lost_trials`"""
         heartbeat = orion.core.config.worker.heartbeat
-        threshold = datetime.datetime.utcnow() - datetime.timedelta(seconds=heartbeat)
+        threshold = datetime.datetime.utcnow() - datetime.timedelta(seconds=heartbeat * 5)
         lte_comparison = {'$lte': threshold}
         query = {
             'experiment': experiment._id,

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import warnings
 
+import orion.core
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils.flatten import flatten, unflatten
 from orion.core.worker.trial import Trial as OrionTrial, validate_status
@@ -689,10 +690,10 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
     def fetch_lost_trials(self, experiment):
         """Fetch all trials that have a heartbeat older than
-        some given time delta (2 minutes by default)
+        some given time delta (5 minutes by default)
         """
-        # TODO: Configure this
-        threshold = to_epoch(datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 2))
+        heartbeat = orion.core.config.worker.heartbeat
+        threshold = to_epoch(datetime.datetime.utcnow() - datetime.timedelta(seconds=heartbeat * 5))
         lte_comparison = {'$lte': threshold}
         query = {
             'experiment': experiment.id,

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -214,7 +214,7 @@ class TestReserveTrial(object):
         """Test that a running trial with an old heartbeat is set to interrupted."""
         trial = copy.deepcopy(base_trial)
         trial['status'] = 'reserved'
-        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=360)
+        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 10)
         with OrionState(trials=[trial]) as cfg:
             exp = Experiment('supernaekei')
             exp._id = cfg.trials[0]['experiment']
@@ -226,7 +226,7 @@ class TestReserveTrial(object):
     def test_fix_only_lost_trials(self):
         """Test that an old trial is set to interrupted but not a recent one."""
         lost_trial, running_trial = generate_trials(['reserved'] * 2)
-        lost_trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=360)
+        lost_trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 10)
         running_trial['heartbeat'] = datetime.datetime.utcnow()
 
         with OrionState(trials=[lost_trial, running_trial]) as cfg:
@@ -249,7 +249,7 @@ class TestReserveTrial(object):
         """Test that a lost trial fixed by a concurrent process does not cause error."""
         trial = copy.deepcopy(base_trial)
         trial['status'] = 'interrupted'
-        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=360)
+        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 10)
         with OrionState(trials=[trial]) as cfg:
             exp = Experiment('supernaekei')
             exp._id = cfg.trials[0]['experiment']
@@ -282,20 +282,20 @@ class TestReserveTrial(object):
         """Test that heartbeat is correctly being configured."""
         trial = copy.deepcopy(base_trial)
         trial['status'] = 'reserved'
-        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=180)
+        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 2)
         with OrionState(trials=[trial]) as cfg:
             exp = Experiment('supernaekei')
             exp._id = cfg.trials[0]['experiment']
 
             assert len(exp.fetch_trials_by_status('reserved')) == 1
 
-            orion.core.config.worker.heartbeat = 360
+            orion.core.config.worker.heartbeat = 60 * 2
 
             exp.fix_lost_trials()
 
             assert len(exp.fetch_trials_by_status('reserved')) == 1
 
-            orion.core.config.worker.heartbeat = 180
+            orion.core.config.worker.heartbeat = 60 * 2 / 10.
 
             exp.fix_lost_trials()
 

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -505,6 +505,7 @@ class TestStorage:
         """Test update heartbeat"""
         lost_trials = [make_lost_trial(2),  # Is not lost for long enough to be catched
                        make_lost_trial(10)]  # Is lost for long enough to be catched
+        # Force recent heartbeat to avoid mixing up with lost trials.
         trials = lost_trials + generate_trials(heartbeat=datetime.datetime.utcnow())
         with OrionState(experiments=[base_experiment], trials=trials, storage=storage) as cfg:
             storage = cfg.storage()

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -85,16 +85,16 @@ def _generate(obj, *args, value):
     return obj
 
 
-def make_lost_trial():
+def make_lost_trial(delay=2):
     """Make a lost trial"""
     obj = copy.deepcopy(base_trial)
     obj['status'] = 'reserved'
     obj['heartbeat'] = (datetime.datetime.utcnow() -
-                        datetime.timedelta(seconds=orion.core.config.worker.heartbeat * 2))
+                        datetime.timedelta(seconds=orion.core.config.worker.heartbeat * delay))
     obj['params'].append({
         'name': '/index',
         'type': 'categorical',
-        'value': 'lost_trial'
+        'value': f'lost_trial_{delay}'
     })
     return obj
 
@@ -102,12 +102,16 @@ def make_lost_trial():
 all_status = ['completed', 'broken', 'reserved', 'interrupted', 'suspended', 'new']
 
 
-def generate_trials(status=None):
+def generate_trials(status=None, heartbeat=None):
     """Generate Trials with different configurations"""
     if status is None:
         status = all_status
 
     new_trials = [_generate(base_trial, 'status', value=s) for s in status]
+
+    if heartbeat:
+        for trial in new_trials:
+            trial['heartbeat'] = heartbeat
 
     # make each trial unique
     for i, trial in enumerate(new_trials):
@@ -499,33 +503,16 @@ class TestStorage:
 
     def test_fetch_lost_trials(self, storage):
         """Test update heartbeat"""
-        with OrionState(experiments=[base_experiment],
-                        trials=generate_trials() + [make_lost_trial()], storage=storage) as cfg:
+        lost_trials = [make_lost_trial(2),  # Is not lost for long enough to be catched
+                       make_lost_trial(10)]  # Is lost for long enough to be catched
+        trials = lost_trials + generate_trials(heartbeat=datetime.datetime.utcnow())
+        with OrionState(experiments=[base_experiment], trials=trials, storage=storage) as cfg:
             storage = cfg.storage()
 
             experiment = cfg.get_experiment('default_name', version=None)
             trials = storage.fetch_lost_trials(experiment)
 
-            count = 0
-            now_datetime = datetime.datetime.utcnow()
-            now_seconds = (now_datetime - datetime.datetime(1970, 1, 1)).total_seconds()
-            for t in cfg.trials:
-                status = t.get('status')
-                if status == 'reserved':
-                    heartbeat = t.get('heartbeat')
-                    if heartbeat is None:
-                        continue
-
-                    diff = 0
-                    if isinstance(heartbeat, datetime.datetime):
-                        diff = (now_datetime - heartbeat).total_seconds()
-                    else:
-                        diff = now_seconds - heartbeat
-
-                    if diff > 60 * 2:
-                        count += 1
-
-            assert len(trials) == count
+            assert len(trials) == 1
 
     def test_change_status_success(self, storage):
         """Change the status of a Trial"""


### PR DESCRIPTION
Why:

The fetch of lost trials should look for trials with heartbeat older
than x * heartbeat (with x > 1) otherwise we will often catch trials
that are being run (ex: heartbeat late by a microsecond). It used to be
2 * heartbeat. For some reason it was now 1 * heartbeat...

How:

Set it back to 5 * heartbeat to be sure, and rework the unittest to
verify that trials lost but with heartbeat that are not 5 * heartbeat
late yet are not fetched.