### PR TITLE
Only publish on release:published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - master
       - develop
   release:
+    types:
+      [published]
+  workflow_dispatch:
 
 jobs:
   pretest:


### PR DESCRIPTION
The release triggered 3 times the workflow. We should only catch one of
the events.

Also added support for manual trigger of the workflow.