### PR TITLE
Add max_broken in exp configuration

### DIFF
--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -97,6 +97,11 @@ class ExperimentClient:
         return self._experiment.max_trials
 
     @property
+    def max_broken(self):
+        """Minimum number of broken trials before the experiment is considered broken."""
+        return self._experiment.max_broken
+
+    @property
     def metadata(self):
         """Metadata of the experiment."""
         return self._experiment.metadata

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -138,7 +138,9 @@ def build(name, version=None, branching=None, **config):
     strategy: str or dict, optional
         Parallel strategy to use to parallelize the algorithm.
     max_trials: int, optional
-        Maximum number or trials before the experiment is considered done.
+        Maximum number of trials before the experiment is considered done.
+    max_broken: int, optional
+        Number of broken trials for the experiment to be considered broken.
     storage: dict, optional
         Configuration of the storage backend.
     branching: dict, optional
@@ -277,6 +279,8 @@ def create_experiment(name, version, space, **kwargs):
         Parallel strategy to use to parallelize the algorithm.
     max_trials: int, optional
         Maximum number or trials before the experiment is considered done.
+    max_broken: int, optional
+        Number of broken trials for the experiment to be considered broken.
     storage: dict, optional
         Configuration of the storage backend.
 
@@ -288,6 +292,7 @@ def create_experiment(name, version, space, **kwargs):
         experiment.pool_size = orion.core.config.experiment.get(
             'pool_size', deprecated='ignore')
     experiment.max_trials = kwargs.get('max_trials', orion.core.config.experiment.max_trials)
+    experiment.max_broken = kwargs.get('max_broken', orion.core.config.experiment.max_broken)
     experiment.space = _instantiate_space(space)
     experiment.algorithms = _instantiate_algo(experiment.space, kwargs.get('algorithms'))
     experiment.producer = kwargs.get('producer', {})
@@ -324,6 +329,7 @@ def fetch_config_from_db(name, version=None):
                  "version %s.", name, config['version'])
 
     backward.populate_space(config, force_update=False)
+    backward.update_max_broken(config)
 
     return config
 

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -34,6 +34,12 @@ def populate_priors(metadata):
     metadata["priors"] = dict(parser.priors)
 
 
+def update_max_broken(config):
+    """Set default max_broken if None (in v <= v0.1.9)"""
+    if not config.get('max_broken', None):
+        config['max_broken'] = orion.core.config.experiment.max_broken
+
+
 def populate_space(config, force_update=True):
     """Add the space definition at the root of config."""
     if 'space' in config and not force_update:

--- a/src/orion/core/utils/format_terminal.py
+++ b/src/orion/core/utils/format_terminal.py
@@ -258,6 +258,7 @@ CONFIG_TEMPLATE = """\
 {title}
 pool size: {experiment.pool_size}
 max trials: {experiment.max_trials}
+max broken: {experiment.max_broken}
 working dir: {experiment.working_dir}
 """
 

--- a/src/orion/serving/responses.py
+++ b/src/orion/serving/responses.py
@@ -73,6 +73,7 @@ def build_experiment_response(experiment: Experiment,
         "orionVersion": experiment.metadata['orion_version'],
         "config": {
             "maxTrials": experiment.max_trials,
+            "maxBroken": experiment.max_broken,
             "poolSize": experiment.pool_size,
             "algorithm": algorithm,
             "space": experiment.configuration['space']

--- a/tests/functional/demo/orion_config.yaml
+++ b/tests/functional/demo/orion_config.yaml
@@ -2,6 +2,7 @@ name: voila_voici
 
 pool_size: 1
 max_trials: 100
+max_broken: 5
 
 algorithms:
   gradient_descent:

--- a/tests/functional/demo/orion_config_other.yaml
+++ b/tests/functional/demo/orion_config_other.yaml
@@ -2,6 +2,7 @@ name: voila_voici
 
 pool_size: 1
 max_trials: 100
+max_broken: 5
 
 algorithms:
   gradient_descent:

--- a/tests/functional/demo/orion_config_random.yaml
+++ b/tests/functional/demo/orion_config_random.yaml
@@ -2,6 +2,7 @@ name: demo_random_search
 
 pool_size: 2
 max_trials: 400
+max_broken: 5
 
 algorithms: random
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -39,6 +39,7 @@ def test_demo_with_default_algo_cli_config_only(database, monkeypatch):
     assert exp['name'] == 'default_algo'
     assert exp['pool_size'] == 1
     assert exp['max_trials'] == 30
+    assert exp['max_broken'] == 3
     assert exp['algorithms'] == {'random': {'seed': None}}
     assert 'user' in exp['metadata']
     assert 'datetime' in exp['metadata']
@@ -74,6 +75,7 @@ def test_demo(database, monkeypatch):
     assert exp['name'] == 'voila_voici'
     assert exp['pool_size'] == 1
     assert exp['max_trials'] == 100
+    assert exp['max_broken'] == 5
     assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
                                                       'dx_tolerance': 1e-7}}
     assert 'user' in exp['metadata']
@@ -117,6 +119,7 @@ def test_demo_with_script_config(database, monkeypatch):
     assert exp['name'] == 'voila_voici'
     assert exp['pool_size'] == 1
     assert exp['max_trials'] == 100
+    assert exp['max_broken'] == 5
     assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
                                                       'dx_tolerance': 1e-7}}
     assert 'user' in exp['metadata']
@@ -162,6 +165,7 @@ def test_demo_with_python_and_script(database, monkeypatch):
     assert exp['name'] == 'voila_voici'
     assert exp['pool_size'] == 1
     assert exp['max_trials'] == 100
+    assert exp['max_broken'] == 5
     assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
                                                       'dx_tolerance': 1e-7}}
     assert 'user' in exp['metadata']
@@ -227,6 +231,7 @@ def test_demo_two_workers(database, monkeypatch):
     assert exp['name'] == 'two_workers_demo'
     assert exp['pool_size'] == 2
     assert exp['max_trials'] == 100
+    assert exp['max_broken'] == 5
     assert exp['algorithms'] == {'random': {'seed': None}}
     assert 'user' in exp['metadata']
     assert 'datetime' in exp['metadata']
@@ -257,6 +262,7 @@ def test_workon():
         }
     config['pool_size'] = 1
     config['max_trials'] = 100
+    config['exp_max_broken'] = 5
     config['user_args'] = [
         os.path.abspath(os.path.join(os.path.dirname(__file__), "black_box.py")),
         "-x~uniform(-50, 50, precision=None)"]
@@ -275,6 +281,7 @@ def test_workon():
         assert exp['name'] == name
         assert exp['pool_size'] == 1
         assert exp['max_trials'] == 100
+        assert exp['max_broken'] == 5
         assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
                                                           'dx_tolerance': 1e-7}}
         assert 'user' in exp['metadata']
@@ -473,7 +480,6 @@ def test_run_with_parallel_strategy(database, monkeypatch, strategy):
     assert len(exp) == 1
     exp = exp[0]
     assert exp['producer']['strategy'] == strategy
-    print(exp['max_trials'])
     assert '_id' in exp
     exp_id = exp['_id']
     trials = list(database.trials.find({'experiment': exp_id}))

--- a/tests/functional/serving/test_experiments_resource.py
+++ b/tests/functional/serving/test_experiments_resource.py
@@ -22,6 +22,7 @@ base_experiment = dict(
     version=1,
     pool_size=1,
     max_trials=10,
+    max_broken=7,
     working_dir='',
     algorithms={'random': {'seed': 1}},
     producer={'strategy': 'NoParallelStrategy'},
@@ -199,6 +200,7 @@ def _assert_config(config):
     """Asserts properties of the ``config`` dictionary"""
     assert config['poolSize'] == 1
     assert config['maxTrials'] == 10
+    assert config['maxBroken'] == 7
 
     algorithm = config['algorithm']
     assert algorithm['name'] == 'random'

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -37,6 +37,7 @@ config = dict(
     version=1,
     pool_size=1,
     max_trials=10,
+    max_broken=5,
     working_dir='',
     algorithms={'random': {'seed': 1}},
     producer={'strategy': 'NoParallelStrategy'},
@@ -195,6 +196,7 @@ class TestCreateExperiment:
             assert experiment.space.configuration == space
 
             assert experiment.max_trials == orion.core.config.experiment.max_trials
+            assert experiment.max_broken == orion.core.config.experiment.max_broken
             assert experiment.working_dir == orion.core.config.experiment.working_dir
             assert experiment.algorithms.configuration == {'random': {'seed': None}}
             assert experiment.configuration['producer'] == {'strategy': 'MaxParallelStrategy'}
@@ -208,6 +210,7 @@ class TestCreateExperiment:
 
             assert exp_config['space'] == config['space']
             assert exp_config['max_trials'] == config['max_trials']
+            assert exp_config['max_broken'] == config['max_broken']
             assert exp_config['working_dir'] == config['working_dir']
             assert exp_config['algorithms'] == config['algorithms']
             assert exp_config['producer'] == config['producer']
@@ -223,6 +226,7 @@ class TestCreateExperiment:
             assert experiment.version == 1
             assert exp_config['space'] == config['space']
             assert exp_config['max_trials'] == config['max_trials']
+            assert exp_config['max_broken'] == config['max_broken']
             assert exp_config['working_dir'] == config['working_dir']
             assert exp_config['algorithms'] == config['algorithms']
             assert exp_config['producer'] == config['producer']
@@ -237,6 +241,7 @@ class TestCreateExperiment:
             assert experiment.space.configuration == config['space']
             assert experiment.algorithms.configuration == config['algorithms']
             assert experiment.max_trials == config['max_trials']
+            assert experiment.max_broken == config['max_broken']
             assert experiment.working_dir == config['working_dir']
             assert experiment.producer['strategy'].configuration == config['producer']['strategy']
 
@@ -250,6 +255,7 @@ class TestCreateExperiment:
 
             assert experiment.algorithms.configuration == config['algorithms']
             assert experiment.max_trials == config['max_trials']
+            assert experiment.max_broken == config['max_broken']
             assert experiment.working_dir == config['working_dir']
             assert experiment.producer['strategy'].configuration == config['producer']['strategy']
 

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -28,6 +28,7 @@ config = dict(
     version=1,
     pool_size=1,
     max_trials=10,
+    max_broken=5,
     working_dir='',
     algorithms={'random': {'seed': 1}},
     producer={'strategy': 'NoParallelStrategy'},

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -395,12 +395,14 @@ def test_format_config(monkeypatch):
     experiment = DummyExperiment()
     experiment.pool_size = 10
     experiment.max_trials = 100
+    experiment.max_broken = 5
     experiment.working_dir = "working_dir"
     assert format_config(experiment) == """\
 Config
 ======
 pool size: 10
 max trials: 100
+max broken: 5
 working dir: working_dir
 """
 
@@ -578,6 +580,7 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment.metadata = {'user_args': commandline}
     experiment.pool_size = 10
     experiment.max_trials = 100
+    experiment.max_broken = 5
     experiment.working_dir = "working_dir"
     experiment.configuration = {'algorithms': algorithm_dict}
 
@@ -642,6 +645,7 @@ Config
 ======
 pool size: 10
 max trials: 100
+max broken: 5
 working dir: working_dir
 
 

--- a/tests/unittests/core/io/orion_config.yaml
+++ b/tests/unittests/core/io/orion_config.yaml
@@ -2,6 +2,7 @@ experiment:
     name: voila_voici
     pool_size: 1
     max_trials: 100
+    max_broken: 5
 
     algorithms: 'random'
 

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -46,6 +46,7 @@ def python_api_config():
                           "active_branch": None,
                           "diff_sha": "diff"}},
         max_trials=1000,
+        max_broken=5,
         working_dir='',
         algorithms={
             'dumbalgo': {
@@ -87,6 +88,7 @@ def new_config(random_dt, script_path):
         version=1,
         pool_size=10,
         max_trials=1000,
+        max_broken=5,
         working_dir='',
         algorithms={
             'dumbalgo': {
@@ -150,6 +152,7 @@ def test_get_cmd_config(config_file):
     assert local_config['algorithms'] == 'random'
     assert local_config['strategy'] == 'NoParallelStrategy'
     assert local_config['max_trials'] == 100
+    assert local_config['max_broken'] == 5
     assert local_config['name'] == 'voila_voici'
     assert local_config['pool_size'] == 1
     assert local_config['storage'] == {
@@ -174,6 +177,7 @@ def test_get_cmd_config_from_incomplete_config(incomplete_config_file):
 
     assert 'algorithms' not in local_config
     assert 'max_trials' not in local_config
+    assert 'max_broken' not in local_config
     assert 'pool_size' not in local_config
     assert 'name' not in local_config['storage']['database']
     assert local_config['storage']['database']['host'] == 'mongodb://user:pass@localhost'
@@ -203,6 +207,7 @@ def test_fetch_config_from_db_hit(new_config):
     assert db_config['metadata'] == new_config['metadata']
     assert db_config['pool_size'] == new_config['pool_size']
     assert db_config['max_trials'] == new_config['max_trials']
+    assert db_config['max_broken'] == new_config['max_broken']
     assert db_config['algorithms'] == new_config['algorithms']
     assert db_config['metadata'] == new_config['metadata']
 
@@ -232,6 +237,7 @@ def test_build_view_from_args_hit(config_file, random_dt, new_config):
     assert exp_view.metadata == new_config['metadata']
     assert exp_view.pool_size == new_config['pool_size']
     assert exp_view.max_trials == new_config['max_trials']
+    assert exp_view.max_broken == new_config['max_broken']
     assert exp_view.algorithms.configuration == new_config['algorithms']
 
 
@@ -252,6 +258,7 @@ def test_build_view_from_args_hit_no_conf_file(config_file, random_dt, new_confi
     assert exp_view.metadata == new_config['metadata']
     assert exp_view.pool_size == new_config['pool_size']
     assert exp_view.max_trials == new_config['max_trials']
+    assert exp_view.max_broken == new_config['max_broken']
     assert exp_view.algorithms.configuration == new_config['algorithms']
 
 
@@ -277,6 +284,7 @@ def test_build_from_args_no_hit(config_file, random_dt, script_path, new_config)
     assert exp.metadata['user_args'] == cmdargs['user_args']
     assert exp.pool_size == 1
     assert exp.max_trials == 100
+    assert exp.max_broken == 5
     assert exp.algorithms.configuration == {'random': {'seed': None}}
 
 
@@ -300,6 +308,7 @@ def test_build_from_args_hit(old_config_file, script_path, new_config):
     assert exp.configuration['refers'] == new_config['refers']
     assert exp.metadata == new_config['metadata']
     assert exp.max_trials == new_config['max_trials']
+    assert exp.max_broken == new_config['max_broken']
     assert exp.algorithms.configuration == new_config['algorithms']
 
 
@@ -371,6 +380,7 @@ def test_build_no_hit(config_file, random_dt, script_path):
     name = 'supernaekei'
     space = {'x': 'uniform(0, 10)'}
     max_trials = 100
+    max_broken = 5
 
     with OrionState(experiments=[], trials=[]):
 
@@ -378,7 +388,8 @@ def test_build_no_hit(config_file, random_dt, script_path):
             experiment_builder.build_view(name)
         assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
 
-        exp = experiment_builder.build(name, space=space, max_trials=max_trials)
+        exp = experiment_builder.build(
+            name, space=space, max_trials=max_trials, max_broken=max_broken)
 
     assert exp.name == name
     assert exp.configuration['refers'] == {'adapter': [], 'parent_id': None, 'root_id': exp._id}
@@ -388,6 +399,7 @@ def test_build_no_hit(config_file, random_dt, script_path):
         'orion_version': 'XYZ'}
     assert exp.configuration['space'] == space
     assert exp.max_trials == max_trials
+    assert exp.max_broken == max_broken
     assert not exp.is_done
     assert exp.algorithms.configuration == {'random': {'seed': None}}
 
@@ -417,6 +429,7 @@ def test_build_hit(python_api_config):
     python_api_config['metadata']['user'] = 'dendi'
     assert exp.metadata == python_api_config['metadata']
     assert exp.max_trials == python_api_config['max_trials']
+    assert exp.max_broken == python_api_config['max_broken']
     assert exp.algorithms.configuration == python_api_config['algorithms']
 
 
@@ -437,6 +450,7 @@ def test_build_without_config_hit(python_api_config):
     assert exp.configuration['refers'] == python_api_config['refers']
     assert exp.metadata == python_api_config['metadata']
     assert exp.max_trials == python_api_config['max_trials']
+    assert exp.max_broken == python_api_config['max_broken']
     assert exp.algorithms.configuration == python_api_config['algorithms']
 
 
@@ -459,6 +473,7 @@ def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
     assert exp.configuration['refers'] == new_config['refers']
     assert exp.metadata == new_config['metadata']
     assert exp.max_trials == new_config['max_trials']
+    assert exp.max_broken == new_config['max_broken']
     assert exp.algorithms.configuration == new_config['algorithms']
 
 
@@ -576,6 +591,7 @@ class TestBuild(object):
         assert exp.metadata == new_config['metadata']
         assert exp.pool_size == new_config['pool_size']
         assert exp.max_trials == new_config['max_trials']
+        assert exp.max_broken == new_config['max_broken']
         assert exp.working_dir == new_config['working_dir']
         assert exp.version == new_config['version']
         assert exp.algorithms.configuration == new_config['algorithms']
@@ -929,6 +945,7 @@ class TestInitExperimentView(object):
         assert exp.metadata == new_config['metadata']
         assert exp.pool_size == new_config['pool_size']
         assert exp.max_trials == new_config['max_trials']
+        assert exp.max_broken == new_config['max_broken']
         assert exp.version == new_config['version']
         assert isinstance(exp.refers['adapter'], BaseAdapter)
         assert exp.algorithms.configuration == new_config['algorithms']

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -243,6 +243,7 @@ def test_fetch_config(config_file):
 
     assert config.pop('experiment') == {
         'max_trials': 100,
+        'max_broken': 5,
         'name': 'voila_voici',
         'pool_size': 1,
         'algorithms': 'random',

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -40,6 +40,7 @@ def new_config(random_dt):
         version=1,
         pool_size=10,
         max_trials=1000,
+        max_broken=5,
         working_dir=None,
         algorithms={'dumbalgo': {}},
         producer={'strategy': 'NoParallelStrategy'},
@@ -433,13 +434,14 @@ def test_is_done_property_no_pending(algorithm):
 
 def test_broken_property():
     """Check experiment stopping conditions for maximum number of broken."""
-    MAX_BROKEN = 3
-    orion.core.config.worker.max_broken = MAX_BROKEN
+    MAX_BROKEN = 5
 
     stati = (['reserved'] * 10) + (['broken'] * (MAX_BROKEN - 1))
     with OrionState(trials=generate_trials(stati)) as cfg:
         exp = Experiment('supernaekei')
         exp._id = cfg.trials[0]['experiment']
+
+        exp.max_broken = MAX_BROKEN
 
         assert not exp.is_broken
 
@@ -448,22 +450,25 @@ def test_broken_property():
         exp = Experiment('supernaekei')
         exp._id = cfg.trials[0]['experiment']
 
+        exp.max_broken = MAX_BROKEN
+
         assert exp.is_broken
 
 
 def test_configurable_broken_property():
     """Check if max_broken changes after configuration."""
-    MAX_BROKEN = 3
-    orion.core.config.worker.max_broken = MAX_BROKEN
+    MAX_BROKEN = 5
 
     stati = (['reserved'] * 10) + (['broken'] * (MAX_BROKEN))
     with OrionState(trials=generate_trials(stati)) as cfg:
         exp = Experiment('supernaekei')
         exp._id = cfg.trials[0]['experiment']
 
+        exp.max_broken = MAX_BROKEN
+
         assert exp.is_broken
 
-        orion.core.config.worker.max_broken += 1
+        exp.max_broken += 1
 
         assert not exp.is_broken
 
@@ -591,6 +596,8 @@ def test_view_is_broken():
     with OrionState(trials=generate_trials(broken)) as cfg:
         exp = Experiment('test-experiment')
         exp._id = cfg.trials[0]['experiment']
+
+        exp.max_broken = 5
 
         assert exp.is_broken
 


### PR DESCRIPTION
The experiment was using `worker.max_broken` but max_broken for the
experiment is also configurable and should be handled differently.