### PR TITLE
Handle rm/add properly in EVC

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -74,6 +74,9 @@ def _build_extended_user_args(config):
     """Return a list of user arguments augmented with key-value pairs found in
     user's script's configuration file.
     """
+    if 'user_args' not in config['metadata']:
+        return []
+
     user_args = config['metadata']['user_args']
 
     # No need to pass config_prefix because we have access to everything

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -230,6 +230,10 @@ def consolidate_config(name, version, config):
     """
     db_config = fetch_config_from_db(name, version)
 
+    # Do not merge spaces, the new definition overrides it.
+    if 'space' in config:
+        db_config.pop('space', None)
+
     new_config = config
     config = resolve_config.merge_configs(db_config, config)
 


### PR DESCRIPTION
[fixes #471 ]

Why:

When removing a hyperparameter from the search space, the merge of
configuration would bring it back from previous version. We should not
merge the search space, only override it if redefined.