### PR TITLE
Override fields with set, not update

### DIFF
--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -469,8 +469,15 @@ class EphemeralDocument(object):
             the data, the corresponding `data[$set]` will be used instead.
 
         """
-        data = flatten(data.get("$set", data))
-        self._data.update(data)
+        if '$set' in data:
+            unflattened_data = unflatten(self._data)
+            for key, value in data['$set'].items():
+                if isinstance(value, dict):
+                    value = flatten(value)
+                unflattened_data[key] = value
+            self._data = flatten(unflattened_data)
+        else:
+            self._data.update(flatten(data))
 
     def to_dict(self):
         """Convert the ephemeral document to a python dictionary"""

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -204,6 +204,20 @@ class TestWrite(object):
         assert value[2]['pool_size'] == 2
         assert value[3]['pool_size'] == 2
 
+    def test_update_with_set(self, database, orion_db):
+        """Should override matching subdict, not update it"""
+        filt = {'metadata.user': 'dendi'}
+        count_before = database['experiments'].count()
+        count_query = database['experiments'].count(filt)
+        # call interface
+        new_algo = {'random': {'seed': 1}}
+        assert orion_db.write('experiments', {'algorithms': new_algo}, filt) == count_query
+
+        assert database['experiments'].count() == count_before
+        value = list(database['experiments'].find(filt))
+        assert len(value) == 1
+        assert value[0]['algorithms'] == new_algo
+
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
         filt = {'_id': exp_config[0][1]['_id']}


### PR DESCRIPTION
Why:

The $set operator in mongodb is meant to replace values, not to update
subdict.

How:

If $set is used to update dict, iterate on fields to $set and replace
with flattened version.