### PR TITLE
Fix cardinality and integer cast

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -430,6 +430,16 @@ class Real(Dimension):
 
         return casted_point
 
+    @staticmethod
+    def get_cardinality(shape, interval):
+        """Return the number of all the possible points based and shape and interval"""
+        return numpy.inf
+
+    @property
+    def cardinality(self):
+        """Return the number of all the possible points from Integer `Dimension`"""
+        return Real.get_cardinality(self.shape, self.interval())
+
 
 class _Discrete(Dimension):
 
@@ -446,7 +456,7 @@ class _Discrete(Dimension):
         """
         samples = super(_Discrete, self).sample(n_samples, seed)
         # Making discrete by ourselves because scipy does not use **floor**
-        return list(map(lambda x: numpy.floor(x).astype(int), samples))
+        return list(map(self.cast, samples))
 
     def interval(self, alpha=1.0):
         """Return a tuple containing lower and upper bound for parameters.
@@ -543,11 +553,15 @@ class Integer(Real, _Discrete):
         """Return the name of the prior"""
         return 'int_{}'.format(super(Integer, self).prior_name)
 
+    @staticmethod
+    def get_cardinality(shape, interval):
+        """Return the number of all the possible points based and shape and interval"""
+        return int(interval[1] - interval[0] + 1) ** _get_shape_cardinality(shape)
+
     @property
     def cardinality(self):
         """Return the number of all the possible points from Integer `Dimension`"""
-        low, high = self.interval()
-        return _get_shape_cardinality(self.shape) * int(high - low)
+        return Integer.get_cardinality(self.shape, self.interval())
 
 
 def _get_shape_cardinality(shape):
@@ -593,10 +607,15 @@ class Categorical(Dimension):
                                                   self._probs))
         super(Categorical, self).__init__(name, prior, **kwargs)
 
+    @staticmethod
+    def get_cardinality(shape, categories):
+        """Return the number of all the possible points based and shape and categories"""
+        return len(categories) ** _get_shape_cardinality(shape)
+
     @property
     def cardinality(self):
         """Return the number of all the possible values from Categorical `Dimension`"""
-        return len(self.categories) * _get_shape_cardinality(self._shape)
+        return Categorical.get_cardinality(self.shape, self.interval())
 
     def sample(self, n_samples=1, seed=None):
         """Draw random samples from `prior`.
@@ -757,13 +776,19 @@ class Fidelity(Dimension):
         """Return `high`"""
         return self.high
 
-    # pylint:disable=no-self-use
+    @staticmethod
+    def get_cardinality(shape, interval):
+        """Return cardinality of Fidelity dimension, leave it to 1 as Fidelity dimension
+        does not contribute to cardinality in a fixed way now.
+        """
+        return 1
+
     @property
     def cardinality(self):
         """Return cardinality of Fidelity dimension, leave it to 1 as Fidelity dimension
         does not contribute to cardinality in a fixed way now.
         """
-        return 1
+        return Fidelity.get_cardinality(self.shape, self.interval())
 
     def get_prior_string(self):
         """Build the string corresponding to current prior"""

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -529,14 +529,25 @@ class Integer(Real, _Discrete):
 
         return super(Integer, self).__contains__(point)
 
-    # pylint:disable=no-self-use
     def cast(self, point):
         """Cast a point to int
 
         If casted point will stay a list or a numpy array depending on the
         given point's type.
         """
-        casted_point = numpy.asarray(point).astype(int)
+        casted_point = numpy.asarray(point).astype(float)
+
+        # Rescale point to make high bound inclusive.
+        low, high = self.interval()
+        if not numpy.any(numpy.isinf([low, high])):
+            high = (high - low)
+            casted_point -= low
+            casted_point = casted_point / high
+            casted_point = casted_point * (high + (1 - 1e-10))
+            casted_point += low
+            casted_point = numpy.floor(casted_point).astype(int)
+        else:
+            casted_point = numpy.floor(casted_point).astype(int)
 
         if not isinstance(point, numpy.ndarray):
             return casted_point.tolist()

--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -151,7 +151,7 @@ class DimensionBuilder(object):
 
         .. note:: Changes scipy convention for uniform's arguments. In scipy,
            ``uniform(a, b)`` means uniform in the interval [a, a+b). Here, it
-           means uniform in the interval [a, b).
+           means uniform in the interval [a, b].
 
         """
         name = self.name
@@ -159,6 +159,16 @@ class DimensionBuilder(object):
         if len(args) == 2:
             return klass(name, 'uniform', args[0], args[1] - args[0], **kwargs)
         return klass(name, 'uniform', *args, **kwargs)
+
+    def randint(self, *args, **kwargs):
+        """Create an `Integer` or `Real` uniformly distributed dimension.
+
+        .. note:: Changes scipy convention for uniform's arguments. In scipy,
+           ``uniform(a, b)`` means uniform in the interval [a, a+b). Here, it
+           means uniform in the interval [a, b].
+
+        """
+        raise NotImplementedError('`randint` is not supported. Use uniform(discrete=True) instead.')
 
     def gaussian(self, *args, **kwargs):
         """Synonym for `scipy.stats.distributions.norm`."""

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -436,7 +436,7 @@ class TransformedDimension(object):
             interval = self.transformer.interval()
             if interval:
                 return interval
-        elif self.original_dimension.prior_name == 'choices':
+        if self.original_dimension.type == 'categorical':
             return self.original_dimension.categories
 
         low, high = self.original_dimension.interval(alpha)

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -326,6 +326,9 @@ class Enumerate(Transformer):
         """
         return self._imap(transformed_point)
 
+    def interval(self, alpha):
+        return (0, len(self.categories) - 1)
+
 
 class OneHotEncode(Transformer):
     """Encode categories to a 1-hot integer space representation."""

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -15,7 +15,7 @@ from abc import (ABCMeta, abstractmethod)
 
 import numpy
 
-from orion.algo.space import (Dimension, Space)
+from orion.algo.space import (Categorical, Dimension, Fidelity, Integer, Real, Space)
 
 
 # pylint: disable=too-many-branches
@@ -521,7 +521,16 @@ class TransformedDimension(object):
     @property
     def cardinality(self):
         """Wrap original `Dimension` capacity"""
-        return self.original_dimension.cardinality
+        if self.type == 'real':
+            return Real.get_cardinality(self.shape, self.interval())
+        elif self.type == 'integer':
+            return Integer.get_cardinality(self.shape, self.interval())
+        elif self.type == 'categorical':
+            return Categorical.get_cardinality(self.shape, self.interval())
+        elif self.type == 'fidelity':
+            return Fidelity.get_cardinality(self.shape, self.interval())
+        else:
+            raise RuntimeError(f'No cardinality can be computed for type `{self.type}`')
 
 
 class TransformedSpace(Space):

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -328,6 +328,7 @@ class Enumerate(Transformer):
 
     # pylint:disable=unused-argument
     def interval(self, alpha=1.0):
+        """Return the interval for the enumerated choices."""
         return (0, len(self.categories) - 1)
 
 

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -326,7 +326,8 @@ class Enumerate(Transformer):
         """
         return self._imap(transformed_point)
 
-    def interval(self, alpha):
+    # pylint:disable=unused-argument
+    def interval(self, alpha=1.0):
         return (0, len(self.categories) - 1)
 
 

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -117,7 +117,7 @@ def test_cardinality_stop(algorithm):
     exp = workon(rosenbrock, discrete_space, algorithms=algorithm, max_trials=100)
 
     trials = exp.fetch_trials()
-    assert len(trials) == 15
+    assert len(trials) == 16
     assert trials[-1].status == 'completed'
 
 
@@ -136,8 +136,6 @@ def test_with_fidelity(algorithm):
     assert trials[-1].status == 'completed'
 
     results = [trial.objective.value for trial in trials]
-    print(min(results))
-    print(max(results))
     best_trial = next(iter(sorted(trials, key=lambda trial: trial.objective.value)))
 
     assert best_trial.objective.name == 'objective'

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -399,7 +399,7 @@ class TestASHA():
     def test_suggest_in_finite_cardinality(self):
         """Test that suggest None when search space is empty"""
         space = Space()
-        space.register(Integer('yolo1', 'uniform', 0, 6))
+        space.register(Integer('yolo1', 'uniform', 0, 5))
         space.register(Fidelity('epoch', 1, 9, 3))
 
         asha = ASHA(space)

--- a/tests/unittests/algo/test_hyperband.py
+++ b/tests/unittests/algo/test_hyperband.py
@@ -461,7 +461,7 @@ class TestHyperband():
     def test_suggest_in_finite_cardinality(self):
         """Test that suggest None when search space is empty"""
         space = Space()
-        space.register(Integer('yolo1', 'uniform', 0, 6))
+        space.register(Integer('yolo1', 'uniform', 0, 5))
         space.register(Fidelity('epoch', 1, 9, 3))
 
         hyperband = Hyperband(space, repetitions=1)

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -369,14 +369,20 @@ class TestInteger(object):
         dim = Integer('yolo', 'uniform', -3, 4)
         assert dim.default_value is None
 
+    def test_cast_borders(self):
+        """Make sure cast to int returns correct borders"""
+        dim = Integer('yolo', 'uniform', -3, 5)
+        assert dim.cast(-3.0) == -3
+        assert dim.cast(2.0) == 2
+
     def test_cast_list(self):
         """Make sure list are cast to int and returned as list of values"""
-        dim = Integer('yolo', 'uniform', -3, 4)
+        dim = Integer('yolo', 'uniform', -3, 5)
         assert dim.cast(['1', '2']) == [1, 2]
 
     def test_cast_array(self):
         """Make sure array are cast to int and returned as array of values"""
-        dim = Integer('yolo', 'uniform', -3, 4)
+        dim = Integer('yolo', 'uniform', -3, 5)
         assert np.all(dim.cast(np.array(['1', '2'])) == np.array([1, 2]))
 
     def test_get_prior_string_discrete(self):

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -721,11 +721,11 @@ class TestSpace(object):
         dim = Fidelity('epoch', 1, 9, 3)
         space.register(dim)
 
-        assert (4 * 2) * 6 * 1 == space.cardinality
+        assert space.cardinality == (4 ** 2) * (6 + 1) * 1
 
-        dim = Integer('yolo3', 'uniform', -3, 2, shape=(3, 1))
+        dim = Integer('yolo3', 'uniform', -3, 2, shape=(3, 2))
         space.register(dim)
-        assert (4 * 2) * 6 * 1 * (2 * 3 * 1) == space.cardinality
+        assert space.cardinality == (4 ** 2) * (6 + 1) * 1 * ((2 + 1) ** (3 * 2))
 
         dim = Real('yolo4', 'norm', 0.9)
         space.register(dim)

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -771,17 +771,17 @@ class TestRequiredSpaceBuilder(object):
         space = Space()
         probs = (0.1, 0.2, 0.3, 0.4)
         categories = ('asdfa', 2, 3, 4)
-        dim = Categorical('yolo', OrderedDict(zip(categories, probs)), shape=2)
+        dim = Categorical('yolo0', OrderedDict(zip(categories, probs)), shape=2)
         space.register(dim)
         dim = Integer('yolo2', 'uniform', -3, 6)
         space.register(dim)
         tspace = build_required_space('integer', space)
-        assert tspace.cardinality == (4 * 2) * 6
+        assert tspace.cardinality == (4 ** 2) * (6 + 1)
 
         dim = Integer('yolo3', 'uniform', -3, 6, shape=(2, 1))
         space.register(dim)
         tspace = build_required_space('integer', space)
-        assert tspace.cardinality == (4 * 2) * 6 * 6 * (2 * 1)
+        assert tspace.cardinality == (4 ** 2) * (6 + 1) * ((6 + 1) ** (2 * 1))
 
 
 def test_quantization_does_not_violate_bounds():


### PR DESCRIPTION

## Fix cardinality

There was two errors.

1. The integer bounds are inclusive, but the cardinality was computed as if
the upper bound was exclusive.

2. The shape affects cardinality exponentially, it would be
(cardinality of one item) ** prod(shape), not (cardinality of one item) * prod(shape).

## Fix casting of Integer

Why:

There is a mismatch between the inclusive bound of Integer and
the underlying distribution (which is real) where high is in theory exclusive
but in practice inclusive due to limited precision and rounding.
We cannot use numpy.round() to fix this because otherwise the probability
is changed for lowest and highest possible numbers. For instance a
uniform distribution (0, 10) would have a probability of 0.5 * (1/10)
for 0 instead of (1/10).

How:

In the cast method, rescale the point from (low, high) to
(low, high + 1) before computing the numpy.floor().astype(int).
Note that some distributions have infinite intervals, in which case we
do no rescaling.

## Deprecate `randint` distribution

uniform(a, b, discrete=True) and randint(a, b) handles differently the intervals are
seems incompatible. We were already recommending uniform over randint
anyway.