### PR TITLE
Add ReshapedSpace and Linearize transformer

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -916,8 +916,11 @@ class Space(dict):
         """Check whether `value` is within the bounds of the space.
         Or check if a name for a dimension is registered in this space.
 
-        :param value: list of values associated with the dimensions contained
-           or a string indicating a dimension's name.
+        Parameters
+        ----------
+        value: list
+            List of values associated with the dimensions contained or a string indicating a
+            dimension's name.
 
         """
         if isinstance(value, str):

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -985,7 +985,7 @@ def pack_point(point, space):
 
 
 def unpack_point(point, space):
-    """Flatten `point` in `space` and convert it to a 1D `numpy.ndarray`.
+    """Flatten `point` in `space` and convert it to a 1D list.
 
     This function is deprecated and will be removed in v0.2.0. Use
     `orion.core.utils.points.flatten_dims` instead.

--- a/src/orion/algo/tpe.py
+++ b/src/orion/algo/tpe.py
@@ -259,7 +259,7 @@ class TPE(BaseAlgorithm):
             above_points = list(map(list, zip(*above_points)))
 
             idx = 0
-            for dimension in self.space.values():
+            for i, dimension in enumerate(self.space.values()):
 
                 shape = dimension.shape
                 if not shape:
@@ -281,7 +281,7 @@ class TPE(BaseAlgorithm):
                                                        self._sample_categorical_point)
                 elif dimension.type == 'fidelity':
                     # fidelity dimension
-                    points = dimension.sample(num)
+                    points = [point[i] for point in self.space.sample(num)]
                 else:
                     raise NotImplementedError()
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -92,7 +92,7 @@ def _validate_input_value(value, exp_space, namespace):
     try:
         value = eval(value)
         is_valid = value in exp_space[namespace]
-    except NameError:
+    except (NameError, SyntaxError):
         is_valid = value in exp_space[namespace]
 
     return is_valid, value

--- a/src/orion/core/worker/primary_algo.py
+++ b/src/orion/core/worker/primary_algo.py
@@ -9,6 +9,7 @@
 
 """
 from orion.algo.base import BaseAlgorithm
+import orion.core.utils.backward as backward
 from orion.core.worker.transformer import build_required_space
 
 
@@ -37,8 +38,8 @@ class PrimaryAlgo(BaseAlgorithm):
         """
         self.algorithm = None
         super(PrimaryAlgo, self).__init__(space, algorithm=algorithm_config)
-        requirements = self.algorithm.requires
-        self.transformed_space = build_required_space(requirements, self.space)
+        requirements = backward.get_algo_requirements(self.algorithm)
+        self.transformed_space = build_required_space(self.space, **requirements)
         self.algorithm.space = self.transformed_space
 
     def seed_rng(self, seed):

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -300,7 +300,14 @@ class Quantize(Transformer):
 
     def transform(self, point):
         """Cast `point` to the floor and then to integers, as numpy arrays."""
-        return numpy.floor(numpy.asarray(point)).astype(int)
+        quantized = numpy.floor(numpy.asarray(point)).astype(int)
+
+        if numpy.any(numpy.isinf(point)):
+            isinf = int(numpy.isinf(point))
+            quantized = (isinf * (quantized - 1) * int(numpy.sign(point)) +
+                         (1 - isinf) * (quantized - 1)).astype(int)
+
+        return quantized
 
     def reverse(self, transformed_point):
         """Cast `transformed_point` to floats, as numpy arrays."""

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa: D102
-# pylint: disable=no-self-use
+# pylint: disable=too-many-lines
 """
 :mod:`orion.core.worker.transformer` -- Perform transformations on Dimensions
 =============================================================================
@@ -12,6 +11,8 @@
 
 """
 from abc import (ABCMeta, abstractmethod)
+import functools
+import itertools
 
 import numpy
 
@@ -21,81 +22,153 @@ from orion.algo.space import (Categorical, Dimension, Fidelity, Integer, Real, S
 NON_LINEAR = ['loguniform', 'reciprocal']
 
 
-# pylint: disable=too-many-branches
-def build_required_space(requirements, original_space):
+# pylint: disable=unused-argument
+@functools.singledispatch
+def build_transform(dim, type_requirement, dist_requirement):
+    """Base transformation factory
+
+    Parameters
+    ----------
+    dim: `orion.algo.space.Dimension`
+        A dimension object which may need transformations to match provided requirements.
+    type_requirement: str, None
+        String defining the requirement of the algorithm. It can be one of the following
+        - 'real', the dim should be transformed so type is `Real`
+        - 'integer', the dim should be transformed so type is `Integer`
+        - 'numerical', the dim should be transformed so type is either `Integer` or `Real`
+        - None, no requirement
+    dist_requirement: str, None
+        String defining the distribution requirement of the algorithm.
+        - 'linear', any dimension with logarithmic prior while be linearized
+        - None, no requirement
+
+    """
+    return []
+
+
+@build_transform.register(Categorical)
+def _(dim, type_requirement, dist_requirement):
+    transformers = []
+    if type_requirement == 'real':
+        transformers.extend([Enumerate(dim.categories),
+                             OneHotEncode(len(dim.categories))])
+    elif type_requirement in ['integer', 'numerical']:
+        transformers.append(Enumerate(dim.categories))
+
+    return transformers
+
+
+@build_transform.register(Fidelity)
+def _(dim, type_requirement, dist_requirement):
+    return []
+
+
+@build_transform.register(Integer)
+def _(dim, type_requirement, dist_requirement):
+    transformers = []
+    if dist_requirement == 'linear' and dim.prior_name in NON_LINEAR:
+        transformers.extend([Reverse(Quantize()), Linearize()])
+        # Turn back to integer because Linearize outputs real
+        if type_requirement != 'real':
+            transformers.extend([Quantize()])
+    elif type_requirement == 'real':
+        transformers.append(Reverse(Quantize()))
+
+    return transformers
+
+
+@build_transform.register(Real)
+def _(dim, type_requirement, dist_requirement):
+    transformers = []
+    if dim.precision is not None:
+        transformers.append(Precision(dim.precision))
+
+    if dist_requirement == 'linear' and dim.prior_name in NON_LINEAR:
+        transformers.append(Linearize())
+    elif type_requirement == 'integer':
+        transformers.append(Quantize())
+
+    return transformers
+
+
+def transform(original_space, type_requirement, dist_requirement):
+    """Build a transformed space"""
+    space = TransformedSpace(original_space)
+    for dim in original_space.values():
+        transformers = build_transform(dim, type_requirement, dist_requirement)
+        space.register(
+            TransformedDimension(
+                transformer=Compose(transformers, dim.type),
+                original_dimension=dim
+            )
+        )
+
+    return space
+
+
+def reshape(space, shape_requirement):
+    """Build a reshaped space"""
+    if shape_requirement is None:
+        return space
+
+    # We assume shape_requirement == 'flattened'
+
+    reshaped_space = ReshapedSpace(space)
+
+    for dim_index, dim in enumerate(space.values()):
+        if numpy.prod(dim.shape) == 1:
+            reshaped_space.register(
+                ReshapedDimension(
+                    transformer=Identity(dim.type),
+                    original_dimension=dim
+                )
+            )
+        else:
+            for index in itertools.product(*map(range, dim.shape)):
+                key = f'{dim.name}[{",".join(map(str, index))}]'
+                reshaped_space.register(
+                    ReshapedDimension(
+                        transformer=View(dim.shape, index, dim_index, dim.type),
+                        original_dimension=dim,
+                        name=key
+                    )
+                )
+
+    return reshaped_space
+
+
+def build_required_space(
+        original_space, type_requirement=None, shape_requirement=None, dist_requirement=None):
     """Build a `Space` object which agrees to the `requirements` imposed
     by the desired optimization algorithm.
 
     It uses appropriate cascade of `Transformer` objects per `Dimension`
-    contained in `original_space`.
+    contained in `original_space`. `ReshapedTransformer` objects are used above
+    the `Transformer`s if the optimizatios algorithm requires flattened dimensions.
 
     Parameters
     ----------
-    requirements : list of str or str
-       Describes requirements that an algorithm needs a parameter space to have
-       in order to be able to operate on it. In case it is a list, the infered
-       transformations are going to be applied from the first item in the list to
-       the last.
     original_space : `orion.algo.space.Space`
        Original problem's definition of parameter space given by the user to Oríon.
-
-    Supported Requirements
-    ----------------------
-     * Null requirement; use problem's parameter space as it is defined
-     * ``'real'``: transform every dimension to a `orion.algo.space.Real` one
-     * ``'integer'``: transform every dimension to a `orion.algo.space.Integer` one
+    type_requirement: str, None
+        String defining the requirement of the algorithm. It can be one of the following
+        - 'real', the dim should be transformed so type is `Real`
+        - 'integer', the dim should be transformed so type is `Integer`
+        - 'numerical', the dim should be transformed so type is either `Integer` or `Real`
+        - None, no requirement
+    shape_requirement: str, None
+        String defining the shape requirement of the algorithm.
+        - 'flattened', any dimension with shape > 1 will be flattened
+        - None, no requirement
+    dist_requirement: str, None
+        String defining the distribution requirement of the algorithm.
+        - 'linear', any dimension with logarithmic prior while be linearized
+        - None, no requirement
 
     """
-    requirements = requirements if isinstance(requirements, list) else [requirements]
-    if not requirements:
-        requirements = [None]
+    space = transform(original_space, type_requirement, dist_requirement)
+    space = reshape(space, shape_requirement)
 
-    space = TransformedSpace()
-    for dim in original_space.values():
-        transformers = []
-        type_ = dim.type
-        prior_name = dim._prior_name  # pylint: disable=protected-access
-        base_domain_type = type_
-        for requirement in requirements:
-            # Real Dimensions
-            if type_ == 'real' and requirement == 'linear' and prior_name in NON_LINEAR:
-                transformers.append(Linearize())
-            # NOTE: Not elif, because we stack a Precision above Linearize if necessary.
-            if (type_ == 'real' and
-                    (requirement in ('real', 'linear', None)) and
-                    (dim.precision is not None)):
-                transformers.append(Precision(dim.precision))
-            elif type_ == 'real' and requirement == 'integer':
-                transformers.append(Quantize())
-            # Integer Dimensions
-            elif type_ == 'integer' and requirement == 'real':
-                transformers.append(Reverse(Quantize()))
-            elif type_ == 'integer' and requirement == 'linear' and prior_name in NON_LINEAR:
-                transformers.extend([Reverse(Quantize()), Linearize()])
-            elif type_ == 'integer' and requirement == 'linear':
-                transformers.append(Reverse(Quantize()))
-            elif type_ == 'integer' and requirement in ('integer', None):
-                pass
-            # Categorical Dimensions
-            elif type_ == 'categorical' and requirement in ('real', 'linear'):
-                transformers.extend([Enumerate(dim.categories),
-                                     OneHotEncode(len(dim.categories))])
-            elif type_ == 'categorical' and requirement == 'integer':
-                transformers.append(Enumerate(dim.categories))
-            elif type_ == 'categorical' and requirement is None:
-                pass
-            elif type_ == 'fidelity' and requirement is None:
-                pass
-            else:
-                raise TypeError("Unsupported dimension type ('{}') "
-                                "or requirement ('{}')".format(type_, requirement))
-            try:
-                last_type = transformers[-1].target_type
-                type_ = last_type if last_type != 'invariant' else type_
-            except IndexError:
-                pass
-        space.register(TransformedDimension(Compose(transformers, base_domain_type),
-                                            dim))
     return space
 
 
@@ -118,10 +191,11 @@ class Transformer(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def reverse(self, transformed_point):
+    def reverse(self, transformed_point, index=None):
         """Reverse transform a point from target dimension to the domain dimension."""
         pass
 
+    # pylint:disable=no-self-use
     def infer_target_shape(self, shape):
         """Return the shape of the dimension after transformation."""
         return shape
@@ -131,7 +205,6 @@ class Transformer(object, metaclass=ABCMeta):
         return "{}({})".format(self.__class__.__name__, what)
 
     def _get_hashable_members(self):
-        print((self.__class__.__name__, self.domain_type, self.target_type))
         return (self.__class__.__name__, self.domain_type, self.target_type)
 
     # pylint:disable=protected-access
@@ -148,11 +221,17 @@ class Identity(Transformer):
     def __init__(self, domain_type=None):
         self._domain_type = domain_type
 
+    @property
+    def first(self):
+        """Signals to ReshapedSpace whether this dimension should be used for `reverse`"""
+        return True
+
     def transform(self, point):
         """Return `point` as it is."""
         return point
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Return `transformed_point` as it is."""
         return transformed_point
 
@@ -173,7 +252,8 @@ class Identity(Transformer):
 
 class Compose(Transformer):
     """Initialize composite transformer with a list of `Transformer` objects
-    and domain type on which it will be applied."""
+    and domain type on which it will be applied.
+    """
 
     def __init__(self, transformers, base_domain_type=None):
         try:
@@ -192,7 +272,8 @@ class Compose(Transformer):
         point = self.composition.transform(point)
         return self.apply.transform(point)
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Reverse transformation by reversing in the opposite order of the `transformers` list."""
         transformed_point = self.apply.reverse(transformed_point)
         return self.composition.reverse(transformed_point)
@@ -243,7 +324,8 @@ class Reverse(Transformer):
         """Use `reserve` of composed `transformer`."""
         return self.transformer.reverse(point)
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Use `transform` of composed `transformer`."""
         return self.transformer.transform(transformed_point)
 
@@ -283,7 +365,8 @@ class Precision(Transformer):
 
         return numpy.asarray(point)
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Cast `transformed_point` to floats, as numpy arrays."""
         return self.transform(transformed_point)
 
@@ -309,7 +392,8 @@ class Quantize(Transformer):
 
         return quantized
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Cast `transformed_point` to floats, as numpy arrays."""
         return numpy.asarray(transformed_point).astype(float)
 
@@ -340,7 +424,8 @@ class Enumerate(Transformer):
         """
         return self._map(point)
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Return categories corresponding to their positions inside `transformed_point`.
 
         :rtype: numpy.ndarray, numpy.object
@@ -383,7 +468,8 @@ class OneHotEncode(Transformer):
         hot[grid + [point_]] = 1
         return hot
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Match real vector representations to integers using an argmax function.
 
         If the number of dimensions is exactly 2, then use 0.5 as a decision boundary,
@@ -434,9 +520,53 @@ class Linearize(Transformer):
         """Linearize logarithmic distribution."""
         return numpy.log(numpy.asarray(point))
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Turn linear distribution to logarithmic distribution."""
         return numpy.exp(numpy.asarray(transformed_point))
+
+
+class View(Transformer):
+    """Look-up single index in a dimensions with shape > 1"""
+
+    def __init__(self, shape, index, dim_index, domain_type=None):
+        self.shape = shape
+        self.index = index
+        self.dim_index = dim_index
+        self._domain_type = domain_type
+
+    @property
+    def first(self):
+        """Signals to ReshapedSpace whether this dimension should be used for `reverse`"""
+        return sum(self.index) == 0
+
+    def transform(self, point):
+        """Only return one element of the group"""
+        return point[self.dim_index][self.index]
+
+    def reverse(self, transformed_point, index=None):
+        """Only return packend point if view of first element, otherwise drop."""
+        subset = transformed_point[index:index + numpy.prod(self.shape)]
+        return numpy.array(subset).reshape(self.shape)
+
+    def interval(self, interval):
+        """Return corresponding view from interval"""
+        return (interval[0][self.index], interval[1][self.index])
+
+    @property
+    def domain_type(self):
+        """Return declared domain type on initialization."""
+        return self._domain_type
+
+    @property
+    def target_type(self):
+        """Return domain type as this will be the target in flatten transformation."""
+        return self.domain_type
+
+    def repr_format(self, what):
+        """Format a string for calling ``__repr__`` in `TransformedDimension`."""
+        return "{}(shape={}, index={}, {})".format(self.__class__.__name__, self.shape, self.index,
+                                                   what)
 
 
 class TransformedDimension(object):
@@ -448,9 +578,6 @@ class TransformedDimension(object):
     NO_DEFAULT_VALUE = Dimension.NO_DEFAULT_VALUE
 
     def __init__(self, transformer, original_dimension):
-        """Initialize a `TransformedDimension` with an `original_dimension` object
-        and the `transformer` that will be used.
-        """
         self.original_dimension = original_dimension
         self.transformer = transformer
 
@@ -458,7 +585,8 @@ class TransformedDimension(object):
         """Expose `Transformer.transform` interface from underlying instance."""
         return self.transformer.transform(point)
 
-    def reverse(self, transformed_point):
+    # pylint:disable=unused-argument
+    def reverse(self, transformed_point, index=None):
         """Expose `Transformer.reverse` interface from underlying instance."""
         return self.transformer.reverse(transformed_point)
 
@@ -499,10 +627,12 @@ class TransformedDimension(object):
                 self.original_dimension == other.original_dimension)
 
     def __hash__(self):
+        """Hash of the transformed dimension"""
         return hash(self._get_hashable_members())
 
     # pylint:disable=protected-access
     def _get_hashable_members(self):
+        """Hashable members of transformation and original dimension"""
         return (self.transformer._get_hashable_members() +
                 self.original_dimension._get_hashable_members())
 
@@ -520,6 +650,11 @@ class TransformedDimension(object):
         """Ask transformer which is its target class."""
         type_ = self.transformer.target_type
         return type_ if type_ != 'invariant' else self.original_dimension.type
+
+    @property
+    def prior_name(self):
+        """Do not change the prior name of the original dimension."""
+        return self.original_dimension.prior_name
 
     @property
     def shape(self):
@@ -541,10 +676,75 @@ class TransformedDimension(object):
             raise RuntimeError(f'No cardinality can be computed for type `{self.type}`')
 
 
+class ReshapedDimension(TransformedDimension):
+    """Duck-type `Dimension` to mimic its functionality."""
+
+    def __init__(self, transformer, original_dimension, name=None):
+        super(ReshapedDimension, self).__init__(transformer, original_dimension)
+        if name is None:
+            name = original_dimension.name
+        self._name = name
+
+    @property
+    def first(self):
+        """Signals to ReshapedSpace whether this dimension should be used for `reverse`"""
+        return self.transformer.first
+
+    def transform(self, point):
+        """Expose `Transformer.transform` interface from underlying instance."""
+        return self.transformer.transform(point)
+
+    def reverse(self, transformed_point, index=None):
+        """Expose `Transformer.reverse` interface from underlying instance."""
+        return self.transformer.reverse(transformed_point, index)
+
+    def interval(self, alpha=1.0):
+        """Map the interval bounds to the transformed ones."""
+        interval = self.original_dimension.interval(alpha)
+        if hasattr(interval[0], 'shape') and numpy.prod(interval[0].shape) > 1:
+            return self.transformer.interval(interval)
+
+        return interval
+
+    @property
+    def cardinality(self):
+        """Compute cardinality"""
+        cardinality = super(ReshapedDimension, self).cardinality
+        if isinstance(self.transformer, View):
+            cardinality /= numpy.prod(self.transformer.shape)
+
+        return cardinality
+
+    def cast(self, point):
+        """Cast a point according to original_dimension and then transform it"""
+        return self.original_dimension.cast(point)
+
+    @property
+    def shape(self):
+        """Shape is fixed to ()."""
+        return ()
+
+    @property
+    def name(self):
+        """Name of the view"""
+        return self._name
+
+
 class TransformedSpace(Space):
-    """Wrap the `Space` to support transformation methods."""
+    """Wrap the `Space` to support transformation methods.
+
+    Parameter
+    ---------
+    space: `orion.algo.space.Space`
+       Original problem's definition of parameter space.
+
+    """
 
     contains = TransformedDimension
+
+    def __init__(self, space, *args, **kwargs):
+        super(TransformedSpace, self).__init__(*args, **kwargs)
+        self._original_space = space
 
     def transform(self, point):
         """Transform a point that was in the original space to be in this one."""
@@ -555,3 +755,88 @@ class TransformedSpace(Space):
         to be in the original one.
         """
         return tuple([dim.reverse(transformed_point[i]) for i, dim in enumerate(self.values())])
+
+    def sample(self, n_samples=1, seed=None):
+        """Sample from the original dimension and forward transform them."""
+        points = self._original_space.sample(n_samples=n_samples, seed=seed)
+        return [self.transform(point) for point in points]
+
+
+class ReshapedSpace(Space):
+    """Wrap the `TransformedSpace` to support reshape methods.
+
+    Parameter
+    ---------
+    space: `orion.core.worker.TransformedSpace`
+       Transformed version of the orinigal problem's definition of parameter space.
+
+    """
+
+    contains = ReshapedDimension
+
+    def __init__(self, original_space, *args, **kwargs):
+        super(ReshapedSpace, self).__init__(*args, **kwargs)
+        self._original_space = original_space
+
+    @property
+    def original(self):
+        """Original space without reshape or transformations"""
+        return self._original_space
+
+    def transform(self, point):
+        """Transform a point that was in the original space to be in this one."""
+        return self.reshape(self.original.transform(point))
+
+    def reverse(self, transformed_point):
+        """Reverses transformation so that a point from this `ReshapedSpace` to be in the original
+        one.
+        """
+        return self.original.reverse(self.restore_shape(transformed_point))
+
+    def reshape(self, point):
+        """Reshape the point"""
+        return tuple([dim.transform(point) for dim in self.values()])
+
+    def restore_shape(self, transformed_point):
+        """Restore shape"""
+        point = []
+        for index, dim in enumerate(self.values()):
+            if dim.first:
+                point.append(dim.reverse(transformed_point, index))
+
+        return point
+
+    def sample(self, n_samples=1, seed=None):
+        """Sample from the original dimension and forward transform them."""
+        points = self.original.sample(n_samples=n_samples, seed=seed)
+        return [self.reshape(point) for point in points]
+
+    def __contains__(self, value):
+        """Check whether `value` is within the bounds of the space.
+        Or check if a name for a dimension is registered in this space.
+
+        Parameters
+        ----------
+        value: list
+            List of values associated with the dimensions contained or a string indicating a
+            dimension's name.
+
+        """
+        if isinstance(value, str):
+            return super(ReshapedSpace, self).__contains__(value)
+
+        try:
+            len(value)
+        except TypeError as exc:
+            raise TypeError("Can check only for dimension names or "
+                            "for tuples with parameter values.") from exc
+
+        if not self:
+            return False
+
+        return self.restore_shape(value) in self.original
+
+    @property
+    def cardinality(self):
+        """Reshape does not affect cardinality"""
+        return self.original.cardinality

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -66,7 +66,7 @@ def _(dim, type_requirement, dist_requirement):
 @build_transform.register(Integer)
 def _(dim, type_requirement, dist_requirement):
     transformers = []
-    if dist_requirement == 'linear' and dim.prior_name in NON_LINEAR:
+    if dist_requirement == 'linear' and dim.prior_name[4:] in NON_LINEAR:
         transformers.extend([Reverse(Quantize()), Linearize()])
         # Turn back to integer because Linearize outputs real
         if type_requirement != 'real':

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -441,7 +441,7 @@ class TransformedDimension(object):
 
     NO_DEFAULT_VALUE = Dimension.NO_DEFAULT_VALUE
 
-    def __init__(self, transformer: Transformer, original_dimension: Dimension):
+    def __init__(self, transformer, original_dimension):
         """Initialize a `TransformedDimension` with an `original_dimension` object
         and the `transformer` that will be used.
         """
@@ -455,11 +455,6 @@ class TransformedDimension(object):
     def reverse(self, transformed_point):
         """Expose `Transformer.reverse` interface from underlying instance."""
         return self.transformer.reverse(transformed_point)
-
-    def sample(self, n_samples=1, seed=None):
-        """Sample from the original dimension and forward transform them."""
-        samples = self.original_dimension.sample(n_samples, seed)
-        return [self.transform(sample) for sample in samples]
 
     def interval(self, alpha=1.0):
         """Map the interval bounds to the transformed ones."""
@@ -502,24 +497,12 @@ class TransformedDimension(object):
 
     # pylint:disable=protected-access
     def _get_hashable_members(self):
-        print(self.transformer._get_hashable_members())
-        print(self.original_dimension._get_hashable_members())
         return (self.transformer._get_hashable_members() +
                 self.original_dimension._get_hashable_members())
 
     def validate(self):
         """Validate original_dimension"""
         self.original_dimension.validate()
-
-    def get_prior_string(self):
-        """Do not change the prior string of original dimension."""
-        return self.transformer.repr_format(self.original_dimension.get_prior_string())
-
-    def get_string(self):
-        """Do not change the string of original dimension."""
-        original_prior = self.original_dimension.get_prior_string()
-        original_string = self.original_dimension.get_string()
-        return original_string.replace(original_prior, self.get_prior_string())
 
     @property
     def name(self):
@@ -541,12 +524,6 @@ class TransformedDimension(object):
     def shape(self):
         """Wrap original shape with transformer, because it may have changed."""
         return self.transformer.infer_target_shape(self.original_dimension.shape)
-
-    @property
-    def default_value(self):
-        """Wrap original default value."""
-        defval = self.original_dimension.default_value
-        return self.transform(defval) if defval is not None else None
 
     def cast(self, point):
         """Cast a point according to original_dimension and then transform it"""

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -177,11 +177,11 @@ class Compose(Transformer):
 
     def __init__(self, transformers, base_domain_type=None):
         try:
-            self.apply = transformers.pop()
+            self.apply = transformers[-1]
         except IndexError:
             self.apply = Identity()
-        if transformers:
-            self.composition = Compose(transformers, base_domain_type)
+        if len(transformers) > 1:
+            self.composition = Compose(transformers[:-1], base_domain_type)
         else:
             self.composition = Identity(base_domain_type)
         assert self.apply.domain_type is None or \

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -439,7 +439,6 @@ class Linearize(Transformer):
         return numpy.exp(numpy.asarray(transformed_point))
 
 
-# pylint:disable=too-many-public-methods
 class TransformedDimension(object):
     """Duck-type `Dimension` to mimic its functionality,
     while transform automatically and appropriately an underlying `Dimension` object
@@ -523,18 +522,9 @@ class TransformedDimension(object):
         return type_ if type_ != 'invariant' else self.original_dimension.type
 
     @property
-    def prior_name(self):
-        """Do not change the prior name of the original dimension."""
-        return self.original_dimension.prior_name
-
-    @property
     def shape(self):
         """Wrap original shape with transformer, because it may have changed."""
         return self.transformer.infer_target_shape(self.original_dimension.shape)
-
-    def cast(self, point):
-        """Cast a point according to original_dimension and then transform it"""
-        return self.transform(self.original_dimension.cast(point))
 
     @property
     def cardinality(self):

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -144,7 +144,7 @@ def build_required_space(
 
     It uses appropriate cascade of `Transformer` objects per `Dimension`
     contained in `original_space`. `ReshapedTransformer` objects are used above
-    the `Transformer`s if the optimizatios algorithm requires flattened dimensions.
+    the `Transformer` if the optimizatios algorithm requires flattened dimensions.
 
     Parameters
     ----------

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -9,7 +9,7 @@ import pytest
 
 from orion.algo.space import (Categorical, Dimension, Integer, Real, Space,)
 from orion.core.worker.transformer import (build_required_space,
-                                           Compose, Enumerate, Identity,
+                                           Compose, Enumerate, Identity, Linearize,
                                            OneHotEncode, Precision, Quantize, Reverse,
                                            TransformedDimension, TransformedSpace,)
 
@@ -459,10 +459,52 @@ class TestOneHotEncode(object):
         assert t.repr_format('asfa') == 'OneHotEncode(asfa)'
 
 
+class TestLinearize(object):
+    """Test subclasses of `Linearize` transformation."""
+
+    def test_domain_and_target_type(self):
+        """Check if attribute-like `domain_type` and `target_type` do
+        what's expected.
+        """
+        t = Linearize()
+        assert t.domain_type == 'real'
+        assert t.target_type == 'real'
+
+    def test_transform(self):
+        """Check if it transforms properly."""
+        t = Linearize()
+        assert t.transform(numpy.e) == 1
+        t.transform(0)
+
+    def test_reverse(self):
+        """Check if it reverses `transform` properly."""
+        t = Linearize()
+        assert t.reverse(1) == numpy.e
+
+    def test_repr_format(self):
+        """Check representation of a transformed dimension."""
+        t = Linearize()
+        assert t.repr_format(1.0) == 'Linearize(1.0)'
+
+
 @pytest.fixture(scope='module')
 def dim():
     """Create an example of `Dimension`."""
     dim = Real('yolo', 'norm', 0.9, shape=(3, 2))
+    return dim
+
+
+@pytest.fixture(scope='module')
+def logdim():
+    """Create an log example of `Dimension`."""
+    dim = Real('yolo4', 'reciprocal', 1.0, 10.0, shape=(3, 2))
+    return dim
+
+
+@pytest.fixture(scope='module')
+def logintdim():
+    """Create an log integer example of `Dimension`."""
+    dim = Integer('yolo5', 'reciprocal', 1, 10, shape=(3, 2))
     return dim
 
 
@@ -699,11 +741,13 @@ class TestTransformedSpace(object):
 
 
 @pytest.fixture(scope='module')
-def space_each_type(dim, dim2):
+def space_each_type(dim, dim2, logdim, logintdim):
     """Create an example `Space`."""
     space = Space()
     space.register(dim)
     space.register(dim2)
+    space.register(logdim)
+    space.register(logintdim)
     space.register(Integer('yolo3', 'randint', 3, 10))
     return space
 
@@ -720,47 +764,83 @@ class TestRequiredSpaceBuilder(object):
     def test_no_requirement(self, space_each_type):
         """Check what is built using 'None' requirement."""
         tspace = build_required_space(None, space_each_type)
-        assert len(tspace) == 3
+        assert len(tspace) == 5
         assert tspace[0].type == 'real'
         assert tspace[1].type == 'categorical'
+        # NOTE:HEAD
         assert tspace[2].type == 'integer'
         assert (str(tspace) ==
                 "Space([Precision(4, Real(name=yolo, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),\n"  # noqa
                 "       Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None),\n"  # noqa
                 "       Integer(name=yolo3, prior={randint: (3, 10), {}}, shape=(), default value=None)])")  # noqa
+        # TODO: Remove
+        # assert tspace[2].type == 'real'
+        # assert tspace[3].type == 'integer'
+        # assert tspace[4].type == 'integer'
+        # assert str(tspace) == str(space_each_type)
 
         tspace = build_required_space([], space_each_type)
-        assert len(tspace) == 3
+        assert len(tspace) == 5
         assert tspace[0].type == 'real'
         assert tspace[1].type == 'categorical'
+        # NOTE:HEAD
         assert tspace[2].type == 'integer'
         assert (str(tspace) ==
                 "Space([Precision(4, Real(name=yolo, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),\n"  # noqa
                 "       Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None),\n"  # noqa
                 "       Integer(name=yolo3, prior={randint: (3, 10), {}}, shape=(), default value=None)])")  # noqa
+        # TODO: Remove
+        # assert tspace[2].type == 'real'
+        # assert tspace[3].type == 'integer'
+        # assert tspace[4].type == 'integer'
+        # assert str(tspace) == str(space_each_type)
 
     def test_integer_requirement(self, space_each_type):
         """Check what is built using 'integer' requirement."""
         tspace = build_required_space('integer', space_each_type)
-        assert len(tspace) == 3
+        assert len(tspace) == 5
         assert tspace[0].type == 'integer'
         assert tspace[1].type == 'integer'
         assert tspace[2].type == 'integer'
+        assert tspace[3].type == 'integer'
+        assert tspace[4].type == 'integer'
         assert(str(tspace) ==
                "Space([Quantize(Real(name=yolo, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),\n"  # noqa
                "       Enumerate(Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None)),\n"  # noqa
+               "       Quantize(Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None)),\n" # noqa
+               "       Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None),\n" # noqa
                "       Integer(name=yolo3, prior={randint: (3, 10), {}}, shape=(), default value=None)])")  # noqa
 
     def test_real_requirement(self, space_each_type):
         """Check what is built using 'real' requirement."""
         tspace = build_required_space('real', space_each_type)
-        assert len(tspace) == 3
+        assert len(tspace) == 5
         assert tspace[0].type == 'real'
         assert tspace[1].type == 'real'
         assert tspace[2].type == 'real'
+        assert tspace[3].type == 'real'
+        assert tspace[4].type == 'real'
+        assert(str(tspace) ==
+               "Space([Real(name=yolo, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None),\n"  # noqa
+               "       OneHotEncode(Enumerate(Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None))),\n"  # noqa
+               "       Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None),\n" # noqa
+               "       ReverseQuantize(Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None)),\n" # noqa
+               "       ReverseQuantize(Integer(name=yolo3, prior={randint: (3, 10), {}}, shape=(), default value=None))])")  # noqa
+
+    def test_linear_requirement(self, space_each_type):
+        """Check what is built using 'linear' requirement."""
+        tspace = build_required_space('linear', space_each_type)
+        assert len(tspace) == 5
+        assert tspace[0].type == 'real'
+        assert tspace[1].type == 'real'
+        assert tspace[2].type == 'real'
+        assert tspace[3].type == 'real'
+        assert tspace[4].type == 'real'
         assert(str(tspace) ==
                "Space([Precision(4, Real(name=yolo, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),\n"  # noqa
                "       OneHotEncode(Enumerate(Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None))),\n"  # noqa
+               "       Linearize(Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None)),\n" # noqa
+               "       Linearize(ReverseQuantize(Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None))),\n" # noqa
                "       ReverseQuantize(Integer(name=yolo3, prior={randint: (3, 10), {}}, shape=(), default value=None))])")  # noqa
 
     def test_capacity(self, space_each_type):


### PR DESCRIPTION
[fixes #368, fixes #175]

Many algorithms and analysis requires a flattened version of the space
where any dimension with shape > 1 is converted into prod(shape)
individual dimensions.

The space transformation builder is refactored to support new format of
requirements. Instead of a confusing list of requirements
(see #368), the algorithm may
define 3 types of requirements,
- the dimension type (real, integer, numerical or None (any)),
- the dimension distribution (linear, or None (any)) and
- the dimension shape (flattened, or None (any))

The ReshapedDimension unpacks a dimension of `shape` into `prod(shape)`
dimensions of shape 1, with name `{name}[index]`.