### PR TITLE
Fix algorithm requirements backward

### DIFF
--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -96,7 +96,9 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
 
     """
 
-    requires = []
+    requires_type = None
+    requires_shape = None
+    requires_dist = None
 
     def __init__(self, space, **kwargs):
         log.debug("Creating Algorithm object of %s type with parameters:\n%s",

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -110,5 +110,5 @@ def get_algo_requirements(algorithm):
 
     return dict(
         type_requirement=algorithm.requires_type,
-        shape_requirement=algorithm.requires_flat,
+        shape_requirement=algorithm.requires_shape,
         dist_requirement=algorithm.requires_dist)

--- a/tests/unittests/core/utils/test_backward.py
+++ b/tests/unittests/core/utils/test_backward.py
@@ -1,0 +1,64 @@
+"""Example usage and tests for :mod:`orion.core.utils.backward`."""
+import pytest
+
+from orion.algo.base import BaseAlgorithm
+import orion.core.utils.backward as backward
+
+
+def create_algo_class(**attributes):
+    """Create algo class with given requirements attributes"""
+    return type('Algo', (BaseAlgorithm, ), attributes)
+
+
+TYPE_REQUIREMENTS = ['real', 'integer', 'numerical']
+
+
+@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+def test_type_requirements(requirement):
+    """Test algorithms type requirement defined in old requirements API"""
+    algo_class = create_algo_class(requires=[requirement])
+    requirements = backward.get_algo_requirements(algo_class)
+    assert len(requirements) == 3
+    assert requirements == {
+        'type_requirement': requirement,
+        'shape_requirement': None,
+        'dist_requirement': None}
+
+
+@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+def test_shape_requirements(requirement):
+    """Test algorithms shape requirement defined in old requirements API"""
+    algo_class = create_algo_class(requires=[requirement, 'flattened'])
+    requirements = backward.get_algo_requirements(algo_class)
+    assert len(requirements) == 3
+    assert requirements == {
+        'type_requirement': requirement,
+        'shape_requirement': 'flattened',
+        'dist_requirement': None}
+
+
+@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+def test_dist_requirements(requirement):
+    """Test algorithms dist requirement defined in old requirements API"""
+    algo_class = create_algo_class(requires=[requirement, 'linear'])
+    requirements = backward.get_algo_requirements(algo_class)
+    assert len(requirements) == 3
+    assert requirements == {
+        'type_requirement': requirement,
+        'shape_requirement': None,
+        'dist_requirement': 'linear'}
+
+
+@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+def test_no_changes(requirement):
+    """Test algorithms following new requirements API"""
+    algo_class = create_algo_class(
+        requires_type=requirement,
+        requires_shape='flattened',
+        requires_dist='linear')
+    requirements = backward.get_algo_requirements(algo_class)
+    assert len(requirements) == 3
+    assert requirements == {
+        'type_requirement': requirement,
+        'shape_requirement': 'flattened',
+        'dist_requirement': 'linear'}


### PR DESCRIPTION
Why:

The requires field was still in BaseAlgorithm leading the backward
compatibility function to always look at .requires instead of the other
fields.