### PR TITLE
Add black checks and remove flake8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toxenv: [flake8, pylint, doc8, docs]
+        toxenv: [pylint, black, doc8, docs]
 
     steps:
     - uses: actions/checkout@v1

--- a/.pylintrc
+++ b/.pylintrc
@@ -52,7 +52,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=abstract-class-instantiated,useless-super-delegation,no-member,keyword-arg-before-vararg,unidiomatic-typecheck,redefined-outer-name,fixme,F0401,intern-builtin,wrong-import-position,wrong-import-order,
-        C0415, F0010, R0205, R1705, R1711, R1720, W0106, W0107, W0127, W0706
+        C0415, F0010, R0205, R1705, R1711, R1720, W0106, W0107, W0127, W0706, C0330, C0326
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -9,7 +9,7 @@
       objective.
 
 """
-from abc import (ABCMeta, abstractmethod)
+from abc import ABCMeta, abstractmethod
 import hashlib
 import logging
 
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 def infer_trial_id(point):
     """Compute a hashing of a point"""
-    return hashlib.md5(str(list(point)).encode('utf-8')).hexdigest()
+    return hashlib.md5(str(list(point)).encode("utf-8")).hexdigest()
 
 
 # pylint: disable=too-many-public-methods
@@ -101,8 +101,11 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
     requires_dist = None
 
     def __init__(self, space, **kwargs):
-        log.debug("Creating Algorithm object of %s type with parameters:\n%s",
-                  type(self).__name__, kwargs)
+        log.debug(
+            "Creating Algorithm object of %s type with parameters:\n%s",
+            type(self).__name__,
+            kwargs,
+        )
         self._trials_info = {}  # Stores Unique Trial -> Result
         self._space = space
         self._param_names = list(kwargs.keys())
@@ -113,13 +116,14 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
                 subalgo_type = list(param)[0]
                 subalgo_kwargs = param[subalgo_type]
                 if isinstance(subalgo_kwargs, dict):
-                    param = OptimizationAlgorithm(subalgo_type,
-                                                  space, **subalgo_kwargs)
-            elif isinstance(param, str) and \
-                    param.lower() in OptimizationAlgorithm.typenames:
+                    param = OptimizationAlgorithm(subalgo_type, space, **subalgo_kwargs)
+            elif (
+                isinstance(param, str)
+                and param.lower() in OptimizationAlgorithm.typenames
+            ):
                 # pylint: disable=too-many-function-args
                 param = OptimizationAlgorithm(param, space)
-            elif varname == 'seed':
+            elif varname == "seed":
                 self.seed_rng(param)
 
             setattr(self, varname, param)
@@ -136,14 +140,14 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
     @property
     def state_dict(self):
         """Return a state dict that can be used to reset the state of the algorithm."""
-        return {'_trials_info': self._trials_info}
+        return {"_trials_info": self._trials_info}
 
     def set_state(self, state_dict):
         """Reset the state of the algorithm based on the given state_dict
 
         :param state_dict: Dictionary representing state of an algorithm
         """
-        self._trials_info = state_dict.get('_trials_info')
+        self._trials_info = state_dict.get("_trials_info")
 
     @abstractmethod
     def suggest(self, num=1):
@@ -208,7 +212,7 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
         if len(self._trials_info) >= self.space.cardinality:
             return True
 
-        if len(self._trials_info) >= getattr(self, 'max_trials', float('inf')):
+        if len(self._trials_info) >= getattr(self, "max_trials", float("inf")):
             return True
 
         return False
@@ -264,7 +268,7 @@ class BaseAlgorithm(object, metaclass=ABCMeta):
         """
         dict_form = dict()
         for attrname in self._param_names:
-            if attrname.startswith('_'):  # Do not log _space or others in conf
+            if attrname.startswith("_"):  # Do not log _space or others in conf
                 continue
             attr = getattr(self, attrname)
             if isinstance(attr, BaseAlgorithm):

--- a/src/orion/algo/mutate_functions.py
+++ b/src/orion/algo/mutate_functions.py
@@ -18,13 +18,15 @@ logger = logging.getLogger(__name__)
 
 def default_mutate(search_space, old_value, **kwargs):
     """Get a default mutate function"""
-    multiply_factor = kwargs.pop('multiply_factor', 3.0)
-    add_factor = kwargs.pop('add_factor', 1)
-    volatility = kwargs.pop('volatility', 0.001)
+    multiply_factor = kwargs.pop("multiply_factor", 3.0)
+    add_factor = kwargs.pop("add_factor", 1)
+    volatility = kwargs.pop("volatility", 0.001)
     if search_space.type == "real":
         lower_bound, upper_bound = search_space.interval()
-        factors = (1.0 / multiply_factor + (multiply_factor - 1.0 / multiply_factor) *
-                   np.random.random())
+        factors = (
+            1.0 / multiply_factor
+            + (multiply_factor - 1.0 / multiply_factor) * np.random.random()
+        )
         if lower_bound <= old_value * factors <= upper_bound:
             new_value = old_value * factors
         elif lower_bound > old_value * factors:
@@ -41,9 +43,9 @@ def default_mutate(search_space, old_value, **kwargs):
         else:
             new_value = int(upper_bound)
     elif search_space.type == "categorical":
-        sample_index = \
-            np.where(np.random.multinomial(1,
-                                           list(search_space.get_prior)) == 1)[0][0]
+        sample_index = np.where(
+            np.random.multinomial(1, list(search_space.get_prior)) == 1
+        )[0][0]
         new_value = int(search_space.categories[sample_index])
     else:
         new_value = old_value

--- a/src/orion/algo/random.py
+++ b/src/orion/algo/random.py
@@ -36,7 +36,7 @@ class Random(BaseAlgorithm):
     def state_dict(self):
         """Return a state dict that can be used to reset the state of the algorithm."""
         _state_dict = super(Random, self).state_dict
-        _state_dict['rng_state'] = self.rng.get_state()
+        _state_dict["rng_state"] = self.rng.get_state()
         return _state_dict
 
     def set_state(self, state_dict):
@@ -46,7 +46,7 @@ class Random(BaseAlgorithm):
         """
         super(Random, self).set_state(state_dict)
         self.seed_rng(0)
-        self.rng.set_state(state_dict['rng_state'])
+        self.rng.set_state(state_dict["rng_state"])
 
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters. Randomly draw samples
@@ -61,7 +61,9 @@ class Random(BaseAlgorithm):
         point_ids = set(self._trials_info.keys())
         i = 0
         while len(points) < num:
-            new_point = self.space.sample(1, seed=tuple(self.rng.randint(0, 1000000, size=3)))[0]
+            new_point = self.space.sample(
+                1, seed=tuple(self.rng.randint(0, 1000000, size=3))
+            )[0]
             point_id = infer_trial_id(new_point)
             if point_id not in point_ids:
                 point_ids.add(point_id)

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -47,15 +47,19 @@ logger = logging.getLogger(__name__)
 def check_random_state(seed):
     """Return numpy global rng or RandomState if seed is specified"""
     if seed is None or seed is numpy.random:
-        rng = numpy.random.mtrand._rand  # pylint:disable=protected-access,c-extension-no-member
+        rng = (
+            numpy.random.mtrand._rand
+        )  # pylint:disable=protected-access,c-extension-no-member
     elif isinstance(seed, numpy.random.RandomState):
         rng = seed
     else:
         try:
             rng = numpy.random.RandomState(seed)
         except Exception as e:
-            raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
-                             ' instance' % seed) from e
+            raise ValueError(
+                "%r cannot be used to seed a numpy.random.RandomState"
+                " instance" % seed
+            ) from e
 
     return rng
 
@@ -63,7 +67,7 @@ def check_random_state(seed):
 # helper class to be able to print [1, ..., 4] instead of [1, '...', 4]
 class _Ellipsis:  # pylint:disable=too-few-public-methods
     def __repr__(self):
-        return '...'
+        return "..."
 
 
 class Dimension:
@@ -122,28 +126,44 @@ class Dimension:
             self.prior = prior
         self._args = args
         self._kwargs = kwargs
-        self._default_value = kwargs.pop('default_value', self.NO_DEFAULT_VALUE)
-        self._shape = kwargs.pop('shape', None)
+        self._default_value = kwargs.pop("default_value", self.NO_DEFAULT_VALUE)
+        self._shape = kwargs.pop("shape", None)
         self.validate()
 
     def validate(self):
         """Validate dimension arguments"""
-        if 'random_state' in self._kwargs or 'seed' in self._kwargs:
-            raise ValueError("random_state/seed cannot be set in a "
-                             "parameter's definition! Set seed globally!")
-        if 'discrete' in self._kwargs:
-            raise ValueError("Do not use kwarg 'discrete' on `Dimension`, "
-                             "use pure `_Discrete` class instead!")
-        if 'size' in self._kwargs:
+        if "random_state" in self._kwargs or "seed" in self._kwargs:
+            raise ValueError(
+                "random_state/seed cannot be set in a "
+                "parameter's definition! Set seed globally!"
+            )
+        if "discrete" in self._kwargs:
+            raise ValueError(
+                "Do not use kwarg 'discrete' on `Dimension`, "
+                "use pure `_Discrete` class instead!"
+            )
+        if "size" in self._kwargs:
             raise ValueError("Use 'shape' keyword only instead of 'size'.")
 
-        if self.default_value is not self.NO_DEFAULT_VALUE and self.default_value not in self:
-            raise ValueError("{} is not a valid value for this Dimension. "
-                             "Can't set default value.".format(self.default_value))
+        if (
+            self.default_value is not self.NO_DEFAULT_VALUE
+            and self.default_value not in self
+        ):
+            raise ValueError(
+                "{} is not a valid value for this Dimension. "
+                "Can't set default value.".format(self.default_value)
+            )
 
     def _get_hashable_members(self):
-        return (self.name, self.shape, self.type, tuple(self._args), tuple(self._kwargs.items()),
-                self.default_value, self._prior_name)
+        return (
+            self.name,
+            self.shape,
+            self.type,
+            tuple(self._args),
+            tuple(self._kwargs.items()),
+            self.default_value,
+            self._prior_name,
+        )
 
     # pylint:disable=protected-access
     def __eq__(self, other):
@@ -180,9 +200,12 @@ class Dimension:
            across many samples.
 
         """
-        samples = [self.prior.rvs(*self._args, size=self.shape,
-                                  random_state=seed,
-                                  **self._kwargs) for _ in range(n_samples)]
+        samples = [
+            self.prior.rvs(
+                *self._args, size=self.shape, random_state=seed, **self._kwargs
+            )
+            for _ in range(n_samples)
+        ]
         return samples
 
     def cast(self, point):
@@ -218,13 +241,19 @@ class Dimension:
     def __repr__(self):
         """Represent the object as a string."""
         return "{0}(name={1}, prior={{{2}: {3}, {4}}}, shape={5}, default value={6})".format(
-            self.__class__.__name__, self.name, self._prior_name,
-            self._args, self._kwargs, self.shape, self._default_value)
+            self.__class__.__name__,
+            self.name,
+            self._prior_name,
+            self._args,
+            self._kwargs,
+            self.shape,
+            self._default_value,
+        )
 
     def get_prior_string(self):
         """Build the string corresponding to current prior"""
         args = copy.deepcopy(list(self._args[:]))
-        if self._prior_name == 'uniform' and len(args) == 2:
+        if self._prior_name == "uniform" and len(args) == 2:
             args[1] = args[0] + args[1]
             args[0] = args[0]
 
@@ -237,14 +266,16 @@ class Dimension:
                 args += ["{}={}".format(k, v)]
 
         if self._shape is not None:
-            args += ['shape={}'.format(self._shape)]
+            args += ["shape={}".format(self._shape)]
         if self.default_value is not self.NO_DEFAULT_VALUE:
-            args += ['default_value={}'.format(repr(self.default_value))]
+            args += ["default_value={}".format(repr(self.default_value))]
 
         prior_name = self._prior_name
-        if prior_name == 'reciprocal':
-            prior_name = 'loguniform'
-        return "{prior_name}({args})".format(prior_name=prior_name, args=", ".join(args))
+        if prior_name == "reciprocal":
+            prior_name = "loguniform"
+        return "{prior_name}({args})".format(
+            prior_name=prior_name, args=", ".join(args)
+        )
 
     def get_string(self):
         """Build the string corresponding to current dimension"""
@@ -260,8 +291,10 @@ class Dimension:
         if isinstance(value, str) or value is None:
             self._name = value
         else:
-            raise TypeError("Dimension's name must be either string or None. "
-                            "Provided: {}, of type: {}".format(value, type(value)))
+            raise TypeError(
+                "Dimension's name must be either string or None. "
+                "Provided: {}, of type: {}".format(value, type(value))
+            )
 
     @property
     def default_value(self):
@@ -287,9 +320,11 @@ class Dimension:
         if self.prior is None:
             return None
 
-        _, _, _, size = self.prior._parse_args_rvs(*self._args,  # pylint:disable=protected-access
-                                                   size=self._shape,
-                                                   **self._kwargs)
+        _, _, _, size = self.prior._parse_args_rvs(
+            *self._args,  # pylint:disable=protected-access
+            size=self._shape,
+            **self._kwargs
+        )
         return size
 
     # pylint:disable=no-self-use
@@ -303,6 +338,7 @@ class Dimension:
 
 def _is_numeric_array(point):
     """Test whether a point is numerical object or an array containing only numerical objects"""
+
     def _is_numeric(item):
         return isinstance(item, (numbers.Number, numpy.ndarray))
 
@@ -344,18 +380,23 @@ class Real(Dimension):
     """
 
     def __init__(self, name, prior, *args, **kwargs):
-        self._low = kwargs.pop('low', -numpy.inf)
-        self._high = kwargs.pop('high', numpy.inf)
+        self._low = kwargs.pop("low", -numpy.inf)
+        self._high = kwargs.pop("high", numpy.inf)
         if self._high <= self._low:
-            raise ValueError("Lower bound {} has to be less than upper bound {}"
-                             .format(self._low, self._high))
+            raise ValueError(
+                "Lower bound {} has to be less than upper bound {}".format(
+                    self._low, self._high
+                )
+            )
 
-        precision = kwargs.pop('precision', 4)
+        precision = kwargs.pop("precision", 4)
         if (isinstance(precision, int) and precision > 0) or precision is None:
             self.precision = precision
         else:
-            raise TypeError("Precision should be a non-negative int or None, "
-                            "instead was {} of type {}.".format(precision, type(precision)))
+            raise TypeError(
+                "Precision should be a non-negative int or None, "
+                "instead was {} of type {}.".format(precision, type(precision))
+            )
 
         super(Real, self).__init__(name, prior, *args, **kwargs)
 
@@ -411,8 +452,10 @@ class Real(Dimension):
                 samples.extend(sample)
                 break
             if not nice:
-                raise ValueError("Improbable bounds: (low={0}, high={1}). "
-                                 "Please make interval larger.".format(self._low, self._high))
+                raise ValueError(
+                    "Improbable bounds: (low={0}, high={1}). "
+                    "Please make interval larger.".format(self._low, self._high)
+                )
 
         return samples
 
@@ -442,7 +485,6 @@ class Real(Dimension):
 
 
 class _Discrete(Dimension):
-
     def sample(self, n_samples=1, seed=None):
         """Draw random samples from `prior`.
 
@@ -540,7 +582,7 @@ class Integer(Real, _Discrete):
         # Rescale point to make high bound inclusive.
         low, high = self.interval()
         if not numpy.any(numpy.isinf([low, high])):
-            high = (high - low)
+            high = high - low
             casted_point -= low
             casted_point = casted_point / high
             casted_point = casted_point * (high + (1 - 1e-10))
@@ -557,12 +599,12 @@ class Integer(Real, _Discrete):
     def get_prior_string(self):
         """Build the string corresponding to current prior"""
         prior_string = super(Integer, self).get_prior_string()
-        return prior_string[:-1] + ', discrete=True)'
+        return prior_string[:-1] + ", discrete=True)"
 
     @property
     def prior_name(self):
         """Return the name of the prior"""
-        return 'int_{}'.format(super(Integer, self).prior_name)
+        return "int_{}".format(super(Integer, self).prior_name)
 
     @staticmethod
     def get_cardinality(shape, interval):
@@ -582,7 +624,7 @@ def _get_shape_cardinality(shape):
         return shape_cardinality
 
     if isinstance(shape, int):
-        shape = (shape, )
+        shape = (shape,)
 
     for cardinality in shape:
         shape_cardinality *= cardinality
@@ -610,12 +652,13 @@ class Categorical(Dimension):
             self._probs = tuple(categories.values())
         else:
             self.categories = tuple(categories)
-            self._probs = tuple(numpy.tile(1. / len(categories), len(categories)))
+            self._probs = tuple(numpy.tile(1.0 / len(categories), len(categories)))
 
         # Just for compatibility; everything should be `Dimension` to let the
         # `Transformer` decorators be able to wrap smoothly anything.
-        prior = distributions.rv_discrete(values=(list(range(len(self.categories))),
-                                                  self._probs))
+        prior = distributions.rv_discrete(
+            values=(list(range(len(self.categories))), self._probs)
+        )
         super(Categorical, self).__init__(name, prior, **kwargs)
 
     @staticmethod
@@ -636,8 +679,10 @@ class Categorical(Dimension):
         """
         rng = check_random_state(seed)
         cat_ndarray = numpy.array(self.categories, dtype=numpy.object)
-        samples = [rng.choice(cat_ndarray, p=self._probs, size=self._shape)
-                   for _ in range(n_samples)]
+        samples = [
+            rng.choice(cat_ndarray, p=self._probs, size=self._shape)
+            for _ in range(n_samples)
+        ]
         return samples
 
     def interval(self, alpha=1.0):
@@ -669,34 +714,39 @@ class Categorical(Dimension):
             probs = self._probs
             prior = list(zip(cats, probs))
 
-        prior = map(lambda x: '{0[0]}: {0[1]:.2f}'.format(x)
-                    if not isinstance(x, _Ellipsis) else str(x), prior)
+        prior = map(
+            lambda x: "{0[0]}: {0[1]:.2f}".format(x)
+            if not isinstance(x, _Ellipsis)
+            else str(x),
+            prior,
+        )
 
-        prior = "{" + ', '.join(prior) + "}"
+        prior = "{" + ", ".join(prior) + "}"
 
-        return "Categorical(name={0}, prior={1}, shape={2}, default value={3})"\
-               .format(self.name, prior, self.shape, self.default_value)
+        return "Categorical(name={0}, prior={1}, shape={2}, default value={3})".format(
+            self.name, prior, self.shape, self.default_value
+        )
 
     def get_prior_string(self):
         """Build the string corresponding to current prior"""
         args = list(map(str, self._args[:]))
         args += ["{}={}".format(k, v) for k, v in self._kwargs.items()]
         if self.default_value is not self.NO_DEFAULT_VALUE:
-            args += ['default_value={}'.format(self.default_value)]
+            args += ["default_value={}".format(self.default_value)]
 
         cats = [repr(c) for c in self.categories]
         if all(p == self._probs[0] for p in self._probs):
-            prior = '[{}]'.format(", ".join(cats))
+            prior = "[{}]".format(", ".join(cats))
         else:
             probs = list(zip(cats, self._probs))
-            prior = '{' + ", ".join('{0}: {1:.2f}'.format(c, p) for c, p in probs) + '}'
+            prior = "{" + ", ".join("{0}: {1:.2f}".format(c, p) for c, p in probs) + "}"
 
         args = [prior]
 
         if self.default_value is not self.NO_DEFAULT_VALUE:
-            args += ['default_value={}'.format(repr(self.default_value))]
+            args += ["default_value={}".format(repr(self.default_value))]
 
-        return 'choices({args})'.format(args=', '.join(args))
+        return "choices({args})".format(args=", ".join(args))
 
     @property
     def get_prior(self):
@@ -772,7 +822,9 @@ class Fidelity(Dimension):
         if low <= 0:
             raise AttributeError("Minimum resources must be a positive number.")
         elif low > high:
-            raise AttributeError("Minimum resources must be smaller than maximum resources.")
+            raise AttributeError(
+                "Minimum resources must be smaller than maximum resources."
+            )
         if base < 1:
             raise AttributeError("Base should be greater than or equal to 1")
         self.name = name
@@ -780,7 +832,7 @@ class Fidelity(Dimension):
         self.high = int(high)
         self.base = int(base)
         self.prior = None
-        self._prior_name = 'None'
+        self._prior_name = "None"
 
     @property
     def default_value(self):
@@ -803,7 +855,7 @@ class Fidelity(Dimension):
 
     def get_prior_string(self):
         """Build the string corresponding to current prior"""
-        return 'fidelity({}, {}, {})'.format(self.low, self.high, self.base)
+        return "fidelity({}, {}, {})".format(self.low, self.high, self.base)
 
     def validate(self):
         """Do not do anything."""
@@ -824,7 +876,8 @@ class Fidelity(Dimension):
     def __repr__(self):
         """Represent the object as a string."""
         return "{0}(name={1}, low={2}, high={3}, base={4})".format(
-            self.__class__.__name__, self.name, self.low, self.high, self.base)
+            self.__class__.__name__, self.name, self.low, self.high, self.base
+        )
 
     def __contains__(self, value):
         """Check if constraints hold for this `point` of `Dimension`.
@@ -882,7 +935,7 @@ class Space(dict):
         """Return a list with the intervals for each contained dimension."""
         res = list()
         for dim in self.values():
-            if dim.type == 'categorical':
+            if dim.type == "categorical":
                 res.append(dim.categories)
             else:
                 res.append(dim.interval(alpha))
@@ -901,15 +954,22 @@ class Space(dict):
         values and string keys.
         """
         if not isinstance(key, str):
-            raise TypeError("Keys registered to {} must be string types. "
-                            "Provided: {}".format(self.__class__.__name__, key))
+            raise TypeError(
+                "Keys registered to {} must be string types. "
+                "Provided: {}".format(self.__class__.__name__, key)
+            )
         if not isinstance(value, self.contains):
-            raise TypeError("Values registered to {} must be {} types. "
-                            "Provided: {}".format(self.__class__.__name__,
-                                                  self.contains.__name__, value))
+            raise TypeError(
+                "Values registered to {} must be {} types. "
+                "Provided: {}".format(
+                    self.__class__.__name__, self.contains.__name__, value
+                )
+            )
         if key in self:
-            raise ValueError("There is already a Dimension registered with this name. "
-                             "Register it with another name. Provided: {}".format(key))
+            raise ValueError(
+                "There is already a Dimension registered with this name. "
+                "Register it with another name. Provided: {}".format(key)
+            )
         super(Space, self).__setitem__(key, value)
 
     def __contains__(self, value):
@@ -929,8 +989,10 @@ class Space(dict):
         try:
             len(value)
         except TypeError as exc:
-            raise TypeError("Can check only for dimension names or "
-                            "for tuples with parameter values.") from exc
+            raise TypeError(
+                "Can check only for dimension names or "
+                "for tuples with parameter values."
+            ) from exc
 
         if not self:
             return False
@@ -944,7 +1006,7 @@ class Space(dict):
     def __repr__(self):
         """Represent as a string the space and the dimensions it contains."""
         dims = list(self.values())
-        return "Space([{}])".format(',\n       '.join(map(str, dims)))
+        return "Space([{}])".format(",\n       ".join(map(str, dims)))
 
     def items(self):
         """Return items sorted according to keys"""
@@ -982,8 +1044,10 @@ def pack_point(point, space):
     This function is deprecated and will be removed in v0.2.0. Use
     `orion.core.utils.points.regroup_dims` instead.
     """
-    logger.warning('`pack_point` is deprecated and will be removed in v0.2.0. Use '
-                   '`orion.core.utils.points.regroup_dims` instead.')
+    logger.warning(
+        "`pack_point` is deprecated and will be removed in v0.2.0. Use "
+        "`orion.core.utils.points.regroup_dims` instead."
+    )
     return regroup_dims(point, space)
 
 
@@ -993,6 +1057,8 @@ def unpack_point(point, space):
     This function is deprecated and will be removed in v0.2.0. Use
     `orion.core.utils.points.flatten_dims` instead.
     """
-    logger.warning('`unpack_point` is deprecated and will be removed in v0.2.0. Use '
-                   '`orion.core.utils.points.regroup_dims` instead.')
+    logger.warning(
+        "`unpack_point` is deprecated and will be removed in v0.2.0. Use "
+        "`orion.core.utils.points.regroup_dims` instead."
+    )
     return flatten_dims(point, space)

--- a/src/orion/algo/tpe.py
+++ b/src/orion/algo/tpe.py
@@ -54,10 +54,9 @@ def ramp_up_weights(total_num, flat_num, equal_weight):
 
 
 # pylint:disable=assignment-from-no-return
-def adaptive_parzen_estimator(mus, low, high,
-                              prior_weight=1.0,
-                              equal_weight=False,
-                              flat_num=25):
+def adaptive_parzen_estimator(
+    mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+):
     """Return the sorted mus, the corresponding sigmas and weights with adaptive kernel estimator.
 
     This adaptive parzen window estimator is based on the original papers and also refer the use of
@@ -89,19 +88,23 @@ def adaptive_parzen_estimator(mus, low, high,
         mixture_mus = numpy.zeros(size + 1)
         mixture_mus[:prior_mu_pos] = sorted_mus[:prior_mu_pos]
         mixture_mus[prior_mu_pos] = prior_mu
-        mixture_mus[prior_mu_pos + 1:] = sorted_mus[prior_mu_pos:]
+        mixture_mus[prior_mu_pos + 1 :] = sorted_mus[prior_mu_pos:]
 
         mixture_weights = numpy.ones(size + 1)
         mixture_weights[:prior_mu_pos] = weights[:prior_mu_pos]
         mixture_weights[prior_mu_pos] = prior_weight
-        mixture_weights[prior_mu_pos + 1:] = weights[prior_mu_pos:]
+        mixture_weights[prior_mu_pos + 1 :] = weights[prior_mu_pos:]
 
         sigmas = numpy.ones(size + 1)
         sigmas[0] = mixture_mus[1] - mixture_mus[0]
         sigmas[-1] = mixture_mus[-1] - mixture_mus[-2]
-        sigmas[1:-1] = numpy.maximum((mixture_mus[1:-1] - mixture_mus[0:-2]),
-                                     (mixture_mus[2:] - mixture_mus[1:-1]))
-        sigmas = numpy.clip(sigmas, prior_sigma / max(10, numpy.sqrt(size)), prior_sigma)
+        sigmas[1:-1] = numpy.maximum(
+            (mixture_mus[1:-1] - mixture_mus[0:-2]),
+            (mixture_mus[2:] - mixture_mus[1:-1]),
+        )
+        sigmas = numpy.clip(
+            sigmas, prior_sigma / max(10, numpy.sqrt(size)), prior_sigma
+        )
 
     else:
         if prior_mu < mus[0]:
@@ -170,26 +173,41 @@ class TPE(BaseAlgorithm):
     """
 
     # pylint:disable=too-many-arguments
-    def __init__(self, space, seed=None,
-                 n_initial_points=20, n_ei_candidates=24,
-                 gamma=0.25, equal_weight=False,
-                 prior_weight=1.0, full_weight_num=25):
+    def __init__(
+        self,
+        space,
+        seed=None,
+        n_initial_points=20,
+        n_ei_candidates=24,
+        gamma=0.25,
+        equal_weight=False,
+        prior_weight=1.0,
+        full_weight_num=25,
+    ):
 
-        super(TPE, self).__init__(space,
-                                  seed=seed,
-                                  n_initial_points=n_initial_points,
-                                  n_ei_candidates=n_ei_candidates,
-                                  gamma=gamma,
-                                  equal_weight=equal_weight,
-                                  prior_weight=prior_weight,
-                                  full_weight_num=full_weight_num)
+        super(TPE, self).__init__(
+            space,
+            seed=seed,
+            n_initial_points=n_initial_points,
+            n_ei_candidates=n_ei_candidates,
+            gamma=gamma,
+            equal_weight=equal_weight,
+            prior_weight=prior_weight,
+            full_weight_num=full_weight_num,
+        )
 
         for dimension in self.space.values():
 
-            if dimension.type != 'fidelity' and \
-                    dimension.prior_name not in ['uniform', 'reciprocal', 'int_uniform', 'choices']:
-                raise ValueError("TPE now only supports uniform, loguniform, uniform discrete "
-                                 "and choices as prior.")
+            if dimension.type != "fidelity" and dimension.prior_name not in [
+                "uniform",
+                "reciprocal",
+                "int_uniform",
+                "choices",
+            ]:
+                raise ValueError(
+                    "TPE now only supports uniform, loguniform, uniform discrete "
+                    "and choices as prior."
+                )
 
             shape = dimension.shape
             if shape and len(shape) != 1:
@@ -197,13 +215,17 @@ class TPE(BaseAlgorithm):
 
         if n_initial_points < 2:
             n_initial_points = 2
-            logger.warning('n_initial_points %s is not valid, set n_initial_points = 2',
-                           str(n_initial_points))
+            logger.warning(
+                "n_initial_points %s is not valid, set n_initial_points = 2",
+                str(n_initial_points),
+            )
 
         if n_ei_candidates < 1:
             n_ei_candidates = 1
-            logger.warning('n_ei_candidates %s is not valid, set n_ei_candidates = 1',
-                           str(n_ei_candidates))
+            logger.warning(
+                "n_ei_candidates %s is not valid, set n_ei_candidates = 1",
+                str(n_ei_candidates),
+            )
 
         self.seed_rng(seed)
 
@@ -219,8 +241,8 @@ class TPE(BaseAlgorithm):
         """Return a state dict that can be used to reset the state of the algorithm."""
         _state_dict = super(TPE, self).state_dict
 
-        _state_dict['rng_state'] = self.rng.get_state()
-        _state_dict['seed'] = self.seed
+        _state_dict["rng_state"] = self.rng.get_state()
+        _state_dict["seed"] = self.seed
         return _state_dict
 
     def set_state(self, state_dict):
@@ -230,8 +252,8 @@ class TPE(BaseAlgorithm):
         """
         super(TPE, self).set_state(state_dict)
 
-        self.seed_rng(state_dict['seed'])
-        self.rng.set_state(state_dict['rng_state'])
+        self.seed_rng(state_dict["seed"])
+        self.rng.set_state(state_dict["rng_state"])
 
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters. Randomly draw samples
@@ -247,7 +269,9 @@ class TPE(BaseAlgorithm):
 
         samples = []
         if len(self._trials_info) < self.n_initial_points:
-            new_point = self.space.sample(1, seed=tuple(self.rng.randint(0, 1000000, size=3)))[0]
+            new_point = self.space.sample(
+                1, seed=tuple(self.rng.randint(0, 1000000, size=3))
+            )[0]
             samples.append(new_point)
         else:
             point = []
@@ -265,29 +289,46 @@ class TPE(BaseAlgorithm):
                 if not shape:
                     shape = (1,)
 
-                if dimension.type == 'real':
-                    points = self._sample_real_dimension(dimension, shape[0],
-                                                         below_points[idx: idx + shape[0]],
-                                                         above_points[idx: idx + shape[0]])
-                elif dimension.type == 'integer' and dimension.prior_name == 'int_uniform':
-                    points = self.sample_one_dimension(dimension, shape[0],
-                                                       below_points[idx: idx + shape[0]],
-                                                       above_points[idx: idx + shape[0]],
-                                                       self._sample_int_point)
-                elif dimension.type == 'categorical' and dimension.prior_name == 'choices':
-                    points = self.sample_one_dimension(dimension, shape[0],
-                                                       below_points[idx: idx + shape[0]],
-                                                       above_points[idx: idx + shape[0]],
-                                                       self._sample_categorical_point)
-                elif dimension.type == 'fidelity':
+                if dimension.type == "real":
+                    points = self._sample_real_dimension(
+                        dimension,
+                        shape[0],
+                        below_points[idx : idx + shape[0]],
+                        above_points[idx : idx + shape[0]],
+                    )
+                elif (
+                    dimension.type == "integer"
+                    and dimension.prior_name == "int_uniform"
+                ):
+                    points = self.sample_one_dimension(
+                        dimension,
+                        shape[0],
+                        below_points[idx : idx + shape[0]],
+                        above_points[idx : idx + shape[0]],
+                        self._sample_int_point,
+                    )
+                elif (
+                    dimension.type == "categorical"
+                    and dimension.prior_name == "choices"
+                ):
+                    points = self.sample_one_dimension(
+                        dimension,
+                        shape[0],
+                        below_points[idx : idx + shape[0]],
+                        above_points[idx : idx + shape[0]],
+                        self._sample_categorical_point,
+                    )
+                elif dimension.type == "fidelity":
                     # fidelity dimension
                     points = [point[i] for point in self.space.sample(num)]
                 else:
                     raise NotImplementedError()
 
                 if len(points) < shape[0]:
-                    logger.warning('TPE failed to sample new point with configuration %s',
-                                   self.configuration)
+                    logger.warning(
+                        "TPE failed to sample new point with configuration %s",
+                        self.configuration,
+                    )
                     return None
 
                 idx += shape[0]
@@ -299,7 +340,9 @@ class TPE(BaseAlgorithm):
         return samples
 
     # pylint:disable=no-self-use
-    def sample_one_dimension(self, dimension, shape_size, below_points, above_points, sampler):
+    def sample_one_dimension(
+        self, dimension, shape_size, below_points, above_points, sampler
+    ):
         """Sample values for a dimension
 
         :param dimension: Dimension.
@@ -319,18 +362,30 @@ class TPE(BaseAlgorithm):
 
     def _sample_real_dimension(self, dimension, shape_size, below_points, above_points):
         """Sample values for real dimension"""
-        if dimension.prior_name == 'uniform':
-            return self.sample_one_dimension(dimension, shape_size, below_points, above_points,
-                                             self._sample_real_point)
-        elif dimension.prior_name == 'reciprocal':
-            return self.sample_one_dimension(dimension, shape_size, below_points, above_points,
-                                             self._sample_loguniform_real_point)
+        if dimension.prior_name == "uniform":
+            return self.sample_one_dimension(
+                dimension,
+                shape_size,
+                below_points,
+                above_points,
+                self._sample_real_point,
+            )
+        elif dimension.prior_name == "reciprocal":
+            return self.sample_one_dimension(
+                dimension,
+                shape_size,
+                below_points,
+                above_points,
+                self._sample_loguniform_real_point,
+            )
         else:
             raise NotImplementedError()
 
     def _sample_loguniform_real_point(self, dimension, below_points, above_points):
         """Sample one value for real dimension in a loguniform way"""
-        return self._sample_real_point(dimension, below_points, above_points, is_log=True)
+        return self._sample_real_point(
+            dimension, below_points, above_points, is_log=True
+        )
 
     def _sample_real_point(self, dimension, below_points, above_points, is_log=False):
         """Sample one value for real dimension based on the observed good and bad points"""
@@ -341,17 +396,29 @@ class TPE(BaseAlgorithm):
             below_points = numpy.log(below_points)
             above_points = numpy.log(above_points)
 
-        below_mus, below_sigmas, below_weights = \
-            adaptive_parzen_estimator(below_points, low, high, self.prior_weight,
-                                      self.equal_weight, flat_num=self.full_weight_num)
-        above_mus, above_sigmas, above_weights = \
-            adaptive_parzen_estimator(above_points, low, high, self.prior_weight,
-                                      self.equal_weight, flat_num=self.full_weight_num)
+        below_mus, below_sigmas, below_weights = adaptive_parzen_estimator(
+            below_points,
+            low,
+            high,
+            self.prior_weight,
+            self.equal_weight,
+            flat_num=self.full_weight_num,
+        )
+        above_mus, above_sigmas, above_weights = adaptive_parzen_estimator(
+            above_points,
+            low,
+            high,
+            self.prior_weight,
+            self.equal_weight,
+            flat_num=self.full_weight_num,
+        )
 
-        gmm_sampler_below = GMMSampler(self, below_mus, below_sigmas,
-                                       low, high, below_weights)
-        gmm_sampler_above = GMMSampler(self, above_mus, above_sigmas,
-                                       low, high, above_weights)
+        gmm_sampler_below = GMMSampler(
+            self, below_mus, below_sigmas, low, high, below_weights
+        )
+        gmm_sampler_above = GMMSampler(
+            self, above_mus, above_sigmas, low, high, above_weights
+        )
 
         candidate_points = gmm_sampler_below.sample(self.n_ei_candidates)
         if candidate_points:
@@ -405,7 +472,9 @@ class TPE(BaseAlgorithm):
             lik_below = sampler_below.get_loglikelis(candidate_points)
             lik_above = sampler_above.get_loglikelis(candidate_points)
 
-            new_point_index = compute_max_ei_point(candidate_points, lik_below, lik_above)
+            new_point_index = compute_max_ei_point(
+                candidate_points, lik_below, lik_above
+            )
             new_point = choices[new_point_index]
 
             return new_point
@@ -413,7 +482,9 @@ class TPE(BaseAlgorithm):
 
     def split_trials(self):
         """Split the observed trials into good and bad ones based on the ratio `gamma``"""
-        sorted_trials = sorted(self._trials_info.values(), key=lambda x: x[1]['objective'])
+        sorted_trials = sorted(
+            self._trials_info.values(), key=lambda x: x[1]["objective"]
+        )
         sorted_points = [list(points) for points, results in sorted_trials]
 
         split_index = int(numpy.ceil(self.gamma * len(sorted_points)))
@@ -432,7 +503,7 @@ class TPE(BaseAlgorithm):
         super(TPE, self).observe(points, results)
 
 
-class GMMSampler():
+class GMMSampler:
     """Gaussian Mixture Model Sampler for TPE algorithm
 
     Parameters
@@ -487,22 +558,24 @@ class GMMSampler():
     def get_loglikelis(self, points):
         """Return the log likelihood for the points"""
         points = numpy.array(points)
-        weight_likelis = [numpy.log(self.weights[i] * pdf.pdf(points))
-                          for i, pdf in enumerate(self.pdfs)]
+        weight_likelis = [
+            numpy.log(self.weights[i] * pdf.pdf(points))
+            for i, pdf in enumerate(self.pdfs)
+        ]
         weight_likelis = numpy.array(weight_likelis)
         # (num_weights, num_points) => (num_points, num_weights)
         weight_likelis = weight_likelis.transpose()
 
         # log-sum-exp trick
         max_likeli = numpy.nanmax(weight_likelis, axis=1)
-        point_likeli = max_likeli + numpy.log(numpy.nansum
-                                              (numpy.exp(weight_likelis - max_likeli[:, None]),
-                                               axis=1))
+        point_likeli = max_likeli + numpy.log(
+            numpy.nansum(numpy.exp(weight_likelis - max_likeli[:, None]), axis=1)
+        )
 
         return point_likeli
 
 
-class CategoricalSampler():
+class CategoricalSampler:
     """Categorical Sampler for discrete integer and categorical choices
 
     Parameters
@@ -525,9 +598,12 @@ class CategoricalSampler():
 
     def _build_multinomial_weights(self):
         """Build weights for categorical distribution based on observations"""
-        weights_obs = ramp_up_weights(len(self.obs),
-                                      self.tpe.full_weight_num, self.tpe.equal_weight)
-        counts_obs = numpy.bincount(self.obs, minlength=len(self.choices), weights=weights_obs)
+        weights_obs = ramp_up_weights(
+            len(self.obs), self.tpe.full_weight_num, self.tpe.equal_weight
+        )
+        counts_obs = numpy.bincount(
+            self.obs, minlength=len(self.choices), weights=weights_obs
+        )
         counts_obs = counts_obs + self.tpe.prior_weight
         self.weights = counts_obs / counts_obs.sum()
 

--- a/src/orion/analysis/__init__.py
+++ b/src/orion/analysis/__init__.py
@@ -11,4 +11,4 @@
 from orion.analysis.lpi import lpi
 from orion.analysis.regret import regret
 
-__all__ = ['lpi', 'regret']
+__all__ = ["lpi", "regret"]

--- a/src/orion/analysis/lpi.py
+++ b/src/orion/analysis/lpi.py
@@ -9,18 +9,23 @@
 """
 import numpy
 import pandas as pd
-from sklearn.ensemble import AdaBoostRegressor, BaggingRegressor,\
-    ExtraTreesRegressor, GradientBoostingRegressor, RandomForestRegressor
+from sklearn.ensemble import (
+    AdaBoostRegressor,
+    BaggingRegressor,
+    ExtraTreesRegressor,
+    GradientBoostingRegressor,
+    RandomForestRegressor,
+)
 
 from orion.core.worker.transformer import build_required_space
 
 
 _regressors_ = {
-    'AdaBoostRegressor': AdaBoostRegressor,
-    'BaggingRegressor': BaggingRegressor,
-    'ExtraTreesRegressor': ExtraTreesRegressor,
-    'GradientBoostingRegressor': GradientBoostingRegressor,
-    'RandomForestRegressor': RandomForestRegressor,
+    "AdaBoostRegressor": AdaBoostRegressor,
+    "BaggingRegressor": BaggingRegressor,
+    "ExtraTreesRegressor": ExtraTreesRegressor,
+    "GradientBoostingRegressor": GradientBoostingRegressor,
+    "RandomForestRegressor": RandomForestRegressor,
 }
 
 
@@ -46,8 +51,9 @@ def train_regressor(regressor_name, data, **kwargs):
     """
     if regressor_name not in _regressors_:
         raise ValueError(
-            f'{regressor_name} is not a supported regressor. '
-            f'Did you mean any of theses: list(_regressors_.keys())')
+            f"{regressor_name} is not a supported regressor. "
+            f"Did you mean any of theses: list(_regressors_.keys())"
+        )
 
     regressor = _regressors_[regressor_name](**kwargs)
     return regressor.fit(data[:, :-1], data[:, -1])
@@ -55,13 +61,14 @@ def train_regressor(regressor_name, data, **kwargs):
 
 def to_numpy(trials, space):
     """Convert trials in DataFrame to Numpy array of (params + objective)"""
-    return trials[list(space.keys()) + ['objective']].to_numpy()
+    return trials[list(space.keys()) + ["objective"]].to_numpy()
 
 
 def flatten(trials_array, flattened_space):
     """Flatten dimensions"""
     flattened_points = numpy.array(
-        [flattened_space.transform(point[:-1]) for point in trials_array])
+        [flattened_space.transform(point[:-1]) for point in trials_array]
+    )
 
     return numpy.concatenate((flattened_points, trials_array[:, -1:]), axis=1)
 
@@ -113,7 +120,7 @@ def _lpi(point, space, model, n):
     grid = make_grid(point, space, model, n)
     variances = compute_variances(grid)
     ratios = variances / variances.sum()
-    return pd.DataFrame(data=ratios, index=space.keys(), columns=['LPI'])
+    return pd.DataFrame(data=ratios, index=space.keys(), columns=["LPI"])
 
 
 def _linear_lpi(point, space, model, n):
@@ -121,12 +128,10 @@ def _linear_lpi(point, space, model, n):
     return
 
 
-modes = dict(
-    best=_lpi,
-    linear=_linear_lpi)
+modes = dict(best=_lpi, linear=_linear_lpi)
 
 
-def lpi(trials, space, mode='best', model='RandomForestRegressor', n=20, **kwargs):
+def lpi(trials, space, mode="best", model="RandomForestRegressor", n=20, **kwargs):
     """
     Calculates the Local Parameter Importance for a collection of :class:`Trial`.
 
@@ -171,12 +176,14 @@ def lpi(trials, space, mode='best', model='RandomForestRegressor', n=20, **kwarg
         param values and LPI metrics are returned in a DataFrame format.
     """
     flattened_space = build_required_space(
-        space, type_requirement='numerical', shape_requirement='flattened')
+        space, type_requirement="numerical", shape_requirement="flattened"
+    )
     if trials.empty or trials.shape[0] == 0:
         return pd.DataFrame(
             data=[0] * len(flattened_space),
             index=flattened_space.keys(),
-            columns=['LPI'])
+            columns=["LPI"],
+        )
 
     data = to_numpy(trials, space)
     data = flatten(data, flattened_space)

--- a/src/orion/analysis/regret.py
+++ b/src/orion/analysis/regret.py
@@ -11,7 +11,7 @@ import numpy
 import pandas as pd
 
 
-def regret(trials, names=('best', 'best_id')):
+def regret(trials, names=("best", "best_id")):
     """
     Calculates the regret for a collection of :class:`Trial`. The regret is calculated sequentially
     from the order of the collection.
@@ -30,15 +30,17 @@ def regret(trials, names=('best', 'best_id')):
     so far and its trial id.
     """
     if len(names) != 2:
-        raise ValueError(f"`names` requires a tuple with 2 elements. {len(names)} provided.")
+        raise ValueError(
+            f"`names` requires a tuple with 2 elements. {len(names)} provided."
+        )
 
     df = pd.DataFrame(trials, copy=True)
     if df.empty:
         return df
 
-    regrets_idx = get_regrets_idx(df['objective'])
-    df[names[0]] = df['objective'].to_numpy()[list(regrets_idx)]
-    df[names[1]] = df['id'].to_numpy()[regrets_idx]
+    regrets_idx = get_regrets_idx(df["objective"])
+    df[names[0]] = df["objective"].to_numpy()[list(regrets_idx)]
+    df[names[1]] = df["id"].to_numpy()[regrets_idx]
 
     return df
 
@@ -48,6 +50,6 @@ def get_regrets_idx(x):
     minima = numpy.minimum.accumulate(x)
     diff = numpy.diff(minima)
     jumps = numpy.arange(len(x))
-    jumps[1:] *= (diff != 0)
+    jumps[1:] *= diff != 0
     jumps = numpy.maximum.accumulate(jumps)
     return jumps

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -9,7 +9,11 @@
 
 """
 from orion.client.cli import (
-    interrupt_trial, report_bad_trial, report_objective, report_results)
+    interrupt_trial,
+    report_bad_trial,
+    report_objective,
+    report_results,
+)
 from orion.client.experiment import ExperimentClient
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.exceptions import RaceCondition
@@ -17,15 +21,33 @@ from orion.core.utils.singleton import update_singletons
 from orion.core.worker.producer import Producer
 from orion.storage.base import setup_storage
 
-__all__ = ['interrupt_trial', 'report_bad_trial', 'report_objective', 'report_results',
-           'create_experiment', 'get_experiment', 'workon']
+__all__ = [
+    "interrupt_trial",
+    "report_bad_trial",
+    "report_objective",
+    "report_results",
+    "create_experiment",
+    "get_experiment",
+    "workon",
+]
 
 
 # pylint: disable=too-many-arguments
 def create_experiment(
-        name, version=None, space=None, algorithms=None,
-        strategy=None, max_trials=None, max_broken=None, storage=None, branching=None,
-        max_idle_time=None, heartbeat=None, working_dir=None, debug=False):
+    name,
+    version=None,
+    space=None,
+    algorithms=None,
+    strategy=None,
+    max_trials=None,
+    max_broken=None,
+    storage=None,
+    branching=None,
+    max_idle_time=None,
+    heartbeat=None,
+    working_dir=None,
+    debug=False,
+):
     """Create an experiment
 
     There is 2 main scenarios
@@ -164,17 +186,31 @@ def create_experiment(
 
     try:
         experiment = experiment_builder.build(
-            name, version=version, space=space, algorithms=algorithms,
-            strategy=strategy, max_trials=max_trials, max_broken=max_broken, branching=branching,
-            working_dir=working_dir)
+            name,
+            version=version,
+            space=space,
+            algorithms=algorithms,
+            strategy=strategy,
+            max_trials=max_trials,
+            max_broken=max_broken,
+            branching=branching,
+            working_dir=working_dir,
+        )
     except RaceCondition:
         # Try again, but if it fails again, raise. Race conditions due to version increment should
         # only occur once in a short window of time unless code version is changing at a crazy pace.
         try:
             experiment = experiment_builder.build(
-                name, version=version, space=space, algorithms=algorithms,
-                strategy=strategy, max_trials=max_trials, max_broken=max_broken,
-                branching=branching, working_dir=working_dir)
+                name,
+                version=version,
+                space=space,
+                algorithms=algorithms,
+                strategy=strategy,
+                max_trials=max_trials,
+                max_broken=max_broken,
+                branching=branching,
+                working_dir=working_dir,
+            )
         except RaceCondition as e:
             raise RaceCondition(
                 "There was a race condition during branching and new version cannot be infered "
@@ -182,7 +218,8 @@ def create_experiment(
                 "error gets raised, it means that different modifications occured during each race "
                 "condition resolution. This is likely due to quick code change during experiment "
                 "creation. Make sure your script is not generating files within your code "
-                "repository.") from e
+                "repository."
+            ) from e
 
     producer = Producer(experiment, max_idle_time)
 
@@ -216,7 +253,9 @@ def get_experiment(name, version=None, storage=None):
     return experiment_builder.build_view(name, version)
 
 
-def workon(function, space, name='loop', algorithms=None, max_trials=None, max_broken=None):
+def workon(
+    function, space, name="loop", algorithms=None, max_trials=None, max_broken=None
+):
     """Optimize a function over a given search space
 
     This will create a new experiment with an in-memory storage and optimize the given function
@@ -256,11 +295,17 @@ def workon(function, space, name='loop', algorithms=None, max_trials=None, max_b
     singletons = update_singletons()
 
     try:
-        setup_storage(storage={'type': 'legacy', 'database': {'type': 'EphemeralDB'}})
+        setup_storage(storage={"type": "legacy", "database": {"type": "EphemeralDB"}})
 
         experiment = experiment_builder.build(
-            name, version=1, space=space, algorithms=algorithms,
-            strategy='NoParallelStrategy', max_trials=max_trials, max_broken=max_broken)
+            name,
+            version=1,
+            space=space,
+            algorithms=algorithms,
+            strategy="NoParallelStrategy",
+            max_trials=max_trials,
+            max_broken=max_broken,
+        )
 
         producer = Producer(experiment)
 

--- a/src/orion/client/cli.py
+++ b/src/orion/client/cli.py
@@ -16,14 +16,17 @@ from orion.core import config
 
 IS_ORION_ON = False
 _HAS_REPORTED_RESULTS = False
-RESULTS_FILENAME = os.getenv('ORION_RESULTS_PATH', None)
+RESULTS_FILENAME = os.getenv("ORION_RESULTS_PATH", None)
 if RESULTS_FILENAME and os.path.isfile(RESULTS_FILENAME):
     import json
+
     IS_ORION_ON = True
 
 if RESULTS_FILENAME and not IS_ORION_ON:
-    raise RuntimeWarning("Results file path provided in environmental variable "
-                         "does not correspond to an existing file.")
+    raise RuntimeWarning(
+        "Results file path provided in environmental variable "
+        "does not correspond to an existing file."
+    )
 
 
 def interrupt_trial():
@@ -31,7 +34,7 @@ def interrupt_trial():
     sys.exit(config.worker.interrupt_signal_code)
 
 
-def report_objective(objective, name='objective'):
+def report_objective(objective, name="objective"):
     """Report only the objective at the end of execution
 
     To send more data (statistic, constraint, gradient), use ``report_results``.
@@ -57,10 +60,10 @@ def report_objective(objective, name='objective'):
         Name of the objective. Default is 'objective'.
 
     """
-    report_results([dict(name=name, type='objective', value=objective)])
+    report_results([dict(name=name, type="objective", value=objective)])
 
 
-def report_bad_trial(objective=1e10, name='objective', data=None):
+def report_bad_trial(objective=1e10, name="objective", data=None):
     """Report a bad trial with large objective to Oríon.
 
     This is especially useful if some parameter values lead to exceptions such as out of memory.
@@ -96,7 +99,7 @@ def report_bad_trial(objective=1e10, name='objective', data=None):
     """
     if data is None:
         data = []
-    report_results([dict(name=name, type='objective', value=objective)] + data)
+    report_results([dict(name=name, type="objective", value=objective)] + data)
 
 
 def report_results(data):
@@ -129,7 +132,7 @@ def report_results(data):
     if _HAS_REPORTED_RESULTS:
         raise RuntimeWarning("Has already reported evaluation results once.")
     if IS_ORION_ON:
-        with open(RESULTS_FILENAME, 'w') as results_file:
+        with open(RESULTS_FILENAME, "w") as results_file:
             json.dump(data, results_file)
     else:
         print(data)

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -16,7 +16,11 @@ import sys
 from numpy import inf as infinity
 
 from orion.core.io.database import DuplicateKeyError
-from orion.core.utils.exceptions import BrokenExperiment, SampleTimeout, WaitingForTrials
+from orion.core.utils.exceptions import (
+    BrokenExperiment,
+    SampleTimeout,
+    WaitingForTrials,
+)
 from orion.core.utils.flatten import flatten, unflatten
 import orion.core.utils.format_trials as format_trials
 import orion.core.worker
@@ -32,14 +36,16 @@ log = logging.getLogger(__name__)
 def set_broken_trials(client):
     """Release all trials with status broken if the process exits without releasing them."""
     if sys.exc_info()[0] is KeyboardInterrupt:
-        status = 'interrupted'
+        status = "interrupted"
     else:
-        status = 'broken'
+        status = "broken"
 
     for trial_id in list(client._pacemakers.keys()):  # pylint: disable=protected-access
         trial = client.get_trial(uid=trial_id)
         if trial is None:
-            log.warning('Trial {} was not found in storage, could not set status to `broken`.')
+            log.warning(
+                "Trial {} was not found in storage, could not set status to `broken`."
+            )
             continue
         client.release(trial, status=status)
 
@@ -242,7 +248,9 @@ class ExperimentClient:
 
         :return: list of `Trial` objects
         """
-        return self._experiment.fetch_trials_by_status(status, with_evc_tree=with_evc_tree)
+        return self._experiment.fetch_trials_by_status(
+            status, with_evc_tree=with_evc_tree
+        )
 
     def fetch_noncompleted_trials(self, with_evc_tree=False):
         """Fetch non-completed trials of this `Experiment` instance.
@@ -302,15 +310,19 @@ class ExperimentClient:
         """
         if results and reserve:
             raise ValueError(
-                'Cannot observe a trial and reserve it. A trial with results has status '
-                '`completed` and cannot be reserved.')
+                "Cannot observe a trial and reserve it. A trial with results has status "
+                "`completed` and cannot be reserved."
+            )
         trial = format_trials.dict_to_trial(params, self.space)
         try:
-            self._experiment.register_trial(trial, status='reserved')
+            self._experiment.register_trial(trial, status="reserved")
             self._maintain_reservation(trial)
         except DuplicateKeyError as e:
-            message = 'A trial with params {} already exist for experiment {}-v{}'.format(
-                params, self.name, self.version)
+            message = (
+                "A trial with params {} already exist for experiment {}-v{}".format(
+                    params, self.name, self.version
+                )
+            )
             raise DuplicateKeyError(message) from e
 
         if results:
@@ -355,21 +367,27 @@ class ExperimentClient:
         since twice the value of `heartbeat`.
 
         """
-        if trial.status == 'reserved' and trial.id in self._pacemakers:
-            log.warning('Trial %s is already reserved.', trial.id)
+        if trial.status == "reserved" and trial.id in self._pacemakers:
+            log.warning("Trial %s is already reserved.", trial.id)
             return
-        elif trial.status == 'reserved' and trial.id not in self._pacemakers:
-            raise RuntimeError('Trial {} is already reserved by another process.'.format(trial.id))
+        elif trial.status == "reserved" and trial.id not in self._pacemakers:
+            raise RuntimeError(
+                "Trial {} is already reserved by another process.".format(trial.id)
+            )
         try:
-            self._experiment.set_trial_status(trial, 'reserved', heartbeat=self.heartbeat)
+            self._experiment.set_trial_status(
+                trial, "reserved", heartbeat=self.heartbeat
+            )
         except FailedUpdate as e:
             if self.get_trial(trial) is None:
-                raise ValueError('Trial {} does not exist in database.'.format(trial.id)) from e
-            raise RuntimeError('Could not reserve trial {}.'.format(trial.id)) from e
+                raise ValueError(
+                    "Trial {} does not exist in database.".format(trial.id)
+                ) from e
+            raise RuntimeError("Could not reserve trial {}.".format(trial.id)) from e
 
         self._maintain_reservation(trial)
 
-    def release(self, trial, status='interrupted'):
+    def release(self, trial, status="interrupted"):
         """Release a trial.
 
         Release the reservation and stop the heartbeat.
@@ -394,9 +412,14 @@ class ExperimentClient:
             self._experiment.set_trial_status(trial, status)
         except FailedUpdate as e:
             if self.get_trial(trial) is None:
-                raise ValueError('Trial {} does not exist in database.'.format(trial.id)) from e
+                raise ValueError(
+                    "Trial {} does not exist in database.".format(trial.id)
+                ) from e
             raise RuntimeError(
-                'Reservation for trial {} has been lost before release.'.format(trial.id)) from e
+                "Reservation for trial {} has been lost before release.".format(
+                    trial.id
+                )
+            ) from e
         finally:
             self._release_reservation(trial)
 
@@ -483,13 +506,17 @@ class ExperimentClient:
         trial.results += [Trial.Result(**result) for result in results]
         try:
             self._experiment.update_completed_trial(trial)
-            self.release(trial, 'completed')
+            self.release(trial, "completed")
         except FailedUpdate as e:
             if self.get_trial(trial) is None:
-                raise ValueError('Trial {} does not exist in database.'.format(trial.id)) from e
+                raise ValueError(
+                    "Trial {} does not exist in database.".format(trial.id)
+                ) from e
 
             self._release_reservation(trial)
-            raise RuntimeError('Reservation for trial {} has been lost.'.format(trial.id)) from e
+            raise RuntimeError(
+                "Reservation for trial {} has been lost.".format(trial.id)
+            ) from e
 
     def workon(self, fct, max_trials=infinity, **kwargs):
         """Optimize a given function
@@ -518,7 +545,7 @@ class ExperimentClient:
         while not self.is_done and trials < max_trials:
             trial = self.suggest()
             if trial is None:
-                log.warning('Algorithm could not sample new points')
+                log.warning("Algorithm could not sample new points")
                 return trials
             kwargs.update(flatten(trial.params))
             results = fct(**unflatten(kwargs))
@@ -530,9 +557,11 @@ class ExperimentClient:
     def close(self):
         """Verify that no reserved trials are remaining and unregister atexit()."""
         if self._pacemakers:
-            raise RuntimeError("There is still reserved trials: {}\nRelease all trials before "
-                               "closing the client, using "
-                               "client.release(trial).".format(self._pacemakers.keys()))
+            raise RuntimeError(
+                "There is still reserved trials: {}\nRelease all trials before "
+                "closing the client, using "
+                "client.release(trial).".format(self._pacemakers.keys())
+            )
 
         atexit.unregister(self.set_broken_trials)
 
@@ -547,12 +576,14 @@ class ExperimentClient:
     def _verify_reservation(self, trial):
         if trial.id not in self._pacemakers:
             raise RuntimeError(
-                'Trial {} had no pacemakers. Was is reserved properly?'.format(trial.id))
+                "Trial {} had no pacemakers. Was is reserved properly?".format(trial.id)
+            )
 
-        if self.get_trial(trial).status != 'reserved':
+        if self.get_trial(trial).status != "reserved":
             self._release_reservation(trial)
             raise RuntimeError(
-                'Reservation for trial {} has been lost.'.format(trial.id))
+                "Reservation for trial {} has been lost.".format(trial.id)
+            )
 
     def _maintain_reservation(self, trial):
         self._pacemakers[trial.id] = TrialPacemaker(trial)
@@ -561,5 +592,6 @@ class ExperimentClient:
     def _release_reservation(self, trial):
         if trial.id not in self._pacemakers:
             raise RuntimeError(
-                'Trial {} had no pacemakers. Was is reserved properly?'.format(trial.id))
+                "Trial {} had no pacemakers. Was is reserved properly?".format(trial.id)
+            )
         self._pacemakers.pop(trial.id).stop()

--- a/src/orion/client/manual.py
+++ b/src/orion/client/manual.py
@@ -41,8 +41,10 @@ def insert_trials(experiment_name, points, raise_exc=True):
        the database.
 
     """
-    log.warning('insert_trials() is deprecated and will be removed in 0.3.0. '
-                'You should use ExperimentClient.insert() instead.')
+    log.warning(
+        "insert_trials() is deprecated and will be removed in 0.3.0. "
+        "You should use ExperimentClient.insert() instead."
+    )
     experiment = create_experiment(experiment_name)
 
     valid_points = []
@@ -59,8 +61,11 @@ def insert_trials(experiment_name, points, raise_exc=True):
         return
 
     new_trials = list(
-        map(lambda data: format_trials.tuple_to_trial(data, experiment.space),
-            valid_points))
+        map(
+            lambda data: format_trials.tuple_to_trial(data, experiment.space),
+            valid_points,
+        )
+    )
 
     for new_trial in new_trials:
         experiment.insert(new_trial.params)

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -29,23 +29,23 @@ logger = logging.getLogger(__name__)
 VERSIONS = get_versions()
 del get_versions
 
-__descr__ = 'Asynchronous [black-box] Optimization'
-__version__ = VERSIONS['version']
-__license__ = 'BSD-3-Clause'
-__author__ = u'Epistímio'
-__author_short__ = u'Epistímio'
-__author_email__ = 'xavier.bouthillier@umontreal.ca'
-__copyright__ = u'2017-2020, Epistímio'
-__url__ = 'https://github.com/epistimio/orion'
+__descr__ = "Asynchronous [black-box] Optimization"
+__version__ = VERSIONS["version"]
+__license__ = "BSD-3-Clause"
+__author__ = u"Epistímio"
+__author_short__ = u"Epistímio"
+__author_email__ = "xavier.bouthillier@umontreal.ca"
+__copyright__ = u"2017-2020, Epistímio"
+__url__ = "https://github.com/epistimio/orion"
 
 DIRS = AppDirs(__name__, __author_short__)
 del AppDirs
 
 DEF_CONFIG_FILES_PATHS = [
-    os.path.join(DIRS.site_data_dir, 'orion_config.yaml.example'),
-    os.path.join(DIRS.site_config_dir, 'orion_config.yaml'),
-    os.path.join(DIRS.user_config_dir, 'orion_config.yaml')
-    ]
+    os.path.join(DIRS.site_data_dir, "orion_config.yaml.example"),
+    os.path.join(DIRS.site_config_dir, "orion_config.yaml"),
+    os.path.join(DIRS.user_config_dir, "orion_config.yaml"),
+]
 
 
 def define_config():
@@ -57,12 +57,18 @@ def define_config():
     define_evc_config(config)
 
     config.add_option(
-        'user_script_config', option_type=str, default='config',
-        deprecate=dict(version='v0.3', alternative='worker.user_script_config'))
+        "user_script_config",
+        option_type=str,
+        default="config",
+        deprecate=dict(version="v0.3", alternative="worker.user_script_config"),
+    )
 
     config.add_option(
-        'debug', option_type=bool, default=False,
-        help='Turn Oríon into debug mode. Storage will be overriden to in-memory EphemeralDB.')
+        "debug",
+        option_type=bool,
+        default=False,
+        help="Turn Oríon into debug mode. Storage will be overriden to in-memory EphemeralDB.",
+    )
 
     return config
 
@@ -72,7 +78,8 @@ def define_storage_config(config):
     storage_config = Configuration()
 
     storage_config.add_option(
-        'type', option_type=str, default='legacy', env_var='ORION_STORAGE_TYPE')
+        "type", option_type=str, default="legacy", env_var="ORION_STORAGE_TYPE"
+    )
 
     config.storage = storage_config
 
@@ -88,21 +95,39 @@ def define_database_config(config):
     try:
         default_host = socket.gethostbyname(socket.gethostname())
     except socket.gaierror:
-        default_host = 'localhost'
+        default_host = "localhost"
 
     database_config.add_option(
-        'name', option_type=str, default='orion', env_var='ORION_DB_NAME',
-        help='Name of the database.')
+        "name",
+        option_type=str,
+        default="orion",
+        env_var="ORION_DB_NAME",
+        help="Name of the database.",
+    )
     database_config.add_option(
-        'type', option_type=str, default='MongoDB', env_var='ORION_DB_TYPE',
-        help=('Type of database. Builtin backends are ``mongodb``, '
-              '``pickleddb`` and ``ephemeraldb``.'))
+        "type",
+        option_type=str,
+        default="MongoDB",
+        env_var="ORION_DB_TYPE",
+        help=(
+            "Type of database. Builtin backends are ``mongodb``, "
+            "``pickleddb`` and ``ephemeraldb``."
+        ),
+    )
     database_config.add_option(
-        'host', option_type=str, default=default_host, env_var='ORION_DB_ADDRESS',
-        help='URI for ``mongodb``, or file path for ``pickleddb``.')
+        "host",
+        option_type=str,
+        default=default_host,
+        env_var="ORION_DB_ADDRESS",
+        help="URI for ``mongodb``, or file path for ``pickleddb``.",
+    )
     database_config.add_option(
-        'port', option_type=int, default=27017, env_var='ORION_DB_PORT',
-        help='Port address for ``mongodb``.')
+        "port",
+        option_type=int,
+        default=27017,
+        env_var="ORION_DB_PORT",
+        help="Port address for ``mongodb``.",
+    )
 
     config.database = database_config
 
@@ -112,37 +137,64 @@ def define_experiment_config(config):
     experiment_config = Configuration()
 
     experiment_config.add_option(
-        'max_trials', option_type=int, default=int(10e8), env_var='ORION_EXP_MAX_TRIALS',
+        "max_trials",
+        option_type=int,
+        default=int(10e8),
+        env_var="ORION_EXP_MAX_TRIALS",
         help="number of trials to be completed for the experiment. This value "
-             "will be saved within the experiment configuration and reused "
-             "across all workers to determine experiment's completion. ")
+        "will be saved within the experiment configuration and reused "
+        "across all workers to determine experiment's completion. ",
+    )
 
     experiment_config.add_option(
-        'worker_trials', option_type=int, default=int(10e8),
-        deprecate=dict(version='v0.3', alternative='worker.max_trials',
-                       name='experiment.worker_trials'),
-        help="This argument will be removed in v0.3. Use --worker-max-trials instead.")
+        "worker_trials",
+        option_type=int,
+        default=int(10e8),
+        deprecate=dict(
+            version="v0.3",
+            alternative="worker.max_trials",
+            name="experiment.worker_trials",
+        ),
+        help="This argument will be removed in v0.3. Use --worker-max-trials instead.",
+    )
 
     experiment_config.add_option(
-        'max_broken', option_type=int, default=3, env_var='ORION_EXP_MAX_BROKEN',
-        help=('Maximum number of broken trials before experiment stops.'))
+        "max_broken",
+        option_type=int,
+        default=3,
+        env_var="ORION_EXP_MAX_BROKEN",
+        help=("Maximum number of broken trials before experiment stops."),
+    )
 
     experiment_config.add_option(
-        'working_dir', option_type=str, default='', env_var='ORION_WORKING_DIR',
-        help="Set working directory for running experiment.")
+        "working_dir",
+        option_type=str,
+        default="",
+        env_var="ORION_WORKING_DIR",
+        help="Set working directory for running experiment.",
+    )
 
     experiment_config.add_option(
-        "pool_size", option_type=int, default=1,
-        deprecate=dict(version='v0.3', alternative=None, name='experiment.pool_size'),
-        help="This argument will be removed in v0.3.")
+        "pool_size",
+        option_type=int,
+        default=1,
+        deprecate=dict(version="v0.3", alternative=None, name="experiment.pool_size"),
+        help="This argument will be removed in v0.3.",
+    )
 
     experiment_config.add_option(
-        'algorithms', option_type=dict, default={'random': {'seed': None}},
-        help='Algorithm configuration for the experiment.')
+        "algorithms",
+        option_type=dict,
+        default={"random": {"seed": None}},
+        help="Algorithm configuration for the experiment.",
+    )
 
     experiment_config.add_option(
-        'strategy', option_type=dict, default={'MaxParallelStrategy': {}},
-        help='Parallel strategy to use with the algorithm.')
+        "strategy",
+        option_type=dict,
+        default={"MaxParallelStrategy": {}},
+        help="Parallel strategy to use with the algorithm.",
+    )
 
     config.experiment = experiment_config
 
@@ -152,38 +204,65 @@ def define_worker_config(config):
     worker_config = Configuration()
 
     worker_config.add_option(
-        'heartbeat', option_type=int, default=120, env_var='ORION_HEARTBEAT',
-        help=('Frequency (seconds) at which the heartbeat of the trial is updated. '
-              'If the heartbeat of a `reserved` trial is larger than twice the configured '
-              'heartbeat, Oríon will reset the status of the trial to `interrupted`. '
-              'This allows restoring lost trials (ex: due to killed worker).'))
+        "heartbeat",
+        option_type=int,
+        default=120,
+        env_var="ORION_HEARTBEAT",
+        help=(
+            "Frequency (seconds) at which the heartbeat of the trial is updated. "
+            "If the heartbeat of a `reserved` trial is larger than twice the configured "
+            "heartbeat, Oríon will reset the status of the trial to `interrupted`. "
+            "This allows restoring lost trials (ex: due to killed worker)."
+        ),
+    )
 
     worker_config.add_option(
-        'max_trials', option_type=int, default=int(10e8), env_var='ORION_WORKER_MAX_TRIALS',
+        "max_trials",
+        option_type=int,
+        default=int(10e8),
+        env_var="ORION_WORKER_MAX_TRIALS",
         help="number of trials to be completed for this worker. "
-             "If the experiment is completed, the worker will die even if it "
-             "did not reach its maximum number of trials ")
+        "If the experiment is completed, the worker will die even if it "
+        "did not reach its maximum number of trials ",
+    )
 
     worker_config.add_option(
-        'max_broken', option_type=int, default=3, env_var='ORION_WORKER_MAX_BROKEN',
-        help=('Maximum number of broken trials before worker stops.'))
+        "max_broken",
+        option_type=int,
+        default=3,
+        env_var="ORION_WORKER_MAX_BROKEN",
+        help=("Maximum number of broken trials before worker stops."),
+    )
 
     worker_config.add_option(
-        'max_idle_time', option_type=int, default=60, env_var='ORION_MAX_IDLE_TIME',
-        help=('Maximum time the producer can spend trying to generate a new suggestion.'
-              'Such timeout are generally caused by slow database, large number of '
-              'concurrent workers leading to many race conditions or small search spaces '
-              'with integer/categorical dimensions that may be fully explored.'))
+        "max_idle_time",
+        option_type=int,
+        default=60,
+        env_var="ORION_MAX_IDLE_TIME",
+        help=(
+            "Maximum time the producer can spend trying to generate a new suggestion."
+            "Such timeout are generally caused by slow database, large number of "
+            "concurrent workers leading to many race conditions or small search spaces "
+            "with integer/categorical dimensions that may be fully explored."
+        ),
+    )
 
     worker_config.add_option(
-        'interrupt_signal_code', option_type=int, default=130, env_var='ORION_INTERRUPT_CODE',
-        help='Signal returned by user script to signal to Oríon that it was interrupted.')
+        "interrupt_signal_code",
+        option_type=int,
+        default=130,
+        env_var="ORION_INTERRUPT_CODE",
+        help="Signal returned by user script to signal to Oríon that it was interrupted.",
+    )
 
     # TODO: Will this support -config as well, or only --config?
     worker_config.add_option(
-        'user_script_config', option_type=str, default='config',
-        env_var='ORION_USER_SCRIPT_CONFIG',
-        help='Config argument name of user\'s script (--config).')
+        "user_script_config",
+        option_type=str,
+        default="config",
+        env_var="ORION_USER_SCRIPT_CONFIG",
+        help="Config argument name of user's script (--config).",
+    )
 
     config.worker = worker_config
 
@@ -196,84 +275,123 @@ def define_evc_config(config):
     #       After this, the cmdline parser should be built based on config.
 
     evc_config.add_option(
-        'auto_resolution', option_type=bool, default=True,
-        deprecate=dict(version='v0.3', alternative='evc.manual_resolution',
-                       name='evc.auto_resolution'),
+        "auto_resolution",
+        option_type=bool,
+        default=True,
+        deprecate=dict(
+            version="v0.3",
+            alternative="evc.manual_resolution",
+            name="evc.auto_resolution",
+        ),
         help="This argument will be removed in v0.3. "
-             "Conflicts are now resolved automatically by default. "
-             "See --manual-resolution to avoid auto-resolution.")
+        "Conflicts are now resolved automatically by default. "
+        "See --manual-resolution to avoid auto-resolution.",
+    )
 
     evc_config.add_option(
-        'manual_resolution', option_type=bool, default=False,
-        env_var='ORION_EVC_MANUAL_RESOLUTION',
-        help=("If ``True``, enter experiment version control conflict resolver for "
-              "manual resolution on branching events. Otherwise, auto-resolution is "
-              "attempted."))
+        "manual_resolution",
+        option_type=bool,
+        default=False,
+        env_var="ORION_EVC_MANUAL_RESOLUTION",
+        help=(
+            "If ``True``, enter experiment version control conflict resolver for "
+            "manual resolution on branching events. Otherwise, auto-resolution is "
+            "attempted."
+        ),
+    )
 
     evc_config.add_option(
-        'non_monitored_arguments', option_type=list, default=[],
-        env_var='ORION_EVC_NON_MONITORED_ARGUMENTS',
-        help=("Ignore these commandline arguments when looking for differences in "
-              "user's commandline call. "
-              "Environment variable and commandline only supports one argument. "
-              "Use global config or local config to pass a list of arguments to ignore."))
+        "non_monitored_arguments",
+        option_type=list,
+        default=[],
+        env_var="ORION_EVC_NON_MONITORED_ARGUMENTS",
+        help=(
+            "Ignore these commandline arguments when looking for differences in "
+            "user's commandline call. "
+            "Environment variable and commandline only supports one argument. "
+            "Use global config or local config to pass a list of arguments to ignore."
+        ),
+    )
 
     evc_config.add_option(
-        'ignore_code_changes', option_type=bool, default=False,
-        env_var='ORION_EVC_IGNORE_CODE_CHANGES',
-        help=("If ``True``, ignore code changes when looking for differences."))
+        "ignore_code_changes",
+        option_type=bool,
+        default=False,
+        env_var="ORION_EVC_IGNORE_CODE_CHANGES",
+        help=("If ``True``, ignore code changes when looking for differences."),
+    )
 
     evc_config.add_option(
-        'algorithm_change', option_type=bool, default=False,
-        env_var='ORION_EVC_ALGO_CHANGE',
-        help=("Set algorithm change as resolved if a branching event occur. "
-              "Child and parent experiment have access to all trials from each other "
-              "when the only difference between them is the algorithm configuration."))
+        "algorithm_change",
+        option_type=bool,
+        default=False,
+        env_var="ORION_EVC_ALGO_CHANGE",
+        help=(
+            "Set algorithm change as resolved if a branching event occur. "
+            "Child and parent experiment have access to all trials from each other "
+            "when the only difference between them is the algorithm configuration."
+        ),
+    )
 
     evc_config.add_option(
-        'code_change_type', option_type=str, default='break',
-        env_var='ORION_EVC_CODE_CHANGE',
-        help=("One of ``break``, ``unsure`` or ``noeffect``. "
-              "Defines how trials should be filtered in Experiment Version Control tree "
-              "if there is a change in the user's code repository. "
-              "If the effect of the change is ``unsure``, "
-              "the child experiment will access the trials of the parent but not "
-              "the other way around. "
-              "This is to ensure parent experiment does not get corrupted with possibly "
-              "incompatible results. "
-              "The child cannot access the trials from parent if ``code_change_type`` "
-              "is ``break``. The parent cannot access trials from child if "
-              "``code_change_type`` is ``unsure`` or ``break``."))
+        "code_change_type",
+        option_type=str,
+        default="break",
+        env_var="ORION_EVC_CODE_CHANGE",
+        help=(
+            "One of ``break``, ``unsure`` or ``noeffect``. "
+            "Defines how trials should be filtered in Experiment Version Control tree "
+            "if there is a change in the user's code repository. "
+            "If the effect of the change is ``unsure``, "
+            "the child experiment will access the trials of the parent but not "
+            "the other way around. "
+            "This is to ensure parent experiment does not get corrupted with possibly "
+            "incompatible results. "
+            "The child cannot access the trials from parent if ``code_change_type`` "
+            "is ``break``. The parent cannot access trials from child if "
+            "``code_change_type`` is ``unsure`` or ``break``."
+        ),
+    )
 
     evc_config.add_option(
-        'cli_change_type', option_type=str, default='break',
-        env_var='ORION_EVC_CMDLINE_CHANGE',
-        help=("One of ``break``, ``unsure`` or ``noeffect``. "
-              "Defines how trials should be filtered in Experiment Version Control tree "
-              "if there is a change in the user's commandline call. "
-              "If the effect of the change is ``unsure``, "
-              "the child experiment will access the trials of the parent but not "
-              "the other way around. "
-              "This is to ensure parent experiment does not get corrupted with possibly "
-              "incompatible results. "
-              "The child cannot access the trials from parent if ``cli_change_type`` "
-              "is ``break``. The parent cannot access trials from child if "
-              "``cli_change_type`` is ``unsure`` or ``break``."))
+        "cli_change_type",
+        option_type=str,
+        default="break",
+        env_var="ORION_EVC_CMDLINE_CHANGE",
+        help=(
+            "One of ``break``, ``unsure`` or ``noeffect``. "
+            "Defines how trials should be filtered in Experiment Version Control tree "
+            "if there is a change in the user's commandline call. "
+            "If the effect of the change is ``unsure``, "
+            "the child experiment will access the trials of the parent but not "
+            "the other way around. "
+            "This is to ensure parent experiment does not get corrupted with possibly "
+            "incompatible results. "
+            "The child cannot access the trials from parent if ``cli_change_type`` "
+            "is ``break``. The parent cannot access trials from child if "
+            "``cli_change_type`` is ``unsure`` or ``break``."
+        ),
+    )
 
     evc_config.add_option(
-        'config_change_type', option_type=str, default='break',
-        env_var='ORION_EVC_CONFIG_CHANGE',
-        help=("One of ``break``, ``unsure`` or ``noeffect``. "
-              "Defines how trials should be filtered in Experiment Version Control tree "
-              "if there is a change in the user's script. "
-              "If the effect of the change is ``unsure``, "
-              "the child experiment will access the trials of the parent but not "
-              "the other way around. "
-              "This is to ensure parent experiment does not get corrupted with possibly "
-              "incompatible results. "
-              "The child cannot access the trials from parent if ``config_change_type`` "
-              "is ``break``. The parent cannot access trials from child if "
-              "``config_change_type`` is ``unsure`` or ``break``."))
+        "config_change_type",
+        option_type=str,
+        default="break",
+        env_var="ORION_EVC_CONFIG_CHANGE",
+        help=(
+            "One of ``break``, ``unsure`` or ``noeffect``. "
+            "Defines how trials should be filtered in Experiment Version Control tree "
+            "if there is a change in the user's script. "
+            "If the effect of the change is ``unsure``, "
+            "the child experiment will access the trials of the parent but not "
+            "the other way around. "
+            "This is to ensure parent experiment does not get corrupted with possibly "
+            "incompatible results. "
+            "The child cannot access the trials from parent if ``config_change_type`` "
+            "is ``break``. The parent cannot access trials from child if "
+            "``config_change_type`` is ``unsure`` or ``break``."
+        ),
+    )
 
     config.evc = evc_config
 
@@ -283,7 +401,7 @@ def build_config():
     config = define_config()
     for file_path in DEF_CONFIG_FILES_PATHS:
         if not os.path.exists(file_path):
-            logger.debug('Config file not found: %s', file_path)
+            logger.debug("Config file not found: %s", file_path)
             continue
 
         config.load_yaml(file_path)

--- a/src/orion/core/_version.py
+++ b/src/orion/core/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/src/orion/core/cli/__init__.py
+++ b/src/orion/core/cli/__init__.py
@@ -19,10 +19,11 @@ log = logging.getLogger(__name__)
 
 def load_modules_parser(orion_parser):
     """Search through the `cli` folder for any module containing a `get_parser` function"""
-    modules = module_import.load_modules_in_path('orion.core.cli',
-                                                 lambda m: hasattr(m, 'add_subparser'))
+    modules = module_import.load_modules_in_path(
+        "orion.core.cli", lambda m: hasattr(m, "add_subparser")
+    )
     for module in modules:
-        get_parser = getattr(module, 'add_subparser')
+        get_parser = getattr(module, "add_subparser")
         get_parser(orion_parser.get_subparsers())
 
 

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -16,7 +16,12 @@ import textwrap
 import orion
 from orion.core.io.database import DatabaseError
 from orion.core.utils.exceptions import (
-    BranchingEvent, InexecutableUserScript, MissingResultFile, NoConfigurationError, NoNameError)
+    BranchingEvent,
+    InexecutableUserScript,
+    MissingResultFile,
+    NoConfigurationError,
+    NoNameError,
+)
 
 
 CLI_DOC_HEADER = "Oríon CLI for asynchronous distributed optimization"
@@ -31,22 +36,32 @@ class OrionArgsParser:
 
         self.parser = argparse.ArgumentParser(
             formatter_class=argparse.RawDescriptionHelpFormatter,
-            description=textwrap.dedent(description))
+            description=textwrap.dedent(description),
+        )
 
         self.parser.add_argument(
-            '-V', '--version',
-            action='version', version='orion ' + orion.core.__version__)
+            "-V",
+            "--version",
+            action="version",
+            version="orion " + orion.core.__version__,
+        )
 
         self.parser.add_argument(
-            '-v', '--verbose',
-            action='count', default=0,
-            help="logging levels of information about the process (-v: INFO. -vv: DEBUG)")
+            "-v",
+            "--verbose",
+            action="count",
+            default=0,
+            help="logging levels of information about the process (-v: INFO. -vv: DEBUG)",
+        )
 
         self.parser.add_argument(
-            '-d', '--debug', action='store_true',
-            help="Use debugging mode with EphemeralDB.")
+            "-d",
+            "--debug",
+            action="store_true",
+            help="Use debugging mode with EphemeralDB.",
+        )
 
-        self.subparsers = self.parser.add_subparsers(dest='command')
+        self.subparsers = self.parser.add_subparsers(dest="command")
 
     def get_subparsers(self):
         """Return the subparser object for this parser."""
@@ -56,19 +71,17 @@ class OrionArgsParser:
         """Call argparse and generate a dictionary of arguments' value"""
         args = vars(self.parser.parse_args(argv))
 
-        verbose = args.pop('verbose', 0)
-        levels = {0: logging.WARNING,
-                  1: logging.INFO,
-                  2: logging.DEBUG}
+        verbose = args.pop("verbose", 0)
+        levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
         logging.basicConfig(level=levels.get(verbose, logging.DEBUG))
 
-        if args['command'] is None:
-            self.parser.parse_args(['--help'])
+        if args["command"] is None:
+            self.parser.parse_args(["--help"])
 
-        function = args.pop('func', None)
-        empty_command = (argv[-1] if argv else sys.argv[-1]) == args['command']
-        if function is None or (empty_command and args.pop('help_empty', False)):
-            self.parser.parse_args([args['command'], '--help'])
+        function = args.pop("func", None)
+        empty_command = (argv[-1] if argv else sys.argv[-1]) == args["command"]
+        if function is None or (empty_command and args.pop("help_empty", False)):
+            self.parser.parse_args([args["command"], "--help"])
 
         return args, function
 
@@ -77,50 +90,68 @@ class OrionArgsParser:
         try:
             args, function = self.parse(argv)
             returncode = function(args)
-        except (NoConfigurationError, NoNameError, DatabaseError, MissingResultFile,
-                BranchingEvent, InexecutableUserScript) as e:
-            print('Error:', e, file=sys.stderr)
+        except (
+            NoConfigurationError,
+            NoNameError,
+            DatabaseError,
+            MissingResultFile,
+            BranchingEvent,
+            InexecutableUserScript,
+        ) as e:
+            print("Error:", e, file=sys.stderr)
 
-            if args.get('verbose', 0) >= 2:
+            if args.get("verbose", 0) >= 2:
                 raise e
 
             return 1
 
         except KeyboardInterrupt:
-            print('Orion is interrupted.')
+            print("Orion is interrupted.")
             return 130
 
         return 0 if returncode is None else returncode
 
 
 def get_basic_args_group(
-        parser,
-        group_name="Oríon arguments",
-        group_help="These arguments determine orion's behaviour"):
+    parser,
+    group_name="Oríon arguments",
+    group_help="These arguments determine orion's behaviour",
+):
     """Return the basic arguments for any command."""
-    basic_args_group = parser.add_argument_group(
-        group_name, description=group_help)
+    basic_args_group = parser.add_argument_group(group_name, description=group_help)
 
     basic_args_group.add_argument(
-        '-n', '--name',
-        type=str, metavar='stringID',
+        "-n",
+        "--name",
+        type=str,
+        metavar="stringID",
         help="experiment's unique name; "
-             "(default: None - specified either here or in a config)")
+        "(default: None - specified either here or in a config)",
+    )
 
     basic_args_group.add_argument(
-        '-u', '--user',
+        "-u",
+        "--user",
         type=str,
         help="user associated to experiment's unique name; "
-             "(default: $USER - can be overriden either here or in a config)")
+        "(default: $USER - can be overriden either here or in a config)",
+    )
 
     basic_args_group.add_argument(
-        '-v', '--version', type=int,
+        "-v",
+        "--version",
+        type=int,
         help="specific version of experiment to fetch; "
-             "(default: None - latest experiment.)")
+        "(default: None - latest experiment.)",
+    )
 
-    basic_args_group.add_argument('-c', '--config', type=argparse.FileType('r'),
-                                  metavar='path-to-config', help="user provided "
-                                  "orion configuration file")
+    basic_args_group.add_argument(
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided " "orion configuration file",
+    )
 
     return basic_args_group
 
@@ -133,13 +164,17 @@ def get_user_args_group(parser):
     usergroup = parser.add_argument_group(
         "User script related arguments",
         description="These arguments determine user's script behaviour "
-                    "and they can serve as orion's parameter declaration.")
+        "and they can serve as orion's parameter declaration.",
+    )
 
     usergroup.add_argument(
-        'user_args', nargs=argparse.REMAINDER, metavar='...',
+        "user_args",
+        nargs=argparse.REMAINDER,
+        metavar="...",
         help="Command line of user script. A configuration "
-             "file intended to be used with 'userscript' must be given as a path "
-             "in the **first positional** argument OR using `--config=<path>` "
-             "keyword argument.")
+        "file intended to be used with 'userscript' must be given as a path "
+        "in the **first positional** argument OR using `--config=<path>` "
+        "keyword argument.",
+    )
 
     return usergroup

--- a/src/orion/core/cli/checks/creation.py
+++ b/src/orion/core/cli/checks/creation.py
@@ -36,7 +36,7 @@ class CreationStage:
     def check_database_creation(self):
         """Check if database of specified type can be created."""
         database = self.p_stage.db_config
-        db_type = database.pop('type')
+        db_type = database.pop("type")
 
         try:
             db = Database(of_type=db_type, **database)
@@ -52,4 +52,4 @@ class CreationStage:
 
     def post_stage(self):
         """Print the created database."""
-        print('DB instance', self.instance)
+        print("DB instance", self.instance)

--- a/src/orion/core/cli/checks/operations.py
+++ b/src/orion/core/cli/checks/operations.py
@@ -39,7 +39,7 @@ class OperationsStage:
         database = self.c_stage.instance
 
         try:
-            database.write('test', {'index': 'value'})
+            database.write("test", {"index": "value"})
         except Exception as ex:
             raise CheckError(str(ex))
 
@@ -50,7 +50,7 @@ class OperationsStage:
         database = self.c_stage.instance
 
         try:
-            result = database.read('test', {'index': 'value'})
+            result = database.read("test", {"index": "value"})
         except Exception as ex:
             raise CheckError(str(ex))
 
@@ -63,7 +63,7 @@ class OperationsStage:
         """Check if database supports count operation."""
         database = self.c_stage.instance
 
-        count = database.count('test', {'index': 'value'})
+        count = database.count("test", {"index": "value"})
 
         if count != 1:
             raise CheckError("Expected 1 hit, received {}.".format(count))
@@ -74,8 +74,8 @@ class OperationsStage:
         """Check if database supports delete operation."""
         database = self.c_stage.instance
 
-        database.remove('test', {'index': 'value'})
-        remaining = database.count('test', {'index': 'value'})
+        database.remove("test", {"index": "value"})
+        remaining = database.count("test", {"index": "value"})
 
         if remaining:
             raise CheckError("{} items remaining.".format(remaining))

--- a/src/orion/core/cli/checks/presence.py
+++ b/src/orion/core/cli/checks/presence.py
@@ -34,11 +34,11 @@ class PresenceStage:
 
         backward.update_db_config(config)
 
-        if 'database' not in config.get('storage', {}):
+        if "database" not in config.get("storage", {}):
             return "Skipping", "No default configuration found for database."
 
-        self.db_config = config['storage']['database']
-        print('\n   ', self.db_config)
+        self.db_config = config["storage"]["database"]
+        print("\n   ", self.db_config)
 
         return "Success", ""
 
@@ -49,18 +49,18 @@ class PresenceStage:
         if not len(config):
             return "Skipping", "Missing configuration file."
 
-        if 'database' not in config.get('storage', {}):
+        if "database" not in config.get("storage", {}):
             return "Skipping", "No database found in configuration file."
 
-        config = config['storage']['database']
-        names = ['type', 'name', 'host', 'port']
+        config = config["storage"]["database"]
+        names = ["type", "name", "host", "port"]
 
         if not any(name in config for name in names):
             return "Skipping", "No configuration value found inside `database`."
 
         self.db_config.update(config)
 
-        print('\n   ', config)
+        print("\n   ", config)
 
         return "Success", ""
 

--- a/src/orion/core/cli/db/rm.py
+++ b/src/orion/core/cli/db/rm.py
@@ -67,35 +67,47 @@ $ orion db rm my-exp-name --version 1
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
     rm_parser = parser.add_parser(
-        'rm',
+        "rm",
         description=DESCRIPTION,
-        help='Deletes experiments and trials',
-        formatter_class=argparse.RawTextHelpFormatter)
+        help="Deletes experiments and trials",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
 
     rm_parser.set_defaults(func=main)
 
-    rm_parser.add_argument(
-        'name',
-        help='Name of the experiment to delete.')
-
-    rm_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
-                           metavar='path-to-config', help="user provided "
-                           "orion configuration file")
+    rm_parser.add_argument("name", help="Name of the experiment to delete.")
 
     rm_parser.add_argument(
-        '-v', '--version', type=int, default=None,
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided " "orion configuration file",
+    )
+
+    rm_parser.add_argument(
+        "-v",
+        "--version",
+        type=int,
+        default=None,
         help="specific version of experiment to fetch; "
-             "(default: last version matching.)")
+        "(default: last version matching.)",
+    )
 
     rm_parser.add_argument(
-        '-s', '--status',
-        help='Remove all trials of the experiment with the given status '
-             '(Will not delete the experiment). '
-             'Also supports --status=* to delete all trials of a given experiment.')
+        "-s",
+        "--status",
+        help="Remove all trials of the experiment with the given status "
+        "(Will not delete the experiment). "
+        "Also supports --status=* to delete all trials of a given experiment.",
+    )
 
     rm_parser.add_argument(
-        '-f', '--force', action='store_true',
-        help='Force delete without asking to enter experiment name twice.')
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force delete without asking to enter experiment name twice.",
+    )
 
     return rm_parser
 
@@ -104,17 +116,21 @@ def process_trial_rm(storage, root, status):
     """Delete the matching trials of the given experiment."""
     trials_total = 0
     for node in root:
-        if status == '*':
+        if status == "*":
             query = {}
         else:
-            query = {'status': status}
+            query = {"status": status}
 
         count = storage.delete_trials(uid=node.item.id, where=query)
-        logger.debug('%d trials deleted in experiment %s-v%d',
-                     count, node.item.name, node.item.version)
+        logger.debug(
+            "%d trials deleted in experiment %s-v%d",
+            count,
+            node.item.name,
+            node.item.version,
+        )
         trials_total += count
 
-    print(f'{trials_total} trials deleted')
+    print(f"{trials_total} trials deleted")
 
 
 def process_exp_rm(storage, root):
@@ -124,15 +140,20 @@ def process_exp_rm(storage, root):
     for node in root:
         count = storage.delete_trials(uid=node.item.id)
         trials_total += count
-        logger.debug('%d trials deleted in experiment %s-v%d',
-                     count, node.item.name, node.item.version)
+        logger.debug(
+            "%d trials deleted in experiment %s-v%d",
+            count,
+            node.item.name,
+            node.item.version,
+        )
         count = storage.delete_experiment(uid=node.item.id)
-        logger.debug('%s experiment %s-v%d deleted',
-                     count, node.item.name, node.item.version)
+        logger.debug(
+            "%s experiment %s-v%d deleted", count, node.item.name, node.item.version
+        )
         exp_total += count
 
-    print(f'{trials_total} trials deleted')
-    print(f'{exp_total} experiments deleted')
+    print(f"{trials_total} trials deleted")
+    print(f"{exp_total} experiments deleted")
 
 
 def delete_experiments(storage, root, name, force):
@@ -140,7 +161,7 @@ def delete_experiments(storage, root, name, force):
     confirmed = confirm_name(EXP_RM_MESSAGE, name, force)
 
     if not confirmed:
-        print('Confirmation failed, aborting operation.')
+        print("Confirmation failed, aborting operation.")
         sys.exit(1)
 
     process_exp_rm(storage, root)
@@ -151,7 +172,7 @@ def delete_trials(storage, root, name, status, force):
     confirmed = confirm_name(TRIALS_RM_MESSAGE, name, force)
 
     if not confirmed:
-        print('Confirmation failed, aborting operation.')
+        print("Confirmation failed, aborting operation.")
         sys.exit(1)
 
     process_trial_rm(storage, root, status)
@@ -160,18 +181,19 @@ def delete_trials(storage, root, name, status, force):
 def main(args):
     """Remove the experiment(s) or trial(s)."""
     config = experiment_builder.get_cmd_config(args)
-    experiment_builder.setup_storage(config.get('storage'))
+    experiment_builder.setup_storage(config.get("storage"))
 
     # Find root experiment
-    root = experiment_builder.build_view(name=args['name'],
-                                         version=args.get('version', None)).node
+    root = experiment_builder.build_view(
+        name=args["name"], version=args.get("version", None)
+    ).node
 
     # List all experiments with children
-    print_tree(root, nameattr='tree_name')
+    print_tree(root, nameattr="tree_name")
 
     storage = get_storage()
 
-    if args['status']:
-        delete_trials(storage, root, args['name'], args['status'], args['force'])
+    if args["status"]:
+        delete_trials(storage, root, args["name"], args["status"], args["force"])
     else:
-        delete_experiments(storage, root, args['name'], args['force'])
+        delete_experiments(storage, root, args["name"], args["force"])

--- a/src/orion/core/cli/db/set.py
+++ b/src/orion/core/cli/db/set.py
@@ -54,41 +54,57 @@ To proceed, type again the name of the experiment: """
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
     set_parser = parser.add_parser(
-        'set',
+        "set",
         description=DESCRIPTION,
         help="Update trials' attributes",
-        formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
 
     set_parser.set_defaults(func=main)
 
-    set_parser.add_argument(
-        'name',
-        help='Name of the experiment to delete.')
+    set_parser.add_argument("name", help="Name of the experiment to delete.")
 
     set_parser.add_argument(
-        '-c', '--config', type=argparse.FileType('r'), metavar='path-to-config',
-        help="user provided orion configuration file")
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided orion configuration file",
+    )
 
     set_parser.add_argument(
-        '-v', '--version', type=int, default=None,
+        "-v",
+        "--version",
+        type=int,
+        default=None,
         help="specific version of experiment to fetch; "
-             "(default: last version matching.)")
+        "(default: last version matching.)",
+    )
 
     set_parser.add_argument(
-        '-f', '--force', action='store_true',
-        help='Force modify without asking to enter experiment name twice.')
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force modify without asking to enter experiment name twice.",
+    )
 
     set_parser.add_argument(
-        'query',
-        help=(f'Query for trials to update. Can be `*` to update all trials. '
-              f'Otherwise format must be <attribute>=<value>. Ex: status=broken. '
-              f'Supported attributes are {VALID_QUERY_ATTRS}'))
+        "query",
+        help=(
+            f"Query for trials to update. Can be `*` to update all trials. "
+            f"Otherwise format must be <attribute>=<value>. Ex: status=broken. "
+            f"Supported attributes are {VALID_QUERY_ATTRS}"
+        ),
+    )
 
     set_parser.add_argument(
-        'update',
-        help=(f'Update for trials. Format must be <attribute>=<value>. '
-              f'Ex: status=interrupted. '
-              f'Supported attributes are {VALID_UPDATE_ATTRS}'))
+        "update",
+        help=(
+            f"Update for trials. Format must be <attribute>=<value>. "
+            f"Ex: status=interrupted. "
+            f"Supported attributes are {VALID_UPDATE_ATTRS}"
+        ),
+    )
 
     return set_parser
 
@@ -98,15 +114,19 @@ def process_updates(storage, root, query, update):
     trials_total = 0
     for node in root:
         count = storage.update_trials(node.item, where=query, **update)
-        logger.debug('%d trials modified in experiment %s-v%d',
-                     count, node.item.name, node.item.version)
+        logger.debug(
+            "%d trials modified in experiment %s-v%d",
+            count,
+            node.item.name,
+            node.item.version,
+        )
         trials_total += count
 
-    print(f'{trials_total} trials modified')
+    print(f"{trials_total} trials modified")
 
 
-VALID_QUERY_ATTRS = ['status', 'id']
-VALID_UPDATE_ATTRS = ['status']
+VALID_QUERY_ATTRS = ["status", "id"]
+VALID_UPDATE_ATTRS = ["status"]
 
 
 def build_query(query):
@@ -114,17 +134,18 @@ def build_query(query):
 
     String format must be <attr name>=<value>
     """
-    if query.strip() == '*':
+    if query.strip() == "*":
         return {}
 
-    attribute, value = query.split('=')
+    attribute, value = query.split("=")
 
     if attribute not in VALID_QUERY_ATTRS:
         raise ValueError(
-            f'Invalid query attribute `{attribute}`. Must be one of {VALID_QUERY_ATTRS}')
+            f"Invalid query attribute `{attribute}`. Must be one of {VALID_QUERY_ATTRS}"
+        )
 
-    if attribute == 'id':
-        attribute = '_id'
+    if attribute == "id":
+        attribute = "_id"
 
     return {attribute: value}
 
@@ -134,11 +155,12 @@ def build_update(update):
 
     String format must be <attr name>=<value>
     """
-    attribute, value = update.split('=')
+    attribute, value = update.split("=")
 
     if attribute not in VALID_UPDATE_ATTRS:
         raise ValueError(
-            f'Invalid update attribute `{attribute}`. Must be one of {VALID_UPDATE_ATTRS}')
+            f"Invalid update attribute `{attribute}`. Must be one of {VALID_UPDATE_ATTRS}"
+        )
 
     return {attribute: value}
 
@@ -146,28 +168,31 @@ def build_update(update):
 def main(args):
     """Remove the experiment(s) or trial(s)."""
     config = experiment_builder.get_cmd_config(args)
-    experiment_builder.setup_storage(config.get('storage'))
+    experiment_builder.setup_storage(config.get("storage"))
 
     # Find root experiment
-    root = experiment_builder.build_view(name=args['name'],
-                                         version=args.get('version', None)).node
+    root = experiment_builder.build_view(
+        name=args["name"], version=args.get("version", None)
+    ).node
 
     try:
-        query = build_query(args['query'])
-        update = build_update(args['update'])
+        query = build_query(args["query"])
+        update = build_update(args["update"])
     except ValueError as e:
-        print(f'Error: {e}', file=sys.stderr)
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
     # List all experiments with children
-    print_tree(root, nameattr='tree_name')
+    print_tree(root, nameattr="tree_name")
 
     confirmed = confirm_name(
-        CONFIRM_MESSAGE.format(query=args['query'], update=args['update']),
-        args['name'], args['force'])
+        CONFIRM_MESSAGE.format(query=args["query"], update=args["update"]),
+        args["name"],
+        args["force"],
+    )
 
     if not confirmed:
-        print('Confirmation failed, aborting operation.')
+        print("Confirmation failed, aborting operation.")
         return 1
 
     storage = get_storage()

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -18,7 +18,7 @@ import orion.core
 from orion.core.utils.terminal import ask_question
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Starts the database configuration wizard'
+SHORT_DESCRIPTION = "Starts the database configuration wizard"
 DESCRIPTION = """
 This command starts the database configuration wizard and creates a configuration file for the
 database.
@@ -27,7 +27,9 @@ database.
 
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
-    setup_parser = parser.add_parser('setup', help=SHORT_DESCRIPTION, description=DESCRIPTION)
+    setup_parser = parser.add_parser(
+        "setup", help=SHORT_DESCRIPTION, description=DESCRIPTION
+    )
 
     setup_parser.set_defaults(func=main)
 
@@ -40,25 +42,29 @@ def main(*args):
     default_file = orion.core.DEF_CONFIG_FILES_PATHS[-1]
 
     if os.path.exists(default_file):
-        cancel = ''
-        while cancel.strip().lower() not in ['y', 'n']:
+        cancel = ""
+        while cancel.strip().lower() not in ["y", "n"]:
             cancel = ask_question(
-                "This will overwrite {}, do you want to proceed? (y/n) ".format(default_file), "n")
+                "This will overwrite {}, do you want to proceed? (y/n) ".format(
+                    default_file
+                ),
+                "n",
+            )
 
-        if cancel.strip().lower() == 'n':
+        if cancel.strip().lower() == "n":
             return
 
     _type = ask_question("Enter the database type: ", "mongodb")
     name = ask_question("Enter the database name: ", "test")
     host = ask_question("Enter the database host: ", "localhost")
 
-    config = {'database': {'type': _type, 'name': name, 'host': host}}
+    config = {"database": {"type": _type, "name": name, "host": host}}
 
     print("Default configuration file will be saved at: ")
     print(default_file)
 
-    dirs = '/'.join(default_file.split('/')[:-1])
+    dirs = "/".join(default_file.split("/")[:-1])
     os.makedirs(dirs, exist_ok=True)
 
-    with open(default_file, 'w') as output:
+    with open(default_file, "w") as output:
         yaml.dump(config, output, default_flow_style=False)

--- a/src/orion/core/cli/db/test.py
+++ b/src/orion/core/cli/db/test.py
@@ -18,17 +18,22 @@ from orion.core.cli.checks.presence import PresenceStage
 from orion.core.utils.exceptions import CheckError
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Verifies that the database is correctly configured'
+SHORT_DESCRIPTION = "Verifies that the database is correctly configured"
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    test_db_parser = parser.add_parser('test', help=SHORT_DESCRIPTION,
-                                       description=SHORT_DESCRIPTION)
+    test_db_parser = parser.add_parser(
+        "test", help=SHORT_DESCRIPTION, description=SHORT_DESCRIPTION
+    )
 
-    test_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
-                                metavar='path-to-config', help="user provided "
-                                "orion configuration file")
+    test_db_parser.add_argument(
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided " "orion configuration file",
+    )
 
     test_db_parser.set_defaults(func=main)
 
@@ -44,7 +49,7 @@ def main(args):
 
     for stage in stages:
         for check in stage.checks():
-            print(check.__doc__, end='.. ')
+            print(check.__doc__, end=".. ")
             try:
                 status, msg = check()
                 print(status)

--- a/src/orion/core/cli/db/upgrade.py
+++ b/src/orion/core/cli/db/upgrade.py
@@ -23,7 +23,7 @@ from orion.storage.legacy import Legacy
 
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Upgrade the database scheme'
+SHORT_DESCRIPTION = "Upgrade the database scheme"
 
 
 # TODO: Move somewhere else to share with `db setup`.
@@ -56,15 +56,21 @@ def ask_question(question, default=None):
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    upgrade_db_parser = parser.add_parser('upgrade', help=SHORT_DESCRIPTION,
-                                          description=SHORT_DESCRIPTION)
+    upgrade_db_parser = parser.add_parser(
+        "upgrade", help=SHORT_DESCRIPTION, description=SHORT_DESCRIPTION
+    )
 
-    upgrade_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
-                                   metavar='path-to-config', help="user provided "
-                                   "orion configuration file")
+    upgrade_db_parser.add_argument(
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided " "orion configuration file",
+    )
 
-    upgrade_db_parser.add_argument('-f', '--force', action='store_true',
-                                   help="Don't prompt user")
+    upgrade_db_parser.add_argument(
+        "-f", "--force", action="store_true", help="Don't prompt user"
+    )
 
     upgrade_db_parser.set_defaults(func=main)
 
@@ -73,24 +79,26 @@ def add_subparser(parser):
 
 def main(args):
     """Upgrade the databases for current version"""
-    print("Upgrading your database may damage your data. Make sure to make a backup before the "
-          "upgrade and stop any other process that may read/write the database during the upgrade.")
+    print(
+        "Upgrading your database may damage your data. Make sure to make a backup before the "
+        "upgrade and stop any other process that may read/write the database during the upgrade."
+    )
 
-    if not args.get('force'):
-        action = ''
-        while action not in ['y', 'yes', 'no', 'n']:
+    if not args.get("force"):
+        action = ""
+        while action not in ["y", "yes", "no", "n"]:
             action = ask_question("Do you wish to proceed? (y/N)", "N").lower()
 
-        if action in ['no', 'n']:
+        if action in ["no", "n"]:
             sys.exit(0)
 
     config = experiment_builder.get_cmd_config(args)
-    storage_config = config.get('storage')
+    storage_config = config.get("storage")
 
     if storage_config is None:
-        storage_config = {'type': 'legacy'}
+        storage_config = {"type": "legacy"}
 
-    storage_config['setup'] = False
+    storage_config["setup"] = False
 
     experiment_builder.setup_storage(storage_config)
 
@@ -98,22 +106,22 @@ def main(args):
 
     upgrade_db_specifics(storage)
 
-    print('Updating documents...')
+    print("Updating documents...")
     upgrade_documents(storage)
-    print('Database upgrade completed successfully')
+    print("Database upgrade completed successfully")
 
 
 def upgrade_db_specifics(storage):
     """Make upgrades that are specific to some backends"""
     if isinstance(storage, Legacy):
         database = storage._db  # pylint: disable=protected-access
-        print('Updating indexes...')
+        print("Updating indexes...")
         update_indexes(database)
         if isinstance(database, PickledDB):
-            print('Updating pickledb scheme...')
+            print("Updating pickledb scheme...")
             upgrade_pickledb(database)
         elif isinstance(database, MongoDB):
-            print('Updating mongodb scheme...')
+            print("Updating mongodb scheme...")
             upgrade_mongodb(database)
 
 
@@ -122,12 +130,12 @@ def upgrade_documents(storage):
     for experiment in storage.fetch_experiments({}):
         add_version(experiment)
         add_space(experiment)
-        storage.update_experiment(uid=experiment.pop('_id'), **experiment)
+        storage.update_experiment(uid=experiment.pop("_id"), **experiment)
 
 
 def add_version(experiment):
     """Add version 1 if not present"""
-    experiment.setdefault('version', 1)
+    experiment.setdefault("version", 1)
 
 
 def add_space(experiment):
@@ -141,13 +149,17 @@ def update_indexes(database):
     This is required for migration to v0.1.6+
     """
     # For backward compatibility
-    index_info = database.index_information('experiments')
-    deprecated_indices = [('name', 'metadata.user'), ('name', 'metadata.user', 'version'),
-                          'name_1_metadata.user_1', 'name_1_metadata.user_1_version_1']
+    index_info = database.index_information("experiments")
+    deprecated_indices = [
+        ("name", "metadata.user"),
+        ("name", "metadata.user", "version"),
+        "name_1_metadata.user_1",
+        "name_1_metadata.user_1_version_1",
+    ]
 
     for deprecated_idx in deprecated_indices:
         if deprecated_idx in index_info:
-            database.drop_index('experiments', deprecated_idx)
+            database.drop_index("experiments", deprecated_idx)
 
 
 # pylint: disable=unused-argument
@@ -161,12 +173,14 @@ def upgrade_pickledb(database):
     # pylint: disable=protected-access
     def upgrade_state(self, state):
         """Set state while ensuring backward compatibility"""
-        self._documents = state['_documents']
+        self._documents = state["_documents"]
 
         # if indexes are from <=v0.1.6
-        if state['_indexes'] and isinstance(next(iter(state['_indexes'].keys())), tuple):
+        if state["_indexes"] and isinstance(
+            next(iter(state["_indexes"].keys())), tuple
+        ):
             self._indexes = dict()
-            for keys, values in state['_indexes'].items():
+            for keys, values in state["_indexes"].items():
                 if isinstance(keys, str):
                     self._indexes[keys] = values
                 # Convert keys that were registered with old index signature
@@ -174,14 +188,14 @@ def upgrade_pickledb(database):
                     keys = [(key, None) for key in keys]
                     self.create_index(keys, unique=True)
         else:
-            self._indexes = state['_indexes']
+            self._indexes = state["_indexes"]
 
-    old_setstate = getattr(EphemeralCollection, '__setstate__', None)
+    old_setstate = getattr(EphemeralCollection, "__setstate__", None)
     EphemeralCollection.__setstate__ = upgrade_state
 
-    document = database.read('experiments', {})[0]
+    document = database.read("experiments", {})[0]
     # One document update is enough to fix all collections
-    database.write('experiments', document, query={'_id': document['_id']})
+    database.write("experiments", document, query={"_id": document["_id"]})
 
     if old_setstate is not None:
         EphemeralCollection.__setstate__ = old_setstate

--- a/src/orion/core/cli/db_main.py
+++ b/src/orion/core/cli/db_main.py
@@ -14,7 +14,7 @@ import logging
 from orion.core.utils import module_import
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Database initialization, upgrade, verification, and edition'
+SHORT_DESCRIPTION = "Database initialization, upgrade, verification, and edition"
 DESCRIPTION = """
 Root command for database operations.
 """
@@ -25,7 +25,7 @@ def add_subparser(parser):
     # Fetch experiment name, user's script path and command line arguments
     # Use `-h` option to show help
 
-    db_parser = parser.add_parser('db', help=SHORT_DESCRIPTION, description=DESCRIPTION)
+    db_parser = parser.add_parser("db", help=SHORT_DESCRIPTION, description=DESCRIPTION)
     subparsers = db_parser.add_subparsers()
 
     load_modules_parser(subparsers)
@@ -35,9 +35,10 @@ def add_subparser(parser):
 
 def load_modules_parser(subparsers):
     """Search through the `cli.db` folder for any module containing a `get_parser` function"""
-    modules = module_import.load_modules_in_path('orion.core.cli.db',
-                                                 lambda m: hasattr(m, 'add_subparser'))
+    modules = module_import.load_modules_in_path(
+        "orion.core.cli.db", lambda m: hasattr(m, "add_subparser")
+    )
 
     for module in modules:
-        get_parser = getattr(module, 'add_subparser')
+        get_parser = getattr(module, "add_subparser")
         get_parser(subparsers)

--- a/src/orion/core/cli/evc.py
+++ b/src/orion/core/cli/evc.py
@@ -18,7 +18,8 @@ def _add_auto_resolution_argument(parser):
         action="store_true",
         default=None,
         help="Deprecated. Conflicts are now resolved automatically by default."
-             "See --manual-resolution to avoid auto-resolution.")
+        "See --manual-resolution to avoid auto-resolution.",
+    )
 
 
 def _add_manual_resolution_argument(parser):
@@ -26,13 +27,16 @@ def _add_manual_resolution_argument(parser):
         "--manual-resolution",
         action="store_true",
         default=None,
-        help="Manually resolve conflicts")
+        help="Manually resolve conflicts",
+    )
 
 
 def _add_non_monitored_arguments_argument(parser):
     parser.add_argument(
-        "--non-monitored-arguments", type=str,
-        help="Ignore these arguments when looking for differences")
+        "--non-monitored-arguments",
+        type=str,
+        help="Ignore these arguments when looking for differences",
+    )
 
 
 def _add_ignore_code_changes_argument(parser):
@@ -40,13 +44,16 @@ def _add_ignore_code_changes_argument(parser):
         "--ignore-code-changes",
         action="store_true",
         default=None,
-        help="Ignore code changes when looking for differences")
+        help="Ignore code changes when looking for differences",
+    )
 
 
 def _add_branch_from_argument(parser):
     parser.add_argument(
-        "--branch-from", type=str,
-        help="Create a new child based on experiment defined by `branch-from`")
+        "--branch-from",
+        type=str,
+        help="Create a new child based on experiment defined by `branch-from`",
+    )
 
 
 def _add_algorithm_argument(parser, resolution_class):
@@ -54,59 +61,69 @@ def _add_algorithm_argument(parser, resolution_class):
         resolution_class.ARGUMENT,
         action="store_true",
         default=None,
-        help="Set algorithm change as resolved if a branching event occur")
+        help="Set algorithm change as resolved if a branching event occur",
+    )
 
 
 def _add_code_argument(parser, resolution_class):
     parser.add_argument(
         resolution_class.ARGUMENT,
         choices=adapters.CodeChange.types,
-        help="Set code change type")
+        help="Set code change type",
+    )
 
 
 def _add_cli_argument(parser, resolution_class):
     parser.add_argument(
         resolution_class.ARGUMENT,
         choices=adapters.CommandLineChange.types,
-        help="Set command line change type")
+        help="Set command line change type",
+    )
 
 
 def _add_config_argument(parser, resolution_class):
     parser.add_argument(
         resolution_class.ARGUMENT,
         choices=adapters.ScriptConfigChange.types,
-        help="Set configuration change type")
+        help="Set configuration change type",
+    )
 
 
 def _add_branch_to_argument(parser, resolution_class):
     parser.add_argument(
-        '-b', resolution_class.ARGUMENT, metavar='stringID',
-        help='Unique name for the new branching experiment')
+        "-b",
+        resolution_class.ARGUMENT,
+        metavar="stringID",
+        help="Unique name for the new branching experiment",
+    )
 
 
 resolution_arguments = {
-    'auto_resolution': _add_auto_resolution_argument,
-    'manual_resolution': _add_manual_resolution_argument,
-    'non_monitored_arguments': _add_non_monitored_arguments_argument,
-    'ignore_code_changes': _add_ignore_code_changes_argument,
-    'algorithm_change': _add_algorithm_argument,
-    'code_change_type': _add_code_argument,
-    'cli_change_type': _add_cli_argument,
-    'config_change_type': _add_config_argument,
-    'branch_from': _add_branch_from_argument,
-    'branch_to': _add_branch_to_argument}
+    "auto_resolution": _add_auto_resolution_argument,
+    "manual_resolution": _add_manual_resolution_argument,
+    "non_monitored_arguments": _add_non_monitored_arguments_argument,
+    "ignore_code_changes": _add_ignore_code_changes_argument,
+    "algorithm_change": _add_algorithm_argument,
+    "code_change_type": _add_code_argument,
+    "cli_change_type": _add_cli_argument,
+    "config_change_type": _add_config_argument,
+    "branch_from": _add_branch_from_argument,
+    "branch_to": _add_branch_to_argument,
+}
 
 
 UNDEFINED_PARSER_ERROR = (
     "A resolution with metavar '{}' is defined but no corresponding parser is defined. "
-    "Please raise an issue on github if you encounter this error message.")
+    "Please raise an issue on github if you encounter this error message."
+)
 
 
 def get_branching_args_group(parser):
     """Return the arguments for automatic branching resolution."""
     branching_args_group = parser.add_argument_group(
         "Oríon branching arguments (optional)",
-        description="Arguments to automatically resolved branching events.")
+        description="Arguments to automatically resolved branching events.",
+    )
 
     _add_manual_resolution_argument(branching_args_group)
     _add_non_monitored_arguments_argument(branching_args_group)
@@ -114,7 +131,9 @@ def get_branching_args_group(parser):
     _add_auto_resolution_argument(branching_args_group)
     _add_branch_from_argument(branching_args_group)
 
-    for resolution_class in sorted(Resolution.__subclasses__(), key=lambda cls: cls.__name__):
+    for resolution_class in sorted(
+        Resolution.__subclasses__(), key=lambda cls: cls.__name__
+    ):
         if not resolution_class.ARGUMENT:
             continue
 

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -19,7 +19,7 @@ import orion.core.io.experiment_builder as experiment_builder
 from orion.core.worker import workon
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Conducts hyperparameter optimization'
+SHORT_DESCRIPTION = "Conducts hyperparameter optimization"
 DESCRIPTION = """
 This command starts hyperparameter optimization process for the user-provided model using the
 configured optimization algorithm and search space.
@@ -28,30 +28,42 @@ configured optimization algorithm and search space.
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    hunt_parser = parser.add_parser('hunt', help=SHORT_DESCRIPTION, description=DESCRIPTION)
+    hunt_parser = parser.add_parser(
+        "hunt", help=SHORT_DESCRIPTION, description=DESCRIPTION
+    )
 
     orion_group = cli.get_basic_args_group(
-        hunt_parser, group_name='Hunt arguments', group_help='')
+        hunt_parser, group_name="Hunt arguments", group_help=""
+    )
 
     orion.core.config.experiment.add_arguments(
         orion_group,
-        rename=dict(max_broken='--exp-max-broken', max_trials='--exp-max-trials'))
+        rename=dict(max_broken="--exp-max-broken", max_trials="--exp-max-trials"),
+    )
 
     orion_group.add_argument(
-        '--max-trials', type=int, metavar='#',
-        help="(DEPRECATED) This argument will be removed in v0.3. Use --exp-max-trials instead")
+        "--max-trials",
+        type=int,
+        metavar="#",
+        help="(DEPRECATED) This argument will be removed in v0.3. Use --exp-max-trials instead",
+    )
 
     orion_group.add_argument(
-        '--init-only', default=False, action='store_true',
-        help="Only create the experiment and register in database, but do not execute any trial.")
+        "--init-only",
+        default=False,
+        action="store_true",
+        help="Only create the experiment and register in database, but do not execute any trial.",
+    )
 
     worker_args_group = hunt_parser.add_argument_group(
         "Worker arguments (optional)",
-        description="Arguments to automatically resolved branching events.")
+        description="Arguments to automatically resolved branching events.",
+    )
 
     orion.core.config.worker.add_arguments(
         worker_args_group,
-        rename=dict(max_broken='--worker-max-broken', max_trials='--worker-max-trials'))
+        rename=dict(max_broken="--worker-max-broken", max_trials="--worker-max-trials"),
+    )
 
     evc_cli.get_branching_args_group(hunt_parser)
 
@@ -65,17 +77,17 @@ def add_subparser(parser):
 
 def main(args):
     """Build experiment and execute hunt command"""
-    args['root'] = None
-    args['leafs'] = []
+    args["root"] = None
+    args["leafs"] = []
     # TODO: simplify when parameter parsing is refactored
     experiment = experiment_builder.build_from_args(args)
 
-    if args['init_only']:
+    if args["init_only"]:
         return
 
     config = experiment_builder.get_cmd_config(args)
     worker_config = orion.core.config.worker.to_dict()
-    if config.get('worker'):
-        worker_config.update(config.get('worker'))
+    if config.get("worker"):
+        worker_config.update(config.get("worker"))
 
     workon(experiment, **worker_config)

--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -17,12 +17,14 @@ import orion.core.io.experiment_builder as experiment_builder
 from orion.core.utils.format_terminal import format_info
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Gives detailed information about experiments'
+SHORT_DESCRIPTION = "Gives detailed information about experiments"
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    info_parser = parser.add_parser('info', help=SHORT_DESCRIPTION, description=SHORT_DESCRIPTION)
+    info_parser = parser.add_parser(
+        "info", help=SHORT_DESCRIPTION, description=SHORT_DESCRIPTION
+    )
     get_basic_args_group(info_parser)
 
     info_parser.set_defaults(func=main)
@@ -35,7 +37,7 @@ def main(args):
     try:
         experiment = experiment_builder.build_view_from_args(args)
     except ValueError:
-        print('Experiment {} not found in db.'.format(args.get('name', None)))
+        print("Experiment {} not found in db.".format(args.get("name", None)))
         sys.exit(1)
 
     print(format_info(experiment))

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -17,23 +17,30 @@ from orion.core.cli import evc as evc_cli
 import orion.core.io.experiment_builder as experiment_builder
 
 log = logging.getLogger(__name__)
-DESCRIPTION = '(DEPRECATED) Use command `orion hunt --init_only` instead'
+DESCRIPTION = "(DEPRECATED) Use command `orion hunt --init_only` instead"
 
 
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
-    init_only_parser = parser.add_parser('init_only', help=DESCRIPTION, description=DESCRIPTION)
+    init_only_parser = parser.add_parser(
+        "init_only", help=DESCRIPTION, description=DESCRIPTION
+    )
 
     orion_group = cli.get_basic_args_group(
-        init_only_parser, group_name='init_only arguments', group_help='')
+        init_only_parser, group_name="init_only arguments", group_help=""
+    )
 
     orion.core.config.experiment.add_arguments(
         orion_group,
-        rename=dict(max_broken='--exp-max-broken', max_trials='--exp-max-trials'))
+        rename=dict(max_broken="--exp-max-broken", max_trials="--exp-max-trials"),
+    )
 
     orion_group.add_argument(
-        '--max-trials', type=int, metavar='#',
-        help="(DEPRECATED) This argument will be removed in v0.3. Use --exp-max-trials instead")
+        "--max-trials",
+        type=int,
+        metavar="#",
+        help="(DEPRECATED) This argument will be removed in v0.3. Use --exp-max-trials instead",
+    )
 
     evc_cli.get_branching_args_group(init_only_parser)
 
@@ -48,6 +55,8 @@ def add_subparser(parser):
 def main(args):
     """Build and initialize experiment"""
     # By building the experiment, we create a new experiment document in database
-    log.warning('Command init_only is deprecated and will be removed in v0.3. '
-                'Use orion hunt --init-only instead.')
+    log.warning(
+        "Command init_only is deprecated and will be removed in v0.3. "
+        "Use orion hunt --init-only instead."
+    )
     experiment_builder.build_from_args(args)

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -22,13 +22,15 @@ from orion.core.utils.format_trials import tuple_to_trial
 
 log = logging.getLogger(__name__)
 
-SHORT_DESCRIPTION = 'Inserts new trials in an existing experiment'
-DESCRIPTION = 'Insert new trials for a given experiment with fixed values'
+SHORT_DESCRIPTION = "Inserts new trials in an existing experiment"
+DESCRIPTION = "Insert new trials for a given experiment with fixed values"
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    insert_parser = parser.add_parser('insert', help=SHORT_DESCRIPTION, description=DESCRIPTION)
+    insert_parser = parser.add_parser(
+        "insert", help=SHORT_DESCRIPTION, description=DESCRIPTION
+    )
 
     cli.get_basic_args_group(insert_parser)
 
@@ -42,10 +44,11 @@ def add_subparser(parser):
 
 def main(args):
     """Fetch config and insert new point"""
-    command_line_user_args = args.pop('user_args', [None])[1:]
+    command_line_user_args = args.pop("user_args", [None])[1:]
     experiment_view = experiment_builder.build_view_from_args(args)
-    experiment = experiment_builder.build(name=experiment_view.name,
-                                          version=experiment_view.version)
+    experiment = experiment_builder.build(
+        name=experiment_view.name, version=experiment_view.version
+    )
 
     transformed_args = _build_from(command_line_user_args)
     exp_space = experiment.space
@@ -63,21 +66,30 @@ def _validate_dimensions(transformed_args, exp_space):
 
     # Find any dimension that is not given by the user and make sure they have a default value
     for exp_n in exp_namespaces:
-        if exp_n not in transformed_args.keys() and exp_space[exp_n].default_value is None:
-            error_msg = "Dimension {} is unspecified and has no default value".format(exp_n)
+        if (
+            exp_n not in transformed_args.keys()
+            and exp_space[exp_n].default_value is None
+        ):
+            error_msg = "Dimension {} is unspecified and has no default value".format(
+                exp_n
+            )
             raise ValueError(error_msg)
 
     # Find any namespace that is not in the space of the experiment,
     # or values that lie outside the prior's interval
     for namespace, value in transformed_args.items():
         if namespace not in exp_space:
-            error_msg = "Found namespace outside of experiment space : {}".format(namespace)
+            error_msg = "Found namespace outside of experiment space : {}".format(
+                namespace
+            )
             raise ValueError(error_msg)
 
         valid, value = _validate_input_value(value, exp_space, namespace)
 
         if not valid:
-            error_msg = "Value {} is outside of dimension's prior interval".format(value)
+            error_msg = "Value {} is outside of dimension's prior interval".format(
+                value
+            )
             raise ValueError(error_msg)
 
         values[namespace] = value
@@ -123,11 +135,11 @@ def _build_from(cmd_args):
 def _build_from_config(config_path):
     converter = infer_converter_from_file_type(config_path)
     userconfig_tmpl = converter.parse(config_path)
-    userconfig_keyword = 'orion='
+    userconfig_keyword = "orion="
 
     transformed_args = {}
     stack = collections.deque()
-    stack.append(('', userconfig_tmpl))
+    stack.append(("", userconfig_tmpl))
     while True:
         try:
             namespace, stuff = stack.pop()
@@ -135,18 +147,20 @@ def _build_from_config(config_path):
             break
         if isinstance(stuff, dict):
             for k, v in stuff.items():
-                stack.append(('/'.join([namespace, str(k)]), v))
+                stack.append(("/".join([namespace, str(k)]), v))
         elif isinstance(stuff, list):
             for position, thing in enumerate(stuff):
-                stack.append(('/'.join([namespace, str(position)]), thing))
+                stack.append(("/".join([namespace, str(position)]), thing))
         elif isinstance(stuff, str):
             if stuff.startswith(userconfig_keyword):
                 if namespace in transformed_args:
-                    error_msg = "Conflict for name '{}' in script configuration "\
-                                "and arguments.".format(namespace)
+                    error_msg = (
+                        "Conflict for name '{}' in script configuration "
+                        "and arguments.".format(namespace)
+                    )
                     raise ValueError(error_msg)
 
-                transformed_args[namespace] = stuff[len(userconfig_keyword):]
+                transformed_args[namespace] = stuff[len(userconfig_keyword) :]
 
     return transformed_args
 
@@ -154,8 +168,8 @@ def _build_from_config(config_path):
 def _build_from_args(cmd_args):
     userconfig = None
     is_userconfig_an_option = None
-    userargs_search = r'\W*([a-zA-Z0-9_-]+)=([^ ]+)'
-    userargs_regex_tmpl = r'(.*)=(.*)'
+    userargs_search = r"\W*([a-zA-Z0-9_-]+)=([^ ]+)"
+    userargs_regex_tmpl = r"(.*)=(.*)"
     userconfig_option = "--config="
 
     transformed_args = {}
@@ -168,30 +182,31 @@ def _build_from_args(cmd_args):
         if len(found) != 1:
             if arg.startswith(userconfig_option):
                 if not userconfig:
-                    userconfig = arg[len(userconfig_option):]
+                    userconfig = arg[len(userconfig_option) :]
                     is_userconfig_an_option = True
                 else:
                     raise ValueError(
-                        "Already found one configuration file in: %s" %
-                        userconfig
-                        )
+                        "Already found one configuration file in: %s" % userconfig
+                    )
             else:
                 userargs_tmpl[None].append(arg)
             continue
 
         name, value = found[0]
-        namespace = '/' + name
+        namespace = "/" + name
 
         if namespace in transformed_args:
-            error_msg = "Conflict for name '{}' in script configuration "\
-                        "and arguments.".format(namespace)
+            error_msg = (
+                "Conflict for name '{}' in script configuration "
+                "and arguments.".format(namespace)
+            )
             raise ValueError(error_msg)
 
         transformed_args[namespace] = value
 
         found = args_prefix_pattern.findall(arg)
         assert len(found) == 1 and found[0][1] == value, "Parsing prefix problem."
-        userargs_tmpl[namespace] = found[0][0] + '='
+        userargs_tmpl[namespace] = found[0][0] + "="
 
     if not userconfig and userargs_tmpl[None]:  # try the first positional argument
         if os.path.isfile(userargs_tmpl[None][0]):

--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -15,7 +15,7 @@ from orion.core.utils.pptree import print_tree
 from orion.storage.base import get_storage
 
 log = logging.getLogger(__name__)
-SHORT_DESCRIPTION = 'Gives a list of experiments'
+SHORT_DESCRIPTION = "Gives a list of experiments"
 DESCRIPTION = """
 This command gives a list of your experiments in a easy-to-read tree-like structure.
 """
@@ -23,7 +23,9 @@ This command gives a list of your experiments in a easy-to-read tree-like struct
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    list_parser = parser.add_parser('list', help=SHORT_DESCRIPTION, description=DESCRIPTION)
+    list_parser = parser.add_parser(
+        "list", help=SHORT_DESCRIPTION, description=DESCRIPTION
+    )
 
     cli.get_basic_args_group(list_parser)
 
@@ -35,26 +37,30 @@ def add_subparser(parser):
 def main(args):
     """List all experiments inside database."""
     config = experiment_builder.get_cmd_config(args)
-    experiment_builder.setup_storage(config.get('storage'))
+    experiment_builder.setup_storage(config.get("storage"))
 
     query = {}
 
-    if args['name']:
-        query['name'] = args['name']
+    if args["name"]:
+        query["name"] = args["name"]
 
     experiments = get_storage().fetch_experiments(query)
 
-    if args['name']:
+    if args["name"]:
         root_experiments = experiments
     else:
-        root_experiments = [exp for exp in experiments
-                            if exp['refers'].get('root_id', exp['_id']) == exp['_id']]
+        root_experiments = [
+            exp
+            for exp in experiments
+            if exp["refers"].get("root_id", exp["_id"]) == exp["_id"]
+        ]
 
     if not root_experiments:
         print("No experiment found")
         return
 
     for root_experiment in root_experiments:
-        root = experiment_builder.build_view(name=root_experiment['name'],
-                                             version=root_experiment.get('version')).node
-        print_tree(root, nameattr='tree_name')
+        root = experiment_builder.build_view(
+            name=root_experiment["name"], version=root_experiment.get("version")
+        ).node
+        print_tree(root, nameattr="tree_name")

--- a/src/orion/core/cli/serve.py
+++ b/src/orion/core/cli/serve.py
@@ -24,11 +24,15 @@ DESCRIPTION = "Starts Oríon's REST API server"
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    serve_parser = parser.add_parser('serve', help=DESCRIPTION, description=DESCRIPTION)
+    serve_parser = parser.add_parser("serve", help=DESCRIPTION, description=DESCRIPTION)
 
-    serve_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
-                              metavar='path-to-config', help="user provided "
-                              "orion configuration file")
+    serve_parser.add_argument(
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided " "orion configuration file",
+    )
 
     serve_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/setup.py
+++ b/src/orion/core/cli/setup.py
@@ -15,12 +15,12 @@ from orion.core.cli.db.setup import main
 
 
 log = logging.getLogger(__name__)
-DESCRIPTION = '(DEPRECATED) Use command `orion db setup` instead'
+DESCRIPTION = "(DEPRECATED) Use command `orion db setup` instead"
 
 
 def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
-    setup_parser = parser.add_parser('setup', help=DESCRIPTION, description=DESCRIPTION)
+    setup_parser = parser.add_parser("setup", help=DESCRIPTION, description=DESCRIPTION)
 
     setup_parser.set_defaults(func=main)
 
@@ -30,7 +30,9 @@ def add_subparser(parser):
 # pylint: disable = unused-argument
 def wrap_main(args):
     """Build a configuration file."""
-    log.warning('Command `orion setup` is deprecated and will be removed in v0.2.0. Use '
-                '`orion db setup` instead.')
+    log.warning(
+        "Command `orion setup` is deprecated and will be removed in v0.2.0. Use "
+        "`orion db setup` instead."
+    )
 
     main(args)

--- a/src/orion/core/cli/status.py
+++ b/src/orion/core/cli/status.py
@@ -30,23 +30,37 @@ experiments by outlining every single trial, its status and its objective.
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    status_parser = parser.add_parser('status', help=SHORT_DESCRIPTION, description=DESCRIPTION)
+    status_parser = parser.add_parser(
+        "status", help=SHORT_DESCRIPTION, description=DESCRIPTION
+    )
 
     cli.get_basic_args_group(status_parser)
 
     status_parser.add_argument(
-        '-a', '--all', action="store_true",
-        help="Show all trials line by line. Otherwise, they are all aggregated by status")
+        "-a",
+        "--all",
+        action="store_true",
+        help="Show all trials line by line. Otherwise, they are all aggregated by status",
+    )
 
     status_parser.add_argument(
-        '-C', '--collapse', action="store_true",
-        help=("Aggregate together results of all child experiments. Otherwise they are all "
-              "printed hierarchically"))
+        "-C",
+        "--collapse",
+        action="store_true",
+        help=(
+            "Aggregate together results of all child experiments. Otherwise they are all "
+            "printed hierarchically"
+        ),
+    )
 
     status_parser.add_argument(
-        '-e', '--expand-versions', action='store_true',
-        help=("Show all the version of every experiments instead of only the latest one")
-        )
+        "-e",
+        "--expand-versions",
+        action="store_true",
+        help=(
+            "Show all the version of every experiments instead of only the latest one"
+        ),
+    )
 
     status_parser.set_defaults(func=main)
 
@@ -56,9 +70,9 @@ def add_subparser(parser):
 def main(args):
     """Fetch config and status experiments"""
     config = experiment_builder.get_cmd_config(args)
-    experiment_builder.setup_storage(config.get('storage'))
+    experiment_builder.setup_storage(config.get("storage"))
 
-    args['all_trials'] = args.pop('all', False)
+    args["all_trials"] = args.pop("all", False)
 
     experiments = get_experiments(args)
 
@@ -66,21 +80,29 @@ def main(args):
         print("No experiment found")
         return
 
-    if args.get('name'):
+    if args.get("name"):
         print_evc([experiments[0]], **args)
         return
 
-    if args.get('version'):
-        if args.get('collapse') or args.get('expand_versions'):
-            raise RuntimeError("Cannot fetch specific version of experiments with --collapse "
-                               "or --expand-versions.")
+    if args.get("version"):
+        if args.get("collapse") or args.get("expand_versions"):
+            raise RuntimeError(
+                "Cannot fetch specific version of experiments with --collapse "
+                "or --expand-versions."
+            )
 
     print_evc(experiments, **args)
 
 
 # pylint: disable=unused-argument
-def print_evc(experiments, version=None, all_trials=False, collapse=False,
-              expand_versions=False, **kwargs):
+def print_evc(
+    experiments,
+    version=None,
+    all_trials=False,
+    collapse=False,
+    expand_versions=False,
+    **kwargs
+):
     """Print each EVC tree
 
     Parameters
@@ -111,19 +133,24 @@ def get_experiments(args):
         Commandline arguments.
 
     """
-    projection = {'name': 1, 'version': 1, 'refers': 1}
+    projection = {"name": 1, "version": 1, "refers": 1}
 
-    query = {'name': args['name']} if args.get('name') else {}
+    query = {"name": args["name"]} if args.get("name") else {}
     experiments = get_storage().fetch_experiments(query, projection)
 
-    if args['name']:
+    if args["name"]:
         root_experiments = experiments
     else:
-        root_experiments = [exp for exp in experiments
-                            if exp['refers'].get('root_id', exp['_id']) == exp['_id']]
+        root_experiments = [
+            exp
+            for exp in experiments
+            if exp["refers"].get("root_id", exp["_id"]) == exp["_id"]
+        ]
 
-    return [experiment_builder.build_view(name=exp['name'], version=exp.get('version', 1))
-            for exp in root_experiments]
+    return [
+        experiment_builder.build_view(name=exp["name"], version=exp.get("version", 1))
+        for exp in root_experiments
+    ]
 
 
 def _has_named_children(exp):
@@ -188,15 +215,17 @@ def print_summary(trials, offset=0):
     for trial in trials:
         status_dict[trial.status].append(trial)
 
-    headers = ['status', 'quantity']
+    headers = ["status", "quantity"]
 
     lines = []
     for status, c_trials in sorted(status_dict.items()):
         line = [status, len(c_trials)]
 
         if c_trials[0].objective:
-            headers.append('min {}'.format(c_trials[0].objective.name))
-            line.append(min(trial.objective.value for trial in c_trials if trial.objective))
+            headers.append("min {}".format(c_trials[0].objective.name))
+            line.append(
+                min(trial.objective.value for trial in c_trials if trial.objective)
+            )
 
         lines.append(line)
 
@@ -205,7 +234,7 @@ def print_summary(trials, offset=0):
         tab = " " * offset
         print(tab + ("\n" + tab).join(grid.split("\n")))
     else:
-        print(" " * offset, 'empty', sep="")
+        print(" " * offset, "empty", sep="")
 
     print("\n")
 
@@ -221,20 +250,20 @@ def print_all_trials(trials, offset=0):
         The number of tabs to the right this experiment is.
 
     """
-    headers = ['id', 'status', 'best objective']
+    headers = ["id", "status", "best objective"]
     lines = []
 
     for trial in sorted(trials, key=lambda t: t.status):
         line = [trial.id, trial.status]
 
         if trial.objective:
-            headers[-1] = 'min {}'.format(trial.objective.name)
+            headers[-1] = "min {}".format(trial.objective.name)
             line.append(trial.objective.value)
 
         lines.append(line)
 
     if not trials:
-        lines.append(['empty', '', ''])
+        lines.append(["empty", "", ""])
 
     grid = tabulate.tabulate(lines, headers=headers)
     tab = " " * offset

--- a/src/orion/core/cli/test_db.py
+++ b/src/orion/core/cli/test_db.py
@@ -16,16 +16,22 @@ from orion.core.cli.db.test import main
 
 
 log = logging.getLogger(__name__)
-DESCRIPTION = '(DEPRECATED) Use command `orion db test` instead'
+DESCRIPTION = "(DEPRECATED) Use command `orion db test` instead"
 
 
 def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
-    test_db_parser = parser.add_parser('test-db', help=DESCRIPTION, description=DESCRIPTION)
+    test_db_parser = parser.add_parser(
+        "test-db", help=DESCRIPTION, description=DESCRIPTION
+    )
 
-    test_db_parser.add_argument('-c', '--config', type=argparse.FileType('r'),
-                                metavar='path-to-config', help="user provided "
-                                "orion configuration file")
+    test_db_parser.add_argument(
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
+        help="user provided " "orion configuration file",
+    )
 
     test_db_parser.set_defaults(func=wrap_main)
 
@@ -34,7 +40,9 @@ def add_subparser(parser):
 
 def wrap_main(args):
     """Run through all checks for database."""
-    log.warning('Command `orion test-db` is deprecated and will be removed in v0.2.0. Use '
-                '`orion db test` instead.')
+    log.warning(
+        "Command `orion test-db` is deprecated and will be removed in v0.2.0. Use "
+        "`orion db test` instead."
+    )
 
     main(args)

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -34,7 +34,7 @@ Adapters can be build using the factory class `Adapter(**kwargs)` or using
 `Adapter.build(list_of_dicts)`.
 
 """
-from abc import (ABCMeta, abstractmethod)
+from abc import ABCMeta, abstractmethod
 import copy
 
 from orion.core.io.space_builder import DimensionBuilder
@@ -133,10 +133,15 @@ class CompositeAdapter(BaseAdapter):
 
         """
         if any(not isinstance(adapter, BaseAdapter) for adapter in adapters):
-            wrong_object_type = [type(adapter) for adapter in adapters
-                                 if not isinstance(adapter, BaseAdapter)][0]
-            raise TypeError("Provided adapters must be adapter objects, not '%s'" %
-                            str(wrong_object_type))
+            wrong_object_type = [
+                type(adapter)
+                for adapter in adapters
+                if not isinstance(adapter, BaseAdapter)
+            ][0]
+            raise TypeError(
+                "Provided adapters must be adapter objects, not '%s'"
+                % str(wrong_object_type)
+            )
 
         self.adapters = adapters
 
@@ -183,10 +188,12 @@ class CompositeAdapter(BaseAdapter):
             :meth:`orion.core.evc.BaseAdapter.configuration`
         """
         if len(self.adapters) > 1:
-            return [adapter.configuration
-                    if len(adapter.configuration) > 1
-                    else adapter.configuration[0]
-                    for adapter in self.adapters]
+            return [
+                adapter.configuration
+                if len(adapter.configuration) > 1
+                else adapter.configuration[0]
+                for adapter in self.adapters
+            ]
         elif self.adapters:
             return self.adapters[0].configuration
 
@@ -222,9 +229,10 @@ def apply_if_valid(name, trial, callback=None, raise_if_not=True):
             return callback is None or callback(trial, param)
 
     if raise_if_not:
-        raise RuntimeError("Provided trial does not have a compatible configuration. "
-                           "A dimension named '%s' should be present.\n %s" %
-                           (name, trial))
+        raise RuntimeError(
+            "Provided trial does not have a compatible configuration. "
+            "A dimension named '%s' should be present.\n %s" % (name, trial)
+        )
 
     return False
 
@@ -259,10 +267,11 @@ class DimensionAddition(BaseAdapter):
         if isinstance(param, dict):
             param = Trial.Param(**param)
         elif not isinstance(param, Trial.Param):
-            raise TypeError("Invalid param argument type ('%s'). "
-                            "Param argument must be a Param object or a dictionnary "
-                            "as defined by Trial.Param.to_dict()." %
-                            str(type(param)))
+            raise TypeError(
+                "Invalid param argument type ('%s'). "
+                "Param argument must be a Param object or a dictionnary "
+                "as defined by Trial.Param.to_dict()." % str(type(param))
+            )
 
         self.param = param
 
@@ -277,9 +286,11 @@ class DimensionAddition(BaseAdapter):
 
         for trial in trials:
             if apply_if_valid(self.param.name, trial, raise_if_not=False):
-                raise RuntimeError("Provided trial does not have a compatible configuration. "
-                                   "A dimension named '%s' was already present.\n %s" %
-                                   (self.param.name, trial))
+                raise RuntimeError(
+                    "Provided trial does not have a compatible configuration. "
+                    "A dimension named '%s' was already present.\n %s"
+                    % (self.param.name, trial)
+                )
 
             adapted_trial = copy.deepcopy(trial)
             # pylint: disable=protected-access
@@ -320,9 +331,7 @@ class DimensionAddition(BaseAdapter):
 
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
-        ret = dict(
-            of_type=self.__class__.__name__.lower(),
-            param=self.param.to_dict())
+        ret = dict(of_type=self.__class__.__name__.lower(), param=self.param.to_dict())
         return ret
 
 
@@ -393,7 +402,7 @@ class DimensionDeletion(BaseAdapter):
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
         ret = self.dimension_addition_adapter.to_dict()
-        ret['of_type'] = 'dimensiondeletion'
+        ret["of_type"] = "dimensiondeletion"
         return ret
 
 
@@ -434,12 +443,13 @@ class DimensionPriorChange(BaseAdapter):
         self.name = name
         self.old_prior = old_prior
         self.new_prior = new_prior
-        self.old_dimension = DimensionBuilder().build('old', old_prior)
-        self.new_dimension = DimensionBuilder().build('new', new_prior)
+        self.old_dimension = DimensionBuilder().build("old", old_prior)
+        self.new_dimension = DimensionBuilder().build("new", new_prior)
 
         if self.old_dimension.shape != self.new_dimension.shape:
-            raise NotImplementedError("Oríon does not support yet adaptations on prior "
-                                      "shape changes.")
+            raise NotImplementedError(
+                "Oríon does not support yet adaptations on prior " "shape changes."
+            )
 
     def forward(self, trials):
         """Filter out trials which have out of bound values based on the child's prior.
@@ -453,7 +463,11 @@ class DimensionPriorChange(BaseAdapter):
             """Test if param's value is in the new prior's bounds"""
             return param.value in self.new_dimension
 
-        return [trial for trial in trials if apply_if_valid(self.name, trial, callback=is_in_bound)]
+        return [
+            trial
+            for trial in trials
+            if apply_if_valid(self.name, trial, callback=is_in_bound)
+        ]
 
     def backward(self, trials):
         """Filter out trials which have out of bound values based on the parent's prior.
@@ -462,7 +476,9 @@ class DimensionPriorChange(BaseAdapter):
 
             :meth:`orion.core.evc.BaseAdapter.backward`
         """
-        return DimensionPriorChange(self.name, self.new_prior, self.old_prior).forward(trials)
+        return DimensionPriorChange(self.name, self.new_prior, self.old_prior).forward(
+            trials
+        )
 
     def to_dict(self):
         """Provide the configuration of the adapter as a dictionary
@@ -475,7 +491,8 @@ class DimensionPriorChange(BaseAdapter):
             of_type=self.__class__.__name__.lower(),
             name=self.name,
             old_prior=self.old_prior,
-            new_prior=self.new_prior)
+            new_prior=self.new_prior,
+        )
         return ret
 
 
@@ -506,10 +523,13 @@ class DimensionRenaming(BaseAdapter):
 
         """
         if any(not isinstance(name, str) for name in [old_name, new_name]):
-            wrong_object_type = [type(name) for name in [old_name, new_name]
-                                 if not isinstance(name, str)][0]
-            raise TypeError("Invalid name type '%s'. Names must be strings." %
-                            str(wrong_object_type))
+            wrong_object_type = [
+                type(name) for name in [old_name, new_name] if not isinstance(name, str)
+            ][0]
+            raise TypeError(
+                "Invalid name type '%s'. Names must be strings."
+                % str(wrong_object_type)
+            )
         self.old_name = old_name
         self.new_name = new_name
 
@@ -552,7 +572,8 @@ class DimensionRenaming(BaseAdapter):
         ret = dict(
             of_type=self.__class__.__name__.lower(),
             old_name=self.old_name,
-            new_name=self.new_name)
+            new_name=self.new_name,
+        )
         return ret
 
 
@@ -590,8 +611,7 @@ class AlgorithmChange(BaseAdapter):
 
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
-        ret = dict(
-            of_type=self.__class__.__name__.lower())
+        ret = dict(of_type=self.__class__.__name__.lower())
         return ret
 
 
@@ -636,8 +656,10 @@ class CodeChange(BaseAdapter):
     def validate(cls, change_type):
         """Validate change type and raise ValueError if invalid"""
         if change_type not in cls.types:
-            raise ValueError("Invalid code change type '%s'. Should be one of %s" %
-                             (change_type, str(cls.types)))
+            raise ValueError(
+                "Invalid code change type '%s'. Should be one of %s"
+                % (change_type, str(cls.types))
+            )
 
     def forward(self, trials):
         """Filter out parent's trials if type of code change is BREAK.
@@ -671,8 +693,8 @@ class CodeChange(BaseAdapter):
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
         ret = dict(
-            of_type=self.__class__.__name__.lower(),
-            change_type=self.change_type)
+            of_type=self.__class__.__name__.lower(), change_type=self.change_type
+        )
         return ret
 
 
@@ -717,8 +739,10 @@ class CommandLineChange(BaseAdapter):
     def validate(cls, change_type):
         """Validate change type and raise ValueError if invalid"""
         if change_type not in cls.types:
-            raise ValueError("Invalid cli change type '%s'. Should be one of %s" %
-                             (change_type, str(cls.types)))
+            raise ValueError(
+                "Invalid cli change type '%s'. Should be one of %s"
+                % (change_type, str(cls.types))
+            )
 
     def forward(self, trials):
         """Filter out parent's trials if type of cli change is BREAK.
@@ -752,8 +776,8 @@ class CommandLineChange(BaseAdapter):
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
         ret = dict(
-            of_type=self.__class__.__name__.lower(),
-            change_type=self.change_type)
+            of_type=self.__class__.__name__.lower(), change_type=self.change_type
+        )
         return ret
 
 
@@ -798,8 +822,10 @@ class ScriptConfigChange(BaseAdapter):
     def validate(cls, change_type):
         """Validate change type and raise ValueError if invalid"""
         if change_type not in cls.types:
-            raise ValueError("Invalid script's config change type '%s'. Should be one of %s" %
-                             (change_type, str(cls.types)))
+            raise ValueError(
+                "Invalid script's config change type '%s'. Should be one of %s"
+                % (change_type, str(cls.types))
+            )
 
     def forward(self, trials):
         """Filter out parent's trials if type of script's config change is BREAK.
@@ -833,8 +859,8 @@ class ScriptConfigChange(BaseAdapter):
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
         ret = dict(
-            of_type=self.__class__.__name__.lower(),
-            change_type=self.change_type)
+            of_type=self.__class__.__name__.lower(), change_type=self.change_type
+        )
         return ret
 
 

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1736,7 +1736,7 @@ class ExperimentNameConflict(Conflict):
             elif self._check_for_greater_versions():
                 raise ValueError(
                     f"Experiment name '{self.new_name}' already exist for version "
-                    "'{self.conflict.version}' and has children. Version cannot be "
+                    f"'{self.conflict.version}' and has children. Version cannot be "
                     "auto-incremented and a new name is required for branching."
                 )
             else:

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -50,7 +50,7 @@ created by resolutions. For instance, a `RenameDimensionResolution` may create a
 of the old name.
 """
 
-from abc import (ABCMeta, abstractmethod)
+from abc import ABCMeta, abstractmethod
 import copy
 import pprint
 import traceback
@@ -74,24 +74,26 @@ def _build_extended_user_args(config):
     """Return a list of user arguments augmented with key-value pairs found in
     user's script's configuration file.
     """
-    if 'user_args' not in config['metadata']:
+    if "user_args" not in config["metadata"]:
         return []
 
-    user_args = config['metadata']['user_args']
+    user_args = config["metadata"]["user_args"]
 
     # No need to pass config_prefix because we have access to everything
     # required in config[metadata][parser] (parsed data)
     parser = OrionCmdlineParser()
-    parser.set_state_dict(config['metadata']['parser'])
+    parser.set_state_dict(config["metadata"]["parser"])
 
-    return user_args + [standard_param_name(key) + value
-                        for key, value in parser.config_file_data.items()]
+    return user_args + [
+        standard_param_name(key) + value
+        for key, value in parser.config_file_data.items()
+    ]
 
 
 def _build_space(config):
     """Build an optimization space based on given configuration"""
     space_builder = SpaceBuilder()
-    space_config = config['space']
+    space_config = config["space"]
     space = space_builder.build(space_config)
 
     return space
@@ -100,7 +102,9 @@ def _build_space(config):
 def detect_conflicts(old_config, new_config, branching=None):
     """Generate a Conflicts object with all conflicts found in pair (old_config, new_config)"""
     conflicts = Conflicts()
-    for conflict_class in sorted(Conflict.__subclasses__(), key=lambda cls: cls.__name__):
+    for conflict_class in sorted(
+        Conflict.__subclasses__(), key=lambda cls: cls.__name__
+    ):
         for conflict in conflict_class.detect(old_config, new_config, branching):
             conflicts.register(conflict)
 
@@ -140,8 +144,11 @@ class Conflicts(object):
 
     def _get(self, callback=None):
         """Fetch conflicts for which callback return True if callback is given, else return all"""
-        return [conflict for conflict in self.conflicts
-                if (callback is None or callback(conflict))]
+        return [
+            conflict
+            for conflict in self.conflicts
+            if (callback is None or callback(conflict))
+        ]
 
     def get(self, types=(), dimension_name=None, callback=None):
         """Fetch conflicts
@@ -162,25 +169,31 @@ class Conflicts(object):
             If argument dimension_name is not None and no conflict is found.
 
         """
+
         def wrap(types, dimension_name, callback):
             """Wrap types, dimension_name and callback inside another callback"""
+
             def _callback(conflict):
                 if callback is not None and not callback(conflict):
                     return False
                 if types and not isinstance(conflict, tuple(types)):
                     return False
-                if (dimension_name is not None and
-                        (not hasattr(conflict, "dimension") or
-                         standard_param_name(conflict.dimension.name) != dimension_name)):
+                if dimension_name is not None and (
+                    not hasattr(conflict, "dimension")
+                    or standard_param_name(conflict.dimension.name) != dimension_name
+                ):
                     return False
 
                 return True
+
             return _callback
 
         found_conflicts = self._get(wrap(types, dimension_name, callback))
 
         if dimension_name is not None and not found_conflicts:
-            raise ValueError("Dimension name \'{}\' not found in conflicts".format(dimension_name))
+            raise ValueError(
+                "Dimension name '{}' not found in conflicts".format(dimension_name)
+            )
 
         return found_conflicts
 
@@ -192,8 +205,10 @@ class Conflicts(object):
             See :meth:`orion.core.evc.conflict.Conflicts.get` for more information.
 
         """
+
         def _is_not_resolved(conflict):
             return not conflict.is_resolved and (callback is None or callback(conflict))
+
         return self.get(types, dimension_name, callback=_is_not_resolved)
 
     def get_resolved(self, types=(), dimension_name=None, callback=None):
@@ -204,8 +219,10 @@ class Conflicts(object):
             See :meth:`orion.core.evc.conflict.Conflicts.get` for more information.
 
         """
+
         def _is_resolved(conflict):
             return conflict.is_resolved and (callback is None or callback(conflict))
+
         return self.get(types, dimension_name, callback=_is_resolved)
 
     def get_resolutions(self, types=(), dimension_name=None, callback=None):
@@ -626,11 +643,14 @@ class NewDimensionConflict(Conflict):
 
         def _validate(self, default_value):
             """Validate default value is NO_DEFAULT_VALUE or is in dimension's interval"""
-            if ((default_value is not Dimension.NO_DEFAULT_VALUE) and
-                    (default_value not in self.conflict.dimension)):
+            if (default_value is not Dimension.NO_DEFAULT_VALUE) and (
+                default_value not in self.conflict.dimension
+            ):
                 raise ValueError(
                     "Default value `{}` is outside of dimension's prior interval `{}`".format(
-                        default_value, self.conflict.prior))
+                        default_value, self.conflict.prior
+                    )
+                )
 
         def get_adapters(self):
             """Return DimensionAddition adapter"""
@@ -640,21 +660,23 @@ class NewDimensionConflict(Conflict):
         @property
         def prefix(self):
             """Build the prefix including the marker"""
-            return '{0}{1}'.format(standard_param_name(self.conflict.dimension.name),
-                                   self.MARKER)
+            return "{0}{1}".format(
+                standard_param_name(self.conflict.dimension.name), self.MARKER
+            )
 
         @property
         def new_prior(self):
             """Build the new prior string, including the default value"""
             tmp_dim = copy.deepcopy(self.conflict.dimension)
-            tmp_dim._default_value = self.default_value  # pylint:disable=protected-access
+            # pylint:disable=protected-access
+            tmp_dim._default_value = self.default_value
             return tmp_dim.get_prior_string()
 
         def __repr__(self):
             """Representation of the resolution as it should be provided in command line of
             configuration file by the user
             """
-            return '{0}{1}'.format(self.prefix, self.new_prior)
+            return "{0}{1}".format(self.prefix, self.new_prior)
 
 
 class ChangedDimensionConflict(Conflict):
@@ -704,8 +726,9 @@ class ChangedDimensionConflict(Conflict):
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
-        return "{0}~{1} != {0}~{2}".format(standard_param_name(self.dimension.name),
-                                           self.old_prior, self.new_prior)
+        return "{0}~{1} != {0}~{2}".format(
+            standard_param_name(self.dimension.name), self.old_prior, self.new_prior
+        )
 
     class ChangeDimensionResolution(Resolution):
         """Representation of a changed prior resolution
@@ -720,14 +743,20 @@ class ChangedDimensionConflict(Conflict):
 
         def get_adapters(self):
             """Return DimensionPriorChange adapter"""
-            return [adapters.DimensionPriorChange(
-                self.conflict.dimension.name, self.conflict.old_prior, self.conflict.new_prior)]
+            return [
+                adapters.DimensionPriorChange(
+                    self.conflict.dimension.name,
+                    self.conflict.old_prior,
+                    self.conflict.new_prior,
+                )
+            ]
 
         @property
         def prefix(self):
             """Build the new prior string, including the default value"""
-            return '{0}{1}'.format(standard_param_name(self.conflict.dimension.name),
-                                   self.MARKER)
+            return "{0}{1}".format(
+                standard_param_name(self.conflict.dimension.name), self.MARKER
+            )
 
         def __repr__(self):
             """Representation of the resolution as it should be provided in command line of
@@ -801,14 +830,15 @@ class MissingDimensionConflict(Conflict):
         arguments = remove_dimension_resolution.find_marked_argument()
         if arguments:
             new_default_value = arguments.split(
-                MissingDimensionConflict.RemoveDimensionResolution.MARKER)[1]
+                MissingDimensionConflict.RemoveDimensionResolution.MARKER
+            )[1]
 
             if not new_default_value:
                 new_default_value = Dimension.NO_DEFAULT_VALUE
             else:
                 new_default_value = self.dimension.cast(new_default_value)
 
-            return {'default_value': new_default_value}
+            return {"default_value": new_default_value}
         return {}
 
     def get_marked_rename_arguments(self, conflicts):
@@ -824,7 +854,8 @@ class MissingDimensionConflict(Conflict):
             return {}
 
         resolution = copy.deepcopy(self).try_resolve(
-            new_dimension_conflict=copy.deepcopy(new_dimension_conflicts[0]))
+            new_dimension_conflict=copy.deepcopy(new_dimension_conflicts[0])
+        )
 
         if not resolution:
             return {}
@@ -832,13 +863,16 @@ class MissingDimensionConflict(Conflict):
         arguments = resolution.find_marked_argument()
 
         if arguments:
-            new_dimension_name = "~>".join(arguments.split('~>')[1:])
+            new_dimension_name = "~>".join(arguments.split("~>")[1:])
 
             try:
-                conflict = conflicts.get([NewDimensionConflict],
-                                         dimension_name=new_dimension_name)[0]
+                conflict = conflicts.get(
+                    [NewDimensionConflict], dimension_name=new_dimension_name
+                )[0]
             except ValueError as e:
-                if "Dimension name '{}' not found".format(new_dimension_name) not in str(e):
+                if "Dimension name '{}' not found".format(
+                    new_dimension_name
+                ) not in str(e):
                     return {}
 
                 raise
@@ -846,11 +880,13 @@ class MissingDimensionConflict(Conflict):
             if conflict.is_resolved:
                 conflicts.revert(str(conflict.resolution))
 
-            return {'new_dimension_conflict': conflict}
+            return {"new_dimension_conflict": conflict}
 
         return {}
 
-    def try_resolve(self, new_dimension_conflict=None, default_value=Dimension.NO_DEFAULT_VALUE):
+    def try_resolve(
+        self, new_dimension_conflict=None, default_value=Dimension.NO_DEFAULT_VALUE
+    ):
         """Try to create a resolution RenameDimensionResolution of RemoveDimensionResolution
 
         Parameters
@@ -873,7 +909,9 @@ class MissingDimensionConflict(Conflict):
             return None
 
         if new_dimension_conflict:
-            return MissingDimensionConflict.RenameDimensionResolution(self, new_dimension_conflict)
+            return MissingDimensionConflict.RenameDimensionResolution(
+                self, new_dimension_conflict
+            )
 
         return MissingDimensionConflict.RemoveDimensionResolution(self, default_value)
 
@@ -916,7 +954,9 @@ class MissingDimensionConflict(Conflict):
                 Dimension used for a rename resolution.
 
             """
-            super(MissingDimensionConflict.RenameDimensionResolution, self).__init__(conflict)
+            super(MissingDimensionConflict.RenameDimensionResolution, self).__init__(
+                conflict
+            )
 
             self.new_dimension_conflict = new_dimension_conflict
             new_dimension_conflict.resolution = self
@@ -925,8 +965,10 @@ class MissingDimensionConflict(Conflict):
                 changed_dimension_conflict = ChangedDimensionConflict(
                     self.conflict.old_config,
                     self.conflict.new_config,
-                    new_dimension_conflict.dimension, self.conflict.prior,
-                    new_dimension_conflict.prior)
+                    new_dimension_conflict.dimension,
+                    self.conflict.prior,
+                    new_dimension_conflict.prior,
+                )
 
                 self.new_conflicts.append(changed_dimension_conflict)
 
@@ -939,7 +981,8 @@ class MissingDimensionConflict(Conflict):
 
             deprecated_conflicts = self.new_conflicts
             if deprecated_conflicts:
-                deprecated_conflicts[0]._is_resolved = True  # pylint:disable=protected-access
+                # pylint:disable=protected-access
+                deprecated_conflicts[0]._is_resolved = True
 
             self.new_conflicts = []
 
@@ -947,22 +990,28 @@ class MissingDimensionConflict(Conflict):
 
         def get_adapters(self):
             """Return DimensionRenaming adapter"""
-            return [adapters.DimensionRenaming(
-                self.conflict.dimension.name, self.new_dimension_conflict.dimension.name)]
+            return [
+                adapters.DimensionRenaming(
+                    self.conflict.dimension.name,
+                    self.new_dimension_conflict.dimension.name,
+                )
+            ]
 
         @property
         def prefix(self):
             """Build the new prior string, including the default value"""
             return "{0}{1}".format(
-                standard_param_name(self.conflict.dimension.name),
-                self.MARKER)
+                standard_param_name(self.conflict.dimension.name), self.MARKER
+            )
 
         def __repr__(self):
             """Representation of the resolution as it should be provided in command line of
             configuration file by the user
             """
             return "{0}{1}".format(
-                self.prefix, standard_param_name(self.new_dimension_conflict.dimension.name))
+                self.prefix,
+                standard_param_name(self.new_dimension_conflict.dimension.name),
+            )
 
     class RemoveDimensionResolution(Resolution):
         """Representation of a remove dimension resolution
@@ -998,7 +1047,9 @@ class MissingDimensionConflict(Conflict):
                 If default_value is invalid for the corresponding dimension.
 
             """
-            super(MissingDimensionConflict.RemoveDimensionResolution, self).__init__(conflict)
+            super(MissingDimensionConflict.RemoveDimensionResolution, self).__init__(
+                conflict
+            )
             if default_value is Dimension.NO_DEFAULT_VALUE:
                 default_value = conflict.dimension.default_value
             else:
@@ -1009,11 +1060,14 @@ class MissingDimensionConflict(Conflict):
 
         def _validate(self, default_value):
             """Validate default value is NO_DEFAULT_VALUE or is in dimension's interval"""
-            if ((default_value is not Dimension.NO_DEFAULT_VALUE) and
-                    (default_value not in self.conflict.dimension)):
+            if (default_value is not Dimension.NO_DEFAULT_VALUE) and (
+                default_value not in self.conflict.dimension
+            ):
                 raise ValueError(
                     "Default value `{}` is outside of dimension's prior interval `{}`".format(
-                        default_value, self.conflict.prior))
+                        default_value, self.conflict.prior
+                    )
+                )
 
         def get_adapters(self):
             """Return DimensionDeletion adapter"""
@@ -1023,8 +1077,9 @@ class MissingDimensionConflict(Conflict):
         @property
         def prefix(self):
             """Build the new prior string, including the default value"""
-            return '{0}{1}'.format(standard_param_name(self.conflict.dimension.name),
-                                   self.MARKER)
+            return "{0}{1}".format(
+                standard_param_name(self.conflict.dimension.name), self.MARKER
+            )
 
         def __repr__(self):
             """Representation of the resolution as it should be provided in command line of
@@ -1050,7 +1105,7 @@ class AlgorithmConflict(Conflict):
         """Detect if algorithm definition in `new_config` differs from `old_config`
         :param branching_config:
         """
-        if old_config['algorithms'] != new_config['algorithms']:
+        if old_config["algorithms"] != new_config["algorithms"]:
             yield cls(old_config, new_config)
 
     def try_resolve(self):
@@ -1064,15 +1119,17 @@ class AlgorithmConflict(Conflict):
     def diff(self):
         """Produce human-readable differences"""
         return colored_diff(
-            pprint.pformat(self.old_config['algorithms']),
-            pprint.pformat(self.new_config['algorithms']))
+            pprint.pformat(self.old_config["algorithms"]),
+            pprint.pformat(self.new_config["algorithms"]),
+        )
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
         # TODO: select different subset rather than printing the old dict
         return "{0}\n   !=\n{1}".format(
-            pprint.pformat(self.old_config['algorithms']),
-            pprint.pformat(self.new_config['algorithms']))
+            pprint.pformat(self.old_config["algorithms"]),
+            pprint.pformat(self.new_config["algorithms"]),
+        )
 
     class AlgorithmResolution(Resolution):
         """Representation of an algorithn configuration resolution
@@ -1110,15 +1167,22 @@ class CodeConflict(Conflict):
         """Detect if commit hash in `new_config` differs from `old_config`
         :param branching_config:
         """
-        old_hash_commit = old_config['metadata'].get('VCS', None)
-        new_hash_commit = new_config['metadata'].get('VCS')
+        old_hash_commit = old_config["metadata"].get("VCS", None)
+        new_hash_commit = new_config["metadata"].get("VCS")
 
-        ignore_code_changes = branching_config is not None and \
-            branching_config.get('ignore_code_changes', False)
-        if not ignore_code_changes and new_hash_commit and old_hash_commit != new_hash_commit:
+        ignore_code_changes = branching_config is not None and branching_config.get(
+            "ignore_code_changes", False
+        )
+        if (
+            not ignore_code_changes
+            and new_hash_commit
+            and old_hash_commit != new_hash_commit
+        ):
             yield cls(old_config, new_config)
 
-    def get_marked_arguments(self, conflicts, code_change_type=None, **branching_kwargs):
+    def get_marked_arguments(
+        self, conflicts, code_change_type=None, **branching_kwargs
+    ):
         """Find and return marked arguments for code change conflict
 
         .. seealso::
@@ -1159,14 +1223,18 @@ class CodeConflict(Conflict):
     def diff(self):
         """Produce human-readable differences"""
         return colored_diff(
-            self.old_config['metadata'].get('VCS', None),
-            self.new_config['metadata'].get('VCS'))
+            self.old_config["metadata"].get("VCS", None),
+            self.new_config["metadata"].get("VCS"),
+        )
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
         return "Old hash commit '{0}'  != new hash commit '{1}'".format(
-            pprint.pformat(self.old_config['metadata'].get('VCS', None)).replace("\n", ""),
-            pprint.pformat(self.new_config['metadata'].get('VCS')).replace("\n", ""))
+            pprint.pformat(self.old_config["metadata"].get("VCS", None)).replace(
+                "\n", ""
+            ),
+            pprint.pformat(self.new_config["metadata"].get("VCS")).replace("\n", ""),
+        )
 
     class CodeResolution(Resolution):
         """Representation of an code change resolution
@@ -1233,11 +1301,12 @@ class CommandLineConflict(Conflict):
 
     # pylint: disable=unused-argument
     @classmethod
-    def get_nameless_args(cls, config, user_script_config=None,
-                          non_monitored_arguments=None, **kwargs):
+    def get_nameless_args(
+        cls, config, user_script_config=None, non_monitored_arguments=None, **kwargs
+    ):
         """Get user's commandline arguments which are not dimension definitions"""
         # Used python API
-        if 'parser' not in config['metadata']:
+        if "parser" not in config["metadata"]:
             return ""
 
         if user_script_config is None:
@@ -1246,15 +1315,20 @@ class CommandLineConflict(Conflict):
             non_monitored_arguments = orion.core.config.evc.non_monitored_arguments
 
         parser = OrionCmdlineParser(user_script_config)
-        parser.set_state_dict(config['metadata']['parser'])
+        parser.set_state_dict(config["metadata"]["parser"])
         priors = parser.priors_to_normal()
         nameless_keys = set(parser.parser.arguments.keys()) - set(priors.keys())
 
-        nameless_args = {key: arg for key, arg in parser.parser.arguments.items()
-                         if key in nameless_keys and key not in non_monitored_arguments}
+        nameless_args = {
+            key: arg
+            for key, arg in parser.parser.arguments.items()
+            if key in nameless_keys and key not in non_monitored_arguments
+        }
 
-        return " ".join(" ".join([key, str(arg)]) for key, arg in
-                        sorted(nameless_args.items(), key=lambda a: a[0]))
+        return " ".join(
+            " ".join([key, str(arg)])
+            for key, arg in sorted(nameless_args.items(), key=lambda a: a[0])
+        )
 
     @classmethod
     def detect(cls, old_config, new_config, branching_config=None):
@@ -1309,14 +1383,17 @@ class CommandLineConflict(Conflict):
     @property
     def diff(self):
         """Produce human-readable differences"""
-        return colored_diff(self.get_nameless_args(self.old_config),
-                            self.get_nameless_args(self.new_config))
+        return colored_diff(
+            self.get_nameless_args(self.old_config),
+            self.get_nameless_args(self.new_config),
+        )
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
-        return "Old arguments \'{0}\' != new arguments \'{1}\'".format(
+        return "Old arguments '{0}' != new arguments '{1}'".format(
             self.get_nameless_args(self.old_config),
-            self.get_nameless_args(self.new_config))
+            self.get_nameless_args(self.new_config),
+        )
 
     class CommandLineResolution(Resolution):
         """Representation of an commandline change resolution
@@ -1386,18 +1463,20 @@ class ScriptConfigConflict(Conflict):
     def get_nameless_config(cls, config, user_script_config=None, **branching_kwargs):
         """Get configuration dict of user's script without dimension definitions"""
         # Used python API
-        if 'parser' not in config['metadata']:
+        if "parser" not in config["metadata"]:
             return ""
 
         if user_script_config is None:
             user_script_config = orion.core.config.worker.user_script_config
 
         parser = OrionCmdlineParser(user_script_config)
-        parser.set_state_dict(config['metadata']['parser'])
+        parser.set_state_dict(config["metadata"]["parser"])
 
-        nameless_config = dict((key, value)
-                               for (key, value) in parser.config_file_data.items()
-                               if not (isinstance(value, str) and value.startswith('orion~')))
+        nameless_config = dict(
+            (key, value)
+            for (key, value) in parser.config_file_data.items()
+            if not (isinstance(value, str) and value.startswith("orion~"))
+        )
 
         return nameless_config
 
@@ -1415,7 +1494,9 @@ class ScriptConfigConflict(Conflict):
         if old_script_config != new_script_config:
             yield cls(old_config, new_config)
 
-    def get_marked_arguments(self, conflicts, config_change_type=None, **branching_kwargs):
+    def get_marked_arguments(
+        self, conflicts, config_change_type=None, **branching_kwargs
+    ):
         """Find and return marked arguments for user's script's config change conflict
 
         .. seealso::
@@ -1457,7 +1538,8 @@ class ScriptConfigConflict(Conflict):
         """Produce human-readable differences"""
         return colored_diff(
             pprint.pformat(self.get_nameless_config(self.old_config)),
-            pprint.pformat(self.get_nameless_config(self.new_config)))
+            pprint.pformat(self.get_nameless_config(self.new_config)),
+        )
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
@@ -1553,7 +1635,7 @@ class ExperimentNameConflict(Conflict):
     @property
     def version(self):
         """Retrieve version of configuration"""
-        return self.old_config['version']
+        return self.old_config["version"]
 
     def try_resolve(self, new_name=None):
         """Try to create a resolution ExperimentNameResolution
@@ -1582,8 +1664,9 @@ class ExperimentNameConflict(Conflict):
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
-        return "Experiment name \'{0}\' already exist with version \'{1}\'".format(
-            self.old_config['name'], self.version)
+        return "Experiment name '{0}' already exist with version '{1}'".format(
+            self.old_config["name"], self.version
+        )
 
     class ExperimentNameResolution(Resolution):
         """Representation of an experiment name resolution
@@ -1620,15 +1703,17 @@ class ExperimentNameConflict(Conflict):
                 If name already exists in database with a direct child for current version.
 
             """
-            super(ExperimentNameConflict.ExperimentNameResolution, self).__init__(conflict)
+            super(ExperimentNameConflict.ExperimentNameResolution, self).__init__(
+                conflict
+            )
 
             self.new_name = new_name
-            self.old_name = self.conflict.old_config['name']
-            self.old_version = self.conflict.old_config.get('version', 1)
+            self.old_name = self.conflict.old_config["name"]
+            self.old_version = self.conflict.old_config.get("version", 1)
             self.new_version = self.old_version
             self.validate()
-            self.conflict.new_config['name'] = self.new_name
-            self.conflict.new_config['version'] = self.new_version
+            self.conflict.new_config["name"] = self.new_name
+            self.conflict.new_config["version"] = self.new_version
 
         def _validate(self):
             """Validate new_name is not in database with a direct child for current version"""
@@ -1640,7 +1725,9 @@ class ExperimentNameConflict(Conflict):
                 if not self._name_is_unique():
                     raise ValueError(
                         "Cannot branch from {} with name {} since it already exists.".format(
-                            self.old_name, self.new_name))
+                            self.old_name, self.new_name
+                        )
+                    )
                 # Since the name changes, we reset the version count.
                 self.new_version = 1
 
@@ -1648,16 +1735,17 @@ class ExperimentNameConflict(Conflict):
             # the version of the experiment.
             elif self._check_for_greater_versions():
                 raise ValueError(
-                    "Experiment name \'{0}\' already exist for version \'{1}\' and has children. "
-                    "Version cannot be auto-incremented and a new name is required for branching."
-                    .format(self.new_name, self.conflict.version))
+                    f"Experiment name '{self.new_name}' already exist for version "
+                    "'{self.conflict.version}' and has children. Version cannot be "
+                    "auto-incremented and a new name is required for branching."
+                )
             else:
                 self.new_name = self.old_name
-                self.new_version = self.conflict.old_config.get('version', 1) + 1
+                self.new_version = self.conflict.old_config.get("version", 1) + 1
 
         def _name_is_unique(self):
             """Return True if given name is not in database for current version"""
-            query = {'name': self.new_name, 'version': self.conflict.version}
+            query = {"name": self.new_name, "version": self.conflict.version}
 
             named_experiments = len(get_storage().fetch_experiments(query))
             return named_experiments == 0
@@ -1667,15 +1755,15 @@ class ExperimentNameConflict(Conflict):
             # If we made it this far, new_name is actually the name of the parent.
             parent = self.conflict.old_config
 
-            query = {'name': parent['name'], 'refers.parent_id': parent['_id']}
+            query = {"name": parent["name"], "refers.parent_id": parent["_id"]}
             children = len(get_storage().fetch_experiments(query))
 
             return bool(children)
 
         def revert(self):
             """Reset conflict set experiment name back to old one in new configuration"""
-            self.conflict.new_config['name'] = self.old_name
-            self.conflict.new_config['version'] = self.old_version
+            self.conflict.new_config["name"] = self.old_name
+            self.conflict.new_config["version"] = self.old_version
             return super(ExperimentNameConflict.ExperimentNameResolution, self).revert()
 
         def get_adapters(self):

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -45,7 +45,12 @@ class ExperimentNode(TreeNode):
 
     """
 
-    __slots__ = ('name', 'version', '_no_parent_lookup', '_no_children_lookup') + TreeNode.__slots__
+    __slots__ = (
+        "name",
+        "version",
+        "_no_parent_lookup",
+        "_no_children_lookup",
+    ) + TreeNode.__slots__
 
     def __init__(self, name, version, experiment=None, parent=None, children=tuple()):
         """Initialize experiment node with item, experiment, parent and children
@@ -70,7 +75,10 @@ class ExperimentNode(TreeNode):
         if self._item is None:
             # TODO: Find another way around the circular import
             import orion.core.io.experiment_builder as experiment_builder
-            self._item = experiment_builder.build_view(name=self.name, version=self.version)
+
+            self._item = experiment_builder.build_view(
+                name=self.name, version=self.version
+            )
             self._item._experiment._node = self
 
         return self._item
@@ -87,13 +95,15 @@ class ExperimentNode(TreeNode):
         """
         if self._parent is None and self._no_parent_lookup:
             self._no_parent_lookup = False
-            query = {'_id': self.item.refers.get('parent_id')}
-            selection = {'name': 1, 'version': 1}
+            query = {"_id": self.item.refers.get("parent_id")}
+            selection = {"name": 1, "version": 1}
             experiments = get_storage().fetch_experiments(query, selection)
 
             if experiments:
                 parent = experiments[0]
-                exp_node = ExperimentNode(name=parent['name'], version=parent.get('version', 1))
+                exp_node = ExperimentNode(
+                    name=parent["name"], version=parent.get("version", 1)
+                )
                 self.set_parent(exp_node)
         return self._parent
 
@@ -110,13 +120,13 @@ class ExperimentNode(TreeNode):
         if self._no_children_lookup:
             self._children = []
             self._no_children_lookup = False
-            query = {'refers.parent_id': self.item.id}
-            selection = {'name': 1, 'version': 1}
+            query = {"refers.parent_id": self.item.id}
+            selection = {"name": 1, "version": 1}
             experiments = get_storage().fetch_experiments(query, selection)
             for child in experiments:
                 self.add_children(
-                    ExperimentNode(name=child['name'],
-                                   version=child.get('version', 1)))
+                    ExperimentNode(name=child["name"], version=child.get("version", 1))
+                )
 
         return self._children
 
@@ -135,23 +145,23 @@ class ExperimentNode(TreeNode):
 
     def fetch_lost_trials(self):
         """See :meth:`orion.core.evc.experiment:Experiment._fetch_trials`"""
-        return self._fetch_trials('fetch_lost_trials')
+        return self._fetch_trials("fetch_lost_trials")
 
     def fetch_trials(self):
         """See :meth:`orion.core.evc.experiment:Experiment._fetch_trials`"""
-        return self._fetch_trials('fetch_trials')
+        return self._fetch_trials("fetch_trials")
 
     def fetch_pending_trials(self):
         """See :meth:`orion.core.evc.experiment:Experiment._fetch_trials`"""
-        return self._fetch_trials('fetch_pending_trials')
+        return self._fetch_trials("fetch_pending_trials")
 
     def fetch_noncompleted_trials(self):
         """See :meth:`orion.core.evc.experiment:Experiment._fetch_trials`"""
-        return self._fetch_trials('fetch_noncompleted_trials')
+        return self._fetch_trials("fetch_noncompleted_trials")
 
     def fetch_trials_by_status(self, status):
         """See :meth:`orion.core.evc.experiment:Experiment._fetch_trials`"""
-        return self._fetch_trials('fetch_trials_by_status', status=status)
+        return self._fetch_trials("fetch_trials_by_status", status=status)
 
     def _fetch_trials(self, fun_name, *args, **kwargs):
         """Fetch trials recursively in the EVC tree using the fetch function `fun_name`.
@@ -169,6 +179,7 @@ class ExperimentNode(TreeNode):
             Keyword arguments to pass to `fun_name.
 
         """
+
         def retrieve_trials(node, parent_or_children):
             """Retrieve the trials of a node/experiment."""
             fun = getattr(node.item, fun_name)
@@ -186,7 +197,7 @@ class ExperimentNode(TreeNode):
         children_trials.set_parent(parent_trials)
 
         adapt_trials(children_trials)
-        return sum([node.item['trials'] for node in children_trials.root], [])
+        return sum([node.item["trials"] for node in children_trials.root], [])
 
 
 def _adapt_parent_trials(node, parent_trials_node):
@@ -198,9 +209,9 @@ def _adapt_parent_trials(node, parent_trials_node):
 
     """
     if parent_trials_node is not None:
-        adapter = node.item['experiment'].refers['adapter']
+        adapter = node.item["experiment"].refers["adapter"]
         for parent in parent_trials_node.root:
-            parent.item['trials'] = adapter.forward(parent.item['trials'])
+            parent.item["trials"] = adapter.forward(parent.item["trials"])
 
     return node.item, parent_trials_node
 
@@ -214,9 +225,9 @@ def _adapt_children_trials(node, children_trials_nodes):
 
     """
     for child in children_trials_nodes:
-        adapter = child.item['experiment'].refers['adapter']
+        adapter = child.item["experiment"].refers["adapter"]
         for subchild in child:  # Includes child itself
-            subchild.item['trials'] = adapter.backward(subchild.item['trials'])
+            subchild.item["trials"] = adapter.backward(subchild.item["trials"])
 
     return node.item, children_trials_nodes
 

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -30,7 +30,7 @@ class PreOrderTraversal(object):
 
     """
 
-    __slots__ = ('stack', )
+    __slots__ = ("stack",)
 
     def __init__(self, tree_node):
         """Initialize the stack for iteration"""
@@ -65,7 +65,7 @@ class DepthFirstTraversal(object):
 
     """
 
-    __slots__ = ('stack', 'seen')
+    __slots__ = ("stack", "seen")
 
     def __init__(self, tree_node):
         """Initialize the stack and set of seen nodes for iteration"""
@@ -181,7 +181,7 @@ class TreeNode(object):
 
     """
 
-    __slots__ = ('_item', '_parent', '_children')
+    __slots__ = ("_item", "_parent", "_children")
 
     def __init__(self, item, parent=None, children=tuple()):
         """Initialize node with item, parent and children
@@ -392,7 +392,9 @@ class TreeNode(object):
             rval, parent_node = function(self, rval_parent_node)
             return TreeNode(rval, parent_node)
         elif node is self.children:
-            rval_children_nodes = [child.map(function, child.children) for child in self.children]
+            rval_children_nodes = [
+                child.map(function, child.children) for child in self.children
+            ]
             rval, children_nodes = function(self, rval_children_nodes)
             return TreeNode(rval, parent=None, children=children_nodes)
         else:
@@ -410,8 +412,12 @@ class TreeNode(object):
 
         children = [child.item for child in self.children]
 
-        return ("%s(%s, parent=%s, children=%s)" %
-                (self.__class__.__name__, str(self.item), str(parent), str(children)))
+        return "%s(%s, parent=%s, children=%s)" % (
+            self.__class__.__name__,
+            str(self.item),
+            str(parent),
+            str(children),
+        )
 
 
 def flattened(trials_tree):

--- a/src/orion/core/io/cmdline_parser.py
+++ b/src/orion/core/io/cmdline_parser.py
@@ -59,16 +59,17 @@ class CmdlineParser(object):
         return dict(
             arguments=list(map(list, self.arguments.items())),
             keys=list(map(list, self.keys.items())),
-            template=self.template)
+            template=self.template,
+        )
 
     def set_state_dict(self, state):
         """Reset the parser based on previous state"""
-        if state.get('keys') is None:
+        if state.get("keys") is None:
             # NOTE: To support experiments prior to 0.1.9
-            state['keys'] = [(key, self._key_to_arg(key)) for key in state['arguments']]
-        self.keys = OrderedDict(state['keys'])
-        self.arguments = OrderedDict(state['arguments'])
-        self.template = state['template']
+            state["keys"] = [(key, self._key_to_arg(key)) for key in state["arguments"]]
+        self.keys = OrderedDict(state["keys"])
+        self.arguments = OrderedDict(state["arguments"])
+        self.template = state["template"]
         self._already_parsed = bool(self.template)
 
     def format(self, configuration):
@@ -93,7 +94,7 @@ class CmdlineParser(object):
         # Hence we iterate over the list as-is and format on each item separately.
         formatted = []
         for item in self.template:
-            if item.startswith('-'):
+            if item.startswith("-"):
                 formatted.append(item)
             else:
                 formatted.append(item.format(**configuration))
@@ -224,13 +225,14 @@ class CmdlineParser(object):
             if item.startswith("-"):
                 # Make sure we're not defining the same argument twice
                 # If the argument is in the form of `--name=value`
-                argument_parts = item.split('=')
+                argument_parts = item.split("=")
                 argument_name = argument_parts[0]
-                key = argument_name.lstrip('-')
+                key = argument_name.lstrip("-")
 
                 if key in keys:
-                    raise ValueError("Conflict: two arguments have the same name: {}"
-                                     .format(key))
+                    raise ValueError(
+                        "Conflict: two arguments have the same name: {}".format(key)
+                    )
 
                 arguments[key] = []
                 keys[key] = argument_name

--- a/src/orion/core/io/config.py
+++ b/src/orion/core/io/config.py
@@ -40,7 +40,7 @@ class ConfigurationError(Exception):
 
 
 def _curate(key):
-    return key.replace('-', '_')
+    return key.replace("-", "_")
 
 
 class Configuration:
@@ -70,8 +70,15 @@ class Configuration:
 
     """
 
-    SPECIAL_KEYS = ['_config', '_subconfigs', '_yaml', '_default', '_env_var', '_help',
-                    '_deprecated']
+    SPECIAL_KEYS = [
+        "_config",
+        "_subconfigs",
+        "_yaml",
+        "_default",
+        "_env_var",
+        "_help",
+        "_deprecated",
+    ]
 
     def __init__(self):
         self._config = {}
@@ -102,13 +109,15 @@ class Configuration:
             if key not in config:
                 continue
             value = config.pop(key)
-            default = self[key + '._default']
-            deprecated = self[key + '._deprecated']
+            default = self[key + "._default"]
+            deprecated = self[key + "._deprecated"]
             logger.debug('Overwritting "%s" default %s with %s', key, default, value)
-            self[key + '._yaml'] = value
-            if deprecated and deprecated.get('alternative'):
-                logger.debug('Overwritting "%s" default %s with %s', key, default, value)
-                root[deprecated.get('alternative') + '._yaml'] = value
+            self[key + "._yaml"] = value
+            if deprecated and deprecated.get("alternative"):
+                logger.debug(
+                    'Overwritting "%s" default %s with %s', key, default, value
+                )
+                root[deprecated.get("alternative") + "._yaml"] = value
 
         for key in self._subconfigs:
             if key not in config:
@@ -139,35 +148,36 @@ class Configuration:
             If the option does not exist
 
         """
-        if key == 'config':
+        if key == "config":
             raise AttributeError
 
         if key not in self._config and key not in self._subconfigs:
-            raise ConfigurationError("Configuration does not have an attribute "
-                                     "'{}'.".format(key))
+            raise ConfigurationError(
+                "Configuration does not have an attribute " "'{}'.".format(key)
+            )
         if key in self._subconfigs:
             return self._subconfigs[key]
 
         config_setting = self._config[key]
-        if 'value' in config_setting:
-            value = config_setting['value']
-        elif ('env_var' in config_setting and
-              config_setting['env_var'] in os.environ):
-            value = os.environ[config_setting['env_var']]
-            if config_setting['type'] in (list, tuple):
-                value = value.split(':')
-        elif 'yaml' in config_setting:
-            value = config_setting['yaml']
-        elif 'default' in config_setting:
-            value = config_setting['default']
+        if "value" in config_setting:
+            value = config_setting["value"]
+        elif "env_var" in config_setting and config_setting["env_var"] in os.environ:
+            value = os.environ[config_setting["env_var"]]
+            if config_setting["type"] in (list, tuple):
+                value = value.split(":")
+        elif "yaml" in config_setting:
+            value = config_setting["yaml"]
+        elif "default" in config_setting:
+            value = config_setting["default"]
         else:
-            raise ConfigurationError("Configuration not set and no default "
-                                     "provided: {}.".format(key))
+            raise ConfigurationError(
+                "Configuration not set and no default " "provided: {}.".format(key)
+            )
 
-        if config_setting.get('deprecated'):
+        if config_setting.get("deprecated"):
             self._deprecate(key)
 
-        return config_setting['type'](value)
+        return config_setting["type"](value)
 
     def __setattr__(self, key, value):
         """Set option value or subconfiguration
@@ -196,35 +206,39 @@ class Configuration:
         key = _curate(key)
         if key not in self.SPECIAL_KEYS and key in self._config:
             self._validate(key, value)
-            self._config[key]['value'] = value
-            if self._config[key].get('deprecated'):
+            self._config[key]["value"] = value
+            if self._config[key].get("deprecated"):
                 self._deprecate(key, value)
 
-        elif key in ['_config', '_subconfigs']:
+        elif key in ["_config", "_subconfigs"]:
             super(Configuration, self).__setattr__(key, value)
 
         elif key in self._subconfigs:
-            raise ValueError('Configuration already contains subconfiguration {}'.format(key))
+            raise ValueError(
+                "Configuration already contains subconfiguration {}".format(key)
+            )
 
         elif isinstance(value, Configuration):
             self._subconfigs[key] = value
 
         else:
-            raise TypeError("Can only set {} as a Configuration, not {}. Use add_option to set a "
-                            "new option.".format(key, type(value)))
+            raise TypeError(
+                "Can only set {} as a Configuration, not {}. Use add_option to set a "
+                "new option.".format(key, type(value))
+            )
 
     # pylint: disable=unused-argument
     def _deprecate(self, key, value=NOT_SET):
-        deprecate = self._config[key]['deprecated']
+        deprecate = self._config[key]["deprecated"]
         message = "(DEPRECATED) Option `%s` will be removed in %s."
-        args = [deprecate.get('name', key), deprecate['version']]
-        if 'alternative' in deprecate:
+        args = [deprecate.get("name", key), deprecate["version"]]
+        if "alternative" in deprecate:
             message += " Use `%s` instead."
-            args.append(deprecate['alternative'])
+            args.append(deprecate["alternative"])
 
         logger.warning(message, *args)
 
-    def get(self, key, deprecated='warn'):
+    def get(self, key, deprecated="warn"):
         """Access value
 
         Parameters
@@ -236,7 +250,7 @@ class Configuration:
             else if 'ignore', no warning will be logged for access to deprecated options.
 
         """
-        with _disable_logger(disable=(deprecated == 'ignore')):
+        with _disable_logger(disable=(deprecated == "ignore")):
             value = self[key]
 
         return value
@@ -253,13 +267,16 @@ class Configuration:
 
         """
         if isinstance(value, Configuration):
-            raise TypeError("Cannot overwrite option {} with a configuration".format(key))
+            raise TypeError(
+                "Cannot overwrite option {} with a configuration".format(key)
+            )
 
         try:
-            self._config[key]['type'](value)
+            self._config[key]["type"](value)
         except ValueError as e:
             message = "Option {} of type {} cannot be set to {} with type {}".format(
-                key, self._config[key]['type'], value, type(value))
+                key, self._config[key]["type"], value, type(value)
+            )
             raise TypeError(message) from e
 
     def __setitem__(self, key, value):
@@ -282,8 +299,8 @@ class Configuration:
         if len(keys) == 2 and keys[-1] in self.SPECIAL_KEYS:
             key, field = keys
             self._validate(key, value)
-            self._config[key][field.lstrip('_')] = value
-            if self._config[key].get('deprecated'):
+            self._config[key][field.lstrip("_")] = value
+            if self._config[key].get("deprecated"):
                 self._deprecate(key)
 
         # Set in current configuration
@@ -315,21 +332,24 @@ class Configuration:
         if len(keys) == 2 and keys[1] in self.SPECIAL_KEYS:
             key_config = self._config.get(keys[0], None)
             if key_config is None:
-                raise ConfigurationError("Configuration does not have an attribute "
-                                         "'{}'.".format(keys[0]))
+                raise ConfigurationError(
+                    "Configuration does not have an attribute " "'{}'.".format(keys[0])
+                )
             return key_config.get(keys[1][1:], None)
         elif len(keys) > 1:
             subconfig = getattr(self, keys[0])
             if subconfig is None:
-                raise ConfigurationError("Configuration does not have an attribute "
-                                         "'{}'.".format(key))
+                raise ConfigurationError(
+                    "Configuration does not have an attribute " "'{}'.".format(key)
+                )
             return subconfig[".".join(keys[1:])]
         # Set in current configuration
         else:
             return getattr(self, keys[0])
 
-    def add_option(self, key, option_type, default=NOT_SET, env_var=None, deprecate=None,
-                   help=None):
+    def add_option(
+        self, key, option_type, default=NOT_SET, env_var=None, deprecate=None, help=None
+    ):
         """Add a configuration setting.
 
         Parameters
@@ -366,29 +386,31 @@ class Configuration:
         """
         key = _curate(key)
         if key in self._config or key in self._subconfigs:
-            raise ValueError('Configuration already contains {}'.format(key))
-        self._config[key] = {'type': option_type}
+            raise ValueError("Configuration already contains {}".format(key))
+        self._config[key] = {"type": option_type}
         if env_var is not None:
-            self._config[key]['env_var'] = env_var
+            self._config[key]["env_var"] = env_var
         if default is not NOT_SET:
-            self._config[key]['default'] = default
+            self._config[key]["default"] = default
         if deprecate is not None:
-            if 'version' not in deprecate:
-                raise ValueError(f'`version` is missing in deprecate option: {deprecate}')
-            self._config[key]['deprecated'] = deprecate
+            if "version" not in deprecate:
+                raise ValueError(
+                    f"`version` is missing in deprecate option: {deprecate}"
+                )
+            self._config[key]["deprecated"] = deprecate
 
         if help is None:
-            help = 'Undocumented'
+            help = "Undocumented"
 
         if default is not NOT_SET:
-            help += ' (default: {})'.format(default)
+            help += " (default: {})".format(default)
         if deprecate is not None:
-            help = '(DEPRECATED) ' + help
-        self._config[key]['help'] = help
+            help = "(DEPRECATED) " + help
+        self._config[key]["help"] = help
 
     def help(self, key):
         """Return the help message for the given option."""
-        return self[key + '._help']
+        return self[key + "._help"]
 
     def add_arguments(self, parser, rename=None):
         """Add arguments to an `argparse` parser based on configuration
@@ -409,15 +431,17 @@ class Configuration:
         for key in self._config:
             # TODO: Try with list and nargs='*', but it may case issues with
             # nargs=argparse.REMAINDER.
-            if self._config[key]['type'] in (dict, list, tuple):
+            if self._config[key]["type"] in (dict, list, tuple):
                 continue
 
             # NOTE: Do not set default, if parser.parse_argv().options[key] is None, then code
             # should look to config[key].
-            arg_name = rename.get(key, "--{}".format(key.replace('_', '-')))
+            arg_name = rename.get(key, "--{}".format(key.replace("_", "-")))
             parser.add_argument(
-                arg_name, type=self._config[key]['type'],
-                help=self._config[key].get('help'))
+                arg_name,
+                type=self._config[key]["type"],
+                help=self._config[key].get("help"),
+            )
 
     def __contains__(self, key):
         """Return True if the option is defined."""

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -43,8 +43,15 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
     ASCENDING = 0
     DESCENDING = 1
 
-    def __init__(self, host='localhost', name=None,
-                 port=None, username=None, password=None, **kwargs):
+    def __init__(
+        self,
+        host="localhost",
+        name=None,
+        port=None,
+        username=None,
+        password=None,
+        **kwargs
+    ):
         """Init method, see attributes of :class:`AbstractDB`."""
         self.host = host
         self.name = name
@@ -268,14 +275,18 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 class ReadOnlyDB(object):
     """Read-only view on a database."""
 
-    __slots__ = ('_database', )
+    __slots__ = ("_database",)
 
     #                     Attributes
-    valid_attributes = (["host", "name", "port", "username", "password"] +
-                        # Properties
-                        ["is_connected"] +
-                        # Methods
-                        ["initiate_connection", "close_connection", "read", "count"])
+    valid_attributes = (
+        ["host", "name", "port", "username", "password"]
+        +
+        # Properties
+        ["is_connected"]
+        +
+        # Methods
+        ["initiate_connection", "close_connection", "read", "count"]
+    )
 
     def __init__(self, database):
         """Init method, see attributes of :class:`AbstractDB`."""
@@ -284,7 +295,9 @@ class ReadOnlyDB(object):
     def __getattr__(self, attr):
         """Get attribute only if valid"""
         if attr not in self.valid_attributes:
-            raise AttributeError("Cannot access attribute %s on view-only experiments." % attr)
+            raise AttributeError(
+                "Cannot access attribute %s on view-only experiments." % attr
+            )
 
         return getattr(self._database, attr)
 
@@ -325,4 +338,4 @@ class Database(AbstractDB, metaclass=SingletonFactory):
 
 
 # set per-module log level
-logging.getLogger('filelock').setLevel('ERROR')
+logging.getLogger("filelock").setLevel("ERROR")

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -18,10 +18,10 @@ from orion.core.utils.flatten import flatten, unflatten
 def _convert_keys_to_name(keys):
     index = []
 
-    if len(keys) == 1 and keys[0] == '_id':
-        index = '_id_'
+    if len(keys) == 1 and keys[0] == "_id":
+        index = "_id_"
     else:
-        index = '_'.join('{}_1'.format(k) for k in keys)
+        index = "_".join("{}_1".format(k) for k in keys)
 
     return index
 
@@ -80,10 +80,9 @@ class EphemeralDB(AbstractDB):
                 data = [data]
             return dbcollection.insert_many(documents=data)
 
-        update_data = {'$set': data}
+        update_data = {"$set": data}
 
-        return dbcollection.update_many(query=query,
-                                        update=update_data)
+        return dbcollection.update_many(query=query, update=update_data)
 
     def read(self, collection_name, query=None, selection=None):
         """Read a collection and return a value according to the query.
@@ -110,7 +109,7 @@ class EphemeralDB(AbstractDB):
         if not dbdoc:
             return None
 
-        id_query = {'_id': dbdoc[0]['_id']}
+        id_query = {"_id": dbdoc[0]["_id"]}
         self.write(collection_name, data, id_query)
         return self.read(collection_name, id_query)[0]
 
@@ -147,7 +146,7 @@ class EphemeralCollection(object):
         """Initialise the collection, with no documents and only _id unique index."""
         self._documents = []
         self._indexes = dict()
-        self.create_index('_id', unique=True)
+        self.create_index("_id", unique=True)
 
     def create_index(self, keys, unique=False):
         """Create given indexes if they do not already exist for this collection.
@@ -182,7 +181,7 @@ class EphemeralCollection(object):
         EphemeralCollection may only contain unique indexes.
         """
         if name not in self._indexes:
-            raise DatabaseError('index not found with name {}'.format(name))
+            raise DatabaseError("index not found with name {}".format(name))
 
         del self._indexes[name]
 
@@ -221,12 +220,15 @@ class EphemeralCollection(object):
             document_values = tuple(document[key] for key in keys)
             if document_values in data:
                 raise DuplicateKeyError(
-                    "Duplicate key error: index={} value={}".format(name, document_values))
+                    "Duplicate key error: index={} value={}".format(
+                        name, document_values
+                    )
+                )
 
     def _get_new_id(self):
         """Return max id + 1"""
         if self._documents:
-            return max(d['_id'] for d in self._documents) + 1
+            return max(d["_id"] for d in self._documents) + 1
 
         return 1
 
@@ -243,8 +245,8 @@ class EphemeralCollection(object):
 
         """
         for document in documents:
-            if '_id' not in document:
-                document['_id'] = self._get_new_id()
+            if "_id" not in document:
+                document["_id"] = self._get_new_id()
             ephemeral_document = EphemeralDocument(document)
             self._validate_index(ephemeral_document)
             self._documents.append(ephemeral_document)
@@ -318,7 +320,7 @@ class EphemeralCollection(object):
         """Drop the collection, removing all documents and indexes."""
         self._documents = []
         self._indexes = dict()
-        self.create_index('_id', unique=True)
+        self.create_index("_id", unique=True)
 
 
 class EphemeralDocument(object):
@@ -355,7 +357,7 @@ class EphemeralDocument(object):
         return True
 
     def _is_operator(self, key):  # pylint: disable=no-self-use
-        return key.split(".")[-1].startswith('$')
+        return key.split(".")[-1].startswith("$")
 
     def _get_key_operator(self, key):
         path = key.split(".")
@@ -363,7 +365,9 @@ class EphemeralDocument(object):
         key = ".".join(path[:-1])
 
         if operator not in self.operators:
-            raise ValueError('Operator \'{}\' is not supported by EphemeralDB'.format(operator))
+            raise ValueError(
+                "Operator '{}' is not supported by EphemeralDB".format(operator)
+            )
 
         return key, self.operators[operator]
 
@@ -391,22 +395,23 @@ class EphemeralDocument(object):
 
             _id is set to 1 if not specified. Only _id may be set to 0 if other keys are set to 1.
         """
-        if len(keys) == 1 and keys.get('_id', 0) == 1:
+        if len(keys) == 1 and keys.get("_id", 0) == 1:
             return keys
 
-        keys_without_id = [key for key in keys if key != '_id']
+        keys_without_id = [key for key in keys if key != "_id"]
         n_keys = sum(keys[key] for key in keys_without_id)
         if n_keys != 0 and n_keys != len(keys_without_id):
             raise ValueError(
-                'Cannot mix selection with 1 and 0s except for _id: {}'.format(keys))
+                "Cannot mix selection with 1 and 0s except for _id: {}".format(keys)
+            )
 
         # All given keys are 0 (with possible exception of _id)
         if n_keys == 0:
             new_keys = dict((key, 1) for key in self._data.keys() if key not in keys)
-            new_keys['_id'] = keys.get('_id', 1)
+            new_keys["_id"] = keys.get("_id", 1)
             keys = new_keys
 
-        keys.setdefault('_id', 1)
+        keys.setdefault("_id", 1)
 
         return keys
 
@@ -443,9 +448,9 @@ class EphemeralDocument(object):
             key_is_match(abc.def.ghi, abc.de) -> False
             key_is_match(abc.def.ghi, xyz) -> False
             """
-            return (key == selected_key or
-                    (key.startswith(selected_key) and
-                     key.replace(selected_key, '')[0] == "."))
+            return key == selected_key or (
+                key.startswith(selected_key) and key.replace(selected_key, "")[0] == "."
+            )
 
         for selected_key, include in filter(lambda item: item[1], keys.items()):
             match = False
@@ -469,9 +474,9 @@ class EphemeralDocument(object):
             the data, the corresponding `data[$set]` will be used instead.
 
         """
-        if '$set' in data:
+        if "$set" in data:
             unflattened_data = unflatten(self._data)
-            for key, value in data['$set'].items():
+            for key, value in data["$set"].items():
                 if isinstance(value, dict):
                     value = flatten(value)
                 unflattened_data[key] = value

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -13,18 +13,18 @@ import functools
 import pymongo
 
 from orion.core.io.database import (
-    AbstractDB, DatabaseError, DatabaseTimeout, DuplicateKeyError)
+    AbstractDB,
+    DatabaseError,
+    DatabaseTimeout,
+    DuplicateKeyError,
+)
 
 
-AUTH_FAILED_MESSAGES = [
-    "auth failed",
-    "Authentication failed."]
+AUTH_FAILED_MESSAGES = ["auth failed", "Authentication failed."]
 
-INDEX_OP_ERROR_MESSAGES = [
-    "index not found with name"]
+INDEX_OP_ERROR_MESSAGES = ["index not found with name"]
 
-DUPLICATE_KEY_MESSAGES = [
-    "duplicate key error"]
+DUPLICATE_KEY_MESSAGES = ["duplicate key error"]
 
 
 def mongodb_exception_wrapper(method):
@@ -37,6 +37,7 @@ def mongodb_exception_wrapper(method):
     pymongo.errors.OperationFailure(AUTH_FAILED_MESSAGES) -> DatabaseError
 
     """
+
     @functools.wraps(method)
     def _decorator(self, *args, **kwargs):
 
@@ -59,14 +60,15 @@ def mongodb_exception_wrapper(method):
         except pymongo.errors.DuplicateKeyError as e:
             raise DuplicateKeyError(str(e)) from e
         except pymongo.errors.BulkWriteError as e:
-            for error in e.details['writeErrors']:
+            for error in e.details["writeErrors"]:
                 if any(m in error["errmsg"] for m in DUPLICATE_KEY_MESSAGES):
                     raise DuplicateKeyError(error["errmsg"]) from e
 
             raise
         except pymongo.errors.ConnectionFailure as e:
-            raise DatabaseError("Connection Failure: database not found on "
-                                "specified uri") from e
+            raise DatabaseError(
+                "Connection Failure: database not found on " "specified uri"
+            ) from e
         except pymongo.errors.OperationFailure as e:
             if any(m in str(e) for m in AUTH_FAILED_MESSAGES):
                 raise DatabaseError("Authentication Failure: bad credentials") from e
@@ -96,8 +98,15 @@ class MongoDB(AbstractDB):
 
     """
 
-    def __init__(self, host='localhost', name=None,
-                 port=None, username=None, password=None, serverSelectionTimeoutMS=5000):
+    def __init__(
+        self,
+        host="localhost",
+        name=None,
+        port=None,
+        username=None,
+        password=None,
+        serverSelectionTimeoutMS=5000,
+    ):
         """Init method, see attributes of :class:`AbstractDB`."""
         self.uri = None
 
@@ -106,9 +115,15 @@ class MongoDB(AbstractDB):
         else:
             port = pymongo.MongoClient.PORT
 
-        super(MongoDB, self).__init__(host, name, port, username, password,
-                                      serverSelectionTimeoutMS=serverSelectionTimeoutMS,
-                                      authSource=name)
+        super(MongoDB, self).__init__(
+            host,
+            name,
+            port,
+            username,
+            password,
+            serverSelectionTimeoutMS=serverSelectionTimeoutMS,
+            authSource=name,
+        )
 
     @mongodb_exception_wrapper
     def initiate_connection(self):
@@ -122,13 +137,15 @@ class MongoDB(AbstractDB):
 
         self._sanitize_attrs()
 
-        self._conn = pymongo.MongoClient(self.uri if self.uri else self.host,
-                                         port=self.port,
-                                         username=self.username,
-                                         password=self.password,
-                                         **self.options)
+        self._conn = pymongo.MongoClient(
+            self.uri if self.uri else self.host,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+            **self.options
+        )
         self._db = self._conn[self.name]
-        self._db.command('ismaster')  # .. seealso:: :meth:`is_connected`
+        self._db.command("ismaster")  # .. seealso:: :meth:`is_connected`
 
     @property
     def is_connected(self):
@@ -137,10 +154,13 @@ class MongoDB(AbstractDB):
         .. note:: MongoDB does not do this automatically when creating the client.
         """
         try:
-            self._db.command('ismaster')
-        except (pymongo.errors.ConnectionFailure,
-                pymongo.errors.OperationFailure,
-                TypeError, AttributeError):
+            self._db.command("ismaster")
+        except (
+            pymongo.errors.ConnectionFailure,
+            pymongo.errors.OperationFailure,
+            TypeError,
+            AttributeError,
+        ):
             _is_connected = False
         else:
             _is_connected = True
@@ -172,8 +192,10 @@ class MongoDB(AbstractDB):
     def index_information(self, collection_name):
         """Return dict of names and sorting order of indexes"""
         dbcollection = self._db[collection_name]
-        return {index: specs.get('unique', False) or index == '_id_'
-                for index, specs in dbcollection.index_information().items()}
+        return {
+            index: specs.get("unique", False) or index == "_id_"
+            for index, specs in dbcollection.index_information().items()
+        }
 
     @mongodb_exception_wrapper
     def drop_index(self, collection_name, name):
@@ -199,8 +221,7 @@ class MongoDB(AbstractDB):
         elif sort_order is self.DESCENDING:
             return pymongo.DESCENDING
         else:
-            raise RuntimeError("Invalid database sort order %s" %
-                               str(sort_order))
+            raise RuntimeError("Invalid database sort order %s" % str(sort_order))
 
     @mongodb_exception_wrapper
     def write(self, collection_name, data, query=None):
@@ -220,11 +241,11 @@ class MongoDB(AbstractDB):
             result = dbcollection.insert_many(documents=data)
             return len(result.inserted_ids)
 
-        update_data = {'$set': data}
+        update_data = {"$set": data}
 
-        result = dbcollection.update_many(filter=query,
-                                          update=update_data,
-                                          upsert=False)
+        result = dbcollection.update_many(
+            filter=query, update=update_data, upsert=False
+        )
         return result.modified_count
 
     def read(self, collection_name, query=None, selection=None):
@@ -252,11 +273,14 @@ class MongoDB(AbstractDB):
         """
         dbcollection = self._db[collection_name]
 
-        update_data = {'$set': data}
+        update_data = {"$set": data}
 
         dbdoc = dbcollection.find_one_and_update(
-            query, update_data, projection=selection,
-            return_document=pymongo.ReturnDocument.AFTER)
+            query,
+            update_data,
+            projection=selection,
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
 
         return dbdoc
 
@@ -267,7 +291,9 @@ class MongoDB(AbstractDB):
 
         """
         dbcollection = self._db[collection_name]
-        if not isinstance(getattr(dbcollection, 'count_documents'), pymongo.collection.Collection):
+        if not isinstance(
+            getattr(dbcollection, "count_documents"), pymongo.collection.Collection
+        ):
             return dbcollection.count_documents(filter=query if query else {})
 
         return dbcollection.count(filter=query)
@@ -295,15 +321,17 @@ class MongoDB(AbstractDB):
             # Arguments in MongoClient overwrite elements from URI
 
             self.uri = self.host
-            self.host, _port = settings['nodelist'][0]
-            if settings['database'] is not None:
-                self.name = settings['database']
+            self.host, _port = settings["nodelist"][0]
+            if settings["database"] is not None:
+                self.name = settings["database"]
             if _port is not None:
                 self.port = _port
-            if settings['username'] is not None:
-                self.username = settings['username']
-            if settings['password'] is not None:
-                self.password = settings['password']
+            if settings["username"] is not None:
+                self.username = settings["username"]
+            if settings["password"] is not None:
+                self.password = settings["password"]
 
             # Use new self.name if authSource not specified in URI
-            self.options['authSource'] = settings['options'].get('authsource', self.name)
+            self.options["authSource"] = settings["options"].get(
+                "authsource", self.name
+            )

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -23,7 +23,7 @@ from orion.core.io.database.ephemeraldb import EphemeralDB
 
 log = logging.getLogger(__name__)
 
-DEFAULT_HOST = os.path.join(orion.core.DIRS.user_data_dir, 'orion', 'orion_db.pkl')
+DEFAULT_HOST = os.path.join(orion.core.DIRS.user_data_dir, "orion", "orion_db.pkl")
 
 TIMEOUT_ERROR_MESSAGE = """\
 Could not acquire lock for PickledDB after {} seconds.
@@ -165,8 +165,9 @@ class PickledDB(AbstractDB):
 
         """
         with self.locked_database() as database:
-            return database.read_and_write(collection_name, query=query, data=data,
-                                           selection=selection)
+            return database.read_and_write(
+                collection_name, query=query, data=data, selection=selection
+            )
 
     def count(self, collection_name, query=None):
         """Count the number of documents in a collection which match the `query`.
@@ -191,7 +192,7 @@ class PickledDB(AbstractDB):
         if not os.path.exists(self.host):
             return EphemeralDB()
 
-        with open(self.host, 'rb') as f:
+        with open(self.host, "rb") as f:
             data = f.read()
             if not data:
                 database = EphemeralDB()
@@ -202,20 +203,23 @@ class PickledDB(AbstractDB):
 
     def _dump_database(self, database):
         """Write pickled DB on disk"""
-        tmp_file = self.host + '.tmp'
+        tmp_file = self.host + ".tmp"
 
         try:
-            with open(tmp_file, 'wb') as f:
+            with open(tmp_file, "wb") as f:
                 pickle.dump(database, f)
 
         except (PicklingError, AttributeError):
-            collection, doc = find_unpickable_doc(database._db)  # pylint: disable=protected-access
-            log.error('Document in (collection: %s) is not pickable\ndoc: %s',
-                      collection, doc.to_dict())
+            # pylint: disable=protected-access
+            collection, doc = find_unpickable_doc(database._db)
+            log.error(
+                "Document in (collection: %s) is not pickable\ndoc: %s",
+                collection,
+                doc.to_dict(),
+            )
 
             key, value = find_unpickable_field(doc)
-            log.error('because (value %s) in (field: %s) is not pickable',
-                      value, key)
+            log.error("because (value %s) in (field: %s) is not pickable", value, key)
             raise
 
         os.rename(tmp_file, self.host)
@@ -223,7 +227,7 @@ class PickledDB(AbstractDB):
     @contextmanager
     def locked_database(self, write=True):
         """Lock database file during wrapped operation call."""
-        lock = FileLock(self.host + '.lock')
+        lock = FileLock(self.host + ".lock")
 
         try:
             with lock.acquire(timeout=self.timeout):

--- a/src/orion/core/io/experiment_branch_builder.py
+++ b/src/orion/core/io/experiment_branch_builder.py
@@ -94,8 +94,12 @@ class ExperimentBranchBuilder:
             conflict = self.conflicts.conflicts[ith_conflict]
 
             resolution = self.conflicts.try_resolve(
-                conflict, silence_errors=silence_errors,
-                **conflict.get_marked_arguments(self.conflicts, **self.branching_arguments))
+                conflict,
+                silence_errors=silence_errors,
+                **conflict.get_marked_arguments(
+                    self.conflicts, **self.branching_arguments
+                )
+            )
 
             if resolution and (self.manual_resolution and not resolution.is_marked):
                 self.conflicts.revert(resolution)
@@ -124,9 +128,11 @@ class ExperimentBranchBuilder:
             If there is no code change conflict left to resolve.
 
         """
-        exp_name_conflicts = self.conflicts.get_remaining([conflicts.ExperimentNameConflict])
+        exp_name_conflicts = self.conflicts.get_remaining(
+            [conflicts.ExperimentNameConflict]
+        )
         if not exp_name_conflicts:
-            raise RuntimeError('No experiment name conflict to solve')
+            raise RuntimeError("No experiment name conflict to solve")
 
         self.conflicts.try_resolve(exp_name_conflicts[0], name)
 
@@ -148,7 +154,7 @@ class ExperimentBranchBuilder:
         """
         code_conflicts = self.conflicts.get_remaining([conflicts.CodeConflict])
         if not code_conflicts:
-            raise RuntimeError('No code conflicts to solve')
+            raise RuntimeError("No code conflicts to solve")
 
         self.conflicts.try_resolve(code_conflicts[0], change_type=change_type)
 
@@ -170,7 +176,7 @@ class ExperimentBranchBuilder:
         """
         cli_conflicts = self.conflicts.get_remaining([conflicts.CommandLineConflict])
         if not cli_conflicts:
-            raise RuntimeError('No command line conflicts to solve')
+            raise RuntimeError("No command line conflicts to solve")
 
         self.conflicts.try_resolve(cli_conflicts[0], change_type)
 
@@ -190,9 +196,11 @@ class ExperimentBranchBuilder:
             If there is no script config conflict left to resolve.
 
         """
-        script_config_conflicts = self.conflicts.get_remaining([conflicts.ScriptConfigConflict])
+        script_config_conflicts = self.conflicts.get_remaining(
+            [conflicts.ScriptConfigConflict]
+        )
         if not script_config_conflicts:
-            raise RuntimeError('No script\'s config conflicts to solve')
+            raise RuntimeError("No script's config conflicts to solve")
 
         self.conflicts.try_resolve(script_config_conflicts[0], change_type)
 
@@ -207,7 +215,7 @@ class ExperimentBranchBuilder:
         """
         algo_conflicts = self.conflicts.get_remaining([conflicts.AlgorithmConflict])
         if not algo_conflicts:
-            raise RuntimeError('No algo conflict to solve')
+            raise RuntimeError("No algo conflict to solve")
 
         self.conflicts.try_resolve(algo_conflicts[0])
 
@@ -234,7 +242,8 @@ class ExperimentBranchBuilder:
         """
         conflict = self.conflicts.get_remaining(
             [conflicts.NewDimensionConflict, conflicts.ChangedDimensionConflict],
-            dimension_name=name)[0]
+            dimension_name=name,
+        )[0]
 
         if isinstance(conflict, conflicts.NewDimensionConflict):
             self.conflicts.try_resolve(conflict, default_value=default_value)
@@ -261,7 +270,8 @@ class ExperimentBranchBuilder:
 
         """
         conflict = self.conflicts.get_remaining(
-            [conflicts.MissingDimensionConflict], dimension_name=name)[0]
+            [conflicts.MissingDimensionConflict], dimension_name=name
+        )[0]
 
         self.conflicts.try_resolve(conflict, default_value=default_value)
 
@@ -289,22 +299,32 @@ class ExperimentBranchBuilder:
 
         """
         potential_conflicts = self.conflicts.get_remaining(
-            [conflicts.MissingDimensionConflict], dimension_name=old_name)
+            [conflicts.MissingDimensionConflict], dimension_name=old_name
+        )
 
-        assert len(potential_conflicts) == 1, ("Many missing dimensions with the same name: "
-                                               "{}".format(", ".join(potential_conflicts)))
+        assert (
+            len(potential_conflicts) == 1
+        ), "Many missing dimensions with the same name: " "{}".format(
+            ", ".join(potential_conflicts)
+        )
 
         old_dim_conflict = potential_conflicts[0]
 
         potential_conflicts = self.conflicts.get_remaining(
-            [conflicts.NewDimensionConflict], dimension_name=new_name)
+            [conflicts.NewDimensionConflict], dimension_name=new_name
+        )
 
-        assert len(potential_conflicts) == 1, ("Many new dimensions with the same name: "
-                                               "{}".format(", ".join(potential_conflicts)))
+        assert (
+            len(potential_conflicts) == 1
+        ), "Many new dimensions with the same name: " "{}".format(
+            ", ".join(potential_conflicts)
+        )
 
         new_dim_conflict = potential_conflicts[0]
 
-        self.conflicts.try_resolve(old_dim_conflict, new_dimension_conflict=new_dim_conflict)
+        self.conflicts.try_resolve(
+            old_dim_conflict, new_dimension_conflict=new_dim_conflict
+        )
 
     def reset(self, name):
         """Revert a resolution and reset its corresponding conflicts

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -102,7 +102,11 @@ from orion.core.io.interactive_commands.branching_prompt import BranchingPrompt
 from orion.core.io.space_builder import SpaceBuilder
 import orion.core.utils.backward as backward
 from orion.core.utils.exceptions import (
-    BranchingEvent, NoConfigurationError, NoNameError, RaceCondition)
+    BranchingEvent,
+    NoConfigurationError,
+    NoNameError,
+    RaceCondition,
+)
 from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.primary_algo import PrimaryAlgo
 from orion.core.worker.strategy import Strategy
@@ -115,6 +119,7 @@ log = logging.getLogger(__name__)
 ##
 # Functions to build experiments
 ##
+
 
 def build(name, version=None, branching=None, **config):
     """Build an experiment object
@@ -173,11 +178,12 @@ def build(name, version=None, branching=None, **config):
 
     config = consolidate_config(name, version, config)
 
-    if 'space' not in config:
+    if "space" not in config:
         raise NoConfigurationError(
-            'Experiment {} does not exist in DB and space was not defined.'.format(name))
+            "Experiment {} does not exist in DB and space was not defined.".format(name)
+        )
 
-    if len(config['space']) == 0:
+    if len(config["space"]) == 0:
         raise NoConfigurationError("No prior found. Please include at least one.")
 
     experiment = create_experiment(**copy.deepcopy(config))
@@ -190,13 +196,15 @@ def build(name, version=None, branching=None, **config):
         return experiment
 
     conflicts = _get_conflicts(experiment, branching)
-    must_branch = len(conflicts.get()) > 1 or branching.get('branch_to')
+    must_branch = len(conflicts.get()) > 1 or branching.get("branch_to")
     if must_branch:
-        branched_experiment = _branch_experiment(experiment, conflicts, version, branching)
+        branched_experiment = _branch_experiment(
+            experiment, conflicts, version, branching
+        )
         try:
             _register_experiment(branched_experiment)
         except DuplicateKeyError as e:
-            raise RaceCondition('There was a race condition during branching.') from e
+            raise RaceCondition("There was a race condition during branching.") from e
 
         return branched_experiment
 
@@ -208,18 +216,18 @@ def clean_config(name, config, branching):
     """Clean configuration from hidden fields (ex: `_id`) and update branching if necessary"""
     config = copy.deepcopy(config)
     for key, value in list(config.items()):
-        if key.startswith('_') or value is None:
+        if key.startswith("_") or value is None:
             config.pop(key)
 
-    if 'strategy' in config:
-        config['producer'] = {'strategy': config.pop('strategy')}
+    if "strategy" in config:
+        config["producer"] = {"strategy": config.pop("strategy")}
 
     if branching is None:
         branching = {}
 
-    if branching.get('branch_from'):
-        branching.setdefault('branch_to', name)
-        name = branching['branch_from']
+    if branching.get("branch_from"):
+        branching.setdefault("branch_to", name)
+        name = branching["branch_from"]
 
     return name, config, branching
 
@@ -231,38 +239,41 @@ def consolidate_config(name, version, config):
     db_config = fetch_config_from_db(name, version)
 
     # Do not merge spaces, the new definition overrides it.
-    if 'space' in config:
-        db_config.pop('space', None)
+    if "space" in config:
+        db_config.pop("space", None)
 
     new_config = config
     config = resolve_config.merge_configs(db_config, config)
 
     metadata = resolve_config.fetch_metadata(
-        config.get('user'), config.get('user_args'), config.get('user_script_config'))
+        config.get("user"), config.get("user_args"), config.get("user_script_config")
+    )
 
-    config = resolve_config.merge_configs(config, {'metadata': metadata})
+    config = resolve_config.merge_configs(config, {"metadata": metadata})
 
     merge_algorithm_config(config, new_config)
     merge_producer_config(config, new_config)
 
-    config.setdefault('name', name)
-    config.setdefault('version', version)
+    config.setdefault("name", name)
+    config.setdefault("version", version)
     return config
 
 
 def merge_algorithm_config(config, new_config):
     """Merge given algorithm configuration with db config"""
     # TODO: Find a better solution
-    if isinstance(config.get('algorithms'), dict) and len(config['algorithms']) > 1:
-        config['algorithms'] = new_config['algorithms']
+    if isinstance(config.get("algorithms"), dict) and len(config["algorithms"]) > 1:
+        config["algorithms"] = new_config["algorithms"]
 
 
 def merge_producer_config(config, new_config):
     """Merge given producer configuration with db config"""
     # TODO: Find a better solution
-    if (isinstance(config.get('producer', {}).get('strategy'), dict) and
-            len(config['producer']['strategy']) > 1):
-        config['producer']['strategy'] = new_config['producer']['strategy']
+    if (
+        isinstance(config.get("producer", {}).get("strategy"), dict)
+        and len(config["producer"]["strategy"]) > 1
+    ):
+        config["producer"]["strategy"] = new_config["producer"]["strategy"]
 
 
 def build_view(name, version=None):
@@ -283,11 +294,13 @@ def build_view(name, version=None):
     db_config = fetch_config_from_db(name, version)
 
     if not db_config:
-        message = ("No experiment with given name '%s' and version '%s' inside database, "
-                   "no view can be created." % (name, version if version else '*'))
+        message = (
+            "No experiment with given name '%s' and version '%s' inside database, "
+            "no view can be created." % (name, version if version else "*")
+        )
         raise NoConfigurationError(message)
 
-    db_config.setdefault('version', 1)
+    db_config.setdefault("version", 1)
 
     experiment = create_experiment(**db_config)
 
@@ -321,21 +334,38 @@ def create_experiment(name, version, space, **kwargs):
 
     """
     experiment = Experiment(name=name, version=version)
-    experiment._id = kwargs.get('_id', None)  # pylint:disable=protected-access
-    experiment.pool_size = kwargs.get('pool_size')
+    experiment._id = kwargs.get("_id", None)  # pylint:disable=protected-access
+    experiment.pool_size = kwargs.get("pool_size")
     if experiment.pool_size is None:
         experiment.pool_size = orion.core.config.experiment.get(
-            'pool_size', deprecated='ignore')
-    experiment.max_trials = kwargs.get('max_trials', orion.core.config.experiment.max_trials)
-    experiment.max_broken = kwargs.get('max_broken', orion.core.config.experiment.max_broken)
+            "pool_size", deprecated="ignore"
+        )
+    experiment.max_trials = kwargs.get(
+        "max_trials", orion.core.config.experiment.max_trials
+    )
+    experiment.max_broken = kwargs.get(
+        "max_broken", orion.core.config.experiment.max_broken
+    )
     experiment.space = _instantiate_space(space)
-    experiment.algorithms = _instantiate_algo(experiment.space, kwargs.get('algorithms'))
-    experiment.producer = kwargs.get('producer', {})
-    experiment.producer['strategy'] = _instantiate_strategy(experiment.producer.get('strategy'))
-    experiment.working_dir = kwargs.get('working_dir', orion.core.config.experiment.working_dir)
-    experiment.metadata = kwargs.get('metadata', {'user': kwargs.get('user', getpass.getuser())})
-    experiment.refers = kwargs.get('refers', {'parent_id': None, 'root_id': None, 'adapter': []})
-    experiment.refers['adapter'] = _instantiate_adapters(experiment.refers.get('adapter', []))
+    experiment.algorithms = _instantiate_algo(
+        experiment.space, kwargs.get("algorithms")
+    )
+    experiment.producer = kwargs.get("producer", {})
+    experiment.producer["strategy"] = _instantiate_strategy(
+        experiment.producer.get("strategy")
+    )
+    experiment.working_dir = kwargs.get(
+        "working_dir", orion.core.config.experiment.working_dir
+    )
+    experiment.metadata = kwargs.get(
+        "metadata", {"user": kwargs.get("user", getpass.getuser())}
+    )
+    experiment.refers = kwargs.get(
+        "refers", {"parent_id": None, "root_id": None, "adapter": []}
+    )
+    experiment.refers["adapter"] = _instantiate_adapters(
+        experiment.refers.get("adapter", [])
+    )
 
     return experiment
 
@@ -352,7 +382,7 @@ def fetch_config_from_db(name, version=None):
         largest version available, the largest version will be selected.
 
     """
-    configs = get_storage().fetch_experiments({'name': name})
+    configs = get_storage().fetch_experiments({"name": name})
 
     if not configs:
         return {}
@@ -360,8 +390,12 @@ def fetch_config_from_db(name, version=None):
     config = _fetch_config_version(configs, version)
 
     if len(configs) > 1:
-        log.info("Many versions for experiment %s have been found. Using latest "
-                 "version %s.", name, config['version'])
+        log.info(
+            "Many versions for experiment %s have been found. Using latest "
+            "version %s.",
+            name,
+            config["version"],
+        )
 
     backward.populate_space(config, force_update=False)
     backward.update_max_broken(config)
@@ -372,6 +406,7 @@ def fetch_config_from_db(name, version=None):
 ##
 # Private helper functions to build experiments
 ##
+
 
 def _instantiate_adapters(config):
     """Instantiate the adapter object
@@ -443,7 +478,7 @@ def _instantiate_strategy(config=None):
 
 def _register_experiment(experiment):
     """Register a new experiment in the database"""
-    experiment.metadata['datetime'] = datetime.datetime.utcnow()
+    experiment.metadata["datetime"] = datetime.datetime.utcnow()
     config = experiment.configuration
     # This will raise DuplicateKeyError if a concurrent experiment with
     # identical (name, metadata.user) is written first in the database.
@@ -452,18 +487,20 @@ def _register_experiment(experiment):
 
     # XXX: Reminder for future DB implementations:
     # MongoDB, updates an inserted dict with _id, so should you :P
-    experiment._id = config['_id']  # pylint:disable=protected-access
+    experiment._id = config["_id"]  # pylint:disable=protected-access
 
     # Update refers in db if experiment is root
-    if experiment.refers.get('parent_id') is None:
-        log.debug('update refers (name: %s)', experiment.name)
-        experiment.refers['root_id'] = experiment.id
-        get_storage().update_experiment(experiment, refers=experiment.configuration['refers'])
+    if experiment.refers.get("parent_id") is None:
+        log.debug("update refers (name: %s)", experiment.name)
+        experiment.refers["root_id"] = experiment.id
+        get_storage().update_experiment(
+            experiment, refers=experiment.configuration["refers"]
+        )
 
 
 def _update_experiment(experiment):
     """Update experiment configuration in database"""
-    log.debug('updating experiment (name: %s)', experiment.name)
+    log.debug("updating experiment (name: %s)", experiment.name)
     config = experiment.configuration
 
     # TODO: Remove since this should not occur anymore without metadata.user in the indices?
@@ -481,13 +518,16 @@ def _branch_experiment(experiment, conflicts, version, branching_arguments):
     """Create a new branch experiment with adapters for the given conflicts"""
     experiment_brancher = ExperimentBranchBuilder(conflicts, **branching_arguments)
 
-    needs_manual_resolution = (not experiment_brancher.is_resolved or
-                               experiment_brancher.manual_resolution)
+    needs_manual_resolution = (
+        not experiment_brancher.is_resolved or experiment_brancher.manual_resolution
+    )
 
     if not experiment_brancher.is_resolved:
         name_conflict = conflicts.get([ExperimentNameConflict])[0]
         if not name_conflict.is_resolved and not version:
-            raise RaceCondition('There was likely a race condition during version increment.')
+            raise RaceCondition(
+                "There was likely a race condition during version increment."
+            )
 
     if needs_manual_resolution:
         # TODO: This should only be possible when using cmdline API
@@ -502,10 +542,10 @@ def _branch_experiment(experiment, conflicts, version, branching_arguments):
             sys.exit()
 
     config = experiment_brancher.conflicting_config
-    config['refers']['adapter'] = experiment_brancher.create_adapters().configuration
-    config['refers']['parent_id'] = experiment.id
+    config["refers"]["adapter"] = experiment_brancher.create_adapters().configuration
+    config["refers"]["parent_id"] = experiment.id
 
-    config.pop('_id')
+    config.pop("_id")
 
     return create_experiment(**config)
 
@@ -513,8 +553,9 @@ def _branch_experiment(experiment, conflicts, version, branching_arguments):
 def _get_conflicts(experiment, branching):
     """Get conflicts between current experiment and corresponding configuration in database"""
     db_experiment = build_view(experiment.name, experiment.version)
-    conflicts = detect_conflicts(db_experiment.configuration, experiment.configuration,
-                                 branching)
+    conflicts = detect_conflicts(
+        db_experiment.configuration, experiment.configuration, branching
+    )
 
     # elif must_branch and not enable_branching:
     #     raise ValueError("Configuration is different and generate a branching event")
@@ -534,7 +575,7 @@ def _fetch_config_version(configs, version=None):
         largest version available, the largest version will be selected.
 
     """
-    max_version = max(configs, key=lambda exp: exp.get('version', 1)).get('version', 1)
+    max_version = max(configs, key=lambda exp: exp.get("version", 1)).get("version", 1)
 
     if version is None:
         version = max_version
@@ -542,12 +583,16 @@ def _fetch_config_version(configs, version=None):
         version = version
 
     if version > max_version:
-        log.warning("Version %s was specified but most recent version is only %s. "
-                    "Using %s.", version, max_version, max_version)
+        log.warning(
+            "Version %s was specified but most recent version is only %s. " "Using %s.",
+            version,
+            max_version,
+            max_version,
+        )
 
     version = min(version, max_version)
 
-    configs = filter(lambda exp: exp.get('version', 1) == version, configs)
+    configs = filter(lambda exp: exp.get("version", 1) == version, configs)
 
     return next(iter(configs))
 
@@ -555,6 +600,7 @@ def _fetch_config_version(configs, version=None):
 ###
 # Functions for commandline API
 ###
+
 
 def build_from_args(cmdargs):
     """Build an experiment based on commandline arguments.
@@ -570,10 +616,10 @@ def build_from_args(cmdargs):
     """
     cmd_config = get_cmd_config(cmdargs)
 
-    if 'name' not in cmd_config:
+    if "name" not in cmd_config:
         raise NoNameError()
 
-    setup_storage(cmd_config['storage'], debug=cmd_config.get('debug'))
+    setup_storage(cmd_config["storage"], debug=cmd_config.get("debug"))
 
     return build(**cmd_config)
 
@@ -589,13 +635,13 @@ def build_view_from_args(cmdargs):
     """
     cmd_config = get_cmd_config(cmdargs)
 
-    if 'name' not in cmd_config:
+    if "name" not in cmd_config:
         raise NoNameError()
 
-    setup_storage(cmd_config['storage'], debug=cmd_config.get('debug'))
+    setup_storage(cmd_config["storage"], debug=cmd_config.get("debug"))
 
-    name = cmd_config.get('name')
-    version = cmd_config.get('version')
+    name = cmd_config.get("name")
+    version = cmd_config.get("version")
 
     return build_view(name, version)
 
@@ -609,27 +655,36 @@ def get_cmd_config(cmdargs):
     cmd_config = resolve_config.fetch_config(cmdargs)
     cmd_config = resolve_config.merge_configs(cmd_config, cmdargs)
 
-    cmd_config.update(cmd_config.pop('experiment', {}))
-    cmd_config['user_script_config'] = cmd_config.get('worker', {}).get('user_script_config', None)
+    cmd_config.update(cmd_config.pop("experiment", {}))
+    cmd_config["user_script_config"] = cmd_config.get("worker", {}).get(
+        "user_script_config", None
+    )
 
-    cmd_config['branching'] = cmd_config.pop('evc', {})
+    cmd_config["branching"] = cmd_config.pop("evc", {})
 
     # TODO: We should move branching specific stuff below in a centralized place for EVC stuff.
-    if (cmd_config['branching'].get('auto_resolution', False) and
-            cmdargs.get('manual_resolution', None) is None):
-        cmd_config['branching']['manual_resolution'] = False
+    if (
+        cmd_config["branching"].get("auto_resolution", False)
+        and cmdargs.get("manual_resolution", None) is None
+    ):
+        cmd_config["branching"]["manual_resolution"] = False
 
-    non_monitored_arguments = cmdargs.get('non_monitored_arguments')
+    non_monitored_arguments = cmdargs.get("non_monitored_arguments")
     if non_monitored_arguments:
-        cmd_config['branching']['non_monitored_arguments'] = non_monitored_arguments.split(':')
+        cmd_config["branching"][
+            "non_monitored_arguments"
+        ] = non_monitored_arguments.split(":")
 
     # TODO: user_args won't be defined if reading from DB only (`orion hunt -n <exp> ` alone)
     metadata = resolve_config.fetch_metadata(
-        cmd_config.get('user'), cmd_config.get('user_args'), cmd_config.get('user_script_config'))
-    cmd_config['metadata'] = metadata
-    cmd_config.pop('config', None)
+        cmd_config.get("user"),
+        cmd_config.get("user_args"),
+        cmd_config.get("user_script_config"),
+    )
+    cmd_config["metadata"] = metadata
+    cmd_config.pop("config", None)
 
-    cmd_config['space'] = cmd_config['metadata'].get('priors', None)
+    cmd_config["space"] = cmd_config["metadata"].get("priors", None)
 
     backward.update_db_config(cmd_config)
 

--- a/src/orion/core/io/interactive_commands/branching_prompt.py
+++ b/src/orion/core/io/interactive_commands/branching_prompt.py
@@ -25,11 +25,12 @@ from orion.core.utils.diff import green, red
 from orion.storage.base import get_storage
 
 
-readline.set_completer_delims(' ')
+readline.set_completer_delims(" ")
 
 
 def wrap_autocomplete(f):
     """Wrap autocomplete to catch errors and print stacktrace"""
+
     @functools.wraps(f)
     def call(self, *args):
 
@@ -53,6 +54,7 @@ def parse_command(f):
     """Wrap command methods to automatically parse using parsers and catch errors to print
     stacktrace without leaving the prompt
     """
+
     @functools.wraps(f)
     def call(self, arg):
 
@@ -80,15 +82,17 @@ class BranchingPrompt(cmd.Cmd):
     between the parent configuration and the new one.
     """
 
-    intro = ('\n\n'
-             'Welcome to Orion\'s experiment branching interactive conflicts resolver\n'
-             '-----------------------------------------------------------------------\n\n'
-             'If you are unfamiliar with this process, you can type '
-             '`help` to print the help message. You can also type `abort` or `(q)uit` at any '
-             'moment to quit without saving.\n'
-             '\n'
-             '%s')
-    prompt = '(orion) '
+    intro = (
+        "\n\n"
+        "Welcome to Orion's experiment branching interactive conflicts resolver\n"
+        "-----------------------------------------------------------------------\n\n"
+        "If you are unfamiliar with this process, you can type "
+        "`help` to print the help message. You can also type `abort` or `(q)uit` at any "
+        "moment to quit without saving.\n"
+        "\n"
+        "%s"
+    )
+    prompt = "(orion) "
 
     def __init__(self, branch_builder):
         """Retrieve the instance of ExperimentBranchBuilder containing the conflicts"""
@@ -101,7 +105,7 @@ class BranchingPrompt(cmd.Cmd):
         self.parser = argparse.ArgumentParser(prog="(orion)", add_help=False)
         subparsers = self.parser.add_subparsers(title="commands")
         for command in self.get_commands():
-            subparser_builder = getattr(self, '_add_{}_parser'.format(command), None)
+            subparser_builder = getattr(self, "_add_{}_parser".format(command), None)
             if subparser_builder:
                 subparser_builder(subparsers)
             else:
@@ -112,53 +116,71 @@ class BranchingPrompt(cmd.Cmd):
 
     def _add_default_subparser(self, name, subparsers):
         method = getattr(self, "do_{}".format(name))
-        subparser = self._build_argument_parser(subparsers, name,
-                                                help=getattr(method, "__doc__", None),
-                                                description=getattr(method, "__doc__", None))
+        subparser = self._build_argument_parser(
+            subparsers,
+            name,
+            help=getattr(method, "__doc__", None),
+            description=getattr(method, "__doc__", None),
+        )
         return subparser
 
     def _add_name_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'name', help=self.do_name.__doc__)
-        subparser.add_argument('experiment_name', metavar='experiment-name')
+        subparser = self._build_argument_parser(
+            subparsers, "name", help=self.do_name.__doc__
+        )
+        subparser.add_argument("experiment_name", metavar="experiment-name")
         return subparser
 
     def _add_code_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'code', help=self.do_code.__doc__)
-        subparser.add_argument('change_type', choices=adapters.CodeChange.types)
+        subparser = self._build_argument_parser(
+            subparsers, "code", help=self.do_code.__doc__
+        )
+        subparser.add_argument("change_type", choices=adapters.CodeChange.types)
         return subparser
 
     def _add_commandline_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'commandline',
-                                                help=self.do_commandline.__doc__)
-        subparser.add_argument('change_type', choices=adapters.CommandLineChange.types)
+        subparser = self._build_argument_parser(
+            subparsers, "commandline", help=self.do_commandline.__doc__
+        )
+        subparser.add_argument("change_type", choices=adapters.CommandLineChange.types)
         return subparser
 
     def _add_config_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'config', help=self.do_config.__doc__)
-        subparser.add_argument('change_type', choices=adapters.ScriptConfigChange.types)
+        subparser = self._build_argument_parser(
+            subparsers, "config", help=self.do_config.__doc__
+        )
+        subparser.add_argument("change_type", choices=adapters.ScriptConfigChange.types)
         return subparser
 
     def _add_add_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'add', help=self.do_add.__doc__)
-        subparser.add_argument('dimension_name', metavar='dimension-name')
-        subparser.add_argument('--default-value', default=Dimension.NO_DEFAULT_VALUE)
+        subparser = self._build_argument_parser(
+            subparsers, "add", help=self.do_add.__doc__
+        )
+        subparser.add_argument("dimension_name", metavar="dimension-name")
+        subparser.add_argument("--default-value", default=Dimension.NO_DEFAULT_VALUE)
         return subparser
 
     def _add_remove_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'remove', help=self.do_remove.__doc__)
-        subparser.add_argument('dimension_name', metavar='dimension-name')
-        subparser.add_argument('--default-value', default=Dimension.NO_DEFAULT_VALUE)
+        subparser = self._build_argument_parser(
+            subparsers, "remove", help=self.do_remove.__doc__
+        )
+        subparser.add_argument("dimension_name", metavar="dimension-name")
+        subparser.add_argument("--default-value", default=Dimension.NO_DEFAULT_VALUE)
         return subparser
 
     def _add_rename_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'rename', help=self.do_rename.__doc__)
-        subparser.add_argument('old_name', metavar='old-name')
-        subparser.add_argument('new_name', metavar='new-name')
+        subparser = self._build_argument_parser(
+            subparsers, "rename", help=self.do_rename.__doc__
+        )
+        subparser.add_argument("old_name", metavar="old-name")
+        subparser.add_argument("new_name", metavar="new-name")
         return subparser
 
     def _add_reset_parser(self, subparsers):
-        subparser = self._build_argument_parser(subparsers, 'reset', help=self.do_reset.__doc__)
-        subparser.add_argument('resolutions', nargs='+', metavar='resolutions')
+        subparser = self._build_argument_parser(
+            subparsers, "reset", help=self.do_reset.__doc__
+        )
+        subparser.add_argument("resolutions", nargs="+", metavar="resolutions")
         return subparser
 
     def solve_conflicts(self):
@@ -168,8 +190,11 @@ class BranchingPrompt(cmd.Cmd):
     def get_commands(self):
         """Get command names of the prompt"""
         # Get rid of 'do_'
-        commands = [attr[3:] for attr in dir(self)
-                    if callable(getattr(self, attr)) and attr.startswith('do_')]
+        commands = [
+            attr[3:]
+            for attr in dir(self)
+            if callable(getattr(self, attr)) and attr.startswith("do_")
+        ]
 
         return commands
 
@@ -185,8 +210,10 @@ class BranchingPrompt(cmd.Cmd):
 
         output = io.StringIO()
         if resolved_conflicts:
-            resolution_strings = set(str(conflict.resolution) for conflict in resolved_conflicts)
-            print('Resolutions:', file=output)
+            resolution_strings = set(
+                str(conflict.resolution) for conflict in resolved_conflicts
+            )
+            print("Resolutions:", file=output)
             print(file=output)
             for resolution_string in resolution_strings:
                 print("    ", green(str(resolution_string)), file=output)
@@ -197,7 +224,7 @@ class BranchingPrompt(cmd.Cmd):
 
         if unsolved_conflicts:
 
-            print('Remaining conflicts:', file=output)
+            print("Remaining conflicts:", file=output)
             print(file=output)
             for conflict in unsolved_conflicts:
                 print("    ", red(str(conflict)), file=output)
@@ -205,8 +232,10 @@ class BranchingPrompt(cmd.Cmd):
         else:
             print(file=output)
             print("Hooray, there is no more conflicts!", file=output)
-            print("You can enter \'commit\' to leave this prompt and register the new branch",
-                  file=output)
+            print(
+                "You can enter 'commit' to leave this prompt and register the new branch",
+                file=output,
+            )
             print(file=output)
 
         return output.getvalue()
@@ -215,7 +244,7 @@ class BranchingPrompt(cmd.Cmd):
     @parse_command
     def do_help(self, options):
         """Print help message for all commands"""
-        output = io.StringIO(initial_value='', newline='\n')
+        output = io.StringIO(initial_value="", newline="\n")
         self.parser.print_help(file=output)
         print(output.getvalue())
 
@@ -258,8 +287,10 @@ class BranchingPrompt(cmd.Cmd):
         """Change the name of the experiment"""
         self.branch_builder.change_experiment_name(options.experiment_name)
 
-        print('TIP: You can use the \'-b\' or \'--branch\' command-line '
-              'argument to automate the naming process.')
+        print(
+            "TIP: You can use the '-b' or '--branch' command-line "
+            "argument to automate the naming process."
+        )
 
         self.do_status("")
 
@@ -269,14 +300,23 @@ class BranchingPrompt(cmd.Cmd):
         if len(line.split(" ")) >= 3:
             names = []
         else:
-            query = {'refers.root_id': self.branch_builder.experiment_config['refers']['root_id'],
-                     'metadata.user': self.branch_builder.experiment_config['metadata']['user']}
-            names = [experiment['name'] for experiment in get_storage().fetch_experiments(query)]
+            query = {
+                "refers.root_id": self.branch_builder.experiment_config["refers"][
+                    "root_id"
+                ],
+                "metadata.user": self.branch_builder.experiment_config["metadata"][
+                    "user"
+                ],
+            }
+            names = [
+                experiment["name"]
+                for experiment in get_storage().fetch_experiments(query)
+            ]
 
         return self._get_completions(names, text)
 
     def _get_completions(self, names, text, ignore=()):
-        return [f + ' ' for f in names if f.startswith(text) and f not in ignore]
+        return [f + " " for f in names if f.startswith(text) and f not in ignore]
 
     @parse_command
     def do_code(self, options):
@@ -330,9 +370,11 @@ class BranchingPrompt(cmd.Cmd):
     @parse_command
     def do_add(self, options):
         """Add the given `new` or `changed` dimension to the configuration"""
-        print('TIP: You can use the \'~+\' marker in place of the usual ~ with '
-              'the command-line to solve this conflict automatically.'
-              '\nEx: -x~+uniform(0,1)')
+        print(
+            "TIP: You can use the '~+' marker in place of the usual ~ with "
+            "the command-line to solve this conflict automatically."
+            "\nEx: -x~+uniform(0,1)"
+        )
 
         self.branch_builder.add_dimension(options.dimension_name, options.default_value)
 
@@ -343,16 +385,22 @@ class BranchingPrompt(cmd.Cmd):
         """Auto-complete addition of new or changed dimensions"""
         return self._complete_dim(
             [conflicts.NewDimensionConflict, conflicts.ChangedDimensionConflict],
-            text, line, begidx, endidx)
+            text,
+            line,
+            begidx,
+            endidx,
+        )
 
     def _complete_add_new_or_missing(self, conflict, text, line, begidx, endidx):
         """Auto-complete addition of new dimensions or deletion of missing dimensions"""
-        dim_is_categorical = conflict.dimension.type == 'categorical'
+        dim_is_categorical = conflict.dimension.type == "categorical"
 
         if len(line.split(" ")) == 3:
-            return ['--default-value ']
+            return ["--default-value "]
         elif len(line.split(" ")) == 4 and dim_is_categorical:
-            return self._get_completions([repr(f) for f in conflict.dimension.categories], text)
+            return self._get_completions(
+                [repr(f) for f in conflict.dimension.categories], text
+            )
 
         return []
 
@@ -363,24 +411,34 @@ class BranchingPrompt(cmd.Cmd):
     @parse_command
     def do_remove(self, options):
         """Remove the given `missing` dimension from the configuration"""
-        print('TIP: You can use the \'~-\' marker in place of the usual ~ with '
-              'the command-line to solve this conflict automatically.'
-              '\nEx: -x~-')
+        print(
+            "TIP: You can use the '~-' marker in place of the usual ~ with "
+            "the command-line to solve this conflict automatically."
+            "\nEx: -x~-"
+        )
 
-        self.branch_builder.remove_dimension(options.dimension_name, options.default_value)
+        self.branch_builder.remove_dimension(
+            options.dimension_name, options.default_value
+        )
 
         self.do_status("")
 
     @wrap_autocomplete
     def complete_remove(self, text, line, begidx, endidx):
         """Auto-complete deletion of missing dimensions"""
-        return self._complete_dim([conflicts.MissingDimensionConflict], text, line, begidx, endidx)
+        return self._complete_dim(
+            [conflicts.MissingDimensionConflict], text, line, begidx, endidx
+        )
 
     def _complete_dim(self, conflict_types, text, line, begidx, endidx):
         """Auto-complete addition or deletion of new, changed or missing dimensions"""
-        potential_conflicts = self.branch_builder.conflicts.get_remaining(conflict_types)
+        potential_conflicts = self.branch_builder.conflicts.get_remaining(
+            conflict_types
+        )
 
-        names = [conflict.dimension.name.lstrip("/") for conflict in potential_conflicts]
+        names = [
+            conflict.dimension.name.lstrip("/") for conflict in potential_conflicts
+        ]
 
         if len(line.split(" ")) == 2:
             return self._get_completions(names, text)
@@ -391,24 +449,33 @@ class BranchingPrompt(cmd.Cmd):
             return []
         name = names[0]
 
-        potential_conflicts = [conflict for conflict in potential_conflicts
-                               if conflict.dimension.name.lstrip("/") == name]
+        potential_conflicts = [
+            conflict
+            for conflict in potential_conflicts
+            if conflict.dimension.name.lstrip("/") == name
+        ]
         if not potential_conflicts:
             return []
         conflict = potential_conflicts[0]
 
-        if isinstance(conflict,
-                      (conflicts.NewDimensionConflict, conflicts.MissingDimensionConflict)):
-            return self._complete_add_new_or_missing(conflict, text, line, begidx, endidx)
+        if isinstance(
+            conflict,
+            (conflicts.NewDimensionConflict, conflicts.MissingDimensionConflict),
+        ):
+            return self._complete_add_new_or_missing(
+                conflict, text, line, begidx, endidx
+            )
         else:
             return self._complete_add_changed(conflict, text, line, begidx, endidx)
 
     @parse_command
     def do_rename(self, options):
         """Rename a dimension"""
-        print('TIP: You can use the \'~>\' marker in place of the usual ~ with '
-              'the command-line to solve this dimension automatically.'
-              '\nEx: -x~>y')
+        print(
+            "TIP: You can use the '~>' marker in place of the usual ~ with "
+            "the command-line to solve this dimension automatically."
+            "\nEx: -x~>y"
+        )
         self.branch_builder.rename_dimension(options.old_name, options.new_name)
 
         self.do_status("")
@@ -420,14 +487,18 @@ class BranchingPrompt(cmd.Cmd):
         """
         if len(line.split(" ")) < 3:
             potential_conflicts = self.branch_builder.conflicts.get_remaining(
-                [conflicts.MissingDimensionConflict])
+                [conflicts.MissingDimensionConflict]
+            )
         elif len(line.split(" ")) == 3:
             potential_conflicts = self.branch_builder.conflicts.get_remaining(
-                [conflicts.NewDimensionConflict])
+                [conflicts.NewDimensionConflict]
+            )
         else:
             potential_conflicts = []
 
-        names = [conflict.dimension.name.lstrip('/') for conflict in potential_conflicts]
+        names = [
+            conflict.dimension.name.lstrip("/") for conflict in potential_conflicts
+        ]
 
         return self._get_completions(names, text)
 
@@ -449,14 +520,14 @@ class BranchingPrompt(cmd.Cmd):
         except ValueError:
             ignore = [shlex.quote(t) for t in shlex.split(line + "'")]
 
-        names = [name.replace('\'"\'"\'', '"') for name in names]
+        names = [name.replace("'\"'\"'", '"') for name in names]
 
         return self._get_completions(names, text, ignore=ignore)
 
     @parse_command
     def do_abort(self, options):
         """Exit the prompt without saving"""
-        print('Closing interactive conflicts solver. Experiment branch won\'t be saved.')
+        print("Closing interactive conflicts solver. Experiment branch won't be saved.")
 
         self.abort = True
         return True
@@ -475,11 +546,13 @@ class BranchingPrompt(cmd.Cmd):
     def do_commit(self, options):
         """Exit the prompt and creates the adapters inside the builders"""
         if not self.branch_builder.is_resolved:
-            print('Error: There is still remaining issues. Enter \'abort\' or \'quit\' to leave '
-                  'without registering the new experiment branch.')
+            print(
+                "Error: There is still remaining issues. Enter 'abort' or 'quit' to leave "
+                "without registering the new experiment branch."
+            )
             return False
 
-        new_name = self.branch_builder.conflicting_config['name']
-        print('Registering experiment branch \'{0}\'.'.format(new_name))
+        new_name = self.branch_builder.conflicting_config["name"]
+        print("Registering experiment branch '{0}'.".format(new_name))
 
         return True

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -32,10 +32,10 @@ log = logging.getLogger(__name__)
 
 
 def _is_nonprior_wave(arg):
-    return arg.startswith('/') or arg == ''
+    return arg.startswith("/") or arg == ""
 
 
-class OrionCmdlineParser():
+class OrionCmdlineParser:
     """Python interface commandline parser
 
     The `OrionCmdlineParser` is used as a way to obtain the parsing process of Orion
@@ -79,7 +79,7 @@ class OrionCmdlineParser():
 
     """
 
-    def __init__(self, config_prefix='config', allow_non_existing_files=False):
+    def __init__(self, config_prefix="config", allow_non_existing_files=False):
         """Create an `OrionCmdlineParser`."""
         self.parser = CmdlineParser()
         self.cmd_priors = OrderedDict()
@@ -94,13 +94,15 @@ class OrionCmdlineParser():
         self.user_script = None
 
         # Extraction methods for the file parsing part.
-        self._extraction_method = {dict: self._extract_dict,
-                                   defaultdict: self._extract_defaultdict,
-                                   list: self._extract_list,
-                                   str: self._extract_file_string}
+        self._extraction_method = {
+            dict: self._extract_dict,
+            defaultdict: self._extract_defaultdict,
+            list: self._extract_list,
+            str: self._extract_file_string,
+        }
 
         # Look for anything followed by a tilt and possible branching attributes + prior
-        self.prior_regex = re.compile(r'(.+)~([\+\-\>]?.+)')
+        self.prior_regex = re.compile(r"(.+)~([\+\-\>]?.+)")
 
     def get_state_dict(self):
         """Give state dict that can be used to reconstruct the parser"""
@@ -111,22 +113,23 @@ class OrionCmdlineParser():
             config_file_data=self.config_file_data,
             config_prefix=self.config_prefix,
             file_config_path=self.file_config_path,
-            converter=self.converter.get_state_dict() if self.converter else None)
+            converter=self.converter.get_state_dict() if self.converter else None,
+        )
 
     def set_state_dict(self, state):
         """Reset the parser based on previous state"""
-        self.parser.set_state_dict(state['parser'])
+        self.parser.set_state_dict(state["parser"])
 
-        self.cmd_priors = OrderedDict(state['cmd_priors'])
-        self.file_priors = OrderedDict(state['file_priors'])
+        self.cmd_priors = OrderedDict(state["cmd_priors"])
+        self.file_priors = OrderedDict(state["file_priors"])
 
-        self.config_file_data = state['config_file_data']
-        self.config_prefix = state['config_prefix']
-        self.file_config_path = state['file_config_path']
+        self.config_file_data = state["config_file_data"]
+        self.config_prefix = state["config_prefix"]
+        self.file_config_path = state["file_config_path"]
 
         if self.file_config_path:
             self.converter = infer_converter_from_file_type(self.file_config_path)
-            self.converter.set_state_dict(state['converter'])
+            self.converter.set_state_dict(state["converter"])
 
     def parse(self, commandline):
         """Parse the commandline given for the definition of priors.
@@ -148,8 +151,10 @@ class OrionCmdlineParser():
 
         duplicated_priors = set(self.cmd_priors.keys()) & set(self.file_priors.keys())
         if duplicated_priors:
-            raise ValueError("Conflict: definition of same prior in commandline and config: "
-                             "{}".format(duplicated_priors))
+            raise ValueError(
+                "Conflict: definition of same prior in commandline and config: "
+                "{}".format(duplicated_priors)
+            )
 
     def infer_user_script(self, user_args):
         """Infer the script name and perform some checks"""
@@ -157,15 +162,21 @@ class OrionCmdlineParser():
             return
 
         # TODO: Parse commandline for any options to python and pick the script filepath properly
-        if user_args[0] == 'python':
+        if user_args[0] == "python":
             user_script = user_args[1]
         else:
             user_script = user_args[0]
 
-        if (not os.path.exists(user_script) and not shutil.which(user_script) and
-                not self.allow_non_existing_files):
-            raise OSError(errno.ENOENT, "The path specified for the script does not exist",
-                          user_script)
+        if (
+            not os.path.exists(user_script)
+            and not shutil.which(user_script)
+            and not self.allow_non_existing_files
+        ):
+            raise OSError(
+                errno.ENOENT,
+                "The path specified for the script does not exist",
+                user_script,
+            )
 
         self.user_script = user_script
 
@@ -198,9 +209,9 @@ class OrionCmdlineParser():
         """
         replaced = []
         for item in args:
-            if item.startswith('-'):
+            if item.startswith("-"):
                 # Get the prior part after the `~`
-                parts = item.split('~')
+                parts = item.split("~")
 
                 if len(parts) > 1 and _is_nonprior_wave(parts[1]):
                     replaced.append(item)
@@ -208,13 +219,13 @@ class OrionCmdlineParser():
 
                 # If the argument was defined has a long one but only has a single letter
                 # then it needs to be shortened.
-                if parts[0].startswith('--') and len(parts[0]) == 3:
+                if parts[0].startswith("--") and len(parts[0]) == 3:
                     parts[0] = parts[0][1:]
 
                 replaced.append(parts[0])
 
                 if len(parts) > 1:
-                    replaced.append('orion~' + parts[1])
+                    replaced.append("orion~" + parts[1])
             else:
                 replaced.append(item)
 
@@ -256,13 +267,16 @@ class OrionCmdlineParser():
         """
         if not os.path.exists(path):
             if self.allow_non_existing_files:
-                log.info("The path specified for the script config does not exist: %s", path)
+                log.info(
+                    "The path specified for the script config does not exist: %s", path
+                )
                 return
             else:
                 raise OSError(
                     errno.ENOENT,
                     "The path specified for the script config does not exist",
-                    path)
+                    path,
+                )
 
         self.converter = infer_converter_from_file_type(path)
         self.config_file_data = self.converter.parse(path)
@@ -270,11 +284,11 @@ class OrionCmdlineParser():
 
     def _extract_defaultdict(self, current_depth, ex_dict):
         for key, value in ex_dict.items():
-            sub_depth = current_depth + '/' + str(key)
+            sub_depth = current_depth + "/" + str(key)
 
             try:
                 if isinstance(value, str):
-                    value = 'orion~' + value
+                    value = "orion~" + value
                 self._extraction_method[type(value)](sub_depth, value)
             except KeyError:
                 pass
@@ -294,7 +308,7 @@ class OrionCmdlineParser():
 
         """
         for key, value in ex_dict.items():
-            sub_depth = current_depth + '/' + str(key)
+            sub_depth = current_depth + "/" + str(key)
 
             try:
                 self._extraction_method[type(value)](sub_depth, value)
@@ -316,7 +330,7 @@ class OrionCmdlineParser():
 
         """
         for i, value in enumerate(ex_list):
-            sub_depth = current_depth + '/' + str(i)
+            sub_depth = current_depth + "/" + str(i)
 
             try:
                 self._extraction_method[type(value)](sub_depth, value)
@@ -337,7 +351,7 @@ class OrionCmdlineParser():
             Value from which to extract a prior.
 
         """
-        substrings = value.split('~')
+        substrings = value.split("~")
 
         if len(substrings) == 1:
             return
@@ -375,8 +389,8 @@ class OrionCmdlineParser():
         _, expression = prior.groups(2)
 
         name = key
-        if not name.startswith('/'):
-            name = '/' + name
+        if not name.startswith("/"):
+            name = "/" + name
 
         insert_into[name] = expression
 
@@ -430,8 +444,10 @@ class OrionCmdlineParser():
 
         """
         if self.file_config_path and config_path is None:
-            raise ValueError('The configuration contains a config file. '
-                             'Cannot format without a `config_path` argument.')
+            raise ValueError(
+                "The configuration contains a config file. "
+                "Cannot format without a `config_path` argument."
+            )
         elif self.file_config_path:
             self._create_config_file(config_path, trial)
         configuration = self._build_configuration(trial)
@@ -461,7 +477,7 @@ class OrionCmdlineParser():
 
             # Since namespace start with '/', we must skip
             # the first element of the list.
-            path = name.split('/')[1:]
+            path = name.split("/")[1:]
             current_depth = instance
 
             for key in path:
@@ -490,11 +506,11 @@ class OrionCmdlineParser():
         configuration = copy.deepcopy(self.parser.arguments)
 
         for name, value in trial.params.items():
-            name = name.lstrip('/')
+            name = name.lstrip("/")
             configuration[name] = value
 
         return configuration
 
     def priors_to_normal(self):
         """Remove the namespace `/` prefix from priors."""
-        return {key.lstrip('/'): arg for key, arg in self.cmd_priors.items()}
+        return {key.lstrip("/"): arg for key, arg in self.cmd_priors.items()}

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -59,26 +59,24 @@ log = logging.getLogger(__name__)
 ################################################################################
 
 # Default settings for command line arguments (option, description)
-DEF_CMD_MAX_TRIALS = (infinity, 'inf/until preempted')
-DEF_CMD_WORKER_TRIALS = (infinity, 'inf/until preempted')
+DEF_CMD_MAX_TRIALS = (infinity, "inf/until preempted")
+DEF_CMD_WORKER_TRIALS = (infinity, "inf/until preempted")
 DEF_CMD_POOL_SIZE = (1, str(1))
 
 # list containing tuples of
 # (environmental variable names, configuration keys, default values)
 ENV_VARS_DB = [
-    ('ORION_DB_NAME', 'name'),
-    ('ORION_DB_TYPE', 'type'),
-    ('ORION_DB_ADDRESS', 'host'),
-    ('ORION_DB_PORT', 'port')
-    ]
+    ("ORION_DB_NAME", "name"),
+    ("ORION_DB_TYPE", "type"),
+    ("ORION_DB_ADDRESS", "host"),
+    ("ORION_DB_PORT", "port"),
+]
 
 # TODO: Default resource from environmental (localhost)
 
 # dictionary describing lists of environmental tuples (e.g. `ENV_VARS_DB`)
 # by a 'key' to be used in the experiment's configuration dict
-ENV_VARS = dict(
-    database=ENV_VARS_DB
-    )
+ENV_VARS = dict(database=ENV_VARS_DB)
 
 
 def _convert_dashes(config, ref):
@@ -89,12 +87,14 @@ def _convert_dashes(config, ref):
     """
     config = copy.deepcopy(config)
     for key in list(config.keys()):
-        converted_key = key.replace('-', '_')
+        converted_key = key.replace("-", "_")
         if converted_key in ref:
             config[converted_key] = config.pop(key)
 
             if all(isinstance(item[converted_key], dict) for item in [config, ref]):
-                config[converted_key] = _convert_dashes(config[converted_key], ref[converted_key])
+                config[converted_key] = _convert_dashes(
+                    config[converted_key], ref[converted_key]
+                )
 
     return config
 
@@ -104,68 +104,64 @@ def _convert_dashes(config, ref):
 # pylint:disable=too-many-branches
 def fetch_config_from_cmdargs(cmdargs):
     """Turn flat cmdargs into nested dicts like orion.core.config."""
-    config_file = cmdargs.pop('config', None)
+    config_file = cmdargs.pop("config", None)
     tmp_cmdargs = copy.deepcopy(cmdargs)
-    tmp_cmdargs['config'] = config_file
-    cmdargs['config'] = config_file
+    tmp_cmdargs["config"] = config_file
+    cmdargs["config"] = config_file
     cmdargs = tmp_cmdargs
 
     cmdargs_config = {}
 
-    if cmdargs.get('max_trials') is not None:
+    if cmdargs.get("max_trials") is not None:
         log.warning(
-            '--max-trials is deprecated and will be removed in v0.3. '
-            'Use --exp-max-trials instead')
-        cmdargs_config['experiment.max_trials'] = cmdargs.pop('max_trials')
+            "--max-trials is deprecated and will be removed in v0.3. "
+            "Use --exp-max-trials instead"
+        )
+        cmdargs_config["experiment.max_trials"] = cmdargs.pop("max_trials")
 
-    if cmdargs.get('worker_trials') is not None:
+    if cmdargs.get("worker_trials") is not None:
         log.warning(
-            '--worker-trials is deprecated and will be removed in v0.3. '
-            'Use --worker-max-trials instead')
-        cmdargs_config['worker.max_trials'] = cmdargs.pop('worker_trials')
+            "--worker-trials is deprecated and will be removed in v0.3. "
+            "Use --worker-max-trials instead"
+        )
+        cmdargs_config["worker.max_trials"] = cmdargs.pop("worker_trials")
 
     mappings = dict(
-        experiment=dict(
-            exp_max_broken='max_broken',
-            exp_max_trials='max_trials'),
-        worker=dict(
-            worker_max_broken='max_broken',
-            worker_max_trials='max_trials'))
+        experiment=dict(exp_max_broken="max_broken", exp_max_trials="max_trials"),
+        worker=dict(worker_max_broken="max_broken", worker_max_trials="max_trials"),
+    )
 
     mappings = dict(
-        experiment=dict(
-            max_broken='exp_max_broken',
-            max_trials='exp_max_trials'),
-        worker=dict(
-            max_broken='worker_max_broken',
-            max_trials='worker_max_trials'))
+        experiment=dict(max_broken="exp_max_broken", max_trials="exp_max_trials"),
+        worker=dict(max_broken="worker_max_broken", max_trials="worker_max_trials"),
+    )
 
     global_config = orion.core.config.to_dict()
 
-    for key in ['config', 'user_args']:
+    for key in ["config", "user_args"]:
         if cmdargs.get(key) not in [False, None]:
             cmdargs_config[key] = cmdargs[key]
 
-    for key in ['name', 'user', 'version']:
+    for key in ["name", "user", "version"]:
         if cmdargs.get(key) not in [False, None]:
-            cmdargs_config[f'experiment.{key}'] = cmdargs[key]
+            cmdargs_config[f"experiment.{key}"] = cmdargs[key]
 
-    for key in ['branch_from', 'branch_to']:
+    for key in ["branch_from", "branch_to"]:
         if cmdargs.get(key) not in [False, None]:
-            cmdargs_config[f'evc.{key}'] = cmdargs[key]
+            cmdargs_config[f"evc.{key}"] = cmdargs[key]
 
     # Apply config at the root
-    for key in ['debug']:
+    for key in ["debug"]:
 
         # Adapt to cli arguments
         cli_key = mappings.get(key, key)
 
         value = cmdargs.pop(cli_key, None)
         if value is not None:
-            cmdargs_config[f'{key}'] = value
+            cmdargs_config[f"{key}"] = value
 
     # Apply to subconfigs
-    for key in ['experiment', 'worker', 'evc']:
+    for key in ["experiment", "worker", "evc"]:
         for subkey in global_config[key].keys():
 
             # Adapt to cli arguments
@@ -173,17 +169,19 @@ def fetch_config_from_cmdargs(cmdargs):
 
             value = cmdargs.pop(cli_key, None)
             if value is not None:
-                cmdargs_config[f'{key}.{subkey}'] = value
+                cmdargs_config[f"{key}.{subkey}"] = value
 
     return unflatten(cmdargs_config)
 
 
 def fetch_config(args):
     """Return the config inside the .yaml file if present."""
-    orion_file = args.get('config')
+    orion_file = args.get("config")
     local_config = {}
     if orion_file:
-        log.debug("Found orion configuration file at: %s", os.path.abspath(orion_file.name))
+        log.debug(
+            "Found orion configuration file at: %s", os.path.abspath(orion_file.name)
+        )
         orion_file.seek(0)
         tmp_config = yaml.safe_load(orion_file)
 
@@ -192,66 +190,81 @@ def fetch_config(args):
         tmp_config = _convert_dashes(tmp_config, global_config)
 
         # Fix deprecations first because some names are shared by experiment and worker
-        max_trials = tmp_config.pop('max_trials', None)
+        max_trials = tmp_config.pop("max_trials", None)
         if max_trials is not None:
             log.warning(
-                '(DEPRECATED) Option `max_trials` is deprecated '
-                'and will be removed in v0.3. Use instead the option'
-                '\nexperiment:\n  max_trials: %s', max_trials)
-            local_config['experiment.max_trials'] = max_trials
+                "(DEPRECATED) Option `max_trials` is deprecated "
+                "and will be removed in v0.3. Use instead the option"
+                "\nexperiment:\n  max_trials: %s",
+                max_trials,
+            )
+            local_config["experiment.max_trials"] = max_trials
 
-        worker_trials = tmp_config.get('experiment', {}).pop('worker_trials', None)
+        worker_trials = tmp_config.get("experiment", {}).pop("worker_trials", None)
         if worker_trials is not None:
             log.warning(
-                '(DEPRECATED) Option `experiment.worker_trials` is deprecated '
-                'and will be removed in v0.3. Use instead the option'
-                '\nworker:\n  max_trials: %s', worker_trials)
-            local_config['worker.max_trials'] = worker_trials
+                "(DEPRECATED) Option `experiment.worker_trials` is deprecated "
+                "and will be removed in v0.3. Use instead the option"
+                "\nworker:\n  max_trials: %s",
+                worker_trials,
+            )
+            local_config["worker.max_trials"] = worker_trials
 
-        worker_trials = tmp_config.pop('worker_trials', None)
+        worker_trials = tmp_config.pop("worker_trials", None)
         if worker_trials is not None:
             log.warning(
-                '(DEPRECATED) Option `worker_trials` is deprecated '
-                'and will be removed in v0.3. Use instead the option'
-                '\nworker:\n  max_trials: %s', worker_trials)
-            local_config['worker.max_trials'] = worker_trials
+                "(DEPRECATED) Option `worker_trials` is deprecated "
+                "and will be removed in v0.3. Use instead the option"
+                "\nworker:\n  max_trials: %s",
+                worker_trials,
+            )
+            local_config["worker.max_trials"] = worker_trials
 
-        producer = tmp_config.pop('producer', None)
+        producer = tmp_config.pop("producer", None)
         if producer is not None:
             log.warning(
-                '(DEPRECATED) Option `producer` is deprecated '
-                'and will be removed in v0.3. Use instead the option'
-                '\nexperiment:\n  strategy: %s', producer['strategy'])
-            local_config['experiment.strategy'] = producer['strategy']
+                "(DEPRECATED) Option `producer` is deprecated "
+                "and will be removed in v0.3. Use instead the option"
+                "\nexperiment:\n  strategy: %s",
+                producer["strategy"],
+            )
+            local_config["experiment.strategy"] = producer["strategy"]
 
-        producer = tmp_config.get('experiment', {}).pop('producer', None)
+        producer = tmp_config.get("experiment", {}).pop("producer", None)
         if producer is not None:
             log.warning(
-                '(DEPRECATED) Option `experiment.producer` is deprecated '
-                'and will be removed in v0.3. Use instead the option'
-                '\nexperiment:\n  strategy: %s', producer['strategy'])
-            local_config['experiment.strategy'] = producer['strategy']
+                "(DEPRECATED) Option `experiment.producer` is deprecated "
+                "and will be removed in v0.3. Use instead the option"
+                "\nexperiment:\n  strategy: %s",
+                producer["strategy"],
+            )
+            local_config["experiment.strategy"] = producer["strategy"]
 
         local_config = unflatten(local_config)
 
         # For backward compatibility
-        for key in ['storage', 'experiment', 'worker', 'evc']:
+        for key in ["storage", "experiment", "worker", "evc"]:
             subkeys = list(global_config[key].keys())
 
             # Arguments that are only supported locally
-            if key == 'experiment':
-                subkeys += ['name', 'version', 'user']
-            elif key == 'evc':
-                subkeys += ['branch_from', 'branch_to']
+            if key == "experiment":
+                subkeys += ["name", "version", "user"]
+            elif key == "evc":
+                subkeys += ["branch_from", "branch_to"]
 
             for subkey in subkeys:
                 # Backward compatibility
                 backward_value = tmp_config.pop(subkey, None)
                 if backward_value is not None:
                     log.warning(
-                        '(DEPRECATED) Option `%s` and will be removed in v0.3. '
-                        'Use instead the option' '\n%s:\n  %s:\n    %s',
-                        subkey, key, subkey, yaml.dump(backward_value, indent=6))
+                        "(DEPRECATED) Option `%s` and will be removed in v0.3. "
+                        "Use instead the option"
+                        "\n%s:\n  %s:\n    %s",
+                        subkey,
+                        key,
+                        subkey,
+                        yaml.dump(backward_value, indent=6),
+                    )
                 value = tmp_config.get(key, {}).pop(subkey, backward_value)
                 if value is not None:
                     local_config.setdefault(key, {})
@@ -278,15 +291,15 @@ def fetch_env_vars():
 
 def fetch_metadata(user=None, user_args=None, user_script_config=None):
     """Infer rest information about the process + versioning"""
-    metadata = {'user': user if user else getpass.getuser()}
+    metadata = {"user": user if user else getpass.getuser()}
 
-    metadata['orion_version'] = orion.core.__version__
+    metadata["orion_version"] = orion.core.__version__
 
     if user_args is None:
         user_args = []
 
     # Trailing white space are catched by argparse as an empty argument
-    if len(user_args) == 1 and user_args[0] == '':
+    if len(user_args) == 1 and user_args[0] == "":
         user_args = []
 
     if user_script_config is None:
@@ -297,8 +310,8 @@ def fetch_metadata(user=None, user_args=None, user_script_config=None):
 
     if cmdline_parser.user_script:
         # TODO: Remove this, it is all in cmdline_parser now
-        metadata['user_script'] = cmdline_parser.user_script
-        metadata['VCS'] = infer_versioning_metadata(cmdline_parser.user_script)
+        metadata["user_script"] = cmdline_parser.user_script
+        metadata["VCS"] = infer_versioning_metadata(cmdline_parser.user_script)
 
     if user_args:
         metadata["user_args"] = user_args
@@ -308,7 +321,7 @@ def fetch_metadata(user=None, user_args=None, user_script_config=None):
     return metadata
 
 
-def merge_configs(*configs, differentiators=('type', )):
+def merge_configs(*configs, differentiators=("type",)):
     """Merge configuration dictionaries following the given hierarchy
 
     Suppose function is called as merge_configs(A, B, C). Then any pair (key, value) in C would
@@ -355,19 +368,23 @@ def merge_configs(*configs, differentiators=('type', )):
     def _can_be_merged(dict_a, dict_b):
 
         for differentiator in differentiators:
-            if (dict_a.get(differentiator, None) and
-                    dict_a[differentiator] != dict_b.get(differentiator, None)):
+            if dict_a.get(differentiator, None) and dict_a[
+                differentiator
+            ] != dict_b.get(differentiator, None):
                 return False
 
         return True
 
     for config_i in configs[1:]:
         for key, value in config_i.items():
-            if (isinstance(value, dict) and
-                    isinstance(merged_config.get(key), dict) and
-                    _can_be_merged(merged_config[key], value)):
-                merged_config[key] = merge_configs(merged_config[key], value,
-                                                   differentiators=differentiators)
+            if (
+                isinstance(value, dict)
+                and isinstance(merged_config.get(key), dict)
+                and _can_be_merged(merged_config[key], value)
+            ):
+                merged_config[key] = merge_configs(
+                    merged_config[key], value, differentiators=differentiators
+                )
             elif value is not None:
                 merged_config[key] = value
 
@@ -381,8 +398,11 @@ def fetch_user_repo(user_script):
         git_repo = git.Repo(dir_path, search_parent_directories=True)
     except git.exc.InvalidGitRepositoryError:
         git_repo = None
-        logging.warning('Script %s is not in a git repository. Code modification '
-                        'won\'t be detected.', os.path.abspath(user_script))
+        logging.warning(
+            "Script %s is not in a git repository. Code modification "
+            "won't be detected.",
+            os.path.abspath(user_script),
+        )
     return git_repo
 
 
@@ -403,15 +423,15 @@ def infer_versioning_metadata(user_script):
     if not git_repo:
         return {}
     vcs = {}
-    vcs['type'] = 'git'
-    vcs['is_dirty'] = git_repo.is_dirty()
-    vcs['HEAD_sha'] = git_repo.head.object.hexsha
+    vcs["type"] = "git"
+    vcs["is_dirty"] = git_repo.is_dirty()
+    vcs["HEAD_sha"] = git_repo.head.object.hexsha
     if git_repo.head.is_detached:
-        vcs['active_branch'] = None
+        vcs["active_branch"] = None
     else:
-        vcs['active_branch'] = git_repo.active_branch.name
+        vcs["active_branch"] = git_repo.active_branch.name
     # The 'diff' of the current version from the latest commit
-    diff = git_repo.git.diff(git_repo.head.commit.tree).encode('utf-8')
+    diff = git_repo.git.diff(git_repo.head.commit.tree).encode("utf-8")
     diff_sha = hashlib.sha256(diff).hexdigest()
-    vcs['diff_sha'] = diff_sha
+    vcs["diff_sha"] = diff_sha
     return vcs

--- a/src/orion/core/utils/__init__.py
+++ b/src/orion/core/utils/__init__.py
@@ -49,10 +49,16 @@ class Factory(ABCMeta):
         cls.modules = []
         base = import_module(cls.__base__.__module__)
         try:
-            py_files = glob(os.path.abspath(os.path.join(base.__path__[0], '[A-Za-z]*.py')))
-            py_mods = map(lambda x: '.' + os.path.split(os.path.splitext(x)[0])[1], py_files)
+            py_files = glob(
+                os.path.abspath(os.path.join(base.__path__[0], "[A-Za-z]*.py"))
+            )
+            py_mods = map(
+                lambda x: "." + os.path.split(os.path.splitext(x)[0])[1], py_files
+            )
             for py_mod in py_mods:
-                cls.modules.append(import_module(py_mod, package=cls.__base__.__module__))
+                cls.modules.append(
+                    import_module(py_mod, package=cls.__base__.__module__)
+                )
         except AttributeError:
             # This means that base class and implementations reside in a module
             # itself and not a subpackage.
@@ -61,9 +67,13 @@ class Factory(ABCMeta):
         # Get types advertised through entry points!
         for entry_point in pkg_resources.iter_entry_points(cls.__name__):
             entry_point.load()
-            log.debug("Found a %s %s from distribution: %s=%s",
-                      entry_point.name, cls.__name__,
-                      entry_point.dist.project_name, entry_point.dist.version)
+            log.debug(
+                "Found a %s %s from distribution: %s=%s",
+                entry_point.name,
+                cls.__name__,
+                entry_point.dist.project_name,
+                entry_point.dist.version,
+            )
 
         # Get types visible from base module or package, but internal
         def get_all_subclasses(parent):
@@ -104,7 +114,8 @@ class Factory(ABCMeta):
                 return inherited_class.__call__(*args, **kwargs)
 
         error = "Could not find implementation of {0}, type = '{1}'".format(
-            cls.__base__.__name__, of_type)
+            cls.__base__.__name__, of_type
+        )
         error += "\nCurrently, there is an implementation for types:\n"
         error += str(cls.typenames)
         raise NotImplementedError(error)

--- a/src/orion/core/utils/_appdirs.py
+++ b/src/orion/core/utils/_appdirs.py
@@ -44,21 +44,21 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     unicode = str
 
-if sys.platform.startswith('java'):
+if sys.platform.startswith("java"):
     import platform
+
     os_name = platform.java_ver()[3][0]
-    if os_name.startswith('Windows'): # "Windows XP", "Windows 7", etc.
-        system = 'win32'
-    elif os_name.startswith('Mac'): # "Mac OS X", etc.
-        system = 'darwin'
-    else: # "Linux", "SunOS", "FreeBSD", etc.
+    if os_name.startswith("Windows"):  # "Windows XP", "Windows 7", etc.
+        system = "win32"
+    elif os_name.startswith("Mac"):  # "Mac OS X", etc.
+        system = "darwin"
+    else:  # "Linux", "SunOS", "FreeBSD", etc.
         # Setting this to "linux2" is not ideal, but only Windows or Mac
         # are actually checked for and the rest of the module expects
         # *sys.platform* style strings.
-        system = 'linux2'
+        system = "linux2"
 else:
     system = sys.platform
-
 
 
 def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
@@ -103,12 +103,12 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
                 path = os.path.join(path, appauthor, appname)
             else:
                 path = os.path.join(path, appname)
-    elif system == 'darwin':
-        path = os.path.expanduser('~/Library/Application Support/')
+    elif system == "darwin":
+        path = os.path.expanduser("~/Library/Application Support/")
         if appname:
             path = os.path.join(path, appname)
     else:
-        path = os.getenv('XDG_DATA_HOME', os.path.expanduser("~/.local/share"))
+        path = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -157,18 +157,20 @@ def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
             else:
                 path = os.path.join(path, appname)
     else:
-        env_site_data_dirs = os.path.join(sys.prefix, 'share')
-        if system == 'darwin':
-            os_specific_dirs = os.path.expanduser('/Library/Application Support')
+        env_site_data_dirs = os.path.join(sys.prefix, "share")
+        if system == "darwin":
+            os_specific_dirs = os.path.expanduser("/Library/Application Support")
         else:
-            os_specific_dirs = os.getenv('XDG_DATA_DIRS')
+            os_specific_dirs = os.getenv("XDG_DATA_DIRS")
 
         if os_specific_dirs is None:
             path = env_site_data_dirs
         else:
             path = os.pathsep.join([env_site_data_dirs, os_specific_dirs])
 
-        pathlist = [os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)]
+        pathlist = [
+            os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)
+        ]
         if appname:
             if version:
                 appname = os.path.join(appname, version)
@@ -217,7 +219,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
     if system in ["win32", "darwin"]:
         path = user_data_dir(appname, appauthor, None, roaming)
     else:
-        path = os.getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config"))
+        path = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -262,8 +264,10 @@ def site_config_dir(appname=None, appauthor=None, version=None, multipath=False)
     else:
         # XDG default for $XDG_CONFIG_DIRS
         # only first, if multipath is False
-        path = os.getenv('XDG_CONFIG_DIRS', '/etc/xdg')
-        pathlist = [os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)]
+        path = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg")
+        pathlist = [
+            os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)
+        ]
         if appname:
             if version:
                 appname = os.path.join(appname, version)
@@ -320,12 +324,12 @@ def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
                 path = os.path.join(path, appname)
             if opinion:
                 path = os.path.join(path, "Cache")
-    elif system == 'darwin':
-        path = os.path.expanduser('~/Library/Caches')
+    elif system == "darwin":
+        path = os.path.expanduser("~/Library/Caches")
         if appname:
             path = os.path.join(path, appname)
     else:
-        path = os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
+        path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -367,7 +371,7 @@ def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
     if system in ["win32", "darwin"]:
         path = user_data_dir(appname, appauthor, None, roaming)
     else:
-        path = os.getenv('XDG_STATE_HOME', os.path.expanduser("~/.local/state"))
+        path = os.getenv("XDG_STATE_HOME", os.path.expanduser("~/.local/state"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -408,9 +412,7 @@ def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
     This can be disabled with the `opinion=False` option.
     """
     if system == "darwin":
-        path = os.path.join(
-            os.path.expanduser('~/Library/Logs'),
-            appname)
+        path = os.path.join(os.path.expanduser("~/Library/Logs"), appname)
     elif system == "win32":
         path = user_data_dir(appname, appauthor, version)
         version = False
@@ -428,8 +430,10 @@ def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
 
 class AppDirs(object):
     """Convenience wrapper for getting application dirs."""
-    def __init__(self, appname=None, appauthor=None, version=None,
-            roaming=False, multipath=False):
+
+    def __init__(
+        self, appname=None, appauthor=None, version=None, roaming=False, multipath=False
+    ):
         self.appname = appname
         self.appauthor = appauthor
         self.version = version
@@ -438,41 +442,43 @@ class AppDirs(object):
 
     @property
     def user_data_dir(self):
-        return user_data_dir(self.appname, self.appauthor,
-                             version=self.version, roaming=self.roaming)
+        return user_data_dir(
+            self.appname, self.appauthor, version=self.version, roaming=self.roaming
+        )
 
     @property
     def site_data_dir(self):
-        return site_data_dir(self.appname, self.appauthor,
-                             version=self.version, multipath=self.multipath)
+        return site_data_dir(
+            self.appname, self.appauthor, version=self.version, multipath=self.multipath
+        )
 
     @property
     def user_config_dir(self):
-        return user_config_dir(self.appname, self.appauthor,
-                               version=self.version, roaming=self.roaming)
+        return user_config_dir(
+            self.appname, self.appauthor, version=self.version, roaming=self.roaming
+        )
 
     @property
     def site_config_dir(self):
-        return site_config_dir(self.appname, self.appauthor,
-                             version=self.version, multipath=self.multipath)
+        return site_config_dir(
+            self.appname, self.appauthor, version=self.version, multipath=self.multipath
+        )
 
     @property
     def user_cache_dir(self):
-        return user_cache_dir(self.appname, self.appauthor,
-                              version=self.version)
+        return user_cache_dir(self.appname, self.appauthor, version=self.version)
 
     @property
     def user_state_dir(self):
-        return user_state_dir(self.appname, self.appauthor,
-                              version=self.version)
+        return user_state_dir(self.appname, self.appauthor, version=self.version)
 
     @property
     def user_log_dir(self):
-        return user_log_dir(self.appname, self.appauthor,
-                            version=self.version)
+        return user_log_dir(self.appname, self.appauthor, version=self.version)
 
 
-#---- internal support stuff
+# ---- internal support stuff
+
 
 def _get_win_folder_from_registry(csidl_name):
     """This is a fallback technique at best. I'm not sure if using the
@@ -480,9 +486,9 @@ def _get_win_folder_from_registry(csidl_name):
     names.
     """
     if PY3:
-      import winreg as _winreg
+        import winreg as _winreg
     else:
-      import _winreg
+        import _winreg
 
     shell_folder_name = {
         "CSIDL_APPDATA": "AppData",
@@ -492,7 +498,7 @@ def _get_win_folder_from_registry(csidl_name):
 
     key = _winreg.OpenKey(
         _winreg.HKEY_CURRENT_USER,
-        r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
+        r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
     )
     dir, type = _winreg.QueryValueEx(key, shell_folder_name)
     return dir
@@ -500,6 +506,7 @@ def _get_win_folder_from_registry(csidl_name):
 
 def _get_win_folder_with_pywin32(csidl_name):
     from win32com.shell import shellcon, shell
+
     dir = shell.SHGetFolderPath(0, getattr(shellcon, csidl_name), 0, 0)
     # Try to make this a unicode path because SHGetFolderPath does
     # not return unicode strings when there is unicode data in the
@@ -517,6 +524,7 @@ def _get_win_folder_with_pywin32(csidl_name):
         if has_high_char:
             try:
                 import win32api
+
                 dir = win32api.GetShortPathName(dir)
             except ImportError:
                 pass
@@ -551,15 +559,22 @@ def _get_win_folder_with_ctypes(csidl_name):
 
     return buf.value
 
+
 def _get_win_folder_with_jna(csidl_name):
     import array
     from com.sun import jna
     from com.sun.jna.platform import win32
 
     buf_size = win32.WinDef.MAX_PATH * 2
-    buf = array.zeros('c', buf_size)
+    buf = array.zeros("c", buf_size)
     shell = win32.Shell32.INSTANCE
-    shell.SHGetFolderPath(None, getattr(win32.ShlObj, csidl_name), None, win32.ShlObj.SHGFP_TYPE_CURRENT, buf)
+    shell.SHGetFolderPath(
+        None,
+        getattr(win32.ShlObj, csidl_name),
+        None,
+        win32.ShlObj.SHGFP_TYPE_CURRENT,
+        buf,
+    )
     dir = jna.Native.toString(buf.tostring()).rstrip("\0")
 
     # Downgrade to short path name if have highbit chars. See
@@ -570,42 +585,48 @@ def _get_win_folder_with_jna(csidl_name):
             has_high_char = True
             break
     if has_high_char:
-        buf = array.zeros('c', buf_size)
+        buf = array.zeros("c", buf_size)
         kernel = win32.Kernel32.INSTANCE
         if kernel.GetShortPathName(dir, buf, buf_size):
             dir = jna.Native.toString(buf.tostring()).rstrip("\0")
 
     return dir
 
+
 if system == "win32":
     try:
         import win32com.shell
+
         _get_win_folder = _get_win_folder_with_pywin32
     except ImportError:
         try:
             from ctypes import windll
+
             _get_win_folder = _get_win_folder_with_ctypes
         except ImportError:
             try:
                 import com.sun.jna
+
                 _get_win_folder = _get_win_folder_with_jna
             except ImportError:
                 _get_win_folder = _get_win_folder_from_registry
 
 
-#---- self test code
+# ---- self test code
 
 if __name__ == "__main__":
     appname = "MyApp"
     appauthor = "MyCompany"
 
-    props = ("user_data_dir",
-             "user_config_dir",
-             "user_cache_dir",
-             "user_state_dir",
-             "user_log_dir",
-             "site_data_dir",
-             "site_config_dir")
+    props = (
+        "user_data_dir",
+        "user_config_dir",
+        "user_cache_dir",
+        "user_state_dir",
+        "user_log_dir",
+        "site_data_dir",
+        "site_config_dir",
+    )
 
     print("-- app dirs %s --" % __version__)
 

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -21,22 +21,26 @@ log = logging.getLogger(__name__)
 
 def update_user_args(metadata):
     """Make sure user script is not removed from metadata"""
-    if "user_script" in metadata and metadata["user_script"] not in metadata["user_args"]:
+    if (
+        "user_script" in metadata
+        and metadata["user_script"] not in metadata["user_args"]
+    ):
         metadata["user_args"] = [metadata["user_script"]] + metadata["user_args"]
 
 
 def populate_priors(metadata):
     """Compute parser state and priors based on user_args and populate metadata."""
-    if 'user_args' not in metadata:
+    if "user_args" not in metadata:
         return
 
     update_user_args(metadata)
 
-    parser = OrionCmdlineParser(orion.core.config.worker.user_script_config,
-                                allow_non_existing_files=True)
-    if 'parser' in metadata:
+    parser = OrionCmdlineParser(
+        orion.core.config.worker.user_script_config, allow_non_existing_files=True
+    )
+    if "parser" in metadata:
         # To keep configs like config user_script_config
-        parser.config_prefix = metadata['parser']['config_prefix']
+        parser.config_prefix = metadata["parser"]["config_prefix"]
     parser.parse(metadata["user_args"])
     metadata["parser"] = parser.get_state_dict()
     metadata["priors"] = dict(parser.priors)
@@ -44,56 +48,64 @@ def populate_priors(metadata):
 
 def update_max_broken(config):
     """Set default max_broken if None (in v <= v0.1.9)"""
-    if not config.get('max_broken', None):
-        config['max_broken'] = orion.core.config.experiment.max_broken
+    if not config.get("max_broken", None):
+        config["max_broken"] = orion.core.config.experiment.max_broken
 
 
 def populate_space(config, force_update=True):
     """Add the space definition at the root of config."""
-    if 'space' in config and not force_update:
+    if "space" in config and not force_update:
         return
 
-    populate_priors(config['metadata'])
+    populate_priors(config["metadata"])
     # Overwrite space to make sure to include changes from user_args
-    if 'priors' in config['metadata']:
-        config['space'] = config['metadata']['priors']
+    if "priors" in config["metadata"]:
+        config["space"] = config["metadata"]["priors"]
 
 
 def db_is_outdated(database):
     """Return True if the database scheme is outdated."""
-    deprecated_indices = [('name', 'metadata.user'), ('name', 'metadata.user', 'version'),
-                          'name_1_metadata.user_1', 'name_1_metadata.user_1_version_1']
+    deprecated_indices = [
+        ("name", "metadata.user"),
+        ("name", "metadata.user", "version"),
+        "name_1_metadata.user_1",
+        "name_1_metadata.user_1_version_1",
+    ]
 
-    index_information = database.index_information('experiments')
+    index_information = database.index_information("experiments")
     return any(index in deprecated_indices for index in index_information.keys())
 
 
 def update_db_config(config):
     """Merge DB config back into storage config"""
-    config.setdefault('storage', orion.core.config.storage.to_dict())
-    if 'database' in config:
-        config['storage'] = {'type': 'legacy'}
-        config['storage']['database'] = config.pop('database')
+    config.setdefault("storage", orion.core.config.storage.to_dict())
+    if "database" in config:
+        config["storage"] = {"type": "legacy"}
+        config["storage"]["database"] = config.pop("database")
 
 
 def get_algo_requirements(algorithm):
     """Return a dict() of requirements of the algorithm based on interface < v0.1.10"""
-    if hasattr(algorithm, 'requires'):
-        log.warning('Algorithm.requires is deprecated and will stop being supporting in v0.3.')
+    if hasattr(algorithm, "requires"):
+        log.warning(
+            "Algorithm.requires is deprecated and will stop being supporting in v0.3."
+        )
         requirements = algorithm.requires
-        requirements = requirements if isinstance(requirements, list) else [requirements]
+        requirements = (
+            requirements if isinstance(requirements, list) else [requirements]
+        )
 
         requirements = copy.deepcopy(requirements)
 
-        if 'linear' in requirements:
-            dist_requirement = 'linear'
-            del requirements[requirements.index('linear')]
+        if "linear" in requirements:
+            dist_requirement = "linear"
+            del requirements[requirements.index("linear")]
         else:
             dist_requirement = None
 
-        if 'flattened' in requirements:
-            shape_requirement = 'flattened'
-            del requirements[requirements.index('flattened')]
+        if "flattened" in requirements:
+            shape_requirement = "flattened"
+            del requirements[requirements.index("flattened")]
         else:
             shape_requirement = None
 
@@ -106,9 +118,11 @@ def get_algo_requirements(algorithm):
         return dict(
             type_requirement=type_requirement,
             shape_requirement=shape_requirement,
-            dist_requirement=dist_requirement)
+            dist_requirement=dist_requirement,
+        )
 
     return dict(
         type_requirement=algorithm.requires_type,
         shape_requirement=algorithm.requires_shape,
-        dist_requirement=algorithm.requires_dist)
+        dist_requirement=algorithm.requires_dist,
+    )

--- a/src/orion/core/utils/diff.py
+++ b/src/orion/core/utils/diff.py
@@ -35,7 +35,7 @@ def colored_diff(string_a, string_b):
 
     colored_result = []
     for i, line in enumerate(result):
-        line = line.strip('\n')
+        line = line.strip("\n")
         if line[0] == "-" or (line[0] == "?" and result[i - 1][0] == "-"):
             line = red(line)
         elif line[0] == "+" or (line[0] == "?" and result[i - 1][0] == "+"):

--- a/src/orion/core/utils/flatten.py
+++ b/src/orion/core/utils/flatten.py
@@ -15,6 +15,7 @@ import copy
 
 def flatten(dictionary):
     """Turn all nested dict keys into a {key}.{subkey} format"""
+
     def _flatten(dictionary):
         if dictionary == {}:
             return dictionary
@@ -27,7 +28,7 @@ def flatten(dictionary):
 
         flat_sub_dictionary = flatten(value)
         for flat_sub_key in list(flat_sub_dictionary.keys()):
-            flat_key = key + '.' + flat_sub_key
+            flat_key = key + "." + flat_sub_key
             flat_sub_dictionary[flat_key] = flat_sub_dictionary.pop(flat_sub_key)
 
         new_dictionary = flat_sub_dictionary

--- a/src/orion/core/utils/format_terminal.py
+++ b/src/orion/core/utils/format_terminal.py
@@ -39,7 +39,8 @@ def format_info(experiment):
         space=format_space(experiment),
         metadata=format_metadata(experiment),
         refers=format_refers(experiment),
-        stats=format_stats(experiment))
+        stats=format_stats(experiment),
+    )
 
     return info_string
 
@@ -52,10 +53,7 @@ TITLE_TEMPLATE = """\
 
 def format_title(title):
     """Render a title above an horizontal bar"""
-    title_string = TITLE_TEMPLATE.format(
-        title=title,
-        title_len=len(title),
-        empty='')
+    title_string = TITLE_TEMPLATE.format(title=title, title_len=len(title), empty="")
 
     return title_string
 
@@ -112,25 +110,28 @@ def format_dict(dictionary, depth=0, width=4, templates=None):
     if templates is None:
         templates = dict()
 
-    empty_leaf_template = templates.get('empty_leaf', DICT_EMPTY_LEAF_TEMPLATE)
-    leaf_template = templates.get('leaf', DICT_LEAF_TEMPLATE)
-    node_template = templates.get('dict_node', DICT_NODE_TEMPLATE)
+    empty_leaf_template = templates.get("empty_leaf", DICT_EMPTY_LEAF_TEMPLATE)
+    leaf_template = templates.get("leaf", DICT_LEAF_TEMPLATE)
+    node_template = templates.get("dict_node", DICT_NODE_TEMPLATE)
 
     dict_string = ""
     for key in sorted(dictionary.keys()):
-        tab = (" " * (depth * width))
+        tab = " " * (depth * width)
         value = dictionary[key]
         if isinstance(value, (dict, list, tuple)):
             if not value:
                 dict_string += empty_leaf_template.format(tab=tab, key=key)
             else:
                 subdict_string = format_dict(
-                    value, depth + 1, width=width, templates=templates)
-                dict_string += node_template.format(tab=tab, key=key, value=subdict_string)
+                    value, depth + 1, width=width, templates=templates
+                )
+                dict_string += node_template.format(
+                    tab=tab, key=key, value=subdict_string
+                )
         else:
             dict_string += leaf_template.format(tab=tab, key=key, value=value)
 
-    return dict_string.replace(' \n', '\n').rstrip("\n")
+    return dict_string.replace(" \n", "\n").rstrip("\n")
 
 
 LIST_TEMPLATE = """\
@@ -200,14 +201,14 @@ def format_list(a_list, depth=0, width=4, templates=None):
     if templates is None:
         templates = dict()
 
-    list_template = templates.get('list', LIST_TEMPLATE)
-    item_template = templates.get('item', LIST_ITEM_TEMPLATE)
-    node_template = templates.get('list_node', LIST_NODE_TEMPLATE)
+    list_template = templates.get("list", LIST_TEMPLATE)
+    item_template = templates.get("item", LIST_ITEM_TEMPLATE)
+    node_template = templates.get("list_node", LIST_NODE_TEMPLATE)
 
-    tab = (" " * (depth * width))
+    tab = " " * (depth * width)
     list_string = ""
     for i, item in enumerate(a_list, 1):
-        subtab = (" " * ((depth + 1) * width))
+        subtab = " " * ((depth + 1) * width)
         if isinstance(item, (dict, list, tuple)):
             item_string = format_dict(item, depth + 1, width=width, templates=templates)
             list_string += node_template.format(tab=subtab, id=i, item=item_string)
@@ -231,7 +232,8 @@ def format_identification(experiment):
         title=format_title("Identification"),
         name=experiment.name,
         version=experiment.version,
-        user=experiment.metadata['user'])
+        user=experiment.metadata["user"],
+    )
 
     return identification_string
 
@@ -244,12 +246,13 @@ COMMANDLINE_TEMPLATE = """\
 
 def format_commandline(experiment):
     """Render a string for commandline section"""
-    if 'user_args' not in experiment.metadata:
-        return ''
+    if "user_args" not in experiment.metadata:
+        return ""
 
     commandline_string = COMMANDLINE_TEMPLATE.format(
         title=format_title("Commandline"),
-        commandline=" ".join(experiment.metadata['user_args']))
+        commandline=" ".join(experiment.metadata["user_args"]),
+    )
 
     return commandline_string
 
@@ -266,8 +269,8 @@ working dir: {experiment.working_dir}
 def format_config(experiment):
     """Render a string for config section"""
     config_string = CONFIG_TEMPLATE.format(
-        title=format_title("Config"),
-        experiment=experiment)
+        title=format_title("Config"), experiment=experiment
+    )
 
     return config_string
 
@@ -282,7 +285,8 @@ def format_algorithm(experiment):
     """Render a string for algorithm section"""
     algorithm_string = ALGORITHM_TEMPLATE.format(
         title=format_title("Algorithm"),
-        configuration=format_dict(experiment.configuration['algorithms']))
+        configuration=format_dict(experiment.configuration["algorithms"]),
+    )
 
     return algorithm_string
 
@@ -297,8 +301,11 @@ def format_space(experiment):
     """Render a string for space section"""
     space_string = SPACE_TEMPLATE.format(
         title=format_title("Space"),
-        params="\n".join(name + ": " + experiment.space[name].get_prior_string()
-                         for name in experiment.space.keys()))
+        params="\n".join(
+            name + ": " + experiment.space[name].get_prior_string()
+            for name in experiment.space.keys()
+        ),
+    )
 
     return space_string
 
@@ -318,7 +325,8 @@ def format_metadata(experiment):
     metadata_string = METADATA_TEMPLATE.format(
         title=format_title("Meta-data"),
         experiment=experiment,
-        vcs=format_dict(experiment.metadata.get('VCS', {}), depth=1, width=2))
+        vcs=format_dict(experiment.metadata.get("VCS", {}), depth=1, width=2),
+    )
 
     return metadata_string
 
@@ -334,19 +342,22 @@ adapter: {adapter}
 def format_refers(experiment):
     """Render a string for refers section"""
     if experiment.node.root is experiment.node:
-        root = ''
-        parent = ''
-        adapter = ''
+        root = ""
+        parent = ""
+        adapter = ""
     else:
         root = experiment.node.root.name
         parent = experiment.node.parent.name
-        adapter = "\n" + format_dict(experiment.refers['adapter'].configuration, depth=1, width=2)
+        adapter = "\n" + format_dict(
+            experiment.refers["adapter"].configuration, depth=1, width=2
+        )
 
     refers_string = REFERS_TEMPLATE.format(
         title=format_title("Parent experiment"),
         root=root,
         parent=parent,
-        adapter=adapter)
+        adapter=adapter,
+    )
 
     return refers_string
 
@@ -385,16 +396,16 @@ def format_stats(experiment):
     """
     stats = experiment.stats
     if not stats:
-        return NO_STATS_TEMPLATE.format(
-            title=format_title("Stats"))
+        return NO_STATS_TEMPLATE.format(title=format_title("Stats"))
 
-    best_params = get_trial_params(stats['best_trials_id'], experiment)
+    best_params = get_trial_params(stats["best_trials_id"], experiment)
 
     stats_string = STATS_TEMPLATE.format(
         title=format_title("Stats"),
         stats=stats,
         best_params=format_dict(best_params, depth=2, width=2),
-        is_done=experiment.is_done)
+        is_done=experiment.is_done,
+    )
 
     return stats_string
 

--- a/src/orion/core/utils/format_trials.py
+++ b/src/orion/core/utils/format_trials.py
@@ -24,10 +24,14 @@ def trial_to_tuple(trial, space):
     trial_keys = set(params.keys())
     space_keys = set(space.keys())
     if trial_keys != space_keys:
-        raise ValueError(""""
+        raise ValueError(
+            """"
 The trial {} has wrong params:
 Trial params: {}
-Space dims: {}""".format(trial.id, sorted(trial_keys), sorted(space_keys)))
+Space dims: {}""".format(
+                trial.id, sorted(trial_keys), sorted(space_keys)
+            )
+        )
     return tuple(params[name] for name in space.keys())
 
 
@@ -44,19 +48,19 @@ def dict_to_trial(data, space):
     for name, dim in space.items():
         if name not in data and dim.default_value is dim.NO_DEFAULT_VALUE:
             raise ValueError(
-                'Dimension {} not specified and does not have a default value.'.format(name))
+                "Dimension {} not specified and does not have a default value.".format(
+                    name
+                )
+            )
         value = data.get(name, dim.default_value)
 
         if value not in dim:
             error_msg = "Dimension {} value {} is outside of prior {}".format(
-                name, value, dim.get_prior_string())
+                name, value, dim.get_prior_string()
+            )
             raise ValueError(error_msg)
 
-        params.append(dict(
-            name=dim.name,
-            type=dim.type,
-            value=value
-            ))
+        params.append(dict(name=dim.name, type=dim.type, value=value))
     assert len(params) == len(space)
     return Trial(params=params)
 
@@ -72,11 +76,7 @@ def tuple_to_trial(data, space):
     assert len(data) == len(space)
     params = []
     for i, dim in enumerate(space.values()):
-        params.append(dict(
-            name=dim.name,
-            type=dim.type,
-            value=data[i]
-            ))
+        params.append(dict(name=dim.name, type=dim.type, value=data[i]))
     return Trial(params=params)
 
 
@@ -88,16 +88,17 @@ def get_trial_results(trial):
     objective = trial.objective
 
     if lie:
-        results['objective'] = lie.value
+        results["objective"] = lie.value
     elif objective:
-        results['objective'] = objective.value
+        results["objective"] = objective.value
     else:
-        results['objective'] = None
+        results["objective"] = None
 
-    results['constraint'] = [result.value for result in trial.results
-                             if result.type == 'constraint']
+    results["constraint"] = [
+        result.value for result in trial.results if result.type == "constraint"
+    ]
     grad = trial.gradient
-    results['gradient'] = tuple(grad.value) if grad else None
+    results["gradient"] = tuple(grad.value) if grad else None
 
     return results
 

--- a/src/orion/core/utils/module_import.py
+++ b/src/orion/core/utils/module_import.py
@@ -18,13 +18,17 @@ def load_modules_in_path(path, filter_function=None):
     Load all modules inside `path` and return a list of those
     fitting the filter function.
     """
-    this_module = __import__(path, fromlist=[''])
+    this_module = __import__(path, fromlist=[""])
     file_path = this_module.__path__[0]
 
-    files = list(map(lambda f: f.split('.')[0],
-                     filter(lambda f2: f2.endswith('py'), os.listdir(file_path))))
+    files = list(
+        map(
+            lambda f: f.split(".")[0],
+            filter(lambda f2: f2.endswith("py"), os.listdir(file_path)),
+        )
+    )
 
-    modules = map(lambda f: __import__(path + '.' + f, fromlist=['']), files)
+    modules = map(lambda f: __import__(path + "." + f, fromlist=[""]), files)
 
     if filter_function is not None:
         modules = filter(filter_function, modules)

--- a/src/orion/core/utils/points.py
+++ b/src/orion/core/utils/points.py
@@ -41,7 +41,9 @@ def regroup_dims(point, space):
             idx += 1
 
     if regrouped not in space:
-        raise AttributeError("The point {} is not a valid point of space {}".format(point, space))
+        raise AttributeError(
+            "The point {} is not a valid point of space {}".format(point, space)
+        )
 
     return regrouped
 

--- a/src/orion/core/utils/pptree.py
+++ b/src/orion/core/utils/pptree.py
@@ -38,6 +38,7 @@ SOFTWARE.
 
 """
 
+
 class Node:
     def __init__(self, name, parent=None):
         self.name = name
@@ -48,7 +49,9 @@ class Node:
             self.parent.children.append(self)
 
 
-def print_tree(current_node, childattr='children', nameattr='name', indent='', last='updown'):
+def print_tree(
+    current_node, childattr="children", nameattr="name", indent="", last="updown"
+):
     if hasattr(current_node, nameattr):
         name = lambda node: getattr(node, nameattr)
     else:
@@ -61,29 +64,42 @@ def print_tree(current_node, childattr='children', nameattr='name', indent='', l
     """ Creation of balanced lists for "up" branch and "down" branch. """
     up = sorted(children(current_node), key=lambda node: nb_children(node))
     down = []
-    while up and sum(size_branch[node] for node in down) < sum(size_branch[node] for node in up):
+    while up and sum(size_branch[node] for node in down) < sum(
+        size_branch[node] for node in up
+    ):
         down.append(up.pop())
 
     """ Printing of "up" branch. """
-    for child in up:     
-        next_last = 'up' if up.index(child) is 0 else ''
-        next_indent = '{0}{1}{2}'.format(indent, ' ' if 'up' in last else '│', ' ' * len(name(current_node)))
+    for child in up:
+        next_last = "up" if up.index(child) is 0 else ""
+        next_indent = "{0}{1}{2}".format(
+            indent, " " if "up" in last else "│", " " * len(name(current_node))
+        )
         print_tree(child, childattr, nameattr, next_indent, next_last)
 
     """ Printing of current node. """
-    if last == 'up': start_shape = '┌'
-    elif last == 'down': start_shape = '└'
-    elif last == 'updown': start_shape = ' '
-    else: start_shape = '├'
+    if last == "up":
+        start_shape = "┌"
+    elif last == "down":
+        start_shape = "└"
+    elif last == "updown":
+        start_shape = " "
+    else:
+        start_shape = "├"
 
-    if up: end_shape = '┤'
-    elif down: end_shape = '┐'
-    else: end_shape = ''
+    if up:
+        end_shape = "┤"
+    elif down:
+        end_shape = "┐"
+    else:
+        end_shape = ""
 
-    print('{0}{1}{2}{3}'.format(indent, start_shape, name(current_node), end_shape))
+    print("{0}{1}{2}{3}".format(indent, start_shape, name(current_node), end_shape))
 
     """ Printing of "down" branch. """
     for child in down:
-        next_last = 'down' if down.index(child) is len(down) - 1 else ''
-        next_indent = '{0}{1}{2}'.format(indent, ' ' if 'down' in last else '│', ' ' * len(name(current_node)))
+        next_last = "down" if down.index(child) is len(down) - 1 else ""
+        next_indent = "{0}{1}{2}".format(
+            indent, " " if "down" in last else "│", " " * len(name(current_node))
+        )
         print_tree(child, childattr, nameattr, next_indent, next_last)

--- a/src/orion/core/utils/singleton.py
+++ b/src/orion/core/utils/singleton.py
@@ -19,8 +19,11 @@ class SingletonAlreadyInstantiatedError(ValueError):
 
     def __init__(self, name):
         """Pass the same constant message to ValueError underneath."""
-        super().__init__("A singleton instance of (type: {}) has already been instantiated."
-                         .format(name))
+        super().__init__(
+            "A singleton instance of (type: {}) has already been instantiated.".format(
+                name
+            )
+        )
 
 
 class SingletonNotInstantiatedError(TypeError):
@@ -30,8 +33,7 @@ class SingletonNotInstantiatedError(TypeError):
 
     def __init__(self, name):
         """Pass the same constant message to TypeError underneath."""
-        super().__init__('No singleton instance of (type: {}) was created'
-                         .format(name))
+        super().__init__("No singleton instance of (type: {}) was created".format(name))
 
 
 class SingletonType(type):

--- a/src/orion/core/utils/terminal.py
+++ b/src/orion/core/utils/terminal.py
@@ -57,7 +57,7 @@ def confirm_name(message, name, force=False):
     """
     if force:
         print(message)
-        print('FORCED')
+        print("FORCED")
         return True
 
     answer = input(message)

--- a/src/orion/core/utils/working_dir.py
+++ b/src/orion/core/utils/working_dir.py
@@ -39,8 +39,9 @@ class WorkingDir:
             os.makedirs(path, exist_ok=True)
             return path
 
-        self._tmpdir = tempfile.TemporaryDirectory(suffix=self._suffix, prefix=self._prefix,
-                                                   dir=self.working_dir)
+        self._tmpdir = tempfile.TemporaryDirectory(
+            suffix=self._suffix, prefix=self._prefix, dir=self.working_dir
+        )
         return self._tmpdir.name
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/src/orion/core/worker/__init__.py
+++ b/src/orion/core/worker/__init__.py
@@ -28,8 +28,10 @@ def reserve_trial(experiment, producer, _depth=1):
     if trial is None and not experiment.is_done:
 
         if _depth > 10:
-            raise WaitingForTrials('No trials are available at the moment '
-                                   'wait for current trials to finish')
+            raise WaitingForTrials(
+                "No trials are available at the moment "
+                "wait for current trials to finish"
+            )
 
         log.debug("#### Failed to pull a new trial from database.")
 
@@ -74,11 +76,20 @@ orion status --name {experiment.name} --version {experiment.version} --all
 """
 
 
-def workon(experiment, max_trials=None, max_broken=None, max_idle_time=None, heartbeat=None,
-           user_script_config=None, interrupt_signal_code=None):
+def workon(
+    experiment,
+    max_trials=None,
+    max_broken=None,
+    max_idle_time=None,
+    heartbeat=None,
+    user_script_config=None,
+    interrupt_signal_code=None,
+):
     """Try to find solution to the search problem defined in `experiment`."""
     producer = Producer(experiment, max_idle_time)
-    consumer = Consumer(experiment, heartbeat, user_script_config, interrupt_signal_code)
+    consumer = Consumer(
+        experiment, heartbeat, user_script_config, interrupt_signal_code
+    )
 
     log.debug("#####  Init Experiment  #####")
     try:
@@ -102,8 +113,11 @@ def workon(experiment, max_trials=None, max_broken=None, max_idle_time=None, hea
         try:
             trial = reserve_trial(experiment, producer)
         except WaitingForTrials as ex:
-            print("### Experiment failed to reserve new trials: {reason}, terminating. "
-                  .format(reason=str(ex)))
+            print(
+                "### Experiment failed to reserve new trials: {reason}, terminating. ".format(
+                    reason=str(ex)
+                )
+            )
             break
 
         if trial is not None:
@@ -117,8 +131,8 @@ def workon(experiment, max_trials=None, max_broken=None, max_idle_time=None, hea
             print(worker_broken_trials, max_broken)
             break
 
-    print('\n' + format_stats(experiment))
+    print("\n" + format_stats(experiment))
 
-    print('\n' + COMPLETION_MESSAGE.format(experiment=experiment))
+    print("\n" + COMPLETION_MESSAGE.format(experiment=experiment))
     if not experiment.is_done:
         print(NONCOMPLETED_MESSAGE.format(experiment=experiment))

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -84,10 +84,23 @@ class Experiment:
 
     """
 
-    __slots__ = ('name', 'refers', 'metadata', 'pool_size', 'max_trials', 'max_broken', 'version',
-                 'space', 'algorithms', 'producer', 'working_dir', '_id',
-                 '_node', '_storage')
-    non_branching_attrs = ('pool_size', 'max_trials', 'max_broken')
+    __slots__ = (
+        "name",
+        "refers",
+        "metadata",
+        "pool_size",
+        "max_trials",
+        "max_broken",
+        "version",
+        "space",
+        "algorithms",
+        "producer",
+        "working_dir",
+        "_id",
+        "_node",
+        "_storage",
+    )
+    non_branching_attrs = ("pool_size", "max_trials", "max_broken")
 
     def __init__(self, name, version=None):
         self._id = None
@@ -119,13 +132,25 @@ class Experiment:
 
         """
         columns = [
-            'id', 'experiment_id', 'status', 'suggested', 'reserved', 'completed', 'objective']
+            "id",
+            "experiment_id",
+            "status",
+            "suggested",
+            "reserved",
+            "completed",
+            "objective",
+        ]
 
         data = []
         for trial in self.fetch_trials(with_evc_tree=with_evc_tree):
             row = [
-                trial.id, trial.experiment, trial.status,
-                trial.submit_time, trial.start_time, trial.end_time]
+                trial.id,
+                trial.experiment,
+                trial.status,
+                trial.submit_time,
+                trial.start_time,
+                trial.end_time,
+            ]
             row.append(trial.objective.value if trial.objective else None)
             params = flatten(trial.params)
             for name in self.space.keys():
@@ -142,7 +167,7 @@ class Experiment:
 
     def fetch_trials(self, with_evc_tree=False):
         """Fetch all trials of the experiment"""
-        return self._select_evc_call(with_evc_tree, 'fetch_trials')
+        return self._select_evc_call(with_evc_tree, "fetch_trials")
 
     def get_trial(self, trial=None, uid=None):
         """Fetch a single Trial, see `orion.storage.base.BaseStorage.get_trial`"""
@@ -172,12 +197,12 @@ class Experiment:
         Selected `Trial` object, None if could not find any.
 
         """
-        log.debug('reserving trial with (score: %s)', score_handle)
+        log.debug("reserving trial with (score: %s)", score_handle)
 
         self.fix_lost_trials()
 
         selected_trial = self._storage.reserve_trial(self)
-        log.debug('reserved trial (trial: %s)', selected_trial)
+        log.debug("reserved trial (trial: %s)", selected_trial)
         return selected_trial
 
     def fix_lost_trials(self):
@@ -192,13 +217,13 @@ class Experiment:
         trials = self._storage.fetch_lost_trials(self)
 
         for trial in trials:
-            log.debug('Setting lost trial %s status to interrupted...', trial.id)
+            log.debug("Setting lost trial %s status to interrupted...", trial.id)
 
             try:
-                self._storage.set_trial_status(trial, status='interrupted')
-                log.debug('success')
+                self._storage.set_trial_status(trial, status="interrupted")
+                log.debug("success")
             except FailedUpdate:
-                log.debug('failed')
+                log.debug("failed")
 
     def update_completed_trial(self, trial, results_file=None):
         """Inform database about an evaluated `trial` with results.
@@ -211,7 +236,7 @@ class Experiment:
             Change status from *reserved* to *completed*.
 
         """
-        trial.status = 'completed'
+        trial.status = "completed"
         trial.end_time = datetime.datetime.utcnow()
         self._storage.retrieve_result(trial, results_file)
         # push trial results updates the entire trial status included
@@ -239,11 +264,11 @@ class Experiment:
             in the database.
 
         """
-        lying_trial.status = 'completed'
+        lying_trial.status = "completed"
         lying_trial.end_time = datetime.datetime.utcnow()
         self._storage.register_lie(lying_trial)
 
-    def register_trial(self, trial, status='new'):
+    def register_trial(self, trial, status="new"):
         """Register new trial in the database.
 
         Inform database about *new* suggested trial with specific parameter values. Trials may only
@@ -282,7 +307,7 @@ class Experiment:
 
         :return: list of `Trial` objects
         """
-        return self._select_evc_call(with_evc_tree, 'fetch_trials_by_status', status)
+        return self._select_evc_call(with_evc_tree, "fetch_trials_by_status", status)
 
     def fetch_noncompleted_trials(self, with_evc_tree=False):
         """Fetch non-completed trials of this `Experiment` instance.
@@ -296,7 +321,7 @@ class Experiment:
 
         :return: list of non-completed `Trial` objects
         """
-        return self._select_evc_call(with_evc_tree, 'fetch_noncompleted_trials')
+        return self._select_evc_call(with_evc_tree, "fetch_noncompleted_trials")
 
     # pylint: disable=invalid-name
     @property
@@ -337,14 +362,14 @@ class Experiment:
         num_completed_trials = 0
         num_pending_trials = 0
         for trial in trials:
-            if trial.status == 'completed':
+            if trial.status == "completed":
                 num_completed_trials += 1
-            elif trial.status in ['new', 'reserved', 'interrupted']:
+            elif trial.status in ["new", "reserved", "interrupted"]:
                 num_pending_trials += 1
 
-        return (
-            (num_completed_trials >= self.max_trials) or
-            (self.algorithms.is_done and num_pending_trials == 0))
+        return (num_completed_trials >= self.max_trials) or (
+            self.algorithms.is_done and num_pending_trials == 0
+        )
 
     @property
     def is_broken(self):
@@ -363,19 +388,23 @@ class Experiment:
         """Return a copy of an `Experiment` configuration as a dictionary."""
         config = dict()
         for attrname in self.__slots__:
-            if attrname.startswith('_'):
+            if attrname.startswith("_"):
                 continue
             attribute = copy.deepcopy(getattr(self, attrname))
             config[attrname] = attribute
-            if attrname in ['algorithms', 'space']:
+            if attrname in ["algorithms", "space"]:
                 config[attrname] = attribute.configuration
-            elif attrname == "refers" and isinstance(attribute.get("adapter"), BaseAdapter):
-                config[attrname]['adapter'] = config[attrname]['adapter'].configuration
+            elif attrname == "refers" and isinstance(
+                attribute.get("adapter"), BaseAdapter
+            ):
+                config[attrname]["adapter"] = config[attrname]["adapter"].configuration
             elif attrname == "producer" and attribute.get("strategy"):
-                config[attrname]['strategy'] = config[attrname]['strategy'].configuration
+                config[attrname]["strategy"] = config[attrname][
+                    "strategy"
+                ].configuration
 
         if self.id is not None:
-            config['_id'] = self.id
+            config["_id"] = self.id
 
         return copy.deepcopy(config)
 
@@ -404,35 +433,38 @@ class Experiment:
            Elapsed time.
 
         """
-        completed_trials = self.fetch_trials_by_status('completed')
+        completed_trials = self.fetch_trials_by_status("completed")
 
         if not completed_trials:
             return dict()
         stats = dict()
-        stats['trials_completed'] = len(completed_trials)
-        stats['best_trials_id'] = None
+        stats["trials_completed"] = len(completed_trials)
+        stats["best_trials_id"] = None
         trial = completed_trials[0]
-        stats['best_evaluation'] = trial.objective.value
-        stats['best_trials_id'] = trial.id
-        stats['start_time'] = self.metadata['datetime']
-        stats['finish_time'] = stats['start_time']
+        stats["best_evaluation"] = trial.objective.value
+        stats["best_trials_id"] = trial.id
+        stats["start_time"] = self.metadata["datetime"]
+        stats["finish_time"] = stats["start_time"]
         for trial in completed_trials:
             # All trials are going to finish certainly after the start date
             # of the experiment they belong to
-            if trial.end_time > stats['finish_time']:  # pylint:disable=no-member
-                stats['finish_time'] = trial.end_time
+            if trial.end_time > stats["finish_time"]:  # pylint:disable=no-member
+                stats["finish_time"] = trial.end_time
             objective = trial.objective.value
-            if objective < stats['best_evaluation']:
-                stats['best_evaluation'] = objective
-                stats['best_trials_id'] = trial.id
-        stats['duration'] = stats['finish_time'] - stats['start_time']
+            if objective < stats["best_evaluation"]:
+                stats["best_evaluation"] = objective
+                stats["best_trials_id"] = trial.id
+        stats["duration"] = stats["finish_time"] - stats["start_time"]
 
         return stats
 
     def __repr__(self):
         """Represent the object as a string."""
-        return "Experiment(name=%s, metadata.user=%s, version=%s)" % \
-            (self.name, self.metadata['user'], self.version)
+        return "Experiment(name=%s, metadata.user=%s, version=%s)" % (
+            self.name,
+            self.metadata["user"],
+            self.version,
+        )
 
 
 # pylint: disable=too-few-public-methods
@@ -445,16 +477,30 @@ class ExperimentView(object):
 
     """
 
-    __slots__ = ('_experiment', )
+    __slots__ = ("_experiment",)
 
     #                     Attributes
-    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials",
-                         "max_broken", "version", "space", "working_dir", "producer"] +
-                        # Properties
-                        ["id", "node", "is_done", "is_broken", "algorithms", "stats",
-                         "configuration"] +
-                        # Methods
-                        ["to_pandas", "fetch_trials", "fetch_trials_by_status", "get_trial"])
+    valid_attributes = (
+        [
+            "_id",
+            "name",
+            "refers",
+            "metadata",
+            "pool_size",
+            "max_trials",
+            "max_broken",
+            "version",
+            "space",
+            "working_dir",
+            "producer",
+        ]
+        +
+        # Properties
+        ["id", "node", "is_done", "is_broken", "algorithms", "stats", "configuration"]
+        +
+        # Methods
+        ["to_pandas", "fetch_trials", "fetch_trials_by_status", "get_trial"]
+    )
 
     def __init__(self, experiment):
         self._experiment = experiment
@@ -463,11 +509,16 @@ class ExperimentView(object):
     def __getattr__(self, name):
         """Get attribute only if valid"""
         if name not in self.valid_attributes:
-            raise AttributeError("Cannot access attribute %s on view-only experiments." % name)
+            raise AttributeError(
+                "Cannot access attribute %s on view-only experiments." % name
+            )
 
         return getattr(self._experiment, name)
 
     def __repr__(self):
         """Represent the object as a string."""
-        return "ExperimentView(name=%s, metadata.user=%s, version=%s)" % \
-            (self.name, self.metadata['user'], self.version)
+        return "ExperimentView(name=%s, metadata.user=%s, version=%s)" % (
+            self.name,
+            self.metadata["user"],
+            self.version,
+        )

--- a/src/orion/core/worker/primary_algo.py
+++ b/src/orion/core/worker/primary_algo.py
@@ -73,10 +73,14 @@ class PrimaryAlgo(BaseAlgorithm):
 
         for point in points:
             if point not in self.transformed_space:
-                raise ValueError("""
+                raise ValueError(
+                    """
 Point is not contained in space:
 Point: {}
-Space: {}""".format(point, self.transformed_space))
+Space: {}""".format(
+                        point, self.transformed_space
+                    )
+                )
 
         return [self.transformed_space.reverse(point) for point in points]
 
@@ -116,8 +120,9 @@ Space: {}""".format(point, self.transformed_space))
 
         """
         assert point in self._space
-        return self.algorithm.judge(self.transformed_space.transform(point),
-                                    measurements)
+        return self.algorithm.judge(
+            self.transformed_space.transform(point), measurements
+        )
 
     @property
     def should_suspend(self):

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -42,14 +42,16 @@ class Producer(object):
         self.experiment = experiment
         self.space = experiment.space
         if self.space is None:
-            raise RuntimeError("Experiment object provided to Producer has not yet completed"
-                               " initialization.")
+            raise RuntimeError(
+                "Experiment object provided to Producer has not yet completed"
+                " initialization."
+            )
         self.algorithm = experiment.algorithms
         self.algorithm.algorithm.max_trials = experiment.max_trials
         if max_idle_time is None:
             max_idle_time = orion.core.config.worker.max_idle_time
         self.max_idle_time = max_idle_time
-        self.strategy = experiment.producer['strategy']
+        self.strategy = experiment.producer["strategy"]
         self.naive_algorithm = None
         # TODO: Move trials_history into PrimaryAlgo during the refactoring of Algorithm with
         #       Strategist and Scheduler.
@@ -66,9 +68,9 @@ class Producer(object):
     def backoff(self):
         """Wait some time and update algorithm."""
         waiting_time = max(0, random.gauss(1, 0.2))
-        log.info('Waiting %d seconds', waiting_time)
+        log.info("Waiting %d seconds", waiting_time)
         time.sleep(waiting_time)
-        log.info('Updating algorithm.')
+        log.info("Updating algorithm.")
         self.update()
         self.failure_count += 1
 
@@ -77,7 +79,10 @@ class Producer(object):
         if time.time() - start > self.max_idle_time:
             raise SampleTimeout(
                 "Algorithm could not sample new points in less than {} seconds."
-                "Failed to sample points {} times".format(self.max_idle_time, self.failure_count))
+                "Failed to sample points {} times".format(
+                    self.max_idle_time, self.failure_count
+                )
+            )
 
     def produce(self):
         """Create and register new trials."""
@@ -87,8 +92,9 @@ class Producer(object):
         self.failure_count = 0
         start = time.time()
 
-        while (sampled_points < self.pool_size and
-               not (self.experiment.is_done or self.naive_algorithm.is_done)):
+        while sampled_points < self.pool_size and not (
+            self.experiment.is_done or self.naive_algorithm.is_done
+        ):
             self._sample_guard(start)
 
             log.debug("### Algorithm suggests new points.")
@@ -101,8 +107,10 @@ class Producer(object):
                 if self.algorithm.is_done:
                     return
 
-                raise WaitingForTrials('Algo does not have more trials to sample.'
-                                       'Waiting for current trials to finish')
+                raise WaitingForTrials(
+                    "Algo does not have more trials to sample."
+                    "Waiting for current trials to finish"
+                )
 
             for new_point in new_points:
                 sampled_points += self.register_trials(new_point)
@@ -138,14 +146,18 @@ class Producer(object):
 
     def _prevalidate_trial(self, new_trial):
         """Verify if trial is not in parent history"""
-        if Trial.compute_trial_hash(new_trial, ignore_experiment=True) in self.params_hashes:
+        if (
+            Trial.compute_trial_hash(new_trial, ignore_experiment=True)
+            in self.params_hashes
+        ):
             raise DuplicateKeyError
 
     def _update_params_hashes(self, trials):
         """Register locally all param hashes of trials"""
         for trial in trials:
             self.params_hashes.add(
-                Trial.compute_trial_hash(trial, ignore_experiment=True, ignore_lie=True))
+                Trial.compute_trial_hash(trial, ignore_experiment=True, ignore_lie=True)
+            )
 
     def update(self):
         """Pull all trials to update model with completed ones and naive model with non completed
@@ -153,8 +165,12 @@ class Producer(object):
         """
         trials = self.experiment.fetch_trials(with_evc_tree=True)
 
-        self._update_algorithm([trial for trial in trials if trial.status == 'completed'])
-        self._update_naive_algorithm([trial for trial in trials if trial.status != 'completed'])
+        self._update_algorithm(
+            [trial for trial in trials if trial.status == "completed"]
+        )
+        self._update_naive_algorithm(
+            [trial for trial in trials if trial.status != "completed"]
+        )
 
     def _update_algorithm(self, completed_trials):
         """Pull newest completed trials to update local model."""
@@ -169,8 +185,12 @@ class Producer(object):
 
         if new_completed_trials:
             log.debug("### Convert them to list of points and their results.")
-            points = list(map(lambda trial: format_trials.trial_to_tuple(trial, self.space),
-                              new_completed_trials))
+            points = list(
+                map(
+                    lambda trial: format_trials.trial_to_tuple(trial, self.space),
+                    new_completed_trials,
+                )
+            )
             results = list(map(format_trials.get_trial_results, new_completed_trials))
 
             log.debug("### Observe them.")
@@ -200,7 +220,9 @@ class Producer(object):
                 try:
                     self.experiment.register_lie(lying_trial)
                 except DuplicateKeyError:
-                    log.debug("#### Duplicate lie. No need to register a duplicate in DB.")
+                    log.debug(
+                        "#### Duplicate lie. No need to register a duplicate in DB."
+                    )
 
         return lying_trials
 
@@ -213,8 +235,12 @@ class Producer(object):
         log.debug("### %s", lying_trials)
         if lying_trials:
             log.debug("### Convert them to list of points and their results.")
-            points = list(map(lambda trial: format_trials.trial_to_tuple(trial, self.space),
-                              lying_trials))
+            points = list(
+                map(
+                    lambda trial: format_trials.trial_to_tuple(trial, self.space),
+                    lying_trials,
+                )
+            )
             results = list(map(format_trials.get_trial_results, lying_trials))
 
             log.debug("### Observe them.")

--- a/src/orion/core/worker/strategy.py
+++ b/src/orion/core/worker/strategy.py
@@ -8,7 +8,7 @@
    :synopsis: Strategies to register objectives for incomplete trials.
 
 """
-from abc import (ABCMeta, abstractmethod)
+from abc import ABCMeta, abstractmethod
 import logging
 
 from orion.core.utils import Factory
@@ -34,15 +34,18 @@ def get_objective(trial):
     :return: Float or None
         The value of the objective, or None if it doesn't exist
     """
-    objectives = [result.value for result in trial.results
-                  if result.type == 'objective']
+    objectives = [
+        result.value for result in trial.results if result.type == "objective"
+    ]
 
     if not objectives:
         objective = None
     elif len(objectives) == 1:
         objective = objectives[0]
     elif len(objectives) > 1:
-        raise RuntimeError("Trial {} has {} objectives".format(trial.id, len(objectives)))
+        raise RuntimeError(
+            "Trial {} has {} objectives".format(trial.id, len(objectives))
+        )
 
     return objective
 
@@ -95,7 +98,7 @@ class BaseParallelStrategy(object, metaclass=ABCMeta):
         objective = get_objective(trial)
         if objective:
             log.warning(CORRUPTED_DB_WARNING, trial.id)
-            return Trial.Result(name='lie', type='lie', value=objective)
+            return Trial.Result(name="lie", type="lie", value=objective)
 
         return None
 
@@ -124,7 +127,7 @@ class NoParallelStrategy(BaseParallelStrategy):
 class MaxParallelStrategy(BaseParallelStrategy):
     """Parallel strategy that uses the max of completed objectives"""
 
-    def __init__(self, default_result=float('inf')):
+    def __init__(self, default_result=float("inf")):
         """Initialize the maximum result used to lie"""
         super(MaxParallelStrategy, self).__init__()
         self.default_result = default_result
@@ -133,13 +136,14 @@ class MaxParallelStrategy(BaseParallelStrategy):
     @property
     def configuration(self):
         """Provide the configuration of the strategy as a dictionary."""
-        return {self.__class__.__name__: {'default_result': self.default_result}}
+        return {self.__class__.__name__: {"default_result": self.default_result}}
 
     def observe(self, points, results):
         """See BaseParallelStrategy.observe"""
         super(MaxParallelStrategy, self).observe(points, results)
-        self.max_result = max(result['objective'] for result in results
-                              if result['objective'] is not None)
+        self.max_result = max(
+            result["objective"] for result in results if result["objective"] is not None
+        )
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
@@ -147,13 +151,13 @@ class MaxParallelStrategy(BaseParallelStrategy):
         if result:
             return result
 
-        return Trial.Result(name='lie', type='lie', value=self.max_result)
+        return Trial.Result(name="lie", type="lie", value=self.max_result)
 
 
 class MeanParallelStrategy(BaseParallelStrategy):
     """Parallel strategy that uses the mean of completed objectives"""
 
-    def __init__(self, default_result=float('inf')):
+    def __init__(self, default_result=float("inf")):
         """Initialize the mean result used to lie"""
         super(MeanParallelStrategy, self).__init__()
         self.default_result = default_result
@@ -162,14 +166,17 @@ class MeanParallelStrategy(BaseParallelStrategy):
     @property
     def configuration(self):
         """Provide the configuration of the strategy as a dictionary."""
-        return {self.__class__.__name__: {'default_result': self.default_result}}
+        return {self.__class__.__name__: {"default_result": self.default_result}}
 
     def observe(self, points, results):
         """See BaseParallelStrategy.observe"""
         super(MeanParallelStrategy, self).observe(points, results)
-        objective_values = [result['objective'] for result in results
-                            if result['objective'] is not None]
-        self.mean_result = sum(value for value in objective_values) / float(len(objective_values))
+        objective_values = [
+            result["objective"] for result in results if result["objective"] is not None
+        ]
+        self.mean_result = sum(value for value in objective_values) / float(
+            len(objective_values)
+        )
 
     def lie(self, trial):
         """See BaseParallelStrategy.lie"""
@@ -177,7 +184,7 @@ class MeanParallelStrategy(BaseParallelStrategy):
         if result:
             return result
 
-        return Trial.Result(name='lie', type='lie', value=self.mean_result)
+        return Trial.Result(name="lie", type="lie", value=self.mean_result)
 
 
 class StubParallelStrategy(BaseParallelStrategy):
@@ -191,7 +198,7 @@ class StubParallelStrategy(BaseParallelStrategy):
     @property
     def configuration(self):
         """Provide the configuration of the strategy as a dictionary."""
-        return {self.__class__.__name__: {'stub_value': self.stub_value}}
+        return {self.__class__.__name__: {"stub_value": self.stub_value}}
 
     def observe(self, points, results):
         """See BaseParallelStrategy.observe"""
@@ -203,7 +210,7 @@ class StubParallelStrategy(BaseParallelStrategy):
         if result:
             return result
 
-        return Trial.Result(name='lie', type='lie', value=self.stub_value)
+        return Trial.Result(name="lie", type="lie", value=self.stub_value)
 
 
 # pylint: disable=too-few-public-methods,abstract-method

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -10,16 +10,16 @@
       algorithm can operate on.
 
 """
-from abc import (ABCMeta, abstractmethod)
+from abc import ABCMeta, abstractmethod
 import functools
 import itertools
 
 import numpy
 
-from orion.algo.space import (Categorical, Dimension, Fidelity, Integer, Real, Space)
+from orion.algo.space import Categorical, Dimension, Fidelity, Integer, Real, Space
 
 
-NON_LINEAR = ['loguniform', 'reciprocal']
+NON_LINEAR = ["loguniform", "reciprocal"]
 
 
 # pylint: disable=unused-argument
@@ -49,10 +49,11 @@ def build_transform(dim, type_requirement, dist_requirement):
 @build_transform.register(Categorical)
 def _(dim, type_requirement, dist_requirement):
     transformers = []
-    if type_requirement == 'real':
-        transformers.extend([Enumerate(dim.categories),
-                             OneHotEncode(len(dim.categories))])
-    elif type_requirement in ['integer', 'numerical']:
+    if type_requirement == "real":
+        transformers.extend(
+            [Enumerate(dim.categories), OneHotEncode(len(dim.categories))]
+        )
+    elif type_requirement in ["integer", "numerical"]:
         transformers.append(Enumerate(dim.categories))
 
     return transformers
@@ -66,12 +67,12 @@ def _(dim, type_requirement, dist_requirement):
 @build_transform.register(Integer)
 def _(dim, type_requirement, dist_requirement):
     transformers = []
-    if dist_requirement == 'linear' and dim.prior_name[4:] in NON_LINEAR:
+    if dist_requirement == "linear" and dim.prior_name[4:] in NON_LINEAR:
         transformers.extend([Reverse(Quantize()), Linearize()])
         # Turn back to integer because Linearize outputs real
-        if type_requirement != 'real':
+        if type_requirement != "real":
             transformers.extend([Quantize()])
-    elif type_requirement == 'real':
+    elif type_requirement == "real":
         transformers.append(Reverse(Quantize()))
 
     return transformers
@@ -83,9 +84,9 @@ def _(dim, type_requirement, dist_requirement):
     if dim.precision is not None:
         transformers.append(Precision(dim.precision))
 
-    if dist_requirement == 'linear' and dim.prior_name in NON_LINEAR:
+    if dist_requirement == "linear" and dim.prior_name in NON_LINEAR:
         transformers.append(Linearize())
-    elif type_requirement == 'integer':
+    elif type_requirement == "integer":
         transformers.append(Quantize())
 
     return transformers
@@ -98,8 +99,7 @@ def transform(original_space, type_requirement, dist_requirement):
         transformers = build_transform(dim, type_requirement, dist_requirement)
         space.register(
             TransformedDimension(
-                transformer=Compose(transformers, dim.type),
-                original_dimension=dim
+                transformer=Compose(transformers, dim.type), original_dimension=dim
             )
         )
 
@@ -121,7 +121,7 @@ def reshape(space, shape_requirement):
                 ReshapedDimension(
                     transformer=Identity(dim.type),
                     original_dimension=dim,
-                    index=dim_index
+                    index=dim_index,
                 )
             )
         else:
@@ -132,7 +132,7 @@ def reshape(space, shape_requirement):
                         transformer=View(dim.shape, index, dim.type),
                         original_dimension=dim,
                         name=key,
-                        index=dim_index
+                        index=dim_index,
                     )
                 )
 
@@ -140,7 +140,8 @@ def reshape(space, shape_requirement):
 
 
 def build_required_space(
-        original_space, type_requirement=None, shape_requirement=None, dist_requirement=None):
+    original_space, type_requirement=None, shape_requirement=None, dist_requirement=None
+):
     """Build a `Space` object which agrees to the `requirements` imposed
     by the desired optimization algorithm.
 
@@ -268,8 +269,10 @@ class Compose(Transformer):
             self.composition = Compose(transformers[:-1], base_domain_type)
         else:
             self.composition = Identity(base_domain_type)
-        assert self.apply.domain_type is None or \
-            self.composition.target_type == self.apply.domain_type
+        assert (
+            self.apply.domain_type is None
+            or self.composition.target_type == self.apply.domain_type
+        )
 
     def transform(self, point):
         """Apply transformers in the increasing order of the `transformers` list."""
@@ -284,7 +287,7 @@ class Compose(Transformer):
 
     def interval(self, alpha=1.0):
         """Return interval of composed transformation."""
-        if hasattr(self.apply, 'interval'):
+        if hasattr(self.apply, "interval"):
             return self.apply.interval(alpha)
 
         return None
@@ -312,16 +315,20 @@ class Compose(Transformer):
 
     # pylint:disable=protected-access
     def _get_hashable_members(self):
-        return ((self.__class__.__name__, ) +
-                self.apply._get_hashable_members() +
-                self.composition._get_hashable_members())
+        return (
+            (self.__class__.__name__,)
+            + self.apply._get_hashable_members()
+            + self.composition._get_hashable_members()
+        )
 
 
 class Reverse(Transformer):
     """Apply the reverse transformation that another one would do."""
 
     def __init__(self, transformer: Transformer):
-        assert not isinstance(transformer, OneHotEncode), "real to categorical is pointless"
+        assert not isinstance(
+            transformer, OneHotEncode
+        ), "real to categorical is pointless"
         self.transformer = transformer
 
     def transform(self, point):
@@ -335,7 +342,9 @@ class Reverse(Transformer):
 
     def repr_format(self, what):
         """Format a string for calling ``__repr__`` in `TransformedDimension`."""
-        return "{}{}".format(self.__class__.__name__, self.transformer.repr_format(what))
+        return "{}{}".format(
+            self.__class__.__name__, self.transformer.repr_format(what)
+        )
 
     @property
     def target_type(self):
@@ -351,8 +360,8 @@ class Reverse(Transformer):
 class Precision(Transformer):
     """Round real numbers to requested precision."""
 
-    domain_type = 'real'
-    target_type = 'real'
+    domain_type = "real"
+    target_type = "real"
 
     def __init__(self, precision=4):
         self.precision = precision
@@ -360,12 +369,20 @@ class Precision(Transformer):
     def transform(self, point):
         """Round `point` to the requested precision, as numpy arrays."""
         # numpy.format_float_scientific precision starts at 0
-        if isinstance(point, (list, tuple)) or (isinstance(point, numpy.ndarray) and point.shape):
-            point = map(lambda x: numpy.format_float_scientific(x, precision=self.precision - 1),
-                        point)
+        if isinstance(point, (list, tuple)) or (
+            isinstance(point, numpy.ndarray) and point.shape
+        ):
+            point = map(
+                lambda x: numpy.format_float_scientific(
+                    x, precision=self.precision - 1
+                ),
+                point,
+            )
             point = list(map(float, point))
         else:
-            point = float(numpy.format_float_scientific(point, precision=self.precision - 1))
+            point = float(
+                numpy.format_float_scientific(point, precision=self.precision - 1)
+            )
 
         return numpy.asarray(point)
 
@@ -382,8 +399,8 @@ class Precision(Transformer):
 class Quantize(Transformer):
     """Transform real numbers to integers, violating injection."""
 
-    domain_type = 'real'
-    target_type = 'integer'
+    domain_type = "real"
+    target_type = "integer"
 
     def transform(self, point):
         """Cast `point` to the floor and then to integers, as numpy arrays."""
@@ -391,8 +408,10 @@ class Quantize(Transformer):
 
         if numpy.any(numpy.isinf(point)):
             isinf = int(numpy.isinf(point))
-            quantized = (isinf * (quantized - 1) * int(numpy.sign(point)) +
-                         (1 - isinf) * (quantized - 1)).astype(int)
+            quantized = (
+                isinf * (quantized - 1) * int(numpy.sign(point))
+                + (1 - isinf) * (quantized - 1)
+            ).astype(int)
 
         return quantized
 
@@ -408,13 +427,13 @@ class Enumerate(Transformer):
     Effectively transform from a list of objects to a range of integers.
     """
 
-    domain_type = 'categorical'
-    target_type = 'integer'
+    domain_type = "categorical"
+    target_type = "integer"
 
     def __init__(self, categories):
         self.categories = categories
         map_dict = {cat: i for i, cat in enumerate(categories)}
-        self._map = numpy.vectorize(lambda x: map_dict[x], otypes='i')
+        self._map = numpy.vectorize(lambda x: map_dict[x], otypes="i")
         self._imap = numpy.vectorize(lambda x: categories[x], otypes=[numpy.object])
 
     def __deepcopy__(self, memo):
@@ -445,8 +464,8 @@ class Enumerate(Transformer):
 class OneHotEncode(Transformer):
     """Encode categories to a 1-hot integer space representation."""
 
-    domain_type = 'integer'
-    target_type = 'real'
+    domain_type = "integer"
+    target_type = "real"
 
     def __init__(self, bound: int):
         self.num_cats = bound
@@ -460,15 +479,19 @@ class OneHotEncode(Transformer):
         .. note:: This transformation possibly appends one more tensor dimension to `point`.
         """
         point_ = numpy.asarray(point)
-        assert numpy.all(point_ < self.num_cats) and numpy.all(point_ >= 0) and\
-            numpy.all(point_ % 1 == 0)
+        assert (
+            numpy.all(point_ < self.num_cats)
+            and numpy.all(point_ >= 0)
+            and numpy.all(point_ % 1 == 0)
+        )
 
         if self.num_cats <= 2:
             return numpy.asarray(point_, dtype=float)
 
         hot = numpy.zeros(self.infer_target_shape(point_.shape))
-        grid = numpy.meshgrid(*[numpy.arange(dim) for dim in point_.shape],
-                              indexing='ij')
+        grid = numpy.meshgrid(
+            *[numpy.arange(dim) for dim in point_.shape], indexing="ij"
+        )
         hot[grid + [point_]] = 1
         return hot
 
@@ -511,14 +534,14 @@ class OneHotEncode(Transformer):
         return tuple(list(shape) + [self.num_cats]) if self.num_cats > 2 else shape
 
     def _get_hashable_members(self):
-        return super(OneHotEncode, self)._get_hashable_members() + (self.num_cats, )
+        return super(OneHotEncode, self)._get_hashable_members() + (self.num_cats,)
 
 
 class Linearize(Transformer):
     """Transform real numbers from loguniform to linear."""
 
-    domain_type = 'real'
-    target_type = 'real'
+    domain_type = "real"
+    target_type = "real"
 
     def transform(self, point):
         """Linearize logarithmic distribution."""
@@ -549,7 +572,7 @@ class View(Transformer):
 
     def reverse(self, transformed_point, index=None):
         """Only return packend point if view of first element, otherwise drop."""
-        subset = transformed_point[index:index + numpy.prod(self.shape)]
+        subset = transformed_point[index : index + numpy.prod(self.shape)]
         return numpy.array(subset).reshape(self.shape)
 
     def interval(self, interval):
@@ -568,8 +591,9 @@ class View(Transformer):
 
     def repr_format(self, what):
         """Format a string for calling ``__repr__`` in `TransformedDimension`."""
-        return "{}(shape={}, index={}, {})".format(self.__class__.__name__, self.shape, self.index,
-                                                   what)
+        return "{}(shape={}, index={}, {})".format(
+            self.__class__.__name__, self.shape, self.index, what
+        )
 
 
 class TransformedDimension(object):
@@ -595,11 +619,11 @@ class TransformedDimension(object):
 
     def interval(self, alpha=1.0):
         """Map the interval bounds to the transformed ones."""
-        if hasattr(self.transformer, 'interval'):
+        if hasattr(self.transformer, "interval"):
             interval = self.transformer.interval()
             if interval:
                 return interval
-        if self.original_dimension.type == 'categorical':
+        if self.original_dimension.type == "categorical":
             return self.original_dimension.categories
 
         low, high = self.original_dimension.interval(alpha)
@@ -626,8 +650,10 @@ class TransformedDimension(object):
         if not (hasattr(other, "transformer") and hasattr(other, "original_dimension")):
             return False
 
-        return (self.transformer == other.transformer and
-                self.original_dimension == other.original_dimension)
+        return (
+            self.transformer == other.transformer
+            and self.original_dimension == other.original_dimension
+        )
 
     def __hash__(self):
         """Hash of the transformed dimension"""
@@ -636,8 +662,10 @@ class TransformedDimension(object):
     # pylint:disable=protected-access
     def _get_hashable_members(self):
         """Hashable members of transformation and original dimension"""
-        return (self.transformer._get_hashable_members() +
-                self.original_dimension._get_hashable_members())
+        return (
+            self.transformer._get_hashable_members()
+            + self.original_dimension._get_hashable_members()
+        )
 
     def validate(self):
         """Validate original_dimension"""
@@ -652,7 +680,7 @@ class TransformedDimension(object):
     def type(self):
         """Ask transformer which is its target class."""
         type_ = self.transformer.target_type
-        return type_ if type_ != 'invariant' else self.original_dimension.type
+        return type_ if type_ != "invariant" else self.original_dimension.type
 
     @property
     def prior_name(self):
@@ -667,16 +695,16 @@ class TransformedDimension(object):
     @property
     def cardinality(self):
         """Wrap original `Dimension` capacity"""
-        if self.type == 'real':
+        if self.type == "real":
             return Real.get_cardinality(self.shape, self.interval())
-        elif self.type == 'integer':
+        elif self.type == "integer":
             return Integer.get_cardinality(self.shape, self.interval())
-        elif self.type == 'categorical':
+        elif self.type == "categorical":
             return Categorical.get_cardinality(self.shape, self.interval())
-        elif self.type == 'fidelity':
+        elif self.type == "fidelity":
             return Fidelity.get_cardinality(self.shape, self.interval())
         else:
-            raise RuntimeError(f'No cardinality can be computed for type `{self.type}`')
+            raise RuntimeError(f"No cardinality can be computed for type `{self.type}`")
 
 
 class ReshapedDimension(TransformedDimension):
@@ -705,7 +733,7 @@ class ReshapedDimension(TransformedDimension):
     def interval(self, alpha=1.0):
         """Map the interval bounds to the transformed ones."""
         interval = self.original_dimension.interval(alpha)
-        if hasattr(interval[0], 'shape') and numpy.prod(interval[0].shape) > 1:
+        if hasattr(interval[0], "shape") and numpy.prod(interval[0].shape) > 1:
             return self.transformer.interval(interval)
 
         return interval
@@ -758,7 +786,9 @@ class TransformedSpace(Space):
         """Reverses transformation so that a point from this `TransformedSpace`
         to be in the original one.
         """
-        return tuple([dim.reverse(transformed_point[i]) for i, dim in enumerate(self.values())])
+        return tuple(
+            [dim.reverse(transformed_point[i]) for i, dim in enumerate(self.values())]
+        )
 
     def sample(self, n_samples=1, seed=None):
         """Sample from the original dimension and forward transform them."""
@@ -832,8 +862,10 @@ class ReshapedSpace(Space):
         try:
             len(value)
         except TypeError as exc:
-            raise TypeError("Can check only for dimension names or "
-                            "for tuples with parameter values.") from exc
+            raise TypeError(
+                "Can check only for dimension names or "
+                "for tuples with parameter values."
+            ) from exc
 
         if not self:
             return False

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -24,8 +24,9 @@ def validate_status(status):
     ``completed``, ``interrupted``, or ``broken``.
     """
     if status is not None and status not in Trial.allowed_stati:
-        raise ValueError("Given status `{0}` not one of: {1}".format(
-            status, Trial.allowed_stati))
+        raise ValueError(
+            "Given status `{0}` not one of: {1}".format(status, Trial.allowed_stati)
+        )
 
 
 class Trial:
@@ -105,7 +106,7 @@ class Trial:
 
         """
 
-        __slots__ = ('name', '_type', 'value')
+        __slots__ = ("name", "_type", "value")
         allowed_types = ()
 
         def __init__(self, **kwargs):
@@ -119,27 +120,27 @@ class Trial:
 
         def _ensure_no_ndarray(self):
             """Make sure the current value is not a `numpy.ndarray`."""
-            if hasattr(self, 'value') and hasattr(self.value, 'tolist'):
+            if hasattr(self, "value") and hasattr(self.value, "tolist"):
                 self.value = self.value.tolist()
 
         def to_dict(self):
             """Needed to be able to convert `Value` to `dict` form."""
-            ret = dict(
-                name=self.name,
-                type=self.type,
-                value=self.value
-                )
+            ret = dict(name=self.name, type=self.type, value=self.value)
             return ret
 
         def __eq__(self, other):
             """Test equality based on self.to_dict()"""
-            return self.name == other.name and self.type == other.type and self.value == other.value
+            return (
+                self.name == other.name
+                and self.type == other.type
+                and self.value == other.value
+            )
 
         def __str__(self):
             """Represent partially with a string."""
             ret = "{0}(name={1}, type={2}, value={3})".format(
-                type(self).__name__, repr(self.name),
-                repr(self.type), repr(self.value))
+                type(self).__name__, repr(self.name), repr(self.type), repr(self.value)
+            )
             return ret
 
         __repr__ = __str__
@@ -152,8 +153,9 @@ class Trial:
         @type.setter
         def type(self, type_):
             if type_ is not None and type_ not in self.allowed_types:
-                raise ValueError("Given type, {0}, not one of: {1}".format(
-                    type_, self.allowed_types))
+                raise ValueError(
+                    "Given type, {0}, not one of: {1}".format(type_, self.allowed_types)
+                )
             self._type = type_
 
     class Result(Value):
@@ -162,7 +164,7 @@ class Trial:
         """
 
         __slots__ = ()
-        allowed_types = ('objective', 'constraint', 'gradient', 'statistic', 'lie')
+        allowed_types = ("objective", "constraint", "gradient", "statistic", "lie")
 
     class Param(Value):
         """Types for a `Param` can be either an integer (discrete value),
@@ -170,32 +172,51 @@ class Trial:
         """
 
         __slots__ = ()
-        allowed_types = ('integer', 'real', 'categorical', 'fidelity')
+        allowed_types = ("integer", "real", "categorical", "fidelity")
 
-    __slots__ = ('experiment', '_id', '_status', 'worker', '_working_dir', 'heartbeat',
-                 'submit_time', 'start_time', 'end_time', '_results', '_params', 'parents',
-                 'id_override')
-    allowed_stati = ('new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken')
+    __slots__ = (
+        "experiment",
+        "_id",
+        "_status",
+        "worker",
+        "_working_dir",
+        "heartbeat",
+        "submit_time",
+        "start_time",
+        "end_time",
+        "_results",
+        "_params",
+        "parents",
+        "id_override",
+    )
+    allowed_stati = (
+        "new",
+        "reserved",
+        "suspended",
+        "completed",
+        "interrupted",
+        "broken",
+    )
 
     def __init__(self, **kwargs):
         """See attributes of `Trial` for meaning and possible arguments for `kwargs`."""
         for attrname in self.__slots__:
-            if attrname in ('_results', '_params', 'parents'):
+            if attrname in ("_results", "_params", "parents"):
                 setattr(self, attrname, list())
             else:
                 setattr(self, attrname, None)
 
-        self.status = 'new'
+        self.status = "new"
 
         # Store the id as an override to support different backends
-        self.id_override = kwargs.pop('_id', None)
+        self.id_override = kwargs.pop("_id", None)
 
         for attrname, value in kwargs.items():
-            if attrname == 'results':
+            if attrname == "results":
                 attr = getattr(self, attrname)
                 for item in value:
                     attr.append(self.Result(**item))
-            elif attrname == 'params':
+            elif attrname == "params":
                 for item in value:
                     self._params.append(self.Param(**item))
             else:
@@ -214,17 +235,18 @@ class Trial:
 
         # Overwrite "results" and "params" with list of dictionaries rather
         # than list of Value objects
-        trial_dictionary['results'] = list(map(lambda x: x.to_dict(), self.results))
-        trial_dictionary['params'] = list(map(lambda x: x.to_dict(), self._params))
+        trial_dictionary["results"] = list(map(lambda x: x.to_dict(), self.results))
+        trial_dictionary["params"] = list(map(lambda x: x.to_dict(), self._params))
 
-        trial_dictionary['_id'] = trial_dictionary.pop('id')
+        trial_dictionary["_id"] = trial_dictionary.pop("id")
 
         return trial_dictionary
 
     def __str__(self):
         """Represent partially with a string."""
         return "Trial(experiment={0}, status={1}, params={2})".format(
-            repr(self.experiment), repr(self._status), self.format_params(self._params))
+            repr(self.experiment), repr(self._status), self.format_params(self._params)
+        )
 
     __repr__ = __str__
 
@@ -241,13 +263,16 @@ class Trial:
     @results.setter
     def results(self, results):
         """Verify results before setting the property"""
-        objective = self._fetch_one_result_of_type('objective', results)
+        objective = self._fetch_one_result_of_type("objective", results)
 
         if objective is None:
-            raise ValueError('No objective found in results: {}'.format(results))
+            raise ValueError("No objective found in results: {}".format(results))
         if not isinstance(objective.value, (float, int)):
             raise ValueError(
-                'Results must contain a type `objective` with type float/int: {}'.format(objective))
+                "Results must contain a type `objective` with type float/int: {}".format(
+                    objective
+                )
+            )
 
         self._results = results
 
@@ -284,7 +309,7 @@ class Trial:
 
         :rtype: `Trial.Result`
         """
-        return self._fetch_one_result_of_type('objective')
+        return self._fetch_one_result_of_type("objective")
 
     @property
     def lie(self):
@@ -292,7 +317,7 @@ class Trial:
 
         :rtype: `Trial.Result`
         """
-        return self._fetch_one_result_of_type('lie')
+        return self._fetch_one_result_of_type("lie")
 
     @property
     def gradient(self):
@@ -300,7 +325,7 @@ class Trial:
 
         :rtype: `Trial.Result`
         """
-        return self._fetch_one_result_of_type('gradient')
+        return self._fetch_one_result_of_type("gradient")
 
     @property
     def constraints(self):
@@ -311,7 +336,7 @@ class Trial:
         -------
         A list of ``Trial.Result`` of type 'constraint'
         """
-        return self._fetch_results('constraint', self.results)
+        return self._fetch_results("constraint", self.results)
 
     @property
     def statistics(self):
@@ -322,7 +347,7 @@ class Trial:
         -------
         A list of ``Trial.Result`` de type 'statistic'
         """
-        return self._fetch_results('statistic', self.results)
+        return self._fetch_results("statistic", self.results)
 
     @property
     def hash_name(self):
@@ -348,9 +373,11 @@ class Trial:
     def full_name(self):
         """Generate a unique name using the full definition of parameters."""
         if not self._params or not self.experiment:
-            raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "
-                             "have not been set.")
-        return self.format_values(self._params, sep='-').replace('/', '.')
+            raise ValueError(
+                "Cannot distinguish this trial, as 'params' or 'experiment' "
+                "have not been set."
+            )
+        return self.format_values(self._params, sep="-").replace("/", ".")
 
     def _fetch_results(self, type, results):
         """Fetch results for the given type"""
@@ -366,42 +393,47 @@ class Trial:
             return None
 
         if len(value) > 1:
-            log.warning("Found multiple results of '%s' type:\n%s",
-                        result_type, value)
-            log.warning("Multi-objective optimization is not currently supported.\n"
-                        "Optimizing according to the first one only: %s", value[0])
+            log.warning("Found multiple results of '%s' type:\n%s", result_type, value)
+            log.warning(
+                "Multi-objective optimization is not currently supported.\n"
+                "Optimizing according to the first one only: %s",
+                value[0],
+            )
 
         return value[0]
 
-    def _repr_values(self, values, sep=','):
+    def _repr_values(self, values, sep=","):
         """Represent with a string the given values."""
         return Trial.format_values(values, sep)
 
-    def params_repr(self, sep=',', ignore_fidelity=False):
+    def params_repr(self, sep=",", ignore_fidelity=False):
         """Represent with a string the parameters contained in this `Trial` object."""
         return Trial.format_params(self._params, sep)
 
     @staticmethod
-    def format_values(values, sep=','):
+    def format_values(values, sep=","):
         """Represent with a string the given values."""
         return sep.join(map(lambda value: "{0.name}:{0.value}".format(value), values))
 
     @staticmethod
-    def format_params(params, sep=',', ignore_fidelity=False):
+    def format_params(params, sep=",", ignore_fidelity=False):
         """Represent with a string the parameters contained in this `Trial` object."""
         if ignore_fidelity:
-            params = [x for x in params if x.type != 'fidelity']
+            params = [x for x in params if x.type != "fidelity"]
         else:
             params = params
         return Trial.format_values(params, sep)
 
     @staticmethod
-    def compute_trial_hash(trial, ignore_fidelity=False, ignore_experiment=False,
-                           ignore_lie=False):
+    def compute_trial_hash(
+        trial, ignore_fidelity=False, ignore_experiment=False, ignore_lie=False
+    ):
         """Generate a unique param md5sum hash for a given `Trial`"""
         if not trial._params and not trial.experiment:
-            raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "
-                             "have not been set.")
+            raise ValueError(
+                "Cannot distinguish this trial, as 'params' or 'experiment' "
+                "have not been set."
+            )
 
         params = Trial.format_params(trial._params, ignore_fidelity=ignore_fidelity)
 
@@ -413,4 +445,6 @@ class Trial:
         if not ignore_lie and trial.lie:
             lie_repr = Trial.format_values([trial.lie])
 
-        return hashlib.md5((params + experiment_repr + lie_repr).encode('utf-8')).hexdigest()
+        return hashlib.md5(
+            (params + experiment_repr + lie_repr).encode("utf-8")
+        ).hexdigest()

--- a/src/orion/core/worker/trial_pacemaker.py
+++ b/src/orion/core/worker/trial_pacemaker.py
@@ -11,7 +11,7 @@ import threading
 
 from orion.storage.base import get_storage
 
-STOPPED_STATUS = {'completed', 'interrupted', 'suspended'}
+STOPPED_STATUS = {"completed", "interrupted", "suspended"}
 
 
 class TrialPacemaker(threading.Thread):

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -16,7 +16,7 @@ from orion.algo.space import Categorical, Fidelity
 import orion.analysis.regret
 
 
-def lpi(experiment, model='RandomForestRegressor', model_kwargs=None, n=20, **kwargs):
+def lpi(experiment, model="RandomForestRegressor", model_kwargs=None, n=20, **kwargs):
     """Plotly implementation of `orion.plotting.lpi`"""
     if not experiment:
         raise ValueError("Parameter 'experiment' is None")
@@ -27,26 +27,31 @@ def lpi(experiment, model='RandomForestRegressor', model_kwargs=None, n=20, **kw
     df = experiment.to_pandas()
     df = orion.analysis.lpi(df, experiment.space, model=model, n=n, **model_kwargs)
 
-    fig = go.Figure(data=[go.Bar(x=df.index.tolist(), y=df['LPI'].tolist())])
+    fig = go.Figure(data=[go.Bar(x=df.index.tolist(), y=df["LPI"].tolist())])
 
     y_axis_label = "Local Parameter Importance (LPI)"
-    fig.update_layout(title=f"LPI for experiment '{experiment.name}'",
-                      xaxis_title="Hyperparameters",
-                      yaxis_title=y_axis_label)
+    fig.update_layout(
+        title=f"LPI for experiment '{experiment.name}'",
+        xaxis_title="Hyperparameters",
+        yaxis_title=y_axis_label,
+    )
 
     return fig
 
 
-def parallel_coordinates(experiment, order=None, colorscale='YlOrRd', **kwargs):
+def parallel_coordinates(experiment, order=None, colorscale="YlOrRd", **kwargs):
     """Plotly implementation of `orion.plotting.parallel_coordinates`"""
+
     def build_frame():
         """Builds the dataframe for the plot"""
         names = list(experiment.space.keys())
 
         df = experiment.to_pandas()
-        df = df.loc[df['status'] == 'completed']
+        df = df.loc[df["status"] == "completed"]
 
-        df[names] = df[names].transform(functools.partial(_curate_params, space=experiment.space))
+        df[names] = df[names].transform(
+            functools.partial(_curate_params, space=experiment.space)
+        )
 
         df = _flatten_dims(df, experiment.space)
 
@@ -56,7 +61,9 @@ def parallel_coordinates(experiment, order=None, colorscale='YlOrRd', **kwargs):
         """Create order if not passed, otherwised verify it"""
         if order is None:
             order = list(experiment.space.keys())
-            fidelity_dims = [dim for dim in experiment.space.values() if isinstance(dim, Fidelity)]
+            fidelity_dims = [
+                dim for dim in experiment.space.values() if isinstance(dim, Fidelity)
+            ]
             if fidelity_dims:
                 del order[order.index(fidelity_dims[0].name)]
                 order.insert(0, fidelity_dims[0].name)
@@ -64,25 +71,27 @@ def parallel_coordinates(experiment, order=None, colorscale='YlOrRd', **kwargs):
             names = set(experiment.space.keys())
             any_invalid = set(order) - names
             if any_invalid:
-                raise ValueError(f'Some names are invalid: {any_invalid} not in {names}')
+                raise ValueError(
+                    f"Some names are invalid: {any_invalid} not in {names}"
+                )
 
         return order
 
     def get_dimension(data, name, dim):
         dim_data = dict(label=name, values=data[name])
         if isinstance(dim, Categorical):
-            dim_data['tickvals'] = list(range(len(dim.categories)))
-            dim_data['ticktext'] = dim.categories
+            dim_data["tickvals"] = list(range(len(dim.categories)))
+            dim_data["ticktext"] = dim.categories
         elif isinstance(dim, Fidelity):
-            dim_data['range'] = (dim.low, dim.high)
+            dim_data["range"] = (dim.low, dim.high)
         else:
-            dim_data['range'] = dim.interval()
+            dim_data["range"] = dim.interval()
         return dim_data
 
     if not experiment:
         raise ValueError("Parameter 'experiment' is None")
 
-    trial = experiment.fetch_trials_by_status('completed')[0]
+    trial = experiment.fetch_trials_by_status("completed")[0]
     df = build_frame()
 
     dimensions = []
@@ -92,19 +101,18 @@ def parallel_coordinates(experiment, order=None, colorscale='YlOrRd', **kwargs):
         if shape:
             assert len(shape) == 1
             for i in range(shape[0]):
-                name_i = f'{name}[{i}]'
+                name_i = f"{name}[{i}]"
                 dimensions.append(get_dimension(df, name_i, dim))
         else:
             dimensions.append(get_dimension(df, name, dim))
 
     objective_name = trial.objective.name
 
-    objectives = df['objective']
-    omin = min(df['objective'])
-    omax = max(df['objective'])
+    objectives = df["objective"]
+    omin = min(df["objective"])
+    omax = max(df["objective"])
 
-    dimensions.append(
-        dict(label=objective_name, range=(omin, omax), values=objectives))
+    dimensions.append(dict(label=objective_name, range=(omin, omax), values=objectives))
 
     fig = go.Figure(
         data=go.Parcoords(
@@ -114,31 +122,35 @@ def parallel_coordinates(experiment, order=None, colorscale='YlOrRd', **kwargs):
                 showscale=True,
                 cmin=omin,
                 cmax=omax,
-                colorbar=dict(title=objective_name)),
-            dimensions=dimensions))
+                colorbar=dict(title=objective_name),
+            ),
+            dimensions=dimensions,
+        )
+    )
 
-    fig.update_layout(title=f"Parallel Coordinates Plot for experiment '{experiment.name}'")
+    fig.update_layout(
+        title=f"Parallel Coordinates Plot for experiment '{experiment.name}'"
+    )
 
     return fig
 
 
 def regret(experiment, order_by, verbose_hover, **kwargs):
     """Plotly implementation of `orion.plotting.regret`"""
+
     def build_frame():
         """Builds the dataframe for the plot"""
         df = experiment.to_pandas()
 
         names = list(experiment.space.keys())
-        df['params'] = df[names].apply(
-            _format_hyperparameters,
-            args=(names, ), axis=1)
+        df["params"] = df[names].apply(_format_hyperparameters, args=(names,), axis=1)
 
-        df = df.loc[df['status'] == 'completed']
+        df = df.loc[df["status"] == "completed"]
         df = df.sort_values(order_by)
         df = orion.analysis.regret(df)
         return df
 
-    ORDER_KEYS = ['suggested', 'reserved', 'completed']
+    ORDER_KEYS = ["suggested", "reserved", "completed"]
 
     if not experiment:
         raise ValueError("Parameter 'experiment' is None")
@@ -146,26 +158,32 @@ def regret(experiment, order_by, verbose_hover, **kwargs):
     if order_by not in ORDER_KEYS:
         raise ValueError(f"Parameter 'order_by' is not one of {ORDER_KEYS}")
 
-    trial = experiment.fetch_trials_by_status('completed')[0]
+    trial = experiment.fetch_trials_by_status("completed")[0]
     df = build_frame()
 
     fig = go.Figure()
 
-    fig.add_scatter(y=df['objective'],
-                    mode='markers',
-                    name='trials',
-                    customdata=list(zip(df['id'], df[order_by], df['params'])),
-                    hovertemplate=_template_trials(verbose_hover))
-    fig.add_scatter(y=df['best'],
-                    mode='lines',
-                    name='best-to-date',
-                    customdata=list(zip(df['best_id'], df['best'])),
-                    hovertemplate=_template_best())
+    fig.add_scatter(
+        y=df["objective"],
+        mode="markers",
+        name="trials",
+        customdata=list(zip(df["id"], df[order_by], df["params"])),
+        hovertemplate=_template_trials(verbose_hover),
+    )
+    fig.add_scatter(
+        y=df["best"],
+        mode="lines",
+        name="best-to-date",
+        customdata=list(zip(df["best_id"], df["best"])),
+        hovertemplate=_template_best(),
+    )
 
     y_axis_label = f"{trial.objective.type.capitalize()} '{trial.objective.name}'"
-    fig.update_layout(title=f"Regret for experiment '{experiment.name}'",
-                      xaxis_title=f"Trials ordered by {order_by} time",
-                      yaxis_title=y_axis_label)
+    fig.update_layout(
+        title=f"Regret for experiment '{experiment.name}'",
+        xaxis_title=f"Trials ordered by {order_by} time",
+        yaxis_title=y_axis_label,
+    )
 
     return fig
 
@@ -189,32 +207,36 @@ def _format_value(value):
 
 
 def _format_hyperparameters(hyperparameters, names):
-    result = ''
+    result = ""
 
     for name, value in zip(names, hyperparameters):
-        x = f'<br>  {name[1:]}: {_format_value(value)}'
+        x = f"<br>  {name[1:]}: {_format_value(value)}"
         result += x
 
     return result
 
 
 def _template_trials(verbose_hover):
-    template = '<b>ID: %{customdata[0]}</b><br>' \
-        'value: %{y}<br>' \
-        'time: %{customdata[1]|%Y-%m-%d %H:%M:%S}<br>'
+    template = (
+        "<b>ID: %{customdata[0]}</b><br>"
+        "value: %{y}<br>"
+        "time: %{customdata[1]|%Y-%m-%d %H:%M:%S}<br>"
+    )
 
     if verbose_hover:
-        template += 'parameters: %{customdata[2]}'
+        template += "parameters: %{customdata[2]}"
 
-    template += '<extra></extra>'
+    template += "<extra></extra>"
 
     return template
 
 
 def _template_best():
-    return '<b>Best ID: %{customdata[0]}</b><br>' \
-        'value: %{customdata[1]}' \
-        '<extra></extra>'
+    return (
+        "<b>Best ID: %{customdata[0]}</b><br>"
+        "value: %{customdata[1]}"
+        "<extra></extra>"
+    )
 
 
 def _curate_params(data, space):
@@ -240,7 +262,7 @@ def _flatten_dims(data, space):
             values = data[key].apply(pd.Series)
 
             # rename each hp
-            values = values.rename(columns=lambda x: f'{key}[{x}]')
+            values = values.rename(columns=lambda x: f"{key}[{x}]")
 
             data = pd.concat([data[:], values[:]], axis=1)
 

--- a/src/orion/plotting/base.py
+++ b/src/orion/plotting/base.py
@@ -10,7 +10,7 @@
 import orion.plotting.backend_plotly as backend
 
 
-def lpi(experiment, model='RandomForestRegressor', model_kwargs=None, n=20, **kwargs):
+def lpi(experiment, model="RandomForestRegressor", model_kwargs=None, n=20, **kwargs):
     """
     Make a bar plot to visualize the local parameter importance metric.
 
@@ -52,7 +52,9 @@ def lpi(experiment, model='RandomForestRegressor', model_kwargs=None, n=20, **kw
         If no experiment is provided or if regressor name is invalid.
 
     """
-    return backend.lpi(experiment, model=model, model_kwargs=model_kwargs, n=n, **kwargs)
+    return backend.lpi(
+        experiment, model=model, model_kwargs=model_kwargs, n=n, **kwargs
+    )
 
 
 def parallel_coordinates(experiment, order=None, **kwargs):
@@ -87,7 +89,7 @@ def parallel_coordinates(experiment, order=None, **kwargs):
     return backend.parallel_coordinates(experiment, order=order, **kwargs)
 
 
-def regret(experiment, order_by='suggested', verbose_hover=True, **kwargs):
+def regret(experiment, order_by="suggested", verbose_hover=True, **kwargs):
     """
     Make a plot to visualize the performance of the hyper-optimization process.
 
@@ -127,9 +129,10 @@ def regret(experiment, order_by='suggested', verbose_hover=True, **kwargs):
 
 
 PLOT_METHODS = {
-    'lpi': lpi,
-    'parallel_coordinates': parallel_coordinates,
-    'regret': regret}
+    "lpi": lpi,
+    "parallel_coordinates": parallel_coordinates,
+    "regret": regret,
+}
 
 
 class PlotAccessor:
@@ -163,10 +166,12 @@ class PlotAccessor:
 
             - 'regret' : Regret plot (default)
         """
-        kind = kwargs.pop('kind', 'regret')
+        kind = kwargs.pop("kind", "regret")
 
         if kind not in PLOT_METHODS.keys():
-            raise ValueError(f"Plot of kind '{kind}' is not one of {list(PLOT_METHODS.keys())}")
+            raise ValueError(
+                f"Plot of kind '{kind}' is not one of {list(PLOT_METHODS.keys())}"
+            )
 
         return PLOT_METHODS[kind](self._experiment, **kwargs)
 

--- a/src/orion/serving/experiments_resource.py
+++ b/src/orion/serving/experiments_resource.py
@@ -15,7 +15,10 @@ from falcon import Request, Response
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 from orion.serving.parameters import retrieve_experiment, verify_query_parameters
-from orion.serving.responses import build_experiment_response, build_experiments_response
+from orion.serving.responses import (
+    build_experiment_response,
+    build_experiments_response,
+)
 from orion.storage.base import get_storage
 
 
@@ -38,8 +41,8 @@ class ExperimentsResource(object):
         Handle GET requests for experiments/:name where `name` is
         the user-defined name of the experiment
         """
-        verify_query_parameters(req.params, ['version'])
-        version = req.get_param_as_int('version')
+        verify_query_parameters(req.params, ["version"])
+        version = req.get_param_as_int("version")
         experiment = retrieve_experiment(name, version)
 
         status = _retrieve_status(experiment)
@@ -54,8 +57,8 @@ def _find_latest_versions(experiments):
     """Find the latest versions of the experiments"""
     leaf_experiments = {}
     for experiment in experiments:
-        name = experiment['name']
-        version = experiment['version']
+        name = experiment["name"]
+        version = experiment["version"]
 
         if name in leaf_experiments:
             leaf_experiments[name] = max(leaf_experiments[name], version)
@@ -79,7 +82,7 @@ def _retrieve_algorithm(experiment: Experiment) -> dict:
     """Populates the `algorithm` key with the configuration of the experiment's algorithm."""
     algorithm_name = list(experiment.algorithms.configuration.keys())[0]
 
-    result = {'name': algorithm_name}
+    result = {"name": algorithm_name}
     result.update(experiment.algorithms.configuration[algorithm_name])
     return result
 
@@ -89,4 +92,4 @@ def _retrieve_best_trial(experiment: Experiment) -> Optional[Trial]:
     if not experiment.stats:
         return None
 
-    return experiment.get_trial(uid=experiment.stats['best_trials_id'])
+    return experiment.get_trial(uid=experiment.stats["best_trials_id"])

--- a/src/orion/serving/parameters.py
+++ b/src/orion/serving/parameters.py
@@ -14,8 +14,11 @@ from orion.core.io import experiment_builder
 from orion.core.utils.exceptions import NoConfigurationError
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
-from orion.serving.responses import ERROR_EXPERIMENT_NOT_FOUND, ERROR_INVALID_PARAMETER, \
-    ERROR_TRIAL_NOT_FOUND
+from orion.serving.responses import (
+    ERROR_EXPERIMENT_NOT_FOUND,
+    ERROR_INVALID_PARAMETER,
+    ERROR_TRIAL_NOT_FOUND,
+)
 
 
 def verify_query_parameters(parameters: dict, supported_parameters: list):
@@ -44,8 +47,9 @@ def verify_status(status):
     """Verifies that the given trial status is supported. Raises falcon.HTTPBadRequest otherwise"""
     if status and status not in Trial.allowed_stati:
         description = 'The "status" parameter is invalid. '
-        description += 'The value of the parameter must be one of {}'.format(
-            list(Trial.allowed_stati))
+        description += "The value of the parameter must be one of {}".format(
+            list(Trial.allowed_stati)
+        )
 
         raise falcon.HTTPBadRequest(ERROR_INVALID_PARAMETER, description)
 
@@ -56,14 +60,16 @@ def _compose_error_message(key: str, supported_parameters: list):
 
     if len(supported_parameters) > 1:
         supported_parameters.sort()
-        error_message += f'one of {supported_parameters}.'
+        error_message += f"one of {supported_parameters}."
     else:
         error_message += f'parameter "{supported_parameters[0]}".'
 
     return error_message
 
 
-def retrieve_experiment(experiment_name: str, version: int = None) -> Optional[Experiment]:
+def retrieve_experiment(
+    experiment_name: str, version: int = None
+) -> Optional[Experiment]:
     """
     Retrieve an experiment from the database with the given name and version.
 
@@ -77,11 +83,14 @@ def retrieve_experiment(experiment_name: str, version: int = None) -> Optional[E
         if version and experiment.version != version:
             raise falcon.HTTPNotFound(
                 title=ERROR_EXPERIMENT_NOT_FOUND,
-                description=f'Experiment "{experiment_name}" has no version "{version}"')
+                description=f'Experiment "{experiment_name}" has no version "{version}"',
+            )
         return experiment
     except NoConfigurationError:
-        raise falcon.HTTPNotFound(title=ERROR_EXPERIMENT_NOT_FOUND,
-                                  description=f'Experiment "{experiment_name}" does not exist')
+        raise falcon.HTTPNotFound(
+            title=ERROR_EXPERIMENT_NOT_FOUND,
+            description=f'Experiment "{experiment_name}" does not exist',
+        )
 
 
 def retrieve_trial(experiment: Experiment, trial_id: str):
@@ -104,6 +113,8 @@ def retrieve_trial(experiment: Experiment, trial_id: str):
     """
     trial = experiment.get_trial(uid=trial_id)
     if not trial:
-        raise falcon.HTTPNotFound(title=ERROR_TRIAL_NOT_FOUND,
-                                  description=f'Trial "{trial_id}" does not exist')
+        raise falcon.HTTPNotFound(
+            title=ERROR_TRIAL_NOT_FOUND,
+            description=f'Trial "{trial_id}" does not exist',
+        )
     return trial

--- a/src/orion/serving/plots_resources.py
+++ b/src/orion/serving/plots_resources.py
@@ -29,7 +29,9 @@ class PlotsResource(object):
         experiment = ExperimentClient(retrieve_experiment(experiment_name), None)
         resp.body = experiment.plot.lpi().to_json()
 
-    def on_get_parallel_coordinates(self, req: Request, resp: Response, experiment_name: str):
+    def on_get_parallel_coordinates(
+        self, req: Request, resp: Response, experiment_name: str
+    ):
         """
         Handle GET requests for plotting parallel coordinates plots on
         plots/parallel_coordinates/:experiment where ``experiment`` is the user-defined name of the

--- a/src/orion/serving/responses.py
+++ b/src/orion/serving/responses.py
@@ -11,9 +11,9 @@
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 
-ERROR_EXPERIMENT_NOT_FOUND = 'Experiment not found'
-ERROR_INVALID_PARAMETER = 'Invalid parameter'
-ERROR_TRIAL_NOT_FOUND = 'Trial not found'
+ERROR_EXPERIMENT_NOT_FOUND = "Experiment not found"
+ERROR_INVALID_PARAMETER = "Invalid parameter"
+ERROR_TRIAL_NOT_FOUND = "Trial not found"
 
 
 def build_trial_response(trial: Trial) -> dict:
@@ -30,19 +30,22 @@ def build_trial_response(trial: Trial) -> dict:
     A JSON-serializable dict representing the given trial.
 
     """
-    return {'id': trial.id,
-            'submitTime': str(trial.submit_time),
-            'startTime': str(trial.start_time),
-            'endTime': str(trial.end_time),
-            'parameters': trial.params,
-            'objective': trial.objective.value,
-            'statistics': {statistic.name: statistic.value for statistic in trial.statistics}}
+    return {
+        "id": trial.id,
+        "submitTime": str(trial.submit_time),
+        "startTime": str(trial.start_time),
+        "endTime": str(trial.end_time),
+        "parameters": trial.params,
+        "objective": trial.objective.value,
+        "statistics": {
+            statistic.name: statistic.value for statistic in trial.statistics
+        },
+    }
 
 
-def build_experiment_response(experiment: Experiment,
-                              status: str,
-                              algorithm: dict,
-                              best_trial: Trial = None):
+def build_experiment_response(
+    experiment: Experiment, status: str, algorithm: dict, best_trial: Trial = None
+):
     """
     Build the response representing an experiment response object according to the API
     specification.
@@ -66,19 +69,21 @@ def build_experiment_response(experiment: Experiment,
         "name": experiment.name,
         "version": experiment.version,
         "status": status,
-        "trialsCompleted": experiment.stats['trials_completed'] if experiment.stats else 0,
-        "startTime": str(experiment.stats['start_time']) if experiment.stats else None,
-        "endTime": str(experiment.stats['finish_time']) if experiment.stats else None,
-        "user": experiment.metadata['user'],
-        "orionVersion": experiment.metadata['orion_version'],
+        "trialsCompleted": experiment.stats["trials_completed"]
+        if experiment.stats
+        else 0,
+        "startTime": str(experiment.stats["start_time"]) if experiment.stats else None,
+        "endTime": str(experiment.stats["finish_time"]) if experiment.stats else None,
+        "user": experiment.metadata["user"],
+        "orionVersion": experiment.metadata["orion_version"],
         "config": {
             "maxTrials": experiment.max_trials,
             "maxBroken": experiment.max_broken,
             "poolSize": experiment.pool_size,
             "algorithm": algorithm,
-            "space": experiment.configuration['space']
+            "space": experiment.configuration["space"],
         },
-        "bestTrial": build_trial_response(best_trial) if best_trial else {}
+        "bestTrial": build_trial_response(best_trial) if best_trial else {},
     }
 
 
@@ -97,10 +102,7 @@ def build_experiments_response(experiments: dict):
     """
     result = []
     for name, version in experiments.items():
-        result.append({
-            'name': name,
-            'version': version
-        })
+        result.append({"name": name, "version": version})
     return result
 
 
@@ -119,7 +121,5 @@ def build_trials_response(trials: list):
     """
     response = []
     for trial in trials:
-        response.append({
-            'id': trial.id
-        })
+        response.append({"id": trial.id})
     return response

--- a/src/orion/serving/runtime.py
+++ b/src/orion/serving/runtime.py
@@ -31,9 +31,9 @@ class RuntimeResource(object):
         """
         database = get_storage()._db.__class__.__name__
         response = {
-            'orion': orion.core.__version__,
-            'server': 'gunicorn',
-            'database': database
+            "orion": orion.core.__version__,
+            "server": "gunicorn",
+            "database": database,
         }
 
         resp.body = json.dumps(response, indent=4)

--- a/src/orion/serving/trials_resource.py
+++ b/src/orion/serving/trials_resource.py
@@ -11,12 +11,16 @@ import json
 
 from falcon import Request, Response
 
-from orion.serving.parameters import retrieve_experiment, retrieve_trial, verify_query_parameters, \
-    verify_status
+from orion.serving.parameters import (
+    retrieve_experiment,
+    retrieve_trial,
+    verify_query_parameters,
+    verify_status,
+)
 from orion.serving.responses import build_trial_response, build_trials_response
 from orion.storage.base import get_storage
 
-SUPPORTED_PARAMETERS = ['ancestors', 'status', 'version']
+SUPPORTED_PARAMETERS = ["ancestors", "status", "version"]
 
 
 class TrialsResource(object):
@@ -25,17 +29,19 @@ class TrialsResource(object):
     def __init__(self):
         self.storage = get_storage()
 
-    def on_get_trials_in_experiment(self, req: Request, resp: Response, experiment_name: str):
+    def on_get_trials_in_experiment(
+        self, req: Request, resp: Response, experiment_name: str
+    ):
         """
         Handle GET requests for trials/:experiment where ``experiment`` is
         the user-defined name of the experiment.
         """
         verify_query_parameters(req.params, SUPPORTED_PARAMETERS)
 
-        status = req.get_param('status', default=None)
+        status = req.get_param("status", default=None)
         verify_status(status)
-        version = req.get_param_as_int('version')
-        with_ancestors = req.get_param_as_bool('ancestors', default=False)
+        version = req.get_param_as_int("version")
+        with_ancestors = req.get_param_as_bool("ancestors", default=False)
 
         experiment = retrieve_experiment(experiment_name, version)
         if status:
@@ -46,8 +52,9 @@ class TrialsResource(object):
         response = build_trials_response(trials)
         resp.body = json.dumps(response)
 
-    def on_get_trial_in_experiment(self, req: Request, resp: Response, experiment_name: str,
-                                   trial_id: str):
+    def on_get_trial_in_experiment(
+        self, req: Request, resp: Response, experiment_name: str, trial_id: str
+    ):
         """
         Handle GET requests for trials/:experiment/:trial_id where ``experiment`` is
         the user-defined name of the experiment and ``trial_id`` the id of the trial.

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -28,7 +28,7 @@ class WebApi(falcon.API):
         super(WebApi, self).__init__()
         self.config = config
 
-        setup_storage(config.get('storage'))
+        setup_storage(config.get("storage"))
 
         # Create our resources
         root_resource = RuntimeResource()
@@ -37,15 +37,25 @@ class WebApi(falcon.API):
         plots_resource = PlotsResource()
 
         # Build routes
-        self.add_route('/', root_resource)
-        self.add_route('/experiments', experiments_resource)
-        self.add_route('/experiments/{name}', experiments_resource, suffix="experiment")
-        self.add_route('/trials/{experiment_name}', trials_resource, suffix='trials_in_experiment')
-        self.add_route('/trials/{experiment_name}/{trial_id}',
-                       trials_resource, suffix='trial_in_experiment')
-        self.add_route('/plots/regret/{experiment_name}', plots_resource, suffix='regret')
-        self.add_route('/plots/parallel_coordinates/{experiment_name}',
-                       plots_resource, suffix='parallel_coordinates')
+        self.add_route("/", root_resource)
+        self.add_route("/experiments", experiments_resource)
+        self.add_route("/experiments/{name}", experiments_resource, suffix="experiment")
+        self.add_route(
+            "/trials/{experiment_name}", trials_resource, suffix="trials_in_experiment"
+        )
+        self.add_route(
+            "/trials/{experiment_name}/{trial_id}",
+            trials_resource,
+            suffix="trial_in_experiment",
+        )
+        self.add_route(
+            "/plots/regret/{experiment_name}", plots_resource, suffix="regret"
+        )
+        self.add_route(
+            "/plots/parallel_coordinates/{experiment_name}",
+            plots_resource,
+            suffix="parallel_coordinates",
+        )
 
     def start(self):
         """A hook to when a Gunicorn worker calls run()."""

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -46,7 +46,7 @@ def get_uid(item=None, uid=None, force_uid=True):
 
     if uid is None:
         if item is None and force_uid:
-            raise MissingArguments('Either `item` or `uid` should be set')
+            raise MissingArguments("Either `item` or `uid` should be set")
         elif item is not None:
             uid = item.id
 
@@ -417,19 +417,21 @@ def setup_storage(storage=None, debug=False):
 
     storage = copy.deepcopy(storage)
 
-    if storage.get('type') == 'legacy' and 'database' not in storage:
-        storage['database'] = orion.core.config.storage.database.to_dict()
-    elif storage.get('type') is None and 'database' in storage:
-        storage['type'] = 'legacy'
+    if storage.get("type") == "legacy" and "database" not in storage:
+        storage["database"] = orion.core.config.storage.database.to_dict()
+    elif storage.get("type") is None and "database" in storage:
+        storage["type"] = "legacy"
 
     # If using same storage type
-    if storage['type'] == orion.core.config.storage.type:
-        storage = resolve_config.merge_configs(orion.core.config.storage.to_dict(), storage)
+    if storage["type"] == orion.core.config.storage.type:
+        storage = resolve_config.merge_configs(
+            orion.core.config.storage.to_dict(), storage
+        )
 
     if debug:
-        storage = {'type': 'legacy', 'database': {'type': 'EphemeralDB'}}
+        storage = {"type": "legacy", "database": {"type": "EphemeralDB"}}
 
-    storage_type = storage.pop('type')
+    storage_type = storage.pop("type")
 
     log.debug("Creating %s storage client with args: %s", storage_type, storage)
     try:
@@ -448,17 +450,17 @@ class ReadOnlyStorageProtocol(object):
         :py:class:`orion.core.storage.BaseStorageProtocol`
     """
 
-    __slots__ = ('_storage', )
+    __slots__ = ("_storage",)
     valid_attributes = {
-        'get_trial',
-        'fetch_trials',
-        'fetch_experiments',
-        'count_broken_trials',
-        'count_completed_trials',
-        'fetch_noncompleted_trials',
-        'fetch_pending_trials',
-        'fetch_lost_trials',
-        'fetch_trials_by_status'
+        "get_trial",
+        "fetch_trials",
+        "fetch_experiments",
+        "count_broken_trials",
+        "count_completed_trials",
+        "fetch_noncompleted_trials",
+        "fetch_pending_trials",
+        "fetch_lost_trials",
+        "fetch_trials_by_status",
     }
 
     def __init__(self, protocol):
@@ -468,6 +470,8 @@ class ReadOnlyStorageProtocol(object):
     def __getattr__(self, attr):
         """Get attribute only if valid"""
         if attr not in self.valid_attributes:
-            raise AttributeError("Cannot access attribute %s on ReadOnlyStorageProtocol." % attr)
+            raise AttributeError(
+                "Cannot access attribute %s on ReadOnlyStorageProtocol." % attr
+            )
 
         return getattr(self._storage, attr)

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -19,7 +19,11 @@ import orion.core.utils.backward as backward
 from orion.core.utils.exceptions import MissingResultFile
 from orion.core.worker.trial import Trial, validate_status
 from orion.storage.base import (
-    BaseStorageProtocol, FailedUpdate, get_uid, MissingArguments)
+    BaseStorageProtocol,
+    FailedUpdate,
+    get_uid,
+    MissingArguments,
+)
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +63,7 @@ def setup_database(config=None):
         config = orion.core.config.database.to_dict()
 
     db_opts = config
-    dbtype = db_opts.pop('type')
+    dbtype = db_opts.pop("type")
 
     log.debug("Creating %s database client with args: %s", dbtype, db_opts)
     try:
@@ -95,31 +99,34 @@ class Legacy(BaseStorageProtocol):
     def _setup_db(self):
         """Database index setup"""
         if backward.db_is_outdated(self._db):
-            raise OutdatedDatabaseError("The database is outdated. You can upgrade it with the "
-                                        "command `orion db upgrade`.")
+            raise OutdatedDatabaseError(
+                "The database is outdated. You can upgrade it with the "
+                "command `orion db upgrade`."
+            )
 
-        self._db.index_information('experiment')
-        self._db.ensure_index('experiments',
-                              [('name', Database.ASCENDING),
-                               ('version', Database.ASCENDING)],
-                              unique=True)
+        self._db.index_information("experiment")
+        self._db.ensure_index(
+            "experiments",
+            [("name", Database.ASCENDING), ("version", Database.ASCENDING)],
+            unique=True,
+        )
 
-        self._db.ensure_index('experiments', 'metadata.datetime')
+        self._db.ensure_index("experiments", "metadata.datetime")
 
-        self._db.ensure_index('trials', 'experiment')
-        self._db.ensure_index('trials', 'status')
-        self._db.ensure_index('trials', 'results')
-        self._db.ensure_index('trials', 'start_time')
-        self._db.ensure_index('trials', [('end_time', Database.DESCENDING)])
+        self._db.ensure_index("trials", "experiment")
+        self._db.ensure_index("trials", "status")
+        self._db.ensure_index("trials", "results")
+        self._db.ensure_index("trials", "start_time")
+        self._db.ensure_index("trials", [("end_time", Database.DESCENDING)])
 
     def create_experiment(self, config):
         """See :func:`~orion.storage.BaseStorageProtocol.create_experiment`"""
-        return self._db.write('experiments', data=config, query=None)
+        return self._db.write("experiments", data=config, query=None)
 
     def delete_experiment(self, experiment=None, uid=None):
         """See :func:`~orion.storage.BaseStorageProtocol.delete_experiment`"""
         uid = get_uid(experiment, uid)
-        return self._db.remove('experiments', query={'_id': uid})
+        return self._db.remove("experiments", query={"_id": uid})
 
     def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_experiment`"""
@@ -129,12 +136,12 @@ class Legacy(BaseStorageProtocol):
             where = dict()
 
         if uid is not None:
-            where['_id'] = uid
-        return self._db.write('experiments', data=kwargs, query=where)
+            where["_id"] = uid
+        return self._db.write("experiments", data=kwargs, query=where)
 
     def fetch_experiments(self, query, selection=None):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_experiments`"""
-        return self._db.read('experiments', query, selection)
+        return self._db.read("experiments", query, selection)
 
     def fetch_trials(self, experiment=None, uid=None):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_trials`"""
@@ -144,20 +151,21 @@ class Legacy(BaseStorageProtocol):
 
     def _fetch_trials(self, query, selection=None):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_trials`"""
+
         def sort_key(item):
             submit_time = item.submit_time
             if submit_time is None:
                 return 0
             return submit_time
 
-        trials = Trial.build(self._db.read('trials', query=query, selection=selection))
+        trials = Trial.build(self._db.read("trials", query=query, selection=selection))
         trials.sort(key=sort_key)
 
         return trials
 
     def register_trial(self, trial):
         """See :func:`~orion.storage.BaseStorageProtocol.register_trial`"""
-        self._db.write('trials', trial.to_dict())
+        self._db.write("trials", trial.to_dict())
         return trial
 
     def delete_trials(self, experiment=None, uid=None, where=None):
@@ -168,12 +176,12 @@ class Legacy(BaseStorageProtocol):
             where = dict()
 
         if uid is not None:
-            where['experiment'] = uid
-        return self._db.remove('trials', query=where)
+            where["experiment"] = uid
+        return self._db.remove("trials", query=where)
 
     def register_lie(self, trial):
         """See :func:`~orion.storage.BaseStorageProtocol.register_lie`"""
-        return self._db.write('lying_trials', trial.to_dict())
+        return self._db.write("lying_trials", trial.to_dict())
 
     def retrieve_result(self, trial, results_file=None, **kwargs):
         """Parse the results file that was generated by the trial process.
@@ -204,10 +212,8 @@ class Legacy(BaseStorageProtocol):
             raise MissingResultFile()
 
         trial.results = [
-            Trial.Result(
-                name=res['name'],
-                type=res['type'],
-                value=res['value']) for res in results
+            Trial.Result(name=res["name"], type=res["type"], value=res["value"])
+            for res in results
         ]
 
         return trial
@@ -219,11 +225,11 @@ class Legacy(BaseStorageProtocol):
 
         if uid is None:
             if trial is None:
-                raise MissingArguments('Either `trial` or `uid` should be set')
+                raise MissingArguments("Either `trial` or `uid` should be set")
 
             uid = trial.id
 
-        result = self._db.read('trials', {'_id': uid})
+        result = self._db.read("trials", {"_id": uid})
         if not result:
             return None
 
@@ -235,8 +241,8 @@ class Legacy(BaseStorageProtocol):
         if where is None:
             where = dict()
 
-        where['experiment'] = uid
-        return self._db.write('trials', data=kwargs, query=where)
+        where["experiment"] = uid
+        return self._db.write("trials", data=kwargs, query=where)
 
     def update_trial(self, trial=None, uid=None, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_trial`"""
@@ -245,26 +251,29 @@ class Legacy(BaseStorageProtocol):
         if where is None:
             where = dict()
 
-        where['_id'] = uid
-        return self._db.write('trials', data=kwargs, query=where)
+        where["_id"] = uid
+        return self._db.write("trials", data=kwargs, query=where)
 
     def fetch_lost_trials(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_lost_trials`"""
         heartbeat = orion.core.config.worker.heartbeat
-        threshold = datetime.datetime.utcnow() - datetime.timedelta(seconds=heartbeat * 5)
-        lte_comparison = {'$lte': threshold}
+        threshold = datetime.datetime.utcnow() - datetime.timedelta(
+            seconds=heartbeat * 5
+        )
+        lte_comparison = {"$lte": threshold}
         query = {
-            'experiment': experiment._id,
-            'status': 'reserved',
-            'heartbeat': lte_comparison
+            "experiment": experiment._id,
+            "status": "reserved",
+            "heartbeat": lte_comparison,
         }
 
         return self._fetch_trials(query)
 
     def push_trial_results(self, trial):
         """See :func:`~orion.storage.BaseStorageProtocol.push_trial_results`"""
-        rc = self.update_trial(trial, **trial.to_dict(),
-                               where={'_id': trial.id, 'status': 'reserved'})
+        rc = self.update_trial(
+            trial, **trial.to_dict(), where={"_id": trial.id, "status": "reserved"}
+        )
         if not rc:
             raise FailedUpdate()
 
@@ -275,15 +284,13 @@ class Legacy(BaseStorageProtocol):
         if heartbeat is None:
             heartbeat = datetime.datetime.utcnow()
 
-        update = dict(
-            status=status,
-            heartbeat=heartbeat,
-            experiment=trial.experiment
-        )
+        update = dict(status=status, heartbeat=heartbeat, experiment=trial.experiment)
 
         validate_status(status)
 
-        rc = self.update_trial(trial, **update, where={'status': trial.status, '_id': trial.id})
+        rc = self.update_trial(
+            trial, **update, where={"status": trial.status, "_id": trial.id}
+        )
 
         if not rc:
             raise FailedUpdate()
@@ -294,7 +301,7 @@ class Legacy(BaseStorageProtocol):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_pending_trials`"""
         query = dict(
             experiment=experiment._id,
-            status={'$in': ['new', 'suspended', 'interrupted']}
+            status={"$in": ["new", "suspended", "interrupted"]},
         )
         return self._fetch_trials(query)
 
@@ -302,18 +309,15 @@ class Legacy(BaseStorageProtocol):
         """See :func:`~orion.storage.BaseStorageProtocol.reserve_trial`"""
         query = dict(
             experiment=experiment._id,
-            status={'$in': ['interrupted', 'new', 'suspended']}
+            status={"$in": ["interrupted", "new", "suspended"]},
         )
         # read and write works on a single document
         now = datetime.datetime.utcnow()
         trial = self._db.read_and_write(
-            'trials',
+            "trials",
             query=query,
-            data=dict(
-                status='reserved',
-                start_time=now,
-                heartbeat=now
-            ))
+            data=dict(status="reserved", start_time=now, heartbeat=now),
+        )
 
         if trial is None:
             return None
@@ -322,36 +326,26 @@ class Legacy(BaseStorageProtocol):
 
     def fetch_noncompleted_trials(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_noncompleted_trials`"""
-        query = dict(
-            experiment=experiment._id,
-            status={'$ne': 'completed'}
-        )
+        query = dict(experiment=experiment._id, status={"$ne": "completed"})
         return self._fetch_trials(query)
 
     def count_completed_trials(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.count_completed_trials`"""
-        query = dict(
-            experiment=experiment._id,
-            status='completed'
-        )
-        return self._db.count('trials', query)
+        query = dict(experiment=experiment._id, status="completed")
+        return self._db.count("trials", query)
 
     def count_broken_trials(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.count_broken_trials`"""
-        query = dict(
-            experiment=experiment._id,
-            status='broken'
-        )
-        return self._db.count('trials', query)
+        query = dict(experiment=experiment._id, status="broken")
+        return self._db.count("trials", query)
 
     def update_heartbeat(self, trial):
         """Update trial's heartbeat"""
-        return self.update_trial(trial, heartbeat=datetime.datetime.utcnow(), status='reserved')
+        return self.update_trial(
+            trial, heartbeat=datetime.datetime.utcnow(), status="reserved"
+        )
 
     def fetch_trials_by_status(self, experiment, status):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_trials_by_status`"""
-        query = dict(
-            experiment=experiment._id,
-            status=status
-        )
+        query = dict(experiment=experiment._id, status=status)
         return self._fetch_trials(query)

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -27,11 +27,11 @@ log = logging.getLogger(__name__)
 
 
 # TODO: Remove this when factory is reworked
-class Track:    # noqa: F811
+class Track:  # noqa: F811
     """Forward declaration because of a weird factory bug where Track is not found"""
 
     def __init__(self, uri):
-        assert False, 'This should not be called'
+        assert False, "This should not be called"
 
 
 HAS_TRACK = False
@@ -47,31 +47,29 @@ try:
 
     HAS_TRACK = True
 except ImportError:
-    REASON = 'Track is not installed'
+    REASON = "Track is not installed"
 
 except SyntaxError:
     major, minor, patch, _, _ = sys.version_info
 
     if minor < 6:
-        REASON = 'Python is too old'
-        log.warning('Track does not support python < 3.6!')
+        REASON = "Python is too old"
+        log.warning("Track does not support python < 3.6!")
     else:
         raise
 
 
 if HAS_TRACK:
     _status = [
-        CustomStatus('new', TrackStatus.CreatedGroup.value + 1),
-        CustomStatus('reserved', TrackStatus.CreatedGroup.value + 2),
+        CustomStatus("new", TrackStatus.CreatedGroup.value + 1),
+        CustomStatus("reserved", TrackStatus.CreatedGroup.value + 2),
     ]
 
-    _status_dict = {
-        s.name: s for s in _status
-    }
-    _status_dict['completed'] = TrackStatus.Completed
-    _status_dict['interrupted'] = TrackStatus.Interrupted
-    _status_dict['broken'] = TrackStatus.Broken
-    _status_dict['suspended'] = TrackStatus.Suspended
+    _status_dict = {s.name: s for s in _status}
+    _status_dict["completed"] = TrackStatus.Completed
+    _status_dict["interrupted"] = TrackStatus.Interrupted
+    _status_dict["broken"] = TrackStatus.Broken
+    _status_dict["suspended"] = TrackStatus.Suspended
 
 
 def get_track_status(val):
@@ -129,15 +127,18 @@ class TrialAdapter:
         self.objectives_values = None
         self._results = []
 
-    def _repr_values(self, values, sep=','):
+    def _repr_values(self, values, sep=","):
         """Represent with a string the given values."""
         return
 
     def __str__(self):
         """Represent partially with a string."""
-        param_rep = ','.join(map(lambda value: "{0.name}:{0.value}".format(value), self._params))
+        param_rep = ",".join(
+            map(lambda value: "{0.name}:{0.value}".format(value), self._params)
+        )
         ret = "TrialAdapter(uid={3}, experiment={0}, status={1}, params={2})".format(
-            repr(self.experiment[:10]), repr(self.status), param_rep, self.storage.uid)
+            repr(self.experiment[:10]), repr(self.status), param_rep, self.storage.uid
+        )
         return ret
 
     __repr__ = __str__
@@ -152,7 +153,9 @@ class TrialAdapter:
     @property
     def hearbeat(self):
         """See `~orion.core.worker.trial.Trial`"""
-        return datetime.datetime.utcfromtimestamp(self.storage.metadata.get('heartbeat', 0))
+        return datetime.datetime.utcfromtimestamp(
+            self.storage.metadata.get("heartbeat", 0)
+        )
 
     @property
     def id(self):
@@ -173,11 +176,13 @@ class TrialAdapter:
         if self.memory is not None:
             return self.memory._params
 
-        types = self.storage.metadata['params_types']
+        types = self.storage.metadata["params_types"]
         params = flatten(self.storage.parameters)
 
         return [
-            OrionTrial.Param(name=add_leading_slash(name), value=params.get(name), type=vtype)
+            OrionTrial.Param(
+                name=add_leading_slash(name), value=params.get(name), type=vtype
+            )
             for name, vtype in types.items()
         ]
 
@@ -200,18 +205,20 @@ class TrialAdapter:
     def to_dict(self):
         """See `~orion.core.worker.trial.Trial`"""
         trial = copy.deepcopy(self.storage.metadata)
-        trial.update({
-            'results': [r.to_dict() for r in self.results],
-            'params': [p.to_dict() for p in self._params],
-            '_id': self.storage.uid,
-            'submit_time': self.submit_time,
-            'experiment': self.experiment,
-            'status': self.status
-        })
+        trial.update(
+            {
+                "results": [r.to_dict() for r in self.results],
+                "params": [p.to_dict() for p in self._params],
+                "_id": self.storage.uid,
+                "submit_time": self.submit_time,
+                "experiment": self.experiment,
+                "status": self.status,
+            }
+        )
 
-        trial.pop('_update_count', 0)
-        trial.pop('metric_types', 0)
-        trial.pop('params_types')
+        trial.pop("_update_count", 0)
+        trial.pop("metric_types", 0)
+        trial.pop("params_types")
 
         return trial
 
@@ -224,11 +231,14 @@ class TrialAdapter:
     @property
     def objective(self):
         """See `~orion.core.worker.trial.Trial`"""
+
         def result(val):
-            return OrionTrial.Result(name=self.objective_key, value=val, type='objective')
+            return OrionTrial.Result(
+                name=self.objective_key, value=val, type="objective"
+            )
 
         if self.objective_key is None:
-            raise RuntimeError('no objective key was defined!')
+            raise RuntimeError("no objective key was defined!")
 
         self.objectives_values = []
 
@@ -257,18 +267,22 @@ class TrialAdapter:
         self._results = []
 
         for k, values in self.storage.metrics.items():
-            result_type = 'statistic'
+            result_type = "statistic"
             if k == self.objective_key:
-                result_type = 'objective'
+                result_type = "objective"
 
             if isinstance(values, dict):
                 items = list(values.items())
                 items.sort(key=lambda v: v[0])
 
                 val = items[-1][1]
-                self._results.append(OrionTrial.Result(name=k, type=result_type, value=val))
+                self._results.append(
+                    OrionTrial.Result(name=k, type=result_type, value=val)
+                )
             elif isinstance(values, list):
-                self._results.append(OrionTrial.Result(name=k, type=result_type, value=values[-1]))
+                self._results.append(
+                    OrionTrial.Result(name=k, type=result_type, value=values[-1])
+                )
 
         return self._results
 
@@ -290,22 +304,24 @@ class TrialAdapter:
     @property
     def submit_time(self):
         """See `~orion.core.worker.trial.Trial`"""
-        return datetime.datetime.utcfromtimestamp(self.storage.metadata.get('submit_time'))
+        return datetime.datetime.utcfromtimestamp(
+            self.storage.metadata.get("submit_time")
+        )
 
     @property
     def end_time(self):
         """See `~orion.core.worker.trial.Trial`"""
-        return datetime.datetime.utcfromtimestamp(self.storage.metadata.get('end_time'))
+        return datetime.datetime.utcfromtimestamp(self.storage.metadata.get("end_time"))
 
     @end_time.setter
     def end_time(self, value):
         """See `~orion.core.worker.trial.Trial`"""
-        self.storage.metadata['end_time'] = value
+        self.storage.metadata["end_time"] = value
 
     @property
     def heartbeat(self):
         """Trial Heartbeat"""
-        heartbeat = self.storage.metadata.get('heartbeat')
+        heartbeat = self.storage.metadata.get("heartbeat")
         if heartbeat:
             return datetime.datetime.utcfromtimestamp(heartbeat)
         return None
@@ -313,12 +329,12 @@ class TrialAdapter:
     @property
     def parents(self):
         """See `~orion.core.worker.trial.Trial`"""
-        return self.storage.metadata.get('parent', [])
+        return self.storage.metadata.get("parent", [])
 
     @parents.setter
     def parents(self, other):
         """See `~orion.core.worker.trial.Trial`"""
-        self.storage.metadata['parent'] = other
+        self.storage.metadata["parent"] = other
 
 
 def experiment_uid(exp=None, name=None, version=None):
@@ -330,12 +346,12 @@ def experiment_uid(exp=None, name=None, version=None):
         version = exp.version
 
     sha = hashlib.sha256()
-    sha.update(name.encode('utf8'))
+    sha.update(name.encode("utf8"))
     sha.update(bytes([version]))
     return sha.hexdigest()
 
 
-class Track(BaseStorageProtocol):   # noqa: F811
+class Track(BaseStorageProtocol):  # noqa: F811
     """Implement a generic protocol to allow Orion to communicate using
     different storage backend
 
@@ -351,18 +367,18 @@ class Track(BaseStorageProtocol):   # noqa: F811
         if not HAS_TRACK:
             # We ignored the import error above in case we did not need track
             # but now that we do we can rethrow it
-            raise ImportError('Track is not installed!')
+            raise ImportError("Track is not installed!")
 
         self.uri = uri
-        self.options = parse_uri(uri)['query']
+        self.options = parse_uri(uri)["query"]
 
         self.client = TrackClient(uri)
         self.backend = self.client.protocol
         self.project = None
         self.group = None
-        self.objective = self.options.get('objective')
+        self.objective = self.options.get("objective")
         self.lies = dict()
-        assert self.objective is not None, 'An objective should be defined!'
+        assert self.objective is not None, "An objective should be defined!"
 
     def _get_project(self, name):
         if self.project is None:
@@ -371,33 +387,33 @@ class Track(BaseStorageProtocol):   # noqa: F811
             if self.project is None:
                 self.project = self.backend.new_project(Project(name=name))
 
-        assert self.project, 'Project should have been found'
+        assert self.project, "Project should have been found"
 
     def create_experiment(self, config):
         """Insert a new experiment inside the database"""
-        self._get_project(config['name'])
+        self._get_project(config["name"])
 
         self.group = self.backend.new_trial_group(
             TrialGroup(
-                name=experiment_uid(name=config['name'], version=config['version']),
+                name=experiment_uid(name=config["name"], version=config["version"]),
                 project_id=self.project.uid,
-                metadata=to_json(config)
+                metadata=to_json(config),
             )
         )
 
         if self.group is None:
-            raise DuplicateKeyError('Experiment was already created')
+            raise DuplicateKeyError("Experiment was already created")
 
-        config['_id'] = self.group.uid
+        config["_id"] = self.group.uid
         return config
 
     def update_experiment(self, experiment=None, uid=None, where=None, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.update_experiment`"""
         uid = get_uid(experiment, uid)
 
-        self.group = self.backend.fetch_and_update_group({
-            '_uid': uid
-        }, 'set_group_metadata', **kwargs)
+        self.group = self.backend.fetch_and_update_group(
+            {"_uid": uid}, "set_group_metadata", **kwargs
+        )
 
         return self.group
 
@@ -405,14 +421,14 @@ class Track(BaseStorageProtocol):   # noqa: F811
         """Fetch all experiments that match the query"""
         new_query = {}
         for k, v in query.items():
-            if k == 'name':
-                new_query['metadata.name'] = v
+            if k == "name":
+                new_query["metadata.name"] = v
 
-            elif k.startswith('metadata'):
-                new_query['metadata.{}'.format(k)] = v
+            elif k.startswith("metadata"):
+                new_query["metadata.{}".format(k)] = v
 
-            elif k == '_id':
-                new_query['_uid'] = v
+            elif k == "_id":
+                new_query["_uid"] = v
 
             else:
                 new_query[k] = v
@@ -421,15 +437,17 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
         experiments = []
         for group in groups:
-            version = group.metadata.get('version', 0)
+            version = group.metadata.get("version", 0)
 
             # metadata is experiment config
             exp = group.metadata
-            exp.update({
-                '_id': group.uid,
-                'version': version,
-                'name': group.project_id,
-            })
+            exp.update(
+                {
+                    "_id": group.uid,
+                    "version": version,
+                    "name": group.project_id,
+                }
+            )
 
             experiments.append(exp)
 
@@ -442,16 +460,20 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
         metadata = dict()
         # pylint: disable=protected-access
-        metadata['params_types'] = {remove_leading_slash(p.name): p.type for p in trial._params}
-        metadata['submit_time'] = to_json(trial.submit_time)
-        metadata['end_time'] = to_json(trial.end_time)
-        metadata['worker'] = trial.worker
-        metadata['metric_types'] = {remove_leading_slash(p.name): p.type for p in trial.results}
-        metadata['metric_types'][self.objective] = 'objective'
+        metadata["params_types"] = {
+            remove_leading_slash(p.name): p.type for p in trial._params
+        }
+        metadata["submit_time"] = to_json(trial.submit_time)
+        metadata["end_time"] = to_json(trial.end_time)
+        metadata["worker"] = trial.worker
+        metadata["metric_types"] = {
+            remove_leading_slash(p.name): p.type for p in trial.results
+        }
+        metadata["metric_types"][self.objective] = "objective"
         heartbeat = to_json(trial.heartbeat)
         if heartbeat is None:
             heartbeat = 0
-        metadata['heartbeat'] = heartbeat
+        metadata["heartbeat"] = heartbeat
 
         metrics = defaultdict(list)
         for p in trial.results:
@@ -460,18 +482,21 @@ class Track(BaseStorageProtocol):   # noqa: F811
         if self.project is None:
             self._get_project(self.group.project_id)
 
-        trial = self.backend.new_trial(TrackTrial(
-            _hash=trial.hash_name,
-            status=get_track_status(trial.status),
-            project_id=self.project.uid,
-            group_id=self.group.uid,
-            parameters=trial.params,
-            metadata=metadata,
-            metrics=metrics
-        ), auto_increment=False)
+        trial = self.backend.new_trial(
+            TrackTrial(
+                _hash=trial.hash_name,
+                status=get_track_status(trial.status),
+                project_id=self.project.uid,
+                group_id=self.group.uid,
+                parameters=trial.params,
+                metadata=metadata,
+                metrics=metrics,
+            ),
+            auto_increment=False,
+        )
 
         if trial is None:
-            raise DuplicateKeyError('Was not able to register Trial!')
+            raise DuplicateKeyError("Was not able to register Trial!")
 
         return TrialAdapter(trial, objective=self.objective)
 
@@ -490,16 +515,17 @@ class Track(BaseStorageProtocol):   # noqa: F811
             Fake trial to register in the database
 
         """
-        warnings.warn('Track does not persist lies!')
+        warnings.warn("Track does not persist lies!")
 
         if trial.id in self.lies:
-            raise DuplicateKeyError('Lie already exists')
+            raise DuplicateKeyError("Lie already exists")
 
         self.lies[trial.id] = trial
         return trial
 
     def _fetch_trials(self, query, *args, **kwargs):
         """Fetch all the trials that match the query"""
+
         def sort_key(item):
             submit_time = item.submit_time
             if submit_time is None:
@@ -510,26 +536,27 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
         new_query = {}
         for k, v in query.items():
-            if k == 'experiment':
-                new_query['group_id'] = v
+            if k == "experiment":
+                new_query["group_id"] = v
 
-            elif k == 'heartbeat':
-                new_query['metadata.heartbeat'] = v
+            elif k == "heartbeat":
+                new_query["metadata.heartbeat"] = v
 
-            elif k == '_id':
-                new_query['uid'] = v
+            elif k == "_id":
+                new_query["uid"] = v
 
-            elif k == 'end_time':
-                new_query['metadata.end_time'] = v
+            elif k == "end_time":
+                new_query["metadata.end_time"] = v
 
-            elif k == 'status' and isinstance(v, str):
-                new_query['status'] = get_track_status(v)
+            elif k == "status" and isinstance(v, str):
+                new_query["status"] = get_track_status(v)
 
             else:
                 new_query[k] = v
 
         trials = [
-            TrialAdapter(t, objective=self.objective) for t in self.backend.fetch_trials(new_query)
+            TrialAdapter(t, objective=self.objective)
+            for t in self.backend.fetch_trials(new_query)
         ]
         trials.sort(key=sort_key)
         return trials
@@ -544,20 +571,21 @@ class Track(BaseStorageProtocol):   # noqa: F811
         refreshed_trial = self.backend.get_trial(trial)[0]
         new_trial = TrialAdapter(refreshed_trial, objective=self.objective)
 
-        assert new_trial.objective is not None, 'Trial should have returned an objective value!'
+        assert (
+            new_trial.objective is not None
+        ), "Trial should have returned an objective value!"
 
-        log.info("trial objective is (%s: %s)", self.objective, new_trial.objective.value)
+        log.info(
+            "trial objective is (%s: %s)", self.objective, new_trial.objective.value
+        )
         return new_trial
 
     def fetch_pending_trials(self, experiment):
         """See :func:`~orion.storage.BaseStorageProtocol.fetch_pending_trials`"""
-        pending_status = ['new', 'suspended', 'interrupted']
+        pending_status = ["new", "suspended", "interrupted"]
         pending_status = [get_track_status(s) for s in pending_status]
 
-        query = dict(
-            group_id=experiment.id,
-            status={'$in': pending_status}
-        )
+        query = dict(group_id=experiment.id, status={"$in": pending_status})
 
         return self._fetch_trials(query)
 
@@ -573,10 +601,11 @@ class Track(BaseStorageProtocol):   # noqa: F811
         """
         validate_status(status)
         try:
-            result_trial = self.backend.fetch_and_update_trial({
-                'uid': trial.id,
-                'status': get_track_status(trial.status)
-            }, 'set_trial_status', status=get_track_status(status))
+            result_trial = self.backend.fetch_and_update_trial(
+                {"uid": trial.id, "status": get_track_status(trial.status)},
+                "set_trial_status",
+                status=get_track_status(status),
+            )
 
         except ItemNotFound as e:
             raise FailedUpdate() from e
@@ -595,7 +624,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
         uid = get_uid(trial, uid)
 
         _hash, _rev = 0, 0
-        data = uid.split('_', maxsplit=1)
+        data = uid.split("_", maxsplit=1)
 
         if len(data) == 1:
             _hash = data[0]
@@ -614,15 +643,13 @@ class Track(BaseStorageProtocol):   # noqa: F811
     def reserve_trial(self, experiment):
         """Select a pending trial and reserve it for the worker"""
         query = dict(
-            group_id=experiment.id,
-            status={'$in': ['new', 'suspended', 'interrupted']}
+            group_id=experiment.id, status={"$in": ["new", "suspended", "interrupted"]}
         )
 
         try:
             trial = self.backend.fetch_and_update_trial(
-                query,
-                'set_trial_status',
-                status=get_track_status('reserved'))
+                query, "set_trial_status", status=get_track_status("reserved")
+            )
 
         except ItemNotFound:
             return None
@@ -639,7 +666,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
         if where is None:
             where = dict()
 
-        where['group_id'] = uid
+        where["group_id"] = uid
 
         count = 0
         for trial in self._fetch_trials(where):
@@ -647,7 +674,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
         return count
 
-    _ignore_updates_for = {'results', 'params', '_id'}
+    _ignore_updates_for = {"results", "params", "_id"}
 
     def update_trial(self, trial=None, uid=None, **kwargs):
         """Update the fields of a given trials
@@ -676,7 +703,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
                 trial = trial.storage
 
             for key, value in kwargs.items():
-                if key == 'status':
+                if key == "status":
                     self.backend.set_trial_status(trial, get_track_status(value))
                 elif key in self._ignore_updates_for:
                     continue
@@ -693,12 +720,14 @@ class Track(BaseStorageProtocol):   # noqa: F811
         some given time delta (5 minutes by default)
         """
         heartbeat = orion.core.config.worker.heartbeat
-        threshold = to_epoch(datetime.datetime.utcnow() - datetime.timedelta(seconds=heartbeat * 5))
-        lte_comparison = {'$lte': threshold}
+        threshold = to_epoch(
+            datetime.datetime.utcnow() - datetime.timedelta(seconds=heartbeat * 5)
+        )
+        lte_comparison = {"$lte": threshold}
         query = {
-            'experiment': experiment.id,
-            'status': 'reserved',
-            'heartbeat': lte_comparison
+            "experiment": experiment.id,
+            "status": "reserved",
+            "heartbeat": lte_comparison,
         }
 
         return self._fetch_trials(query)
@@ -711,8 +740,7 @@ class Track(BaseStorageProtocol):   # noqa: F811
     def fetch_noncompleted_trials(self, experiment):
         """Fetch all non completed trials"""
         query = dict(
-            group_id=experiment.id,
-            status={'$ne': get_track_status('completed')}
+            group_id=experiment.id, status={"$ne": get_track_status("completed")}
         )
         return self.backend.fetch_trials(query)
 
@@ -723,13 +751,14 @@ class Track(BaseStorageProtocol):   # noqa: F811
 
     def count_completed_trials(self, experiment):
         """Count the number of completed trials"""
-        return len(self._fetch_trials(dict(status='completed', group_id=experiment.id)))
+        return len(self._fetch_trials(dict(status="completed", group_id=experiment.id)))
 
     def count_broken_trials(self, experiment):
         """Count the number of broken trials"""
-        return len(self._fetch_trials(dict(status='broken', group_id=experiment.id)))
+        return len(self._fetch_trials(dict(status="broken", group_id=experiment.id)))
 
     def update_heartbeat(self, trial):
         """Update trial's heartbeat"""
-        self.backend.log_trial_metadata(trial.storage,
-                                        heartbeat=to_epoch(datetime.datetime.utcnow()))
+        self.backend.log_trial_metadata(
+            trial.storage, heartbeat=to_epoch(datetime.datetime.utcnow())
+        )

--- a/src/orion/testing/state.py
+++ b/src/orion/testing/state.py
@@ -14,7 +14,10 @@ import tempfile
 import yaml
 
 from orion.core.io import experiment_builder as experiment_builder
-from orion.core.utils.singleton import SingletonAlreadyInstantiatedError, update_singletons
+from orion.core.utils.singleton import (
+    SingletonAlreadyInstantiatedError,
+    update_singletons,
+)
 from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage, Storage
 
@@ -59,8 +62,16 @@ class BaseOrionState:
     resources = []
     workers = []
 
-    def __init__(self, experiments=None, trials=None, workers=None, lies=None, resources=None,
-                 from_yaml=None, storage=None):
+    def __init__(
+        self,
+        experiments=None,
+        trials=None,
+        workers=None,
+        lies=None,
+        resources=None,
+        from_yaml=None,
+        storage=None,
+    ):
         if from_yaml is not None:
             with open(from_yaml) as f:
                 exp_config = list(yaml.safe_load_all(f))
@@ -127,16 +138,16 @@ class BaseOrionState:
         for i, t_dict in enumerate(self._lies):
             self._lies[i] = Trial(**t_dict).to_dict()
 
-        self._trials.sort(key=lambda obj: int(obj['_id'], 16), reverse=True)
+        self._trials.sort(key=lambda obj: int(obj["_id"], 16), reverse=True)
 
         for i, experiment in enumerate(self._experiments):
-            if 'user_script' in experiment['metadata']:
+            if "user_script" in experiment["metadata"]:
                 path = os.path.join(
-                    os.path.dirname(__file__),
-                    experiment["metadata"]["user_script"])
+                    os.path.dirname(__file__), experiment["metadata"]["user_script"]
+                )
                 experiment["metadata"]["user_script"] = path
 
-            experiment['_id'] = i
+            experiment["_id"] = i
 
         self._set_tables()
 
@@ -144,7 +155,7 @@ class BaseOrionState:
         """Iterate over the database configuration and replace ${file}
         by the name of a temporary file
         """
-        self.tempfile, self.tempfile_path = tempfile.mkstemp('_orion_test')
+        self.tempfile, self.tempfile_path = tempfile.mkstemp("_orion_test")
         _remove(self.tempfile_path)
 
         def map_dict(fun, dictionary):
@@ -154,7 +165,7 @@ class BaseOrionState:
         def replace_file(v):
             """Replace `${file}` by a generated temporary file"""
             if isinstance(v, str):
-                v = v.replace('${file}', self.tempfile_path)
+                v = v.replace("${file}", self.tempfile_path)
 
             if isinstance(v, dict):
                 v = map_dict(replace_file, v)
@@ -181,7 +192,7 @@ class BaseOrionState:
             return get_storage()
 
         try:
-            config['of_type'] = config.pop('type')
+            config["of_type"] = config.pop("type")
             db = Storage(**config)
             self.storage_config = config
         except SingletonAlreadyInstantiatedError:
@@ -211,9 +222,9 @@ class LegacyOrionState(BaseOrionState):
         self.storage(config)
         self.initialized = True
 
-        if hasattr(get_storage(), '_db'):
-            self.database.remove('experiments', {})
-            self.database.remove('trials', {})
+        if hasattr(get_storage(), "_db"):
+            self.database.remove("experiments", {})
+            self.database.remove("trials", {})
 
         self.load_experience_configuration()
         return self
@@ -226,15 +237,15 @@ class LegacyOrionState(BaseOrionState):
 
     def _set_tables(self):
         if self._experiments:
-            self.database.write('experiments', self._experiments)
+            self.database.write("experiments", self._experiments)
         if self._trials:
-            self.database.write('trials', self._trials)
+            self.database.write("trials", self._trials)
         if self._workers:
-            self.database.write('workers', self._workers)
+            self.database.write("workers", self._workers)
         if self._resources:
-            self.database.write('resources', self._resources)
+            self.database.write("resources", self._resources)
         if self._lies:
-            self.database.write('lying_trials', self._lies)
+            self.database.write("lying_trials", self._lies)
 
         self.lies = self._lies
         self.trials = self._trials
@@ -242,8 +253,8 @@ class LegacyOrionState(BaseOrionState):
     def cleanup(self):
         """Cleanup after testing"""
         if self.initialized:
-            self.database.remove('experiments', {})
-            self.database.remove('trials', {})
+            self.database.remove("experiments", {})
+            self.database.remove("trials", {})
             if self.tempfile is not None:
                 os.close(self.tempfile)
             _remove(self.tempfile_path)
@@ -254,9 +265,9 @@ class LegacyOrionState(BaseOrionState):
 # pylint: disable=C0103
 def OrionState(*args, **kwargs):
     """Build an orion state in function of the storage type"""
-    storage = kwargs.get('storage')
+    storage = kwargs.get("storage")
 
-    if not storage or storage['type'] == 'legacy':
+    if not storage or storage["type"] == "legacy":
         return LegacyOrionState(*args, **kwargs)
 
     return BaseOrionState(*args, **kwargs)
@@ -264,8 +275,8 @@ def OrionState(*args, **kwargs):
 
 def customized_mutate_example(search_space, old_value, **kwargs):
     """Define a customized mutate function example"""
-    multiply_factor = kwargs.pop('multiply_factor', 3.0)
-    add_factor = kwargs.pop('add_factor', 1)
+    multiply_factor = kwargs.pop("multiply_factor", 3.0)
+    add_factor = kwargs.pop("add_factor", 1)
     if search_space.type == "real":
         new_value = old_value / multiply_factor
     elif search_space.type == "integer":
@@ -277,13 +288,7 @@ def customized_mutate_example(search_space, old_value, **kwargs):
 
 def _get_default_test_storage():
     """Return default configuration for the test storage"""
-    return {
-        'type': 'legacy',
-        'database': {
-            'type': 'PickledDB',
-            'host': '${file}'
-        }
-    }
+    return {"type": "legacy", "database": {"type": "PickledDB", "host": "${file}"}}
 
 
 def _remove(file_name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from pymongo import MongoClient
 import pytest
 import yaml
 
-from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
+from orion.algo.base import BaseAlgorithm, OptimizationAlgorithm
 import orion.core
 from orion.core.io import resolve_config
 from orion.core.io.database import Database
@@ -33,7 +33,7 @@ def shield_from_user_config(request):
 def _pop_out_yaml_from_config(config):
     """Remove any configuration fetch from yaml file"""
     for key in config._config.keys():
-        config._config[key].pop('yaml', None)
+        config._config[key].pop("yaml", None)
 
     for key in config._subconfigs.keys():
         _pop_out_yaml_from_config(config._subconfigs[key])
@@ -42,9 +42,17 @@ def _pop_out_yaml_from_config(config):
 class DumbAlgo(BaseAlgorithm):
     """Stab class for `BaseAlgorithm`."""
 
-    def __init__(self, space, value=5,
-                 scoring=0, judgement=None,
-                 suspend=False, done=False, seed=None, **nested_algo):
+    def __init__(
+        self,
+        space,
+        value=5,
+        scoring=0,
+        judgement=None,
+        suspend=False,
+        done=False,
+        seed=None,
+        **nested_algo
+    ):
         """Configure returns, allow for variable variables."""
         self._times_called_suspend = 0
         self._times_called_is_done = 0
@@ -57,12 +65,16 @@ class DumbAlgo(BaseAlgorithm):
         self._judge_point = None
         self._measurements = None
         self.possible_values = [value]
-        super(DumbAlgo, self).__init__(space, value=value,
-                                       scoring=scoring, judgement=judgement,
-                                       suspend=suspend,
-                                       done=done,
-                                       seed=seed,
-                                       **nested_algo)
+        super(DumbAlgo, self).__init__(
+            space,
+            value=value,
+            scoring=scoring,
+            judgement=judgement,
+            suspend=suspend,
+            done=done,
+            seed=seed,
+            **nested_algo
+        )
 
     def seed(self, seed):
         """Set the index to seed.
@@ -76,8 +88,14 @@ class DumbAlgo(BaseAlgorithm):
     def state_dict(self):
         """Return a state dict that can be used to reset the state of the algorithm."""
         _state_dict = super(DumbAlgo, self).state_dict
-        _state_dict.update({'index': self._index, 'suggested': self._suggested, 'num': self._num,
-                            'done': self.done})
+        _state_dict.update(
+            {
+                "index": self._index,
+                "suggested": self._suggested,
+                "num": self._num,
+                "done": self.done,
+            }
+        )
         return _state_dict
 
     def set_state(self, state_dict):
@@ -86,10 +104,10 @@ class DumbAlgo(BaseAlgorithm):
         :param state_dict: Dictionary representing state of an algorithm
         """
         super(DumbAlgo, self).set_state(state_dict)
-        self._index = state_dict['index']
-        self._suggested = state_dict['suggested']
-        self._num = state_dict['num']
-        self.done = state_dict['done']
+        self._index = state_dict["index"]
+        self._suggested = state_dict["suggested"]
+        self._num = state_dict["num"]
+        self.done = state_dict["done"]
 
     def suggest(self, num=1):
         """Suggest based on `value`."""
@@ -97,7 +115,9 @@ class DumbAlgo(BaseAlgorithm):
 
         rval = []
         while len(rval) < num:
-            value = self.possible_values[min(self._index, len(self.possible_values) - 1)]
+            value = self.possible_values[
+                min(self._index, len(self.possible_values) - 1)
+            ]
             self._index += 1
             rval.append(value)
 
@@ -153,14 +173,15 @@ def empty_config():
 @pytest.fixture()
 def test_config(empty_config):
     """Return orion's config overwritten with local config file"""
-    config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               "orion_config.yaml")
+    config_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "orion_config.yaml"
+    )
     empty_config.load_yaml(config_file)
 
     return empty_config
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def dumbalgo():
     """Return stab algorithm class."""
     return DumbAlgo
@@ -169,23 +190,41 @@ def dumbalgo():
 @pytest.fixture()
 def categorical_values():
     """Return a list of all the categorical points possible for `supernaedo2` and `supernaedo3`"""
-    return [('rnn', 'rnn'), ('lstm_with_attention', 'rnn'), ('gru', 'rnn'),
-            ('rnn', 'gru'), ('lstm_with_attention', 'gru'), ('gru', 'gru'),
-            ('rnn', 'lstm'), ('lstm_with_attention', 'lstm'), ('gru', 'lstm')]
+    return [
+        ("rnn", "rnn"),
+        ("lstm_with_attention", "rnn"),
+        ("gru", "rnn"),
+        ("rnn", "gru"),
+        ("lstm_with_attention", "gru"),
+        ("gru", "gru"),
+        ("rnn", "lstm"),
+        ("lstm_with_attention", "lstm"),
+        ("gru", "lstm"),
+    ]
 
 
 @pytest.fixture()
 def exp_config_file():
     """Return configuration file used for stuff"""
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                        'unittests', 'core', 'experiment.yaml')
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "unittests",
+        "core",
+        "experiment.yaml",
+    )
 
 
 @pytest.fixture()
 def exp_config():
     """Load an example database."""
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-              'unittests', 'core', 'experiment.yaml')) as f:
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "unittests",
+            "core",
+            "experiment.yaml",
+        )
+    ) as f:
         exp_config = list(yaml.safe_load_all(f))
 
     for i, t_dict in enumerate(exp_config[1]):
@@ -193,17 +232,18 @@ def exp_config():
 
     for config in exp_config[0]:
         config["metadata"]["user_script"] = os.path.join(
-            os.path.dirname(__file__), config["metadata"]["user_script"])
+            os.path.dirname(__file__), config["metadata"]["user_script"]
+        )
         backward.populate_space(config)
-        config['version'] = 1
+        config["version"] = 1
 
     return exp_config
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def database():
     """Return Mongo database object to test with example entries."""
-    client = MongoClient(username='user', password='pass', authSource='orion_test')
+    client = MongoClient(username="user", password="pass", authSource="orion_test")
     database = client.orion_test
     yield database
     client.close()
@@ -215,7 +255,7 @@ def mock_database():
     Lightweight fixture for an empty, in-memory database using :class:`OrionState`.
     The database is automatically discarded after each test method.
     """
-    storage = {'type': 'legacy', 'database': {'type': 'EphemeralDB'}}
+    storage = {"type": "legacy", "database": {"type": "EphemeralDB"}}
     with OrionState(storage=storage) as state:
         yield state
 
@@ -244,7 +284,7 @@ def null_db_instances():
     PickledDB.instance = None
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def seed():
     """Return a fixed ``numpy.random.RandomState`` and global seed."""
     seed = 5
@@ -260,8 +300,9 @@ def version_XYZ(monkeypatch):
 
     def fetch_metadata(user=None, user_args=None, user_script_config=None):
         metadata = non_patched_fetch_metadata(user, user_args, user_script_config)
-        metadata['orion_version'] = 'XYZ'
+        metadata["orion_version"] = "XYZ"
         return metadata
+
     monkeypatch.setattr(resolve_config, "fetch_metadata", fetch_metadata)
 
 
@@ -270,12 +311,12 @@ def create_db_instance(null_db_instances, clean_db):
     """Create and save a singleton database instance."""
     try:
         database = {
-            'type': 'MongoDB',
-            'name': 'orion_test',
-            'username': 'user',
-            'password': 'pass'
+            "type": "MongoDB",
+            "name": "orion_test",
+            "username": "user",
+            "password": "pass",
         }
-        db = Storage(of_type='legacy', database=database)
+        db = Storage(of_type="legacy", database=database)
     except ValueError:
         db = Storage()
 
@@ -292,15 +333,17 @@ def script_path():
 @pytest.fixture()
 def mock_infer_versioning_metadata(monkeypatch):
     """Mock infer_versioning_metadata and create a VCS"""
+
     def fixed_dictionary(user_script):
         """Create VCS"""
         vcs = {}
-        vcs['type'] = 'git'
-        vcs['is_dirty'] = False
-        vcs['HEAD_sha'] = "test"
-        vcs['active_branch'] = None
-        vcs['diff_sha'] = "diff"
+        vcs["type"] = "git"
+        vcs["is_dirty"] = False
+        vcs["HEAD_sha"] = "test"
+        vcs["active_branch"] = None
+        vcs["diff_sha"] = "diff"
         return vcs
+
     monkeypatch.setattr(resolve_config, "infer_versioning_metadata", fixed_dictionary)
 
 
@@ -310,15 +353,15 @@ def setup_pickleddb_database():
     update_singletons()
     temporary_file = tempfile.NamedTemporaryFile()
 
-    os.environ['ORION_DB_TYPE'] = "pickleddb"
-    os.environ['ORION_DB_ADDRESS'] = temporary_file.name
+    os.environ["ORION_DB_TYPE"] = "pickleddb"
+    os.environ["ORION_DB_ADDRESS"] = temporary_file.name
     yield
     temporary_file.close()
-    del os.environ['ORION_DB_TYPE']
-    del os.environ['ORION_DB_ADDRESS']
+    del os.environ["ORION_DB_TYPE"]
+    del os.environ["ORION_DB_ADDRESS"]
 
 
 @pytest.fixture()
 def with_user_userxyz(monkeypatch):
     """Make ``getpass.getuser()`` return ``'userxyz'``."""
-    monkeypatch.setattr(getpass, 'getuser', lambda: 'userxyz')
+    monkeypatch.setattr(getpass, "getuser", lambda: "userxyz")

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -9,142 +9,145 @@ import pytest
 from orion.client import workon
 
 
-storage = {
-    'type': 'legacy',
-    'database': {'type': 'ephemeraldb'}}
+storage = {"type": "legacy", "database": {"type": "ephemeraldb"}}
 
 
-space = {
-    'x': 'uniform(-50, 50)'
-    }
+space = {"x": "uniform(-50, 50)"}
 
 
-space_with_fidelity = {
-    'x': space['x'],
-    'noise': 'fidelity(1,10,4)'}
+space_with_fidelity = {"x": space["x"], "noise": "fidelity(1,10,4)"}
 
 
 algorithm_configs = {
-    'random': {
-        'random': {
-            'seed': 1}},
-    'tpe': {
-        'tpe': {
-            'seed': 1,
-            'n_initial_points': 20,
-            'n_ei_candidates': 24,
-            'gamma': 0.25,
-            'equal_weight': False,
-            'prior_weight': 1.0,
-            'full_weight_num': 25}},
-    'asha': {
-        'asha': {
-            'seed': 1,
-            'num_rungs': 4,
-            'num_brackets': 1,
-            'grace_period': None,
-            'max_resources': None,
-            'reduction_factor': None}},
-    'hyperband': {
-        'hyperband': {
-            'repetitions': 5,
-            'seed': 1}}
-    }
+    "random": {"random": {"seed": 1}},
+    "tpe": {
+        "tpe": {
+            "seed": 1,
+            "n_initial_points": 20,
+            "n_ei_candidates": 24,
+            "gamma": 0.25,
+            "equal_weight": False,
+            "prior_weight": 1.0,
+            "full_weight_num": 25,
+        }
+    },
+    "asha": {
+        "asha": {
+            "seed": 1,
+            "num_rungs": 4,
+            "num_brackets": 1,
+            "grace_period": None,
+            "max_resources": None,
+            "reduction_factor": None,
+        }
+    },
+    "hyperband": {"hyperband": {"repetitions": 5, "seed": 1}},
+}
 
-no_fidelity_algorithms = ['random', 'tpe']
-no_fidelity_algorithm_configs = {key: algorithm_configs[key] for key in no_fidelity_algorithms}
+no_fidelity_algorithms = ["random", "tpe"]
+no_fidelity_algorithm_configs = {
+    key: algorithm_configs[key] for key in no_fidelity_algorithms
+}
 
-fidelity_only_algorithms = ['asha', 'hyperband']
-fidelity_only_algorithm_configs = {key: algorithm_configs[key] for key in fidelity_only_algorithms}
+fidelity_only_algorithms = ["asha", "hyperband"]
+fidelity_only_algorithm_configs = {
+    key: algorithm_configs[key] for key in fidelity_only_algorithms
+}
 
 
 def rosenbrock(x, noise=None):
     """Evaluate partial information of a quadratic."""
-    z = (x - 34.56789)
+    z = x - 34.56789
     if noise:
         noise = (1 - noise / 10) + 0.0001
         z *= random.gauss(0, noise)
 
-    return [{'name': 'objective', 'type': 'objective', 'value': 4 * z**2 + 23.4},
-            {'name': 'gradient', 'type': 'gradient', 'value': [8 * z]}]
+    return [
+        {"name": "objective", "type": "objective", "value": 4 * z ** 2 + 23.4},
+        {"name": "gradient", "type": "gradient", "value": [8 * z]},
+    ]
 
 
 @pytest.mark.parametrize(
-    'algorithm',
+    "algorithm",
     fidelity_only_algorithm_configs.values(),
-    ids=list(fidelity_only_algorithm_configs.keys()))
+    ids=list(fidelity_only_algorithm_configs.keys()),
+)
 def test_missing_fidelity(algorithm):
     """Test a simple usage scenario."""
     with pytest.raises(RuntimeError) as exc:
         workon(rosenbrock, space, algorithms=algorithm, max_trials=100)
 
-    assert "https://orion.readthedocs.io/en/develop/user/algorithms.html" in str(exc.value)
+    assert "https://orion.readthedocs.io/en/develop/user/algorithms.html" in str(
+        exc.value
+    )
 
 
 @pytest.mark.parametrize(
-    'algorithm',
+    "algorithm",
     no_fidelity_algorithm_configs.values(),
-    ids=list(no_fidelity_algorithm_configs.keys()))
+    ids=list(no_fidelity_algorithm_configs.keys()),
+)
 def test_simple(algorithm):
     """Test a simple usage scenario."""
     max_trials = 100
     exp = workon(rosenbrock, space, algorithms=algorithm, max_trials=max_trials)
 
     assert exp.max_trials == max_trials
-    assert exp.configuration['algorithms'] == algorithm
+    assert exp.configuration["algorithms"] == algorithm
 
     trials = exp.fetch_trials()
     assert len(trials) == max_trials
-    assert trials[-1].status == 'completed'
+    assert trials[-1].status == "completed"
 
     best_trial = sorted(trials, key=lambda trial: trial.objective.value)[0]
-    assert best_trial.objective.name == 'objective'
+    assert best_trial.objective.name == "objective"
     assert abs(best_trial.objective.value - 23.4) < 0.1
     assert len(best_trial.params) == 1
     param = best_trial._params[0]
-    assert param.name == 'x'
-    assert param.type == 'real'
+    assert param.name == "x"
+    assert param.type == "real"
 
 
 @pytest.mark.parametrize(
-    'algorithm',
+    "algorithm",
     no_fidelity_algorithm_configs.values(),
-    ids=list(no_fidelity_algorithm_configs.keys()))
+    ids=list(no_fidelity_algorithm_configs.keys()),
+)
 def test_cardinality_stop(algorithm):
     """Test when algo needs to stop because all space is explored (dicrete space)."""
     discrete_space = copy.deepcopy(space)
-    discrete_space['x'] = 'uniform(-10, 5, discrete=True)'
+    discrete_space["x"] = "uniform(-10, 5, discrete=True)"
     exp = workon(rosenbrock, discrete_space, algorithms=algorithm, max_trials=100)
 
     trials = exp.fetch_trials()
     assert len(trials) == 16
-    assert trials[-1].status == 'completed'
+    assert trials[-1].status == "completed"
 
 
 @pytest.mark.parametrize(
-    'algorithm',
-    algorithm_configs.values(),
-    ids=list(algorithm_configs.keys()))
+    "algorithm", algorithm_configs.values(), ids=list(algorithm_configs.keys())
+)
 def test_with_fidelity(algorithm):
     """Test a scenario with fidelity."""
     exp = workon(rosenbrock, space_with_fidelity, algorithms=algorithm, max_trials=100)
 
-    assert exp.configuration['algorithms'] == algorithm
+    assert exp.configuration["algorithms"] == algorithm
 
     trials = exp.fetch_trials()
     assert len(trials) <= 100
-    assert trials[-1].status == 'completed'
+    assert trials[-1].status == "completed"
 
     results = [trial.objective.value for trial in trials]
     best_trial = next(iter(sorted(trials, key=lambda trial: trial.objective.value)))
 
-    assert best_trial.objective.name == 'objective'
+    assert best_trial.objective.name == "objective"
     assert abs(best_trial.objective.value - 23.4) < 1e-5
     assert len(best_trial.params) == 2
     fidelity = best_trial._params[0]
-    assert fidelity.name == 'noise'
-    assert fidelity.type == 'fidelity'
+    assert fidelity.name == "noise"
+    assert fidelity.type == "fidelity"
     assert fidelity.value == 10
     param = best_trial._params[1]
-    assert param.name == 'x'
-    assert param.type == 'real'
+    assert param.name == "x"
+    assert param.type == "real"

--- a/tests/functional/backward_compatibility/black_box.py
+++ b/tests/functional/backward_compatibility/black_box.py
@@ -10,15 +10,15 @@ from orion.client import report_results
 def function(x, noise):
     """Evaluate partial information of a quadratic."""
     z = (x - 34.56789) * random.gauss(0, noise)
-    return 4 * z**2 + 23.4, 8 * z
+    return 4 * z ** 2 + 23.4, 8 * z
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('--fidelity', type=int, default=10)
+    parser.add_argument("-x", type=float, required=True)
+    parser.add_argument("--fidelity", type=int, default=10)
     inputs = parser.parse_args()
 
     assert 0 <= inputs.fidelity <= 10
@@ -30,14 +30,8 @@ def execute():
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/backward_compatibility/python_api.py
+++ b/tests/functional/backward_compatibility/python_api.py
@@ -5,12 +5,12 @@ from orion.client import create_experiment
 
 
 create_experiment(
-    'hunt-python',
-    space={'x': 'uniform(-50,50)'},
-    algorithms={'random': {'seed': 1}})
+    "hunt-python", space={"x": "uniform(-50,50)"}, algorithms={"random": {"seed": 1}}
+)
 
 create_experiment(
-    'hunt-python-branch-old',
-    space={'x': 'uniform(-50,50)'},
-    algorithms={'random': {'seed': 1}},
-    branching={'branch_from': 'hunt-python'})
+    "hunt-python-branch-old",
+    space={"x": "uniform(-50,50)"},
+    algorithms={"random": {"seed": 1}},
+    branching={"branch_from": "hunt-python"},
+)

--- a/tests/functional/backward_compatibility/test_versions.py
+++ b/tests/functional/backward_compatibility/test_versions.py
@@ -19,12 +19,12 @@ from orion.storage.legacy import Legacy
 
 DIRNAME = os.path.dirname(os.path.abspath(__file__))
 
-PYTHON_SCRIPT_PATH = os.path.join(DIRNAME, 'python_api.py')
-SCRIPT_PATH = os.path.join(DIRNAME, 'black_box.py')
-CONFIG_FILE = os.path.join(DIRNAME, 'random.yaml')
+PYTHON_SCRIPT_PATH = os.path.join(DIRNAME, "python_api.py")
+SCRIPT_PATH = os.path.join(DIRNAME, "black_box.py")
+CONFIG_FILE = os.path.join(DIRNAME, "random.yaml")
 
 # Ignore pre-0.1.6 because was on orion.core and pypi project was deleted.
-VERSIONS = ['0.1.6', '0.1.7', '0.1.8', '0.1.9']
+VERSIONS = ["0.1.6", "0.1.7", "0.1.8", "0.1.9"]
 
 
 def get_branch_argument(version):
@@ -32,12 +32,12 @@ def get_branch_argument(version):
 
     Before v0.1.8 it was --branch. From v0.1.8 and forward it is now --branch-to.
     """
-    return '--branch' if version < '0.1.8' else '--branch-to'
+    return "--branch" if version < "0.1.8" else "--branch-to"
 
 
 def clean_mongodb():
     """Clean collections."""
-    client = MongoClient(username='user', password='pass', authSource='orion_test')
+    client = MongoClient(username="user", password="pass", authSource="orion_test")
     database = client.orion_test
     database.experiments.drop()
     database.lying_trials.drop()
@@ -55,22 +55,22 @@ def set_env():
     This function expects the env var ORION_DB_TYPE to be set.
 
     """
-    db_type = os.environ['ORION_DB_TYPE']
-    if db_type == 'pickleddb':
-        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'save.pkl')
-        os.environ['ORION_DB_ADDRESS'] = file_path
+    db_type = os.environ["ORION_DB_TYPE"]
+    if db_type == "pickleddb":
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "save.pkl")
+        os.environ["ORION_DB_ADDRESS"] = file_path
         if os.path.exists(file_path):
             os.remove(file_path)
-    elif db_type == 'mongodb':
-        os.environ['ORION_DB_ADDRESS'] = 'mongodb://user:pass@localhost'
-        os.environ['ORION_DB_NAME'] = 'orion_test'
+    elif db_type == "mongodb":
+        os.environ["ORION_DB_ADDRESS"] = "mongodb://user:pass@localhost"
+        os.environ["ORION_DB_NAME"] = "orion_test"
         clean_mongodb()
 
 
 def execute(command):
     """Execute a command and return the decoded stdout."""
     out = subprocess.check_output(command.split())
-    return out.decode('utf-8')
+    return out.decode("utf-8")
 
 
 def setup_virtualenv(version):
@@ -78,57 +78,109 @@ def setup_virtualenv(version):
     virtualenv_dir = get_virtualenv_dir(version)
     if os.path.exists(virtualenv_dir):
         shutil.rmtree(virtualenv_dir)
-    execute('virtualenv {}'.format(virtualenv_dir))
-    command = '{}/bin/pip install --ignore-installed orion=={}'.format(
-        virtualenv_dir, version)
+    execute("virtualenv {}".format(virtualenv_dir))
+    command = "{}/bin/pip install --ignore-installed orion=={}".format(
+        virtualenv_dir, version
+    )
     execute(command)
 
 
 def get_version(orion_script):
     """Get Oríon version for given Oríon executer's path."""
-    command = '{} --version'.format(orion_script)
+    command = "{} --version".format(orion_script)
     stdout = subprocess.check_output(command, shell=True)
 
-    return stdout.decode('utf-8').strip('\n')
+    return stdout.decode("utf-8").strip("\n")
 
 
 def get_virtualenv_dir(version):
     """Get virtualenv directory for given version."""
-    return 'version-{}'.format(version)
+    return "version-{}".format(version)
 
 
 def fill_from_cmdline_api(orion_script, version):
     """Add experiments and trials using the commandline API"""
     # TODO(v0.3.0): Adapt when removing init_only after deprecation phase
-    print(execute(' '.join([
-        orion_script, '-vv', 'init_only', '--name', 'init-cmdline',
-        '--config', CONFIG_FILE,
-        SCRIPT_PATH, '-x~uniform(-50,50)'])))
+    print(
+        execute(
+            " ".join(
+                [
+                    orion_script,
+                    "-vv",
+                    "init_only",
+                    "--name",
+                    "init-cmdline",
+                    "--config",
+                    CONFIG_FILE,
+                    SCRIPT_PATH,
+                    "-x~uniform(-50,50)",
+                ]
+            )
+        )
+    )
 
     # TODO(v0.3.0): Adapt when removing init_only after deprecation phase
-    print(execute(' '.join([
-        orion_script, '-vv', 'init_only', '--name', 'init-cmdline',
-        get_branch_argument(version), 'init-cmdline-branch-old',
-        '--config', CONFIG_FILE])))
+    print(
+        execute(
+            " ".join(
+                [
+                    orion_script,
+                    "-vv",
+                    "init_only",
+                    "--name",
+                    "init-cmdline",
+                    get_branch_argument(version),
+                    "init-cmdline-branch-old",
+                    "--config",
+                    CONFIG_FILE,
+                ]
+            )
+        )
+    )
 
-    print(execute(' '.join([
-        orion_script, '-vv', 'hunt', '--name', 'hunt-cmdline',
-        '--config', CONFIG_FILE,
-        SCRIPT_PATH, '-x~uniform(-50,50)'])))
+    print(
+        execute(
+            " ".join(
+                [
+                    orion_script,
+                    "-vv",
+                    "hunt",
+                    "--name",
+                    "hunt-cmdline",
+                    "--config",
+                    CONFIG_FILE,
+                    SCRIPT_PATH,
+                    "-x~uniform(-50,50)",
+                ]
+            )
+        )
+    )
 
-    print(execute(' '.join([
-        orion_script, '-vv', 'hunt', '--name', 'hunt-cmdline',
-        get_branch_argument(version), 'hunt-cmdline-branch-old',
-        '--config', CONFIG_FILE])))
+    print(
+        execute(
+            " ".join(
+                [
+                    orion_script,
+                    "-vv",
+                    "hunt",
+                    "--name",
+                    "hunt-cmdline",
+                    get_branch_argument(version),
+                    "hunt-cmdline-branch-old",
+                    "--config",
+                    CONFIG_FILE,
+                ]
+            )
+        )
+    )
 
 
 def fill_from_python_api(python_script, version):
     """Add experiments and trials using the python API"""
-    print(execute(' '.join([
-        python_script, PYTHON_SCRIPT_PATH, version])))
+    print(execute(" ".join([python_script, PYTHON_SCRIPT_PATH, version])))
 
 
-@pytest.fixture(scope='class', params=VERSIONS)
+@pytest.fixture(scope="class", params=VERSIONS)
 def fill_db(request):
     """Add experiments and trials in DB for given version of Oríon."""
     set_env()
@@ -137,20 +189,20 @@ def fill_db(request):
 
     setup_virtualenv(version)
 
-    orion_script = os.path.join(get_virtualenv_dir(version), 'bin', 'orion')
-    python_script = os.path.join(get_virtualenv_dir(version), 'bin', 'python')
+    orion_script = os.path.join(get_virtualenv_dir(version), "bin", "orion")
+    python_script = os.path.join(get_virtualenv_dir(version), "bin", "python")
 
     orion_version = get_version(orion_script)
-    assert orion_version == 'orion {}'.format(version)
+    assert orion_version == "orion {}".format(version)
 
     fill_from_cmdline_api(orion_script, version)
-    if version > '0.1.7':
+    if version > "0.1.7":
         fill_from_python_api(python_script, version)
 
-    orion_version = get_version('orion')
-    assert orion_version != 'orion {}'.format(version)
+    orion_version = get_version("orion")
+    assert orion_version != "orion {}".format(version)
 
-    print(execute('orion -vv db upgrade -f'))
+    print(execute("orion -vv db upgrade -f"))
 
     return version
 
@@ -172,7 +224,7 @@ def build_storage():
     return get_storage()
 
 
-@pytest.mark.usefixtures('fill_db')
+@pytest.mark.usefixtures("fill_db")
 class TestBackwardCompatibility:
     """Tests for backward compatibility between Oríon versions."""
 
@@ -180,83 +232,109 @@ class TestBackwardCompatibility:
         """Verify db upgrade was successful"""
         storage = build_storage()
 
-        index_info = storage._db.index_information('experiments')
-        assert (set([key for key, is_unique in index_info.items() if is_unique]) ==
-                set(['_id_', 'name_1_version_1']))
+        index_info = storage._db.index_information("experiments")
+        assert set([key for key, is_unique in index_info.items() if is_unique]) == set(
+            ["_id_", "name_1_version_1"]
+        )
 
         experiments = storage.fetch_experiments({})
-        assert 'version' in experiments[0]
-        assert 'priors' in experiments[0]['metadata']
+        assert "version" in experiments[0]
+        assert "priors" in experiments[0]["metadata"]
 
     def test_db_test(self):
         """Verify db test command"""
-        out = execute('orion db test')
-        assert 'Failure' not in out
+        out = execute("orion db test")
+        assert "Failure" not in out
 
     def test_list(self, fill_db):
         """Verify list command"""
-        out = execute('orion list')
-        assert 'init-cmdline-v1' in out
-        assert 'init-cmdline-branch-old-v1' in out
-        assert 'hunt-cmdline-v1' in out
-        assert 'hunt-cmdline-branch-old-v1' in out
+        out = execute("orion list")
+        assert "init-cmdline-v1" in out
+        assert "init-cmdline-branch-old-v1" in out
+        assert "hunt-cmdline-v1" in out
+        assert "hunt-cmdline-branch-old-v1" in out
 
         version = fill_db
-        if version > '0.1.7':
-            assert 'hunt-python-v1' in out
+        if version > "0.1.7":
+            assert "hunt-python-v1" in out
 
     def test_status(self, fill_db):
         """Verify status command"""
-        out = execute('orion status')
-        assert 'init-cmdline-v1' in out
-        assert 'init-cmdline-branch-old-v1' in out
-        assert 'hunt-cmdline-v1' in out
-        assert 'hunt-cmdline-branch-old-v1' in out
+        out = execute("orion status")
+        assert "init-cmdline-v1" in out
+        assert "init-cmdline-branch-old-v1" in out
+        assert "hunt-cmdline-v1" in out
+        assert "hunt-cmdline-branch-old-v1" in out
 
         version = fill_db
-        if version > '0.1.7':
-            assert 'hunt-python-v1' in out
+        if version > "0.1.7":
+            assert "hunt-python-v1" in out
 
     def test_info_cmdline_api(self):
         """Verify info command from commandline api"""
-        out = execute('orion info --name hunt-cmdline')
-        assert 'name: hunt-cmdline' in out
+        out = execute("orion info --name hunt-cmdline")
+        assert "name: hunt-cmdline" in out
 
     def test_info_python_api(self, fill_db):
         """Verify info command from python api"""
         version = fill_db
-        if version < '0.1.8':
+        if version < "0.1.8":
             pytest.skip("Python API not supported by {}".format(version))
 
-        out = execute('orion info --name hunt-python')
-        assert 'name: hunt-python' in out
+        out = execute("orion info --name hunt-python")
+        assert "name: hunt-python" in out
 
     # TODO(v0.3.0): Adapt when removing init_only after deprecation phase
     def test_init_only(self):
         """Verify init_only command"""
-        print(execute(' '.join([
-            'orion', 'init_only', '--name', 'init-cmdline',
-            '--branch-to', 'init-cmdline-branch'])))
+        print(
+            execute(
+                " ".join(
+                    [
+                        "orion",
+                        "init_only",
+                        "--name",
+                        "init-cmdline",
+                        "--branch-to",
+                        "init-cmdline-branch",
+                    ]
+                )
+            )
+        )
 
     def test_hunt_cmdline_api(self):
         """Verify hunt command from cmdline api parent"""
-        print(execute(' '.join([
-            'orion', 'hunt', '--name', 'hunt-cmdline',
-            '--branch-to', 'hunt-cmdline-branch'])))
+        print(
+            execute(
+                " ".join(
+                    [
+                        "orion",
+                        "hunt",
+                        "--name",
+                        "hunt-cmdline",
+                        "--branch-to",
+                        "hunt-cmdline-branch",
+                    ]
+                )
+            )
+        )
 
     def test_hunt_python_api(self, fill_db):
         """Verify hunt command from python api parent"""
         version = fill_db
-        if version < '0.1.8':
+        if version < "0.1.8":
             pytest.skip("Python API not supported by {}".format(version))
 
         def function(x):
             """Evaluate partial information of a quadratic."""
             z = x - 34.56789
-            return [dict(
-                name='example_objective',
-                type='objective',
-                value=4 * z**2 + 23.4)]
+            return [
+                dict(
+                    name="example_objective", type="objective", value=4 * z ** 2 + 23.4
+                )
+            ]
 
-        exp = create_experiment('hunt-python', branching={'branch-to': 'hunt-python-branch'})
+        exp = create_experiment(
+            "hunt-python", branching={"branch-to": "hunt-python-branch"}
+        )
         exp.workon(function, max_trials=10)

--- a/tests/functional/branching/black_box.py
+++ b/tests/functional/branching/black_box.py
@@ -10,14 +10,14 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     y = x - 34.56789
-    return 4 * y**2 + 23.4, 8 * y
+    return 4 * y ** 2 + 23.4, 8 * y
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument("-x", type=float, required=True)
     inputs = parser.parse_args()
 
     # 2. Perform computations
@@ -25,14 +25,8 @@ def execute():
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/branching/black_box_new.py
+++ b/tests/functional/branching/black_box_new.py
@@ -10,15 +10,15 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     y = x - 34.56789
-    return 4 * y**2 + 23.4, 8 * y
+    return 4 * y ** 2 + 23.4, 8 * y
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('--a-new', type=str)
+    parser.add_argument("-x", type=float, required=True)
+    parser.add_argument("--a-new", type=str)
     inputs = parser.parse_args()
 
     # 2. Perform computations
@@ -26,14 +26,8 @@ def execute():
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/branching/black_box_with_y.py
+++ b/tests/functional/branching/black_box_with_y.py
@@ -9,15 +9,15 @@ from orion.client import report_results
 def function(x, y):
     """Evaluate partial information of a quadratic."""
     y = x + y - 34.56789
-    return 4 * y**2 + 23.4, 8 * y
+    return 4 * y ** 2 + 23.4, 8 * y
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('-y', type=float, default=0.0)
+    parser.add_argument("-x", type=float, required=True)
+    parser.add_argument("-y", type=float, default=0.0)
     inputs = parser.parse_args()
 
     # 2. Perform computations
@@ -25,14 +25,8 @@ def execute():
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/branching/black_box_with_z.py
+++ b/tests/functional/branching/black_box_with_z.py
@@ -10,15 +10,15 @@ from orion.client import report_results
 def function(x, z):
     """Evaluate partial information of a quadratic."""
     y = x + z - 34.56789
-    return 4 * y**2 + 23.4, 8 * y
+    return 4 * y ** 2 + 23.4, 8 * y
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('-z', type=float, default=0.0)
+    parser.add_argument("-x", type=float, required=True)
+    parser.add_argument("-z", type=float, default=0.0)
     inputs = parser.parse_args()
 
     # 2. Perform computations
@@ -26,14 +26,8 @@ def execute():
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -13,7 +13,7 @@ from orion.storage.base import get_storage
 
 def execute(command, assert_code=0):
     """Execute orion command and return returncode"""
-    returncode = orion.core.cli.main(command.split(' '))
+    returncode = orion.core.cli.main(command.split(" "))
     assert returncode == assert_code
 
 
@@ -22,8 +22,14 @@ def init_full_x(clean_db, monkeypatch):
     """Init original experiment"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     name = "full_x"
-    orion.core.cli.main(("hunt --init-only -n {name} --config orion_config.yaml ./black_box.py "
-                         "-x~uniform(-10,10)").format(name=name).split(" "))
+    orion.core.cli.main(
+        (
+            "hunt --init-only -n {name} --config orion_config.yaml ./black_box.py "
+            "-x~uniform(-10,10)"
+        )
+        .format(name=name)
+        .split(" ")
+    )
     orion.core.cli.main("insert -n {name} script -x=0".format(name=name).split(" "))
 
 
@@ -33,14 +39,27 @@ def init_full_x_full_y(init_full_x):
     name = "full_x"
     branch = "full_x_full_y"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box_with_y.py "
-         "-x~uniform(-10,10) "
-         "-y~+uniform(-10,10,default_value=1)").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=1 -y=1".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-1 -y=1".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=1 -y=-1".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-1 -y=-1".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box_with_y.py "
+            "-x~uniform(-10,10) "
+            "-y~+uniform(-10,10,default_value=1)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=1 -y=1".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-1 -y=1".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=1 -y=-1".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-1 -y=-1".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -49,11 +68,20 @@ def init_half_x_full_y(init_full_x_full_y):
     name = "full_x_full_y"
     branch = "half_x_full_y"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
-         "-x~+uniform(0,10) "
-         "-y~uniform(-10,10,default_value=1)").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=2 -y=2".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=2 -y=-2".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "-x~+uniform(0,10) "
+            "-y~uniform(-10,10,default_value=1)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=2 -y=2".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=2 -y=-2".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -62,11 +90,20 @@ def init_full_x_half_y(init_full_x_full_y):
     name = "full_x_full_y"
     branch = "full_x_half_y"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
-         "-x~uniform(-10,10) "
-         "-y~+uniform(0,10,default_value=1)").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=3 -y=3".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-3 -y=3".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "-x~uniform(-10,10) "
+            "-y~+uniform(0,10,default_value=1)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=3 -y=3".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-3 -y=3".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -74,14 +111,26 @@ def init_full_x_rename_y_z(init_full_x_full_y):
     """Rename y from full x full y to z"""
     name = "full_x_full_y"
     branch = "full_x_rename_y_z"
-    orion.core.cli.main((
-        "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-        "./black_box_with_z.py -x~uniform(-10,10) -y~>z -z~uniform(-10,10,default_value=1)"
-        ).format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=4 -z=4".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-4 -z=4".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=4 -z=-4".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-4 -z=-4".format(branch=branch).split(" "))
+    orion.core.cli.main(
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box_with_z.py -x~uniform(-10,10) -y~>z -z~uniform(-10,10,default_value=1)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=4 -z=4".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-4 -z=4".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=4 -z=-4".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-4 -z=-4".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -89,12 +138,20 @@ def init_full_x_rename_half_y_half_z(init_full_x_half_y):
     """Rename y from full x half y to z"""
     name = "full_x_half_y"
     branch = "full_x_rename_half_y_half_z"
-    orion.core.cli.main((
-        "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-        "./black_box_with_z.py -x~uniform(-10,10) -y~>z -z~uniform(0,10,default_value=1)"
-        ).format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=5 -z=5".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-5 -z=5".format(branch=branch).split(" "))
+    orion.core.cli.main(
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box_with_z.py -x~uniform(-10,10) -y~>z -z~uniform(0,10,default_value=1)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=5 -z=5".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-5 -z=5".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -103,14 +160,27 @@ def init_full_x_rename_half_y_full_z(init_full_x_half_y):
     name = "full_x_half_y"
     branch = "full_x_rename_half_y_full_z"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box_with_z.py "
-         "-x~uniform(-10,10) -y~>z "
-         "-z~+uniform(-10,10,default_value=1)").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=6 -z=6".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-6 -z=6".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=6 -z=-6".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-6 -z=-6".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box_with_z.py "
+            "-x~uniform(-10,10) -y~>z "
+            "-z~+uniform(-10,10,default_value=1)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=6 -z=6".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-6 -z=6".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=6 -z=-6".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-6 -z=-6".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -119,11 +189,20 @@ def init_full_x_remove_y(init_full_x_full_y):
     name = "full_x_full_y"
     branch = "full_x_remove_y"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box.py "
-         "-x~uniform(-10,10) -y~-").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=7".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-7".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box.py "
+            "-x~uniform(-10,10) -y~-"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=7".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-7".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -132,11 +211,20 @@ def init_full_x_full_y_add_z_remove_y(init_full_x_full_y):
     name = "full_x_full_y"
     branch = "full_x_full_z_remove_y"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box.py -x~uniform(-10,10) "
-         "-z~uniform(-20,10,default_value=0)").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=7 -z=2".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-7 -z=2".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box.py -x~uniform(-10,10) "
+            "-z~uniform(-20,10,default_value=0)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=7 -z=2".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-7 -z=2".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -145,11 +233,20 @@ def init_full_x_remove_z(init_full_x_rename_y_z):
     name = "full_x_rename_y_z"
     branch = "full_x_remove_z"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box.py "
-         "-x~uniform(-10,10) -z~-").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=8".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-8".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box.py "
+            "-x~uniform(-10,10) -z~-"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=8".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-8".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -158,11 +255,20 @@ def init_full_x_remove_z_default_4(init_full_x_rename_y_z):
     name = "full_x_rename_y_z"
     branch = "full_x_remove_z_default_4"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box.py "
-         "-x~uniform(-10,10) -z~-4").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=9".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-9".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box.py "
+            "-x~uniform(-10,10) -z~-4"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=9".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-9".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -171,11 +277,20 @@ def init_full_x_new_algo(init_full_x):
     name = "full_x"
     branch = "full_x_new_algo"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} "
-         "--algorithm-change --config new_algo_config.yaml "
-         "./black_box.py -x~uniform(-10,10)").format(name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=1.1".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-1.1".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} "
+            "--algorithm-change --config new_algo_config.yaml "
+            "./black_box.py -x~uniform(-10,10)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=1.1".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-1.1".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
@@ -184,36 +299,57 @@ def init_full_x_new_cli(init_full_x):
     name = "full_x"
     branch = "full_x_new_cli"
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
-         "./black_box_new.py -x~uniform(-10,10) --a-new argument").format(
-             name=name, branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=1.2".format(branch=branch).split(" "))
-    orion.core.cli.main("insert -n {branch} script -x=-1.2".format(branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "./black_box_new.py -x~uniform(-10,10) --a-new argument"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=1.2".format(branch=branch).split(" ")
+    )
+    orion.core.cli.main(
+        "insert -n {branch} script -x=-1.2".format(branch=branch).split(" ")
+    )
 
 
 @pytest.fixture
 def init_full_x_ignore_cli(init_full_x):
     """Use the --non-monitored-arguments argument"""
     name = "full_x_with_new_opt"
-    orion.core.cli.main(("hunt --init-only -n {name} --config orion_config.yaml ./black_box_new.py "
-                         "-x~uniform(-10,10)").format(name=name).split(" "))
+    orion.core.cli.main(
+        (
+            "hunt --init-only -n {name} --config orion_config.yaml ./black_box_new.py "
+            "-x~uniform(-10,10)"
+        )
+        .format(name=name)
+        .split(" ")
+    )
     orion.core.cli.main("insert -n {name} script -x=0".format(name=name).split(" "))
 
     orion.core.cli.main(
-        ("hunt --init-only -n {name} --non-monitored-arguments a-new "
-         "--config orion_config.yaml ./black_box_new.py "
-         "-x~uniform(-10,10) --a-new argument").format(name=name).split(" "))
+        (
+            "hunt --init-only -n {name} --non-monitored-arguments a-new "
+            "--config orion_config.yaml ./black_box_new.py "
+            "-x~uniform(-10,10) --a-new argument"
+        )
+        .format(name=name)
+        .split(" ")
+    )
     orion.core.cli.main("insert -n {name} script -x=1.2".format(name=name).split(" "))
     orion.core.cli.main("insert -n {name} script -x=-1.2".format(name=name).split(" "))
 
 
 @pytest.fixture
-def init_entire(init_half_x_full_y,  # 1.1.1
-                init_full_x_rename_half_y_half_z,  # 1.1.2.1
-                init_full_x_rename_half_y_full_z,  # 1.1.2.2
-                init_full_x_remove_y,  # 1.1.4
-                init_full_x_remove_z,  # 1.1.3.1
-                init_full_x_remove_z_default_4):  # 1.1.3.2
+def init_entire(
+    init_half_x_full_y,  # 1.1.1
+    init_full_x_rename_half_y_half_z,  # 1.1.2.1
+    init_full_x_rename_half_y_full_z,  # 1.1.2.2
+    init_full_x_remove_y,  # 1.1.4
+    init_full_x_remove_z,  # 1.1.3.1
+    init_full_x_remove_z_default_4,
+):  # 1.1.3.2
     """Initialize all experiments"""
     pass
 
@@ -233,297 +369,378 @@ def get_name_value_pairs(trials):
 
 def test_init(init_full_x, create_db_instance):
     """Test if original experiment contains trial 0"""
-    experiment = experiment_builder.build_view(name='full_x')
+    experiment = experiment_builder.build_view(name="full_x")
 
-    assert (experiment.refers['adapter'].configuration == [])
+    assert experiment.refers["adapter"].configuration == []
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 0), ), )
+    assert pairs == ((("/x", 0),),)
 
 
 def test_full_x_full_y(init_full_x_full_y, create_db_instance):
     """Test if full x full y is properly initialized and can fetch original trial"""
-    experiment = experiment_builder.build_view(name='full_x_full_y')
+    experiment = experiment_builder.build_view(name="full_x_full_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'change_type': 'noeffect', 'of_type': 'commandlinechange'},
-             {'of_type': 'dimensionaddition',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"change_type": "noeffect", "of_type": "commandlinechange"},
+        {
+            "of_type": "dimensionaddition",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 1), ('/y', 1)),
-                     (('/x', -1), ('/y', 1)),
-                     (('/x', 1), ('/y', -1)),
-                     (('/x', -1), ('/y', -1)))
+    assert pairs == (
+        (("/x", 1), ("/y", 1)),
+        (("/x", -1), ("/y", 1)),
+        (("/x", 1), ("/y", -1)),
+        (("/x", -1), ("/y", -1)),
+    )
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/y', 1)),
-                     (('/x', 1), ('/y', 1)),
-                     (('/x', -1), ('/y', 1)),
-                     (('/x', 1), ('/y', -1)),
-                     (('/x', -1), ('/y', -1)))
+    assert pairs == (
+        (("/x", 0), ("/y", 1)),
+        (("/x", 1), ("/y", 1)),
+        (("/x", -1), ("/y", 1)),
+        (("/x", 1), ("/y", -1)),
+        (("/x", -1), ("/y", -1)),
+    )
 
 
 def test_half_x_full_y(init_half_x_full_y, create_db_instance):
     """Test if half x full y is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name='half_x_full_y')
+    experiment = experiment_builder.build_view(name="half_x_full_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'dimensionpriorchange',
-              'name': '/x',
-              'old_prior': 'uniform(-10, 10)',
-              'new_prior': 'uniform(0, 10)'}])
+    assert experiment.refers["adapter"].configuration == [
+        {
+            "of_type": "dimensionpriorchange",
+            "name": "/x",
+            "old_prior": "uniform(-10, 10)",
+            "new_prior": "uniform(0, 10)",
+        }
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 2), ('/y', 2)),
-                     (('/x', 2), ('/y', -2)))
+    assert pairs == ((("/x", 2), ("/y", 2)), (("/x", 2), ("/y", -2)))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/y', 1)),
-                     (('/x', 1), ('/y', 1)),
-                     (('/x', 1), ('/y', -1)),
-                     (('/x', 2), ('/y', 2)),
-                     (('/x', 2), ('/y', -2)))
+    assert pairs == (
+        (("/x", 0), ("/y", 1)),
+        (("/x", 1), ("/y", 1)),
+        (("/x", 1), ("/y", -1)),
+        (("/x", 2), ("/y", 2)),
+        (("/x", 2), ("/y", -2)),
+    )
 
 
 def test_full_x_half_y(init_full_x_half_y, create_db_instance):
     """Test if full x half y is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name='full_x_half_y')
+    experiment = experiment_builder.build_view(name="full_x_half_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'dimensionpriorchange',
-              'name': '/y',
-              'old_prior': 'uniform(-10, 10, default_value=1)',
-              'new_prior': 'uniform(0, 10, default_value=1)'}])
+    assert experiment.refers["adapter"].configuration == [
+        {
+            "of_type": "dimensionpriorchange",
+            "name": "/y",
+            "old_prior": "uniform(-10, 10, default_value=1)",
+            "new_prior": "uniform(0, 10, default_value=1)",
+        }
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 3), ('/y', 3)),
-                     (('/x', -3), ('/y', 3)))
+    assert pairs == ((("/x", 3), ("/y", 3)), (("/x", -3), ("/y", 3)))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/y', 1)),
-                     (('/x', 1), ('/y', 1)),
-                     (('/x', -1), ('/y', 1)),
-                     (('/x', 3), ('/y', 3)),
-                     (('/x', -3), ('/y', 3)))
+    assert pairs == (
+        (("/x", 0), ("/y", 1)),
+        (("/x", 1), ("/y", 1)),
+        (("/x", -1), ("/y", 1)),
+        (("/x", 3), ("/y", 3)),
+        (("/x", -3), ("/y", 3)),
+    )
 
 
 def test_full_x_rename_y_z(init_full_x_rename_y_z, create_db_instance):
     """Test if full x full z is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name='full_x_rename_y_z')
+    experiment = experiment_builder.build_view(name="full_x_rename_y_z")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'commandlinechange', 'change_type': 'noeffect'},
-             {'of_type': 'dimensionrenaming', 'old_name': '/y', 'new_name': '/z'}])
+    assert experiment.refers["adapter"].configuration == [
+        {"of_type": "commandlinechange", "change_type": "noeffect"},
+        {"of_type": "dimensionrenaming", "old_name": "/y", "new_name": "/z"},
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 4), ('/z', 4)),
-                     (('/x', -4), ('/z', 4)),
-                     (('/x', 4), ('/z', -4)),
-                     (('/x', -4), ('/z', -4)))
+    assert pairs == (
+        (("/x", 4), ("/z", 4)),
+        (("/x", -4), ("/z", 4)),
+        (("/x", 4), ("/z", -4)),
+        (("/x", -4), ("/z", -4)),
+    )
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/z', 1)),
-                     (('/x', 1), ('/z', 1)),
-                     (('/x', -1), ('/z', 1)),
-                     (('/x', 1), ('/z', -1)),
-                     (('/x', -1), ('/z', -1)),
-                     (('/x', 4), ('/z', 4)),
-                     (('/x', -4), ('/z', 4)),
-                     (('/x', 4), ('/z', -4)),
-                     (('/x', -4), ('/z', -4)))
+    assert pairs == (
+        (("/x", 0), ("/z", 1)),
+        (("/x", 1), ("/z", 1)),
+        (("/x", -1), ("/z", 1)),
+        (("/x", 1), ("/z", -1)),
+        (("/x", -1), ("/z", -1)),
+        (("/x", 4), ("/z", 4)),
+        (("/x", -4), ("/z", 4)),
+        (("/x", 4), ("/z", -4)),
+        (("/x", -4), ("/z", -4)),
+    )
 
 
-def test_full_x_rename_half_y_half_z(init_full_x_rename_half_y_half_z, create_db_instance):
+def test_full_x_rename_half_y_half_z(
+    init_full_x_rename_half_y_half_z, create_db_instance
+):
     """Test if full x half z is properly initialized and can fetch from its 3 parents"""
-    experiment = experiment_builder.build_view(name='full_x_rename_half_y_half_z')
+    experiment = experiment_builder.build_view(name="full_x_rename_half_y_half_z")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'commandlinechange', 'change_type': 'noeffect'},
-             {'of_type': 'dimensionrenaming', 'old_name': '/y', 'new_name': '/z'}])
+    assert experiment.refers["adapter"].configuration == [
+        {"of_type": "commandlinechange", "change_type": "noeffect"},
+        {"of_type": "dimensionrenaming", "old_name": "/y", "new_name": "/z"},
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 5), ('/z', 5)),
-                     (('/x', -5), ('/z', 5)))
+    assert pairs == ((("/x", 5), ("/z", 5)), (("/x", -5), ("/z", 5)))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/z', 1)),
-                     (('/x', 1), ('/z', 1)),
-                     (('/x', -1), ('/z', 1)),
-                     (('/x', 3), ('/z', 3)),
-                     (('/x', -3), ('/z', 3)),
-                     (('/x', 5), ('/z', 5)),
-                     (('/x', -5), ('/z', 5)))
+    assert pairs == (
+        (("/x", 0), ("/z", 1)),
+        (("/x", 1), ("/z", 1)),
+        (("/x", -1), ("/z", 1)),
+        (("/x", 3), ("/z", 3)),
+        (("/x", -3), ("/z", 3)),
+        (("/x", 5), ("/z", 5)),
+        (("/x", -5), ("/z", 5)),
+    )
 
 
-def test_full_x_rename_half_y_full_z(init_full_x_rename_half_y_full_z, create_db_instance):
+def test_full_x_rename_half_y_full_z(
+    init_full_x_rename_half_y_full_z, create_db_instance
+):
     """Test if full x half->full z is properly initialized and can fetch from its 3 parents"""
-    experiment = experiment_builder.build_view(name='full_x_rename_half_y_full_z')
+    experiment = experiment_builder.build_view(name="full_x_rename_half_y_full_z")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'commandlinechange', 'change_type': 'noeffect'},
-             {'of_type': 'dimensionrenaming', 'old_name': '/y', 'new_name': '/z'},
-             {'of_type': 'dimensionpriorchange',
-              'name': '/z',
-              'old_prior': 'uniform(0, 10, default_value=1)',
-              'new_prior': 'uniform(-10, 10, default_value=1)'}])
+    assert experiment.refers["adapter"].configuration == [
+        {"of_type": "commandlinechange", "change_type": "noeffect"},
+        {"of_type": "dimensionrenaming", "old_name": "/y", "new_name": "/z"},
+        {
+            "of_type": "dimensionpriorchange",
+            "name": "/z",
+            "old_prior": "uniform(0, 10, default_value=1)",
+            "new_prior": "uniform(-10, 10, default_value=1)",
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 6), ('/z', 6)),
-                     (('/x', -6), ('/z', 6)),
-                     (('/x', 6), ('/z', -6)),
-                     (('/x', -6), ('/z', -6)))
+    assert pairs == (
+        (("/x", 6), ("/z", 6)),
+        (("/x", -6), ("/z", 6)),
+        (("/x", 6), ("/z", -6)),
+        (("/x", -6), ("/z", -6)),
+    )
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/z', 1)),
-                     (('/x', 1), ('/z', 1)),
-                     (('/x', -1), ('/z', 1)),
-                     (('/x', 3), ('/z', 3)),
-                     (('/x', -3), ('/z', 3)),
-                     (('/x', 6), ('/z', 6)),
-                     (('/x', -6), ('/z', 6)),
-                     (('/x', 6), ('/z', -6)),
-                     (('/x', -6), ('/z', -6)))
+    assert pairs == (
+        (("/x", 0), ("/z", 1)),
+        (("/x", 1), ("/z", 1)),
+        (("/x", -1), ("/z", 1)),
+        (("/x", 3), ("/z", 3)),
+        (("/x", -3), ("/z", 3)),
+        (("/x", 6), ("/z", 6)),
+        (("/x", -6), ("/z", 6)),
+        (("/x", 6), ("/z", -6)),
+        (("/x", -6), ("/z", -6)),
+    )
 
 
 def test_full_x_remove_y(init_full_x_remove_y, create_db_instance):
     """Test if full x removed y is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name='full_x_remove_y')
+    experiment = experiment_builder.build_view(name="full_x_remove_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'commandlinechange', 'change_type': 'noeffect'},
-             {'of_type': 'dimensiondeletion',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"of_type": "commandlinechange", "change_type": "noeffect"},
+        {
+            "of_type": "dimensiondeletion",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 7), ), (('/x', -7), ))
+    assert pairs == ((("/x", 7),), (("/x", -7),))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ), (('/x', 1), ), (('/x', -1), ), (('/x', 7), ), (('/x', -7), ))
+    assert pairs == (
+        (("/x", 0),),
+        (("/x", 1),),
+        (("/x", -1),),
+        (("/x", 7),),
+        (("/x", -7),),
+    )
 
 
-def test_full_x_full_y_add_z_remove_y(init_full_x_full_y_add_z_remove_y, create_db_instance):
+def test_full_x_full_y_add_z_remove_y(
+    init_full_x_full_y_add_z_remove_y, create_db_instance
+):
     """Test that if z is added and y removed at the same time, both are correctly detected"""
-    experiment = experiment_builder.build_view(name='full_x_full_z_remove_y')
+    experiment = experiment_builder.build_view(name="full_x_full_z_remove_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'commandlinechange', 'change_type': 'noeffect'},
-             {'of_type': 'dimensiondeletion',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}},
-             {'of_type': 'dimensionaddition',
-              'param': {'name': '/z', 'type': 'real', 'value': 0}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"of_type": "commandlinechange", "change_type": "noeffect"},
+        {
+            "of_type": "dimensiondeletion",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+        {
+            "of_type": "dimensionaddition",
+            "param": {"name": "/z", "type": "real", "value": 0},
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 7), ('/z', 2)), (('/x', -7), ('/z', 2)))
+    assert pairs == ((("/x", 7), ("/z", 2)), (("/x", -7), ("/z", 2)))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert pairs == ((('/x', 0), ('/z', 0)), (('/x', 1), ('/z', 0)),
-                     (('/x', -1), ('/z', 0)), (('/x', 7), ('/z', 2)),
-                     (('/x', -7), ('/z', 2)))
+    assert pairs == (
+        (("/x", 0), ("/z", 0)),
+        (("/x", 1), ("/z", 0)),
+        (("/x", -1), ("/z", 0)),
+        (("/x", 7), ("/z", 2)),
+        (("/x", -7), ("/z", 2)),
+    )
 
 
 def test_full_x_remove_z(init_full_x_remove_z, create_db_instance):
     """Test if full x removed z is properly initialized and can fetch from 2 of its 3 parents"""
-    experiment = experiment_builder.build_view(name='full_x_remove_z')
+    experiment = experiment_builder.build_view(name="full_x_remove_z")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'change_type': 'noeffect', 'of_type': 'commandlinechange'},
-             {'of_type': 'dimensiondeletion',
-              'param': {'name': '/z', 'type': 'real', 'value': 1}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"change_type": "noeffect", "of_type": "commandlinechange"},
+        {
+            "of_type": "dimensiondeletion",
+            "param": {"name": "/z", "type": "real", "value": 1},
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 8), ), (('/x', -8), ))
+    assert pairs == ((("/x", 8),), (("/x", -8),))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
     # Note that full_x_rename_y_z are filtered out because default_value=1
-    assert pairs == ((('/x', 0), ), (('/x', 1), ), (('/x', -1), ), (('/x', 8), ), (('/x', -8), ))
+    assert pairs == (
+        (("/x", 0),),
+        (("/x", 1),),
+        (("/x", -1),),
+        (("/x", 8),),
+        (("/x", -8),),
+    )
 
 
 def test_full_x_remove_z_default_4(init_full_x_remove_z_default_4, create_db_instance):
     """Test if full x removed z  (default 4) is properly initialized and can fetch
     from 1 of its 3 parents
     """
-    experiment = experiment_builder.build_view(name='full_x_remove_z_default_4')
+    experiment = experiment_builder.build_view(name="full_x_remove_z_default_4")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'change_type': 'noeffect', 'of_type': 'commandlinechange'},
-             {'of_type': 'dimensiondeletion',
-              'param': {'name': '/z', 'type': 'real', 'value': 4.0}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"change_type": "noeffect", "of_type": "commandlinechange"},
+        {
+            "of_type": "dimensiondeletion",
+            "param": {"name": "/z", "type": "real", "value": 4.0},
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 9), ), (('/x', -9), ))
+    assert pairs == ((("/x", 9),), (("/x", -9),))
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
     # Note that full_x and full_x_full_y are filtered out because default_value=4
-    assert pairs == ((('/x', 4), ), (('/x', -4), ), (('/x', 9), ), (('/x', -9), ))
+    assert pairs == ((("/x", 4),), (("/x", -4),), (("/x", 9),), (("/x", -9),))
 
 
 def test_entire_full_x_full_y(init_entire, create_db_instance):
     """Test if full x full y can fetch from its parent and all children"""
-    experiment = experiment_builder.build_view(name='full_x_full_y')
+    experiment = experiment_builder.build_view(name="full_x_full_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'change_type': 'noeffect', 'of_type': 'commandlinechange'},
-             {'of_type': 'dimensionaddition',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"change_type": "noeffect", "of_type": "commandlinechange"},
+        {
+            "of_type": "dimensionaddition",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+    ]
 
     pairs = get_name_value_pairs(experiment.fetch_trials())
-    assert pairs == ((('/x', 1), ('/y', 1)),
-                     (('/x', -1), ('/y', 1)),
-                     (('/x', 1), ('/y', -1)),
-                     (('/x', -1), ('/y', -1)))
+    assert pairs == (
+        (("/x", 1), ("/y", 1)),
+        (("/x", -1), ("/y", 1)),
+        (("/x", 1), ("/y", -1)),
+        (("/x", -1), ("/y", -1)),
+    )
 
     pairs = get_name_value_pairs(experiment.fetch_trials(with_evc_tree=True))
-    assert set(pairs) == set(((('/x', 0), ('/y', 1)),
-                              # full_x_full_y
-                              (('/x', 1), ('/y', 1)),
-                              (('/x', -1), ('/y', 1)),
-                              (('/x', 1), ('/y', -1)),
-                              (('/x', -1), ('/y', -1)),
-                              # half_x_full_y
-                              (('/x', 2), ('/y', 2)),
-                              (('/x', 2), ('/y', -2)),
-                              # full_x_half_y
-                              (('/x', 3), ('/y', 3)),
-                              (('/x', -3), ('/y', 3)),
-                              # full_x_rename_y_z
-                              (('/x', 4), ('/y', 4)),
-                              (('/x', -4), ('/y', 4)),
-                              (('/x', 4), ('/y', -4)),
-                              (('/x', -4), ('/y', -4)),
-                              # full_x_rename_half_y_half_z
-                              (('/x', 5), ('/y', 5)),
-                              (('/x', -5), ('/y', 5)),
-                              # full_x_rename_half_y_full_z
-                              (('/x', 6), ('/y', 6)),
-                              (('/x', -6), ('/y', 6)),
-                              # full_x_remove_y
-                              (('/x', 7), ('/y', 1)),
-                              (('/x', -7), ('/y', 1)),
-                              # full_x_remove_z
-                              (('/x', 8), ('/y', 1)),
-                              (('/x', -8), ('/y', 1)),
-                              # full_x_remove_z_default_4
-                              (('/x', 9), ('/y', 4)),
-                              (('/x', -9), ('/y', 4))))
+    assert set(pairs) == set(
+        (
+            (("/x", 0), ("/y", 1)),
+            # full_x_full_y
+            (("/x", 1), ("/y", 1)),
+            (("/x", -1), ("/y", 1)),
+            (("/x", 1), ("/y", -1)),
+            (("/x", -1), ("/y", -1)),
+            # half_x_full_y
+            (("/x", 2), ("/y", 2)),
+            (("/x", 2), ("/y", -2)),
+            # full_x_half_y
+            (("/x", 3), ("/y", 3)),
+            (("/x", -3), ("/y", 3)),
+            # full_x_rename_y_z
+            (("/x", 4), ("/y", 4)),
+            (("/x", -4), ("/y", 4)),
+            (("/x", 4), ("/y", -4)),
+            (("/x", -4), ("/y", -4)),
+            # full_x_rename_half_y_half_z
+            (("/x", 5), ("/y", 5)),
+            (("/x", -5), ("/y", 5)),
+            # full_x_rename_half_y_full_z
+            (("/x", 6), ("/y", 6)),
+            (("/x", -6), ("/y", 6)),
+            # full_x_remove_y
+            (("/x", 7), ("/y", 1)),
+            (("/x", -7), ("/y", 1)),
+            # full_x_remove_z
+            (("/x", 8), ("/y", 1)),
+            (("/x", -8), ("/y", 1)),
+            # full_x_remove_z_default_4
+            (("/x", 9), ("/y", 4)),
+            (("/x", -9), ("/y", 4)),
+        )
+    )
 
 
 def test_run_entire_full_x_full_y(init_entire, create_db_instance):
     """Test if branched experiment can be executed without triggering a branching event again"""
-    experiment = experiment_builder.build_view(name='full_x_full_y')
+    experiment = experiment_builder.build_view(name="full_x_full_y")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'change_type': 'noeffect', 'of_type': 'commandlinechange'},
-             {'of_type': 'dimensionaddition',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}}])
+    assert experiment.refers["adapter"].configuration == [
+        {"change_type": "noeffect", "of_type": "commandlinechange"},
+        {
+            "of_type": "dimensionaddition",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+    ]
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 23
     assert len(experiment.fetch_trials()) == 4
 
-    orion.core.cli.main(("-vv hunt --max-trials 20 --pool-size 1 -n full_x_full_y "
-                         "./black_box_with_y.py "
-                         "-x~uniform(-10,10) "
-                         "-y~uniform(-10,10,default_value=1)").split(" "))
+    orion.core.cli.main(
+        (
+            "-vv hunt --max-trials 20 --pool-size 1 -n full_x_full_y "
+            "./black_box_with_y.py "
+            "-x~uniform(-10,10) "
+            "-y~uniform(-10,10,default_value=1)"
+        ).split(" ")
+    )
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 39
     assert len(experiment.fetch_trials()) == 20
@@ -531,12 +748,14 @@ def test_run_entire_full_x_full_y(init_entire, create_db_instance):
 
 def test_run_entire_full_x_full_y_no_args(init_entire, create_db_instance):
     """Test if branched experiment can be executed without script arguments"""
-    experiment = experiment_builder.build_view(name='full_x_full_y')
+    experiment = experiment_builder.build_view(name="full_x_full_y")
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 23
     assert len(experiment.fetch_trials()) == 4
 
-    orion.core.cli.main(("-vv hunt --max-trials 20 --pool-size 1 -n full_x_full_y").split(" "))
+    orion.core.cli.main(
+        ("-vv hunt --max-trials 20 --pool-size 1 -n full_x_full_y").split(" ")
+    )
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 39
     assert len(experiment.fetch_trials()) == 20
@@ -544,14 +763,18 @@ def test_run_entire_full_x_full_y_no_args(init_entire, create_db_instance):
 
 def test_new_algo(init_full_x_new_algo):
     """Test that new algo conflict is automatically resolved"""
-    experiment = experiment_builder.build_view(name='full_x_new_algo')
+    experiment = experiment_builder.build_view(name="full_x_new_algo")
 
-    assert (experiment.refers['adapter'].configuration == [{'of_type': 'algorithmchange'}])
+    assert experiment.refers["adapter"].configuration == [
+        {"of_type": "algorithmchange"}
+    ]
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 3
     assert len(experiment.fetch_trials()) == 2
 
-    orion.core.cli.main(("-vv hunt --max-trials 20 --pool-size 1 -n full_x_new_algo").split(" "))
+    orion.core.cli.main(
+        ("-vv hunt --max-trials 20 --pool-size 1 -n full_x_new_algo").split(" ")
+    )
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 21
     assert len(experiment.fetch_trials()) == 20
@@ -562,13 +785,17 @@ def test_new_algo_not_resolved(init_full_x, capsys):
     name = "full_x"
     branch = "full_x_new_algo"
     error_code = orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} --config new_algo_config.yaml "
-         "--manual-resolution ./black_box.py -x~uniform(-10,10)")
-        .format(name=name, branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} --config new_algo_config.yaml "
+            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
     assert error_code == 1
 
     captured = capsys.readouterr()
-    assert captured.out == ''
+    assert captured.out == ""
     assert "Configuration is different and generates a branching event" in captured.err
     assert "gradient_descent" in captured.err
 
@@ -577,48 +804,63 @@ def test_ignore_cli(init_full_x_ignore_cli):
     """Test that a non-monitored parameter conflict is not generating a child"""
     name = "full_x"
     orion.core.cli.main(
-        ("hunt --init-only -n {name} --non-monitored-arguments a-new "
-         "--manual-resolution ./black_box.py -x~uniform(-10,10)")
-        .format(name=name).split(" "))
+        (
+            "hunt --init-only -n {name} --non-monitored-arguments a-new "
+            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+        )
+        .format(name=name)
+        .split(" ")
+    )
 
 
-@pytest.mark.usefixtures('init_full_x', 'mock_infer_versioning_metadata')
+@pytest.mark.usefixtures("init_full_x", "mock_infer_versioning_metadata")
 def test_new_code_triggers_code_conflict(capsys):
     """Test that a different git hash is generating a child"""
     name = "full_x"
     error_code = orion.core.cli.main(
-        ("hunt --init-only -n {name} "
-         "--manual-resolution ./black_box.py -x~uniform(-10,10)")
-        .format(name=name).split(" "))
+        (
+            "hunt --init-only -n {name} "
+            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+        )
+        .format(name=name)
+        .split(" ")
+    )
     assert error_code == 1
 
     captured = capsys.readouterr()
-    assert captured.out == ''
+    assert captured.out == ""
     assert "Configuration is different and generates a branching event" in captured.err
     assert "--code-change-type" in captured.err
 
 
-@pytest.mark.usefixtures('init_full_x', 'mock_infer_versioning_metadata')
+@pytest.mark.usefixtures("init_full_x", "mock_infer_versioning_metadata")
 def test_new_code_ignores_code_conflict():
     """Test that a different git hash is *not* generating a child if --ignore-code-changes"""
     name = "full_x"
     orion.core.cli.main(
-        ("hunt --init-only -n {name} --ignore-code-changes "
-         "--manual-resolution ./black_box.py -x~uniform(-10,10)")
-        .format(name=name).split(" "))
+        (
+            "hunt --init-only -n {name} --ignore-code-changes "
+            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+        )
+        .format(name=name)
+        .split(" ")
+    )
 
 
 def test_new_cli(init_full_x_new_cli):
     """Test that new cli conflict is automatically resolved"""
-    experiment = experiment_builder.build_view(name='full_x_new_cli')
+    experiment = experiment_builder.build_view(name="full_x_new_cli")
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'change_type': 'noeffect', 'of_type': 'commandlinechange'}])
+    assert experiment.refers["adapter"].configuration == [
+        {"change_type": "noeffect", "of_type": "commandlinechange"}
+    ]
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 3
     assert len(experiment.fetch_trials()) == 2
 
-    orion.core.cli.main(("-vv hunt --max-trials 20 --pool-size 1 -n full_x_new_cli").split(" "))
+    orion.core.cli.main(
+        ("-vv hunt --max-trials 20 --pool-size 1 -n full_x_new_cli").split(" ")
+    )
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 21
     assert len(experiment.fetch_trials()) == 20
@@ -627,71 +869,100 @@ def test_new_cli(init_full_x_new_cli):
 def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):
     """Test that auto-resolution does resolve all conflicts"""
     # Patch cmdloop to avoid autoresolution's prompt
-    monkeypatch.setattr('sys.__stdin__.isatty', lambda: True)
+    monkeypatch.setattr("sys.__stdin__.isatty", lambda: True)
 
     name = "full_x_full_y"
     branch = "half_x_no_y_new_w"
     # If autoresolution was not succesfull, this to fail with a sys.exit without registering the
     # experiment
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
-         "-x~uniform(0,10) "
-         "-w~choices(['a','b'])").format(name=name, branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "-x~uniform(0,10) "
+            "-w~choices(['a','b'])"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
 
     experiment = experiment_builder.build_view(name=branch)
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'dimensionpriorchange',
-              'name': '/x',
-              'new_prior': 'uniform(0, 10)',
-              'old_prior': 'uniform(-10, 10)'},
-             {'of_type': 'dimensiondeletion',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}},
-             {'of_type': 'dimensionaddition',
-              'param': {'name': '/w', 'type': 'categorical', 'value': None}}])
+    assert experiment.refers["adapter"].configuration == [
+        {
+            "of_type": "dimensionpriorchange",
+            "name": "/x",
+            "new_prior": "uniform(0, 10)",
+            "old_prior": "uniform(-10, 10)",
+        },
+        {
+            "of_type": "dimensiondeletion",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+        {
+            "of_type": "dimensionaddition",
+            "param": {"name": "/w", "type": "categorical", "value": None},
+        },
+    ]
 
 
 def test_auto_resolution_with_fidelity(init_full_x_full_y, monkeypatch):
     """Test that auto-resolution does resolve all conflicts including new fidelity"""
     # Patch cmdloop to avoid autoresolution's prompt
-    monkeypatch.setattr('sys.__stdin__.isatty', lambda: True)
+    monkeypatch.setattr("sys.__stdin__.isatty", lambda: True)
 
     name = "full_x_full_y"
     branch = "half_x_no_y_new_w"
     # If autoresolution was not succesfull, this to fail with a sys.exit without registering the
     # experiment
     orion.core.cli.main(
-        ("hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
-         "-x~uniform(0,10) "
-         "-w~fidelity(1,10)").format(name=name, branch=branch).split(" "))
+        (
+            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "-x~uniform(0,10) "
+            "-w~fidelity(1,10)"
+        )
+        .format(name=name, branch=branch)
+        .split(" ")
+    )
 
     experiment = experiment_builder.build_view(name=branch)
 
-    assert (experiment.refers['adapter'].configuration ==
-            [{'of_type': 'dimensionpriorchange',
-              'name': '/x',
-              'new_prior': 'uniform(0, 10)',
-              'old_prior': 'uniform(-10, 10)'},
-             {'of_type': 'dimensiondeletion',
-              'param': {'name': '/y', 'type': 'real', 'value': 1}},
-             {'of_type': 'dimensionaddition',
-              'param': {'name': '/w', 'type': 'fidelity', 'value': 10}}])
+    assert experiment.refers["adapter"].configuration == [
+        {
+            "of_type": "dimensionpriorchange",
+            "name": "/x",
+            "new_prior": "uniform(0, 10)",
+            "old_prior": "uniform(-10, 10)",
+        },
+        {
+            "of_type": "dimensiondeletion",
+            "param": {"name": "/y", "type": "real", "value": 1},
+        },
+        {
+            "of_type": "dimensionaddition",
+            "param": {"name": "/w", "type": "fidelity", "value": 10},
+        },
+    ]
 
 
 def test_init_w_version_from_parent_w_children(clean_db, monkeypatch, capsys):
     """Test that init of experiment from version with children fails."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    execute("hunt --init-only -n experiment --config orion_config.yaml "
-            "./black_box.py -x~normal(0,1)")
-    execute("hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)")
+    execute(
+        "hunt --init-only -n experiment --config orion_config.yaml "
+        "./black_box.py -x~normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+    )
 
     execute(
         "hunt --init-only -n experiment -v 1 "
         "./black_box.py -x~normal(0,1) -y~+normal(0,1) -z~normal(0,1)",
-        assert_code=1)
+        assert_code=1,
+    )
 
     captured = capsys.readouterr()
-    assert captured.out == ''
+    assert captured.out == ""
     assert "Configuration is different and generates a branching event" in captured.err
     assert "Experiment name" in captured.err
 
@@ -699,52 +970,76 @@ def test_init_w_version_from_parent_w_children(clean_db, monkeypatch, capsys):
 def test_init_w_version_from_exp_wout_child(clean_db, monkeypatch):
     """Test that init of experiment from version without child works."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    execute("hunt --init-only -n experiment --config orion_config.yaml "
-            "./black_box.py -x~normal(0,1)")
-    execute("hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)")
-    execute("hunt --init-only -n experiment -v 2 ./black_box.py "
-            "-x~normal(0,1) -y~+normal(0,1) -z~+normal(0,1)")
+    execute(
+        "hunt --init-only -n experiment --config orion_config.yaml "
+        "./black_box.py -x~normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment -v 2 ./black_box.py "
+        "-x~normal(0,1) -y~+normal(0,1) -z~+normal(0,1)"
+    )
 
-    exp = get_storage().fetch_experiments({'name': 'experiment', 'version': 3})
+    exp = get_storage().fetch_experiments({"name": "experiment", "version": 3})
     assert len(list(exp))
 
 
 def test_init_w_version_gt_max(clean_db, monkeypatch):
     """Test that init of experiment from version higher than max works."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    execute("hunt --init-only -n experiment --config orion_config.yaml "
-            "./black_box.py -x~normal(0,1)")
-    execute("hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)")
-    execute("hunt --init-only -n experiment -v 2000 ./black_box.py "
-            "-x~normal(0,1) -y~+normal(0,1) -z~+normal(0,1)")
+    execute(
+        "hunt --init-only -n experiment --config orion_config.yaml "
+        "./black_box.py -x~normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment -v 2000 ./black_box.py "
+        "-x~normal(0,1) -y~+normal(0,1) -z~+normal(0,1)"
+    )
 
-    exp = get_storage().fetch_experiments({'name': 'experiment', 'version': 3})
+    exp = get_storage().fetch_experiments({"name": "experiment", "version": 3})
     assert len(list(exp))
 
 
 def test_init_check_increment_w_children(clean_db, monkeypatch):
     """Test that incrementing version works with not same-named children."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    execute("hunt --init-only -n experiment --config orion_config.yaml "
-            "./black_box.py -x~normal(0,1)")
-    execute("hunt --init-only -n experiment --branch-to experiment_2 ./black_box.py "
-            "-x~normal(0,1) -y~+normal(0,1)")
-    execute("hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -z~+normal(0,1)")
+    execute(
+        "hunt --init-only -n experiment --config orion_config.yaml "
+        "./black_box.py -x~normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment --branch-to experiment_2 ./black_box.py "
+        "-x~normal(0,1) -y~+normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -z~+normal(0,1)"
+    )
 
-    exp = get_storage().fetch_experiments({'name': 'experiment', 'version': 2})
+    exp = get_storage().fetch_experiments({"name": "experiment", "version": 2})
     assert len(list(exp))
 
 
 def test_branch_from_selected_version(clean_db, monkeypatch):
     """Test that branching from a version passed with `--version` works."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    execute("hunt --init-only -n experiment --config orion_config.yaml "
-            "./black_box.py -x~normal(0,1)")
-    execute("hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)")
-    execute("hunt --init-only -n experiment --version 1 -b experiment_2 ./black_box.py "
-            "-x~normal(0,1) -z~+normal(0,1)")
+    execute(
+        "hunt --init-only -n experiment --config orion_config.yaml "
+        "./black_box.py -x~normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+    )
+    execute(
+        "hunt --init-only -n experiment --version 1 -b experiment_2 ./black_box.py "
+        "-x~normal(0,1) -z~+normal(0,1)"
+    )
 
     storage = get_storage()
-    parent = storage.fetch_experiments({'name': 'experiment', 'version': 1})[0]
-    exp = storage.fetch_experiments({'name': 'experiment_2'})[0]
-    assert exp['refers']['parent_id'] == parent['_id']
+    parent = storage.fetch_experiments({"name": "experiment", "version": 1})[0]
+    exp = storage.fetch_experiments({"name": "experiment_2"})[0]
+    assert exp["refers"]["parent_id"] == parent["_id"]

--- a/tests/functional/client/black_box.py
+++ b/tests/functional/client/black_box.py
@@ -3,7 +3,11 @@
 """Script that will always interrupt trials."""
 import argparse
 
-from orion.client import interrupt_trial, report_bad_trial, report_objective  # noqa: F401
+from orion.client import (
+    interrupt_trial,
+    report_bad_trial,
+    report_objective,
+)  # noqa: F401
 
 
 def no_report():
@@ -14,11 +18,11 @@ def no_report():
 def execute():
     """Execute a simple pipeline as an example."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('fct', type=str)
-    parser.add_argument('--name', type=str)
-    parser.add_argument('--objective', type=str)
-    parser.add_argument('--data', type=str)
-    parser.add_argument('-x', type=float)
+    parser.add_argument("fct", type=str)
+    parser.add_argument("--name", type=str)
+    parser.add_argument("--objective", type=str)
+    parser.add_argument("--data", type=str)
+    parser.add_argument("-x", type=float)
 
     inputs = parser.parse_args()
 
@@ -34,11 +38,11 @@ def execute():
         if value is not None:
             kwargs[key] = value
 
-    kwargs.pop('fct')
-    kwargs.pop('x')
+    kwargs.pop("fct")
+    kwargs.pop("x")
 
-    if 'data' in kwargs:
-        kwargs['data'] = [dict(name=kwargs['data'], type='constraint', value=1.0)]
+    if "data" in kwargs:
+        kwargs["data"] = [dict(name=kwargs["data"], type="constraint", value=1.0)]
 
     globals()[inputs.fct](**kwargs)
 

--- a/tests/functional/client/test_cli_client.py
+++ b/tests/functional/client/test_cli_client.py
@@ -15,25 +15,34 @@ def test_interrupt(database, monkeypatch, capsys):
     """Test interruption from within user script."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    error_code = orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", "interrupt_trial"] + user_args)
+    error_code = orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            "interrupt_trial",
+        ]
+        + user_args
+    )
 
     assert error_code == 130
 
     captured = capsys.readouterr()
-    assert captured.out == 'Orion is interrupted.\n'
-    assert captured.err == ''
+    assert captured.out == "Orion is interrupted.\n"
+    assert captured.err == ""
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 1
-    assert trials[0]['status'] == 'interrupted'
+    assert trials[0]["status"] == "interrupted"
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -42,8 +51,7 @@ def test_interrupt_diff_code(database, monkeypatch, capsys):
     """Test interruption from within user script with custom int code"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
     # Set local to 200
     orion.core.config.worker.interrupt_signal_code = 200
@@ -53,39 +61,59 @@ def test_interrupt_diff_code(database, monkeypatch, capsys):
         return os.environ
 
     with monkeypatch.context() as m:
-        m.setattr(Consumer, 'get_execution_environment', empty_env)
+        m.setattr(Consumer, "get_execution_environment", empty_env)
 
         # Interrupt won't be interpreted properly and trials will be marked as broken
-        error_code = orion.core.cli.main([
-            "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-            "python", "black_box.py", "interrupt_trial"] + user_args)
+        error_code = orion.core.cli.main(
+            [
+                "hunt",
+                "--config",
+                "./orion_config.yaml",
+                "--worker-trials",
+                "2",
+                "python",
+                "black_box.py",
+                "interrupt_trial",
+            ]
+            + user_args
+        )
 
         assert error_code == 0
 
-        exp = list(database.experiments.find({'name': 'voila_voici'}))
+        exp = list(database.experiments.find({"name": "voila_voici"}))
         exp = exp[0]
-        exp_id = exp['_id']
-        trials = list(database.trials.find({'experiment': exp_id}))
+        exp_id = exp["_id"]
+        trials = list(database.trials.find({"experiment": exp_id}))
         assert len(trials) == 2
-        assert trials[0]['status'] == 'broken'
+        assert trials[0]["status"] == "broken"
 
     # This time we use true `get_execution_environment which pass properly int code to child.
-    error_code = orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", "interrupt_trial"] + user_args)
+    error_code = orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            "interrupt_trial",
+        ]
+        + user_args
+    )
 
     assert error_code == 130
 
     captured = capsys.readouterr()
-    assert 'Orion is interrupted.\n' in captured.out
-    assert captured.err == ''
+    assert "Orion is interrupted.\n" in captured.out
+    assert captured.err == ""
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 3
-    assert trials[-1]['status'] == 'interrupted'
+    assert trials[-1]["status"] == "interrupted"
 
 
 # TODO:
@@ -95,72 +123,107 @@ def test_interrupt_diff_code(database, monkeypatch, capsys):
 # Add all this in DOC.
 
 
-@pytest.mark.parametrize('fct', ['report_bad_trial', 'report_objective'])
+@pytest.mark.parametrize("fct", ["report_bad_trial", "report_objective"])
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.usefixtures("null_db_instances")
 def test_report_no_name(database, monkeypatch, fct):
     """Test report helper functions with default names"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", fct, "--objective", "1.0"] + user_args)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            fct,
+            "--objective",
+            "1.0",
+        ]
+        + user_args
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 2
-    assert trials[0]['status'] == 'completed'
-    assert trials[0]['results'][0]['name'] == 'objective'
-    assert trials[0]['results'][0]['type'] == 'objective'
-    assert trials[0]['results'][0]['value'] == 1.0
+    assert trials[0]["status"] == "completed"
+    assert trials[0]["results"][0]["name"] == "objective"
+    assert trials[0]["results"][0]["type"] == "objective"
+    assert trials[0]["results"][0]["value"] == 1.0
 
 
-@pytest.mark.parametrize('fct', ['report_bad_trial', 'report_objective'])
+@pytest.mark.parametrize("fct", ["report_bad_trial", "report_objective"])
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.usefixtures("null_db_instances")
 def test_report_with_name(database, monkeypatch, fct):
     """Test report helper functions with custom names"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", fct, "--objective", "1.0", "--name", "metric"] + user_args)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            fct,
+            "--objective",
+            "1.0",
+            "--name",
+            "metric",
+        ]
+        + user_args
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 2
-    assert trials[0]['status'] == 'completed'
-    assert trials[0]['results'][0]['name'] == 'metric'
-    assert trials[0]['results'][0]['type'] == 'objective'
-    assert trials[0]['results'][0]['value'] == 1.0
+    assert trials[0]["status"] == "completed"
+    assert trials[0]["results"][0]["name"] == "metric"
+    assert trials[0]["results"][0]["type"] == "objective"
+    assert trials[0]["results"][0]["value"] == 1.0
 
 
-@pytest.mark.parametrize('fct', ['report_bad_trial', 'report_objective'])
+@pytest.mark.parametrize("fct", ["report_bad_trial", "report_objective"])
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.usefixtures("null_db_instances")
 def test_report_with_bad_objective(database, monkeypatch, fct):
     """Test report helper functions with bad objective types"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
     with pytest.raises(ValueError) as exc:
-        orion.core.cli.main([
-            "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-            "python", "black_box.py", fct, "--objective", "oh oh"] + user_args)
+        orion.core.cli.main(
+            [
+                "hunt",
+                "--config",
+                "./orion_config.yaml",
+                "--worker-trials",
+                "2",
+                "python",
+                "black_box.py",
+                fct,
+                "--objective",
+                "oh oh",
+            ]
+            + user_args
+        )
 
-    assert 'must contain a type `objective` with type float/int' in str(exc.value)
+    assert "must contain a type `objective` with type float/int" in str(exc.value)
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -169,22 +232,31 @@ def test_report_with_bad_trial_no_objective(database, monkeypatch):
     """Test bad trial report helper function with default objective."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", "report_bad_trial"] + user_args)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            "report_bad_trial",
+        ]
+        + user_args
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 2
-    assert trials[0]['status'] == 'completed'
-    assert trials[0]['results'][0]['name'] == 'objective'
-    assert trials[0]['results'][0]['type'] == 'objective'
-    assert trials[0]['results'][0]['value'] == 1e10
+    assert trials[0]["status"] == "completed"
+    assert trials[0]["results"][0]["name"] == "objective"
+    assert trials[0]["results"][0]["type"] == "objective"
+    assert trials[0]["results"][0]["value"] == 1e10
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -193,26 +265,37 @@ def test_report_with_bad_trial_with_data(database, monkeypatch):
     """Test bad trial report helper function with additional data."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", "report_bad_trial", "--data", "another"] + user_args)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            "report_bad_trial",
+            "--data",
+            "another",
+        ]
+        + user_args
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 2
-    assert trials[0]['status'] == 'completed'
-    assert trials[0]['results'][0]['name'] == 'objective'
-    assert trials[0]['results'][0]['type'] == 'objective'
-    assert trials[0]['results'][0]['value'] == 1e10
+    assert trials[0]["status"] == "completed"
+    assert trials[0]["results"][0]["name"] == "objective"
+    assert trials[0]["results"][0]["type"] == "objective"
+    assert trials[0]["results"][0]["value"] == 1e10
 
-    assert trials[0]['results'][1]['name'] == 'another'
-    assert trials[0]['results'][1]['type'] == 'constraint'
-    assert trials[0]['results'][1]['value'] == 1.0
+    assert trials[0]["results"][1]["name"] == "another"
+    assert trials[0]["results"][1]["type"] == "constraint"
+    assert trials[0]["results"][1]["value"] == 1.0
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -221,15 +304,24 @@ def test_no_report(database, monkeypatch, capsys):
     """Test script call without any results reported."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    errorcode = orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--worker-trials", "2",
-        "python", "black_box.py", 'no_report'] + user_args)
+    errorcode = orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--worker-trials",
+            "2",
+            "python",
+            "black_box.py",
+            "no_report",
+        ]
+        + user_args
+    )
 
     assert errorcode == 1
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert 'Cannot parse result file' in captured.err
+    assert "Cannot parse result file" in captured.err

--- a/tests/functional/commands/black_box.py
+++ b/tests/functional/commands/black_box.py
@@ -9,14 +9,14 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     z = x - 34.56789
-    return 4 * z**2 + 23.4, 8 * z
+    return 4 * z ** 2 + 23.4, 8 * z
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument("-x", type=float, required=True)
     inputs = parser.parse_args()
 
     # 2. Perform computations
@@ -24,14 +24,8 @@ def execute():
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -8,7 +8,7 @@ from pymongo import MongoClient
 import pytest
 import yaml
 
-from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
+from orion.algo.base import BaseAlgorithm, OptimizationAlgorithm
 import orion.core.cli
 from orion.core.io.database import Database
 import orion.core.io.experiment_builder as experiment_builder
@@ -20,9 +20,16 @@ from orion.storage.base import get_storage
 class DumbAlgo(BaseAlgorithm):
     """Stab class for `BaseAlgorithm`."""
 
-    def __init__(self, space, value=5,
-                 scoring=0, judgement=None,
-                 suspend=False, done=False, **nested_algo):
+    def __init__(
+        self,
+        space,
+        value=5,
+        scoring=0,
+        judgement=None,
+        suspend=False,
+        done=False,
+        **nested_algo
+    ):
         """Configure returns, allow for variable variables."""
         self._times_called_suspend = 0
         self._times_called_is_done = 0
@@ -32,11 +39,15 @@ class DumbAlgo(BaseAlgorithm):
         self._score_point = None
         self._judge_point = None
         self._measurements = None
-        super(DumbAlgo, self).__init__(space, value=value,
-                                       scoring=scoring, judgement=judgement,
-                                       suspend=suspend,
-                                       done=done,
-                                       **nested_algo)
+        super(DumbAlgo, self).__init__(
+            space,
+            value=value,
+            scoring=scoring,
+            judgement=judgement,
+            suspend=suspend,
+            done=done,
+            **nested_algo
+        )
 
     def suggest(self, num=1):
         """Suggest based on `value`."""
@@ -77,7 +88,7 @@ OptimizationAlgorithm.types.append(DumbAlgo)
 OptimizationAlgorithm.typenames.append(DumbAlgo.__name__.lower())
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def dumbalgo():
     """Return stab algorithm class."""
     return DumbAlgo
@@ -86,8 +97,9 @@ def dumbalgo():
 @pytest.fixture()
 def exp_config():
     """Load an example database."""
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-              'experiment.yaml')) as f:
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "experiment.yaml")
+    ) as f:
         exp_config = list(yaml.safe_load_all(f))
 
     for config in exp_config[0]:
@@ -96,10 +108,10 @@ def exp_config():
     return exp_config
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def database():
     """Return Mongo database object to test with example entries."""
-    client = MongoClient(username='user', password='pass', authSource='orion_test')
+    client = MongoClient(username="user", password="pass", authSource="orion_test")
     database = client.orion_test
     yield database
     client.close()
@@ -119,8 +131,9 @@ def clean_db(database, db_instance):
 def db_instance(null_db_instances):
     """Create and save a singleton database instance."""
     try:
-        db = Database(of_type='MongoDB', name='orion_test',
-                      username='user', password='pass')
+        db = Database(
+            of_type="MongoDB", name="orion_test", username="user", password="pass"
+        )
     except ValueError:
         db = Database()
 
@@ -135,18 +148,18 @@ def only_experiments_db(clean_db, database, exp_config):
 
 def ensure_deterministic_id(name, db_instance, version=1, update=None):
     """Change the id of experiment to its name."""
-    experiment = db_instance.read('experiments', {'name': name, 'version': version})[0]
-    db_instance.remove('experiments', {'_id': experiment['_id']})
+    experiment = db_instance.read("experiments", {"name": name, "version": version})[0]
+    db_instance.remove("experiments", {"_id": experiment["_id"]})
     _id = name + "_" + str(version)
-    experiment['_id'] = _id
+    experiment["_id"] = _id
 
-    if experiment['refers']['parent_id'] is None:
-        experiment['refers']['root_id'] = _id
+    if experiment["refers"]["parent_id"] is None:
+        experiment["refers"]["root_id"] = _id
 
     if update is not None:
         experiment.update(update)
 
-    db_instance.write('experiments', experiment)
+    db_instance.write("experiments", experiment)
 
 
 # Experiments combinations fixtures
@@ -154,21 +167,26 @@ def ensure_deterministic_id(name, db_instance, version=1, update=None):
 def one_experiment(monkeypatch, db_instance):
     """Create an experiment without trials."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    name = 'test_single_exp'
-    orion.core.cli.main(['hunt', '--init-only', '-n', name,
-                         './black_box.py', '--x~uniform(0,1)'])
+    name = "test_single_exp"
+    orion.core.cli.main(
+        ["hunt", "--init-only", "-n", name, "./black_box.py", "--x~uniform(0,1)"]
+    )
     ensure_deterministic_id(name, db_instance)
-    return get_storage().fetch_experiments({'name': name})[0]
+    return get_storage().fetch_experiments({"name": name})[0]
 
 
 @pytest.fixture
 def one_experiment_changed_vcs(one_experiment):
     """Create an experiment without trials."""
-    experiment = experiment_builder.build(name=one_experiment['name'])
+    experiment = experiment_builder.build(name=one_experiment["name"])
 
-    experiment.metadata['VCS'] = {
-        'type': 'git', 'is_dirty': False, 'HEAD_sha': 'new', 'active_branch': 'master',
-        'diff_sha': None}
+    experiment.metadata["VCS"] = {
+        "type": "git",
+        "is_dirty": False,
+        "HEAD_sha": "new",
+        "active_branch": "master",
+        "diff_sha": None,
+    }
 
     get_storage().update_experiment(experiment, metadata=experiment.metadata)
 
@@ -176,16 +194,16 @@ def one_experiment_changed_vcs(one_experiment):
 @pytest.fixture
 def one_experiment_no_version(monkeypatch, one_experiment):
     """Create an experiment without trials."""
-    one_experiment['name'] = one_experiment['name'] + '-no-version'
-    one_experiment.pop('version')
+    one_experiment["name"] = one_experiment["name"] + "-no-version"
+    one_experiment.pop("version")
 
     def fetch_without_version(query, selection=None):
-        if query.get('name') == one_experiment['name'] or query == {}:
+        if query.get("name") == one_experiment["name"] or query == {}:
             return [copy.deepcopy(one_experiment)]
 
         return []
 
-    monkeypatch.setattr(get_storage(), 'fetch_experiments', fetch_without_version)
+    monkeypatch.setattr(get_storage(), "fetch_experiments", fetch_without_version)
 
     return one_experiment
 
@@ -193,7 +211,9 @@ def one_experiment_no_version(monkeypatch, one_experiment):
 @pytest.fixture
 def with_experiment_using_python_api(monkeypatch, one_experiment):
     """Create an experiment without trials."""
-    experiment = experiment_builder.build(name='from-python-api', space={'x': 'uniform(0, 10)'})
+    experiment = experiment_builder.build(
+        name="from-python-api", space={"x": "uniform(0, 10)"}
+    )
 
     return experiment
 
@@ -201,11 +221,11 @@ def with_experiment_using_python_api(monkeypatch, one_experiment):
 @pytest.fixture
 def with_experiment_missing_conf_file(monkeypatch, one_experiment):
     """Create an experiment without trials."""
-    exp = experiment_builder.build(name='test_single_exp', version=1)
-    conf_file = 'idontexist.yaml'
-    exp.metadata['user_config'] = conf_file
-    exp.metadata['user_args'] += ['--config', conf_file]
-    Database().write('experiments', exp.configuration, query={'_id': exp.id})
+    exp = experiment_builder.build(name="test_single_exp", version=1)
+    conf_file = "idontexist.yaml"
+    exp.metadata["user_config"] = conf_file
+    exp.metadata["user_args"] += ["--config", conf_file]
+    Database().write("experiments", exp.configuration, query={"_id": exp.id})
 
     return exp
 
@@ -213,78 +233,98 @@ def with_experiment_missing_conf_file(monkeypatch, one_experiment):
 @pytest.fixture
 def broken_refers(one_experiment, db_instance):
     """Create an experiment with broken refers."""
-    ensure_deterministic_id('test_single_exp', db_instance, update=dict(refers={'oups': 'broken'}))
+    ensure_deterministic_id(
+        "test_single_exp", db_instance, update=dict(refers={"oups": "broken"})
+    )
 
 
 @pytest.fixture
 def single_without_success(one_experiment):
     """Create an experiment without a succesful trial."""
     statuses = list(Trial.allowed_stati)
-    statuses.remove('completed')
+    statuses.remove("completed")
 
-    exp = experiment_builder.build(name='test_single_exp')
-    x = {'name': '/x', 'type': 'real'}
+    exp = experiment_builder.build(name="test_single_exp")
+    x = {"name": "/x", "type": "real"}
 
     x_value = 0
     for status in statuses:
-        x['value'] = x_value
+        x["value"] = x_value
         trial = Trial(experiment=exp.id, params=[x], status=status)
         x_value += 1
-        Database().write('trials', trial.to_dict())
+        Database().write("trials", trial.to_dict())
 
 
 @pytest.fixture
 def single_with_trials(single_without_success):
     """Create an experiment with all types of trials."""
-    exp = experiment_builder.build(name='test_single_exp')
+    exp = experiment_builder.build(name="test_single_exp")
 
-    x = {'name': '/x', 'type': 'real', 'value': 100}
+    x = {"name": "/x", "type": "real", "value": 100}
     results = {"name": "obj", "type": "objective", "value": 0}
-    trial = Trial(experiment=exp.id, params=[x], status='completed', results=[results])
-    Database().write('trials', trial.to_dict())
+    trial = Trial(experiment=exp.id, params=[x], status="completed", results=[results])
+    Database().write("trials", trial.to_dict())
 
 
 @pytest.fixture
 def two_experiments(monkeypatch, db_instance):
     """Create an experiment and its child."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_double_exp',
-                         './black_box.py', '--x~uniform(0,1)'])
-    ensure_deterministic_id('test_double_exp', db_instance)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_double_exp",
+            "./black_box.py",
+            "--x~uniform(0,1)",
+        ]
+    )
+    ensure_deterministic_id("test_double_exp", db_instance)
 
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_double_exp',
-                         '--branch-to', 'test_double_exp_child', './black_box.py',
-                         '--x~+uniform(0,1,default_value=0)', '--y~+uniform(0,1,default_value=0)'])
-    ensure_deterministic_id('test_double_exp_child', db_instance)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_double_exp",
+            "--branch-to",
+            "test_double_exp_child",
+            "./black_box.py",
+            "--x~+uniform(0,1,default_value=0)",
+            "--y~+uniform(0,1,default_value=0)",
+        ]
+    )
+    ensure_deterministic_id("test_double_exp_child", db_instance)
 
 
 @pytest.fixture
 def family_with_trials(two_experiments):
     """Create two related experiments with all types of trials."""
-    exp = experiment_builder.build(name='test_double_exp')
-    exp2 = experiment_builder.build(name='test_double_exp_child')
-    x = {'name': '/x', 'type': 'real'}
-    y = {'name': '/y', 'type': 'real'}
+    exp = experiment_builder.build(name="test_double_exp")
+    exp2 = experiment_builder.build(name="test_double_exp_child")
+    x = {"name": "/x", "type": "real"}
+    y = {"name": "/y", "type": "real"}
 
     x_value = 0
     for status in Trial.allowed_stati:
-        x['value'] = x_value
-        y['value'] = x_value
+        x["value"] = x_value
+        y["value"] = x_value
         trial = Trial(experiment=exp.id, params=[x], status=status)
-        x['value'] = x_value
+        x["value"] = x_value
         trial2 = Trial(experiment=exp2.id, params=[x, y], status=status)
         x_value += 1
-        Database().write('trials', trial.to_dict())
-        Database().write('trials', trial2.to_dict())
+        Database().write("trials", trial.to_dict())
+        Database().write("trials", trial2.to_dict())
 
 
 @pytest.fixture
 def unrelated_with_trials(family_with_trials, single_with_trials):
     """Create two unrelated experiments with all types of trials."""
-    exp = experiment_builder.build(name='test_double_exp_child')
+    exp = experiment_builder.build(name="test_double_exp_child")
 
-    Database().remove('trials', {'experiment': exp.id})
-    Database().remove('experiments', {'_id': exp.id})
+    Database().remove("trials", {"experiment": exp.id})
+    Database().remove("experiments", {"_id": exp.id})
 
 
 @pytest.fixture
@@ -302,65 +342,96 @@ def three_experiments_with_trials(family_with_trials, single_with_trials):
 @pytest.fixture
 def three_experiments_family(two_experiments, db_instance):
     """Create three experiments, one of which is the parent of the other two."""
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_double_exp',
-                         '--branch-to', 'test_double_exp_child2', './black_box.py',
-                         '--x~+uniform(0,1,default_value=0)', '--z~+uniform(0,1,default_value=0)'])
-    ensure_deterministic_id('test_double_exp_child2', db_instance)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_double_exp",
+            "--branch-to",
+            "test_double_exp_child2",
+            "./black_box.py",
+            "--x~+uniform(0,1,default_value=0)",
+            "--z~+uniform(0,1,default_value=0)",
+        ]
+    )
+    ensure_deterministic_id("test_double_exp_child2", db_instance)
 
 
 @pytest.fixture
 def three_family_with_trials(three_experiments_family, family_with_trials):
     """Create three experiments, all related, two direct children, with all types of trials."""
-    exp = experiment_builder.build(name='test_double_exp_child2')
-    x = {'name': '/x', 'type': 'real'}
-    z = {'name': '/z', 'type': 'real'}
+    exp = experiment_builder.build(name="test_double_exp_child2")
+    x = {"name": "/x", "type": "real"}
+    z = {"name": "/z", "type": "real"}
 
     x_value = 0
     for status in Trial.allowed_stati:
-        x['value'] = x_value
-        z['value'] = x_value * 100
+        x["value"] = x_value
+        z["value"] = x_value * 100
         trial = Trial(experiment=exp.id, params=[x, z], status=status)
         x_value += 1
-        Database().write('trials', trial.to_dict())
+        Database().write("trials", trial.to_dict())
 
 
 @pytest.fixture
 def three_experiments_family_branch(two_experiments, db_instance):
     """Create three experiments, each parent of the following one."""
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_double_exp_child',
-                         '--branch-to', 'test_double_exp_grand_child', './black_box.py',
-                         '--x~+uniform(0,1,default_value=0)', '--y~uniform(0,1,default_value=0)',
-                         '--z~+uniform(0,1,default_value=0)'])
-    ensure_deterministic_id('test_double_exp_grand_child', db_instance)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_double_exp_child",
+            "--branch-to",
+            "test_double_exp_grand_child",
+            "./black_box.py",
+            "--x~+uniform(0,1,default_value=0)",
+            "--y~uniform(0,1,default_value=0)",
+            "--z~+uniform(0,1,default_value=0)",
+        ]
+    )
+    ensure_deterministic_id("test_double_exp_grand_child", db_instance)
 
 
 @pytest.fixture
-def three_family_branch_with_trials(three_experiments_family_branch, family_with_trials):
+def three_family_branch_with_trials(
+    three_experiments_family_branch, family_with_trials
+):
     """Create three experiments, all related, one child and one grandchild,
     with all types of trials.
 
     """
-    exp = experiment_builder.build(name='test_double_exp_grand_child')
-    x = {'name': '/x', 'type': 'real'}
-    y = {'name': '/y', 'type': 'real'}
-    z = {'name': '/z', 'type': 'real'}
+    exp = experiment_builder.build(name="test_double_exp_grand_child")
+    x = {"name": "/x", "type": "real"}
+    y = {"name": "/y", "type": "real"}
+    z = {"name": "/z", "type": "real"}
 
     x_value = 0
     for status in Trial.allowed_stati:
-        x['value'] = x_value
-        y['value'] = x_value * 10
-        z['value'] = x_value * 100
+        x["value"] = x_value
+        y["value"] = x_value * 10
+        z["value"] = x_value * 100
         trial = Trial(experiment=exp.id, params=[x, y, z], status=status)
         x_value += 1
-        Database().write('trials', trial.to_dict())
+        Database().write("trials", trial.to_dict())
 
 
 @pytest.fixture
 def two_experiments_same_name(one_experiment, db_instance):
     """Create two experiments with the same name but different versions."""
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_single_exp',
-                         './black_box.py', '--x~uniform(0,1)', '--y~+normal(0,1)'])
-    ensure_deterministic_id('test_single_exp', db_instance, version=2)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_single_exp",
+            "./black_box.py",
+            "--x~uniform(0,1)",
+            "--y~+normal(0,1)",
+        ]
+    )
+    ensure_deterministic_id("test_single_exp", db_instance, version=2)
 
 
 @pytest.fixture
@@ -368,10 +439,22 @@ def three_experiments_family_same_name(two_experiments_same_name, db_instance):
     """Create three experiments, two of them with the same name but different versions and one
     with a child.
     """
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_single_exp', '-v', '1', '-b',
-                         'test_single_exp_child', './black_box.py', '--x~uniform(0,1)',
-                         '--y~+normal(0,1)'])
-    ensure_deterministic_id('test_single_exp_child', db_instance)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_single_exp",
+            "-v",
+            "1",
+            "-b",
+            "test_single_exp_child",
+            "./black_box.py",
+            "--x~uniform(0,1)",
+            "--y~+normal(0,1)",
+        ]
+    )
+    ensure_deterministic_id("test_single_exp_child", db_instance)
 
 
 @pytest.fixture
@@ -379,45 +462,74 @@ def three_experiments_branch_same_name(two_experiments_same_name, db_instance):
     """Create three experiments, two of them with the same name but different versions and last one
     with a child.
     """
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_single_exp', '-b',
-                         'test_single_exp_child', './black_box.py', '--x~uniform(0,1)',
-                         '--y~normal(0,1)', '--z~+normal(0,1)'])
-    ensure_deterministic_id('test_single_exp_child', db_instance)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_single_exp",
+            "-b",
+            "test_single_exp_child",
+            "./black_box.py",
+            "--x~uniform(0,1)",
+            "--y~normal(0,1)",
+            "--z~+normal(0,1)",
+        ]
+    )
+    ensure_deterministic_id("test_single_exp_child", db_instance)
 
 
 @pytest.fixture
 def three_experiments_same_name(two_experiments_same_name, db_instance):
     """Create three experiments with the same name but different versions."""
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_single_exp',
-                         './black_box.py', '--x~uniform(0,1)', '--y~normal(0,1)',
-                         '--z~+normal(0,1)'])
-    ensure_deterministic_id('test_single_exp', db_instance, version=3)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_single_exp",
+            "./black_box.py",
+            "--x~uniform(0,1)",
+            "--y~normal(0,1)",
+            "--z~+normal(0,1)",
+        ]
+    )
+    ensure_deterministic_id("test_single_exp", db_instance, version=3)
 
 
 @pytest.fixture
 def three_experiments_same_name_with_trials(two_experiments_same_name, db_instance):
     """Create three experiments with the same name but different versions."""
-    orion.core.cli.main(['hunt', '--init-only', '-n', 'test_single_exp',
-                         './black_box.py', '--x~uniform(0,1)', '--y~normal(0,1)',
-                         '--z~+normal(0,1)'])
-    ensure_deterministic_id('test_single_exp', db_instance, version=3)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "test_single_exp",
+            "./black_box.py",
+            "--x~uniform(0,1)",
+            "--y~normal(0,1)",
+            "--z~+normal(0,1)",
+        ]
+    )
+    ensure_deterministic_id("test_single_exp", db_instance, version=3)
 
-    exp = experiment_builder.build(name='test_single_exp', version=1)
-    exp2 = experiment_builder.build(name='test_single_exp', version=2)
-    exp3 = experiment_builder.build(name='test_single_exp', version=3)
+    exp = experiment_builder.build(name="test_single_exp", version=1)
+    exp2 = experiment_builder.build(name="test_single_exp", version=2)
+    exp3 = experiment_builder.build(name="test_single_exp", version=3)
 
-    x = {'name': '/x', 'type': 'real'}
-    y = {'name': '/y', 'type': 'real'}
-    z = {'name': '/z', 'type': 'real'}
+    x = {"name": "/x", "type": "real"}
+    y = {"name": "/y", "type": "real"}
+    z = {"name": "/z", "type": "real"}
     x_value = 0
     for status in Trial.allowed_stati:
-        x['value'] = x_value
-        y['value'] = x_value * 10
-        z['value'] = x_value * 100
+        x["value"] = x_value
+        y["value"] = x_value * 10
+        z["value"] = x_value * 100
         trial = Trial(experiment=exp.id, params=[x], status=status)
         trial2 = Trial(experiment=exp2.id, params=[x, y], status=status)
         trial3 = Trial(experiment=exp3.id, params=[x, y, z], status=status)
-        Database().write('trials', trial.to_dict())
-        Database().write('trials', trial2.to_dict())
-        Database().write('trials', trial3.to_dict())
+        Database().write("trials", trial.to_dict())
+        Database().write("trials", trial2.to_dict())
+        Database().write("trials", trial3.to_dict())
         x_value += 1

--- a/tests/functional/commands/test_db_commands.py
+++ b/tests/functional/commands/test_db_commands.py
@@ -9,9 +9,9 @@ import orion.core.cli
 def test_no_args(capsys):
     """Test that help is printed when no args are given."""
     with pytest.raises(SystemExit):
-        orion.core.cli.main(['db'])
+        orion.core.cli.main(["db"])
 
     captured = capsys.readouterr().out
 
-    assert 'usage:' in captured
-    assert 'Traceback' not in captured
+    assert "usage:" in captured
+    assert "Traceback" not in captured

--- a/tests/functional/commands/test_db_rm.py
+++ b/tests/functional/commands/test_db_rm.py
@@ -9,36 +9,39 @@ from orion.storage.base import get_storage
 
 def execute(command, assert_code=0):
     """Execute orion command and return returncode"""
-    returncode = orion.core.cli.main(command.split(' '))
+    returncode = orion.core.cli.main(command.split(" "))
     assert returncode == assert_code
 
 
 def test_no_exp(clean_db, capsys):
     """Test that rm non-existing exp exits gracefully"""
-    execute('db rm i-dont-exist', assert_code=1)
+    execute("db rm i-dont-exist", assert_code=1)
 
     captured = capsys.readouterr()
 
-    assert captured.err.startswith("Error: No experiment with given name 'i-dont-exist'")
+    assert captured.err.startswith(
+        "Error: No experiment with given name 'i-dont-exist'"
+    )
 
 
 def test_confirm_name(monkeypatch, clean_db, single_with_trials):
     """Test name must be confirmed for deletion"""
-    def incorrect_name(*args):
-        return 'oops'
 
-    monkeypatch.setattr('builtins.input', incorrect_name)
+    def incorrect_name(*args):
+        return "oops"
+
+    monkeypatch.setattr("builtins.input", incorrect_name)
 
     with pytest.raises(SystemExit):
-        execute('db rm test_single_exp')
+        execute("db rm test_single_exp")
 
     def correct_name(*args):
-        return 'test_single_exp'
+        return "test_single_exp"
 
-    monkeypatch.setattr('builtins.input', correct_name)
+    monkeypatch.setattr("builtins.input", correct_name)
 
     assert len(get_storage().fetch_experiments({})) == 1
-    execute('db rm test_single_exp')
+    execute("db rm test_single_exp")
     assert len(get_storage().fetch_experiments({})) == 0
 
 
@@ -46,7 +49,7 @@ def test_one_exp(clean_db, single_with_trials):
     """Test that one exp is deleted properly"""
     assert len(get_storage().fetch_experiments({})) == 1
     assert len(get_storage()._fetch_trials({})) > 0
-    execute('db rm -f test_single_exp')
+    execute("db rm -f test_single_exp")
     assert len(get_storage().fetch_experiments({})) == 0
     assert len(get_storage()._fetch_trials({})) == 0
 
@@ -55,7 +58,7 @@ def test_rm_all_evc(clean_db, three_family_branch_with_trials):
     """Test that deleting root removes all experiments"""
     assert len(get_storage().fetch_experiments({})) == 3
     assert len(get_storage()._fetch_trials({})) > 0
-    execute('db rm -f test_double_exp --version 1')
+    execute("db rm -f test_double_exp --version 1")
     assert len(get_storage().fetch_experiments({})) == 0
     assert len(get_storage()._fetch_trials({})) == 0
 
@@ -64,7 +67,7 @@ def test_rm_under_evc(clean_db, three_family_branch_with_trials):
     """Test that deleting an experiment removes all children"""
     assert len(get_storage().fetch_experiments({})) == 3
     assert len(get_storage()._fetch_trials({})) > 0
-    execute('db rm -f test_double_exp_child --version 1')
+    execute("db rm -f test_double_exp_child --version 1")
     assert len(get_storage().fetch_experiments({})) == 1
     assert len(get_storage()._fetch_trials({})) > 0
     # TODO: Test that the correct trials were deleted
@@ -73,36 +76,50 @@ def test_rm_under_evc(clean_db, three_family_branch_with_trials):
 def test_rm_default_leaf(clean_db, three_experiments_same_name):
     """Test that deleting an experiment removes the leaf by default"""
     assert len(get_storage().fetch_experiments({})) == 3
-    execute('db rm -f test_single_exp')
+    execute("db rm -f test_single_exp")
     assert len(get_storage().fetch_experiments({})) == 2
 
 
 def test_rm_trials_by_status(clean_db, single_with_trials):
     """Test that trials can be deleted by status"""
     trials = get_storage()._fetch_trials({})
-    n_broken = sum(trial.status == 'broken' for trial in trials)
+    n_broken = sum(trial.status == "broken" for trial in trials)
     assert n_broken > 0
-    execute('db rm -f test_single_exp --status broken')
+    execute("db rm -f test_single_exp --status broken")
     assert len(get_storage()._fetch_trials({})) == len(trials) - n_broken
 
 
 def test_rm_trials_all(clean_db, single_with_trials):
     """Test that trials all be deleted with '*'"""
     assert len(get_storage()._fetch_trials({})) > 0
-    execute('db rm -f test_single_exp --status *')
+    execute("db rm -f test_single_exp --status *")
     assert len(get_storage()._fetch_trials({})) == 0
 
 
 def test_rm_trials_in_evc(clean_db, three_family_branch_with_trials):
     """Test that trials of parent experiment are not deleted"""
     assert len(get_storage().fetch_experiments({})) == 3
-    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_1'})) > 0
-    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_child_1'})) > 0
-    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_grand_child_1'})) > 0
-    execute('db rm -f test_double_exp_child --status *')
+    assert len(get_storage()._fetch_trials({"experiment": "test_double_exp_1"})) > 0
+    assert (
+        len(get_storage()._fetch_trials({"experiment": "test_double_exp_child_1"})) > 0
+    )
+    assert (
+        len(
+            get_storage()._fetch_trials({"experiment": "test_double_exp_grand_child_1"})
+        )
+        > 0
+    )
+    execute("db rm -f test_double_exp_child --status *")
     # Make sure no experiments were deleted
     assert len(get_storage().fetch_experiments({})) == 3
     # Make sure only trials of given experiment were deleted
-    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_1'})) > 0
-    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_child_1'})) == 0
-    assert len(get_storage()._fetch_trials({'experiment': 'test_double_exp_grand_child_1'})) == 0
+    assert len(get_storage()._fetch_trials({"experiment": "test_double_exp_1"})) > 0
+    assert (
+        len(get_storage()._fetch_trials({"experiment": "test_double_exp_child_1"})) == 0
+    )
+    assert (
+        len(
+            get_storage()._fetch_trials({"experiment": "test_double_exp_grand_child_1"})
+        )
+        == 0
+    )

--- a/tests/functional/commands/test_db_set.py
+++ b/tests/functional/commands/test_db_set.py
@@ -8,41 +8,44 @@ from orion.storage.base import get_storage
 
 def execute(command, assert_code=0):
     """Execute orion command and return returncode"""
-    returncode = orion.core.cli.main(command.split(' '))
+    returncode = orion.core.cli.main(command.split(" "))
     assert returncode == assert_code
 
 
 def test_no_exp(clean_db, capsys):
     """Test that set non-existing exp exits gracefully"""
-    execute('db set i-dont-exist whatever=1 idontcare=2', assert_code=1)
+    execute("db set i-dont-exist whatever=1 idontcare=2", assert_code=1)
 
     captured = capsys.readouterr()
 
-    assert captured.err.startswith("Error: No experiment with given name 'i-dont-exist'")
+    assert captured.err.startswith(
+        "Error: No experiment with given name 'i-dont-exist'"
+    )
 
 
 def test_confirm_name(monkeypatch, clean_db, single_with_trials):
     """Test name must be confirmed for update"""
+
     def incorrect_name(*args):
-        return 'oops'
+        return "oops"
 
-    monkeypatch.setattr('builtins.input', incorrect_name)
+    monkeypatch.setattr("builtins.input", incorrect_name)
 
-    execute('db set test_single_exp status=broken status=interrupted', assert_code=1)
+    execute("db set test_single_exp status=broken status=interrupted", assert_code=1)
 
     def correct_name(*args):
-        return 'test_single_exp'
+        return "test_single_exp"
 
-    monkeypatch.setattr('builtins.input', correct_name)
+    monkeypatch.setattr("builtins.input", correct_name)
 
-    assert len(get_storage()._fetch_trials({'status': 'broken'})) > 0
-    execute('db set test_single_exp status=broken status=interrupted')
-    assert len(get_storage()._fetch_trials({'status': 'broken'})) == 0
+    assert len(get_storage()._fetch_trials({"status": "broken"})) > 0
+    execute("db set test_single_exp status=broken status=interrupted")
+    assert len(get_storage()._fetch_trials({"status": "broken"})) == 0
 
 
 def test_invalid_query(clean_db, single_with_trials, capsys):
     """Test error message when query is invalid"""
-    execute('db set -f test_single_exp whatever=1 idontcare=2', assert_code=1)
+    execute("db set -f test_single_exp whatever=1 idontcare=2", assert_code=1)
 
     captured = capsys.readouterr()
 
@@ -51,7 +54,7 @@ def test_invalid_query(clean_db, single_with_trials, capsys):
 
 def test_invalid_update(clean_db, single_with_trials, capsys):
     """Test error message when update attribute is invalid"""
-    execute('db set -f test_single_exp status=new yoopidoo=2', assert_code=1)
+    execute("db set -f test_single_exp status=new yoopidoo=2", assert_code=1)
 
     captured = capsys.readouterr()
 
@@ -61,14 +64,16 @@ def test_invalid_update(clean_db, single_with_trials, capsys):
 def test_update_trial(clean_db, single_with_trials, capsys):
     """Test that trial is updated properly"""
     trials = get_storage()._fetch_trials({})
-    assert sum(trial.status == 'broken' for trial in trials) > 0
+    assert sum(trial.status == "broken" for trial in trials) > 0
     trials = dict(zip((trial.id for trial in trials), trials))
-    execute('db set -f test_single_exp status=broken status=interrupted')
+    execute("db set -f test_single_exp status=broken status=interrupted")
     for trial in get_storage()._fetch_trials({}):
-        if trials[trial.id].status == 'broken':
-            assert trial.status == 'interrupted', 'status not changed properly'
+        if trials[trial.id].status == "broken":
+            assert trial.status == "interrupted", "status not changed properly"
         else:
-            assert trials[trial.id].status == trial.status, 'status should not have been changed'
+            assert (
+                trials[trial.id].status == trial.status
+            ), "status should not have been changed"
 
     captured = capsys.readouterr()
 
@@ -79,14 +84,14 @@ def test_update_trial_with_id(clean_db, single_with_trials, capsys):
     """Test that trial is updated properly when querying with the id"""
     trials = get_storage()._fetch_trials({})
     trials = dict(zip((trial.id for trial in trials), trials))
-    trial = get_storage()._fetch_trials({'status': 'broken'})[0]
-    execute(f'db set -f test_single_exp id={trial.id} status=interrupted')
+    trial = get_storage()._fetch_trials({"status": "broken"})[0]
+    execute(f"db set -f test_single_exp id={trial.id} status=interrupted")
     for new_trial in get_storage()._fetch_trials({}):
         if new_trial.id == trial.id:
-            assert new_trial.status == 'interrupted', 'status not changed properly'
+            assert new_trial.status == "interrupted", "status not changed properly"
         else:
             status_unchanged = trials[new_trial.id].status == new_trial.status
-            assert status_unchanged, 'status should not have been changed'
+            assert status_unchanged, "status should not have been changed"
 
     captured = capsys.readouterr()
 
@@ -97,9 +102,11 @@ def test_update_no_match_query(clean_db, single_with_trials, capsys):
     """Test that no trials are updated when there is no match"""
     trials = get_storage()._fetch_trials({})
     trials = dict(zip((trial.id for trial in trials), trials))
-    execute('db set -f test_single_exp status=invalid status=interrupted')
+    execute("db set -f test_single_exp status=invalid status=interrupted")
     for trial in get_storage()._fetch_trials({}):
-        assert trials[trial.id].status == trial.status, 'status should not have been changed'
+        assert (
+            trials[trial.id].status == trial.status
+        ), "status should not have been changed"
 
     captured = capsys.readouterr()
 
@@ -108,13 +115,13 @@ def test_update_no_match_query(clean_db, single_with_trials, capsys):
 
 def test_update_child_only(clean_db, three_experiments_same_name_with_trials, capsys):
     """Test trials of the parent experiment are not updated"""
-    exp1 = experiment_builder.build_view(name='test_single_exp', version=1)
-    exp2 = experiment_builder.build_view(name='test_single_exp', version=2)
-    exp3 = experiment_builder.build_view(name='test_single_exp', version=3)
-    execute('db set -f test_single_exp --version 2 status=broken status=interrupted')
-    assert len(exp1.fetch_trials_by_status('broken')) > 0
-    assert len(exp2.fetch_trials_by_status('broken')) == 0
-    assert len(exp3.fetch_trials_by_status('broken')) == 0
+    exp1 = experiment_builder.build_view(name="test_single_exp", version=1)
+    exp2 = experiment_builder.build_view(name="test_single_exp", version=2)
+    exp3 = experiment_builder.build_view(name="test_single_exp", version=3)
+    execute("db set -f test_single_exp --version 2 status=broken status=interrupted")
+    assert len(exp1.fetch_trials_by_status("broken")) > 0
+    assert len(exp2.fetch_trials_by_status("broken")) == 0
+    assert len(exp3.fetch_trials_by_status("broken")) == 0
 
     captured = capsys.readouterr()
 
@@ -123,29 +130,31 @@ def test_update_child_only(clean_db, three_experiments_same_name_with_trials, ca
 
 def test_update_default_leaf(clean_db, three_experiments_same_name_with_trials, capsys):
     """Test trials of the parent experiment are not updated"""
-    exp1 = experiment_builder.build_view(name='test_single_exp', version=1)
-    exp2 = experiment_builder.build_view(name='test_single_exp', version=2)
-    exp3 = experiment_builder.build_view(name='test_single_exp', version=3)
-    execute('db set -f test_single_exp status=broken status=interrupted')
-    assert len(exp1.fetch_trials_by_status('broken')) > 0
-    assert len(exp2.fetch_trials_by_status('broken')) > 0
-    assert len(exp3.fetch_trials_by_status('broken')) == 0
+    exp1 = experiment_builder.build_view(name="test_single_exp", version=1)
+    exp2 = experiment_builder.build_view(name="test_single_exp", version=2)
+    exp3 = experiment_builder.build_view(name="test_single_exp", version=3)
+    execute("db set -f test_single_exp status=broken status=interrupted")
+    assert len(exp1.fetch_trials_by_status("broken")) > 0
+    assert len(exp2.fetch_trials_by_status("broken")) > 0
+    assert len(exp3.fetch_trials_by_status("broken")) == 0
 
     captured = capsys.readouterr()
 
     assert captured.out.endswith("1 trials modified\n")
 
 
-def test_no_update_id_from_parent(clean_db, three_experiments_same_name_with_trials, capsys):
+def test_no_update_id_from_parent(
+    clean_db, three_experiments_same_name_with_trials, capsys
+):
     """Test trials of the parent experiment are not updated"""
-    exp1 = experiment_builder.build_view(name='test_single_exp', version=1)
-    exp2 = experiment_builder.build_view(name='test_single_exp', version=2)
-    exp3 = experiment_builder.build_view(name='test_single_exp', version=3)
-    trial = exp1.fetch_trials_by_status('broken')[0]
-    execute(f'db set -f test_single_exp id={trial.id} status=shouldnothappen')
-    assert len(exp1.fetch_trials_by_status('shouldnothappen')) == 0
-    assert len(exp2.fetch_trials_by_status('shouldnothappen')) == 0
-    assert len(exp3.fetch_trials_by_status('shouldnothappen')) == 0
+    exp1 = experiment_builder.build_view(name="test_single_exp", version=1)
+    exp2 = experiment_builder.build_view(name="test_single_exp", version=2)
+    exp3 = experiment_builder.build_view(name="test_single_exp", version=3)
+    trial = exp1.fetch_trials_by_status("broken")[0]
+    execute(f"db set -f test_single_exp id={trial.id} status=shouldnothappen")
+    assert len(exp1.fetch_trials_by_status("shouldnothappen")) == 0
+    assert len(exp2.fetch_trials_by_status("shouldnothappen")) == 0
+    assert len(exp3.fetch_trials_by_status("shouldnothappen")) == 0
 
     captured = capsys.readouterr()
 

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -13,18 +13,18 @@ def test_hunt_no_prior(clean_db, one_experiment, capsys):
     captured = capsys.readouterr().err
 
     assert "No prior found" in captured
-    assert 'Traceback' not in captured
+    assert "Traceback" not in captured
 
 
 def test_no_args(capsys):
     """Test that help is printed when no args are given."""
     with pytest.raises(SystemExit):
-        orion.core.cli.main(['hunt'])
+        orion.core.cli.main(["hunt"])
 
     captured = capsys.readouterr().out
 
-    assert 'usage:' in captured
-    assert 'Traceback' not in captured
+    assert "usage:" in captured
+    assert "Traceback" not in captured
 
 
 def test_no_name(capsys):
@@ -34,4 +34,4 @@ def test_no_name(capsys):
 
     captured = capsys.readouterr().err
 
-    assert captured == 'Error: No name provided for the experiment.\n'
+    assert captured == "Error: No name provided for the experiment.\n"

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -7,31 +7,31 @@ import orion.core.io.resolve_config
 
 def test_info_no_hit(clean_db, one_experiment, capsys):
     """Test info if no experiment with given name."""
-    returncode = orion.core.cli.main(['info', '--name', 'i do not exist'])
+    returncode = orion.core.cli.main(["info", "--name", "i do not exist"])
 
     assert returncode == 1
 
     captured = capsys.readouterr().err
 
-    assert captured.startswith('Error: No experiment with given name \'i do not exist\'')
+    assert captured.startswith("Error: No experiment with given name 'i do not exist'")
 
 
 def test_info_hit(clean_db, one_experiment, capsys):
     """Test info if existing experiment."""
-    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+    orion.core.cli.main(["info", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
-    assert '--x~uniform(0,1)' in captured
+    assert "--x~uniform(0,1)" in captured
 
 
 def test_info_broken(clean_db, broken_refers, capsys):
     """Test info if experiment.refers is missing."""
-    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+    orion.core.cli.main(["info", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
-    assert '--x~uniform(0,1)' in captured
+    assert "--x~uniform(0,1)" in captured
 
 
 def test_info_no_branching(clean_db, one_experiment_changed_vcs, capsys):
@@ -39,40 +39,40 @@ def test_info_no_branching(clean_db, one_experiment_changed_vcs, capsys):
 
     Version should not increase!
     """
-    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+    orion.core.cli.main(["info", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
-    assert '\nversion: 1\n' in captured
+    assert "\nversion: 1\n" in captured
 
 
 def test_info_python_api(clean_db, with_experiment_using_python_api, capsys):
     """Test info if config built using python api"""
-    orion.core.cli.main(['info', '--name', 'from-python-api'])
+    orion.core.cli.main(["info", "--name", "from-python-api"])
 
     captured = capsys.readouterr().out
 
-    assert 'from-python-api' in captured
-    assert 'Commandline' not in captured
+    assert "from-python-api" in captured
+    assert "Commandline" not in captured
 
 
 def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
     """Test info can handle experiments when the user script config file is missing"""
-    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+    orion.core.cli.main(["info", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
-    assert '--x~uniform(0,1)' in captured
+    assert "--x~uniform(0,1)" in captured
 
 
 def test_info_cmdline_api(clean_db, with_experiment_using_python_api, capsys):
     """Test info if config built using cmdline api"""
-    orion.core.cli.main(['info', '--name', 'test_single_exp'])
+    orion.core.cli.main(["info", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
-    assert 'test_single_exp' in captured
-    assert 'Commandline' in captured
+    assert "test_single_exp" in captured
+    assert "Commandline" in captured
 
 
 def test_no_args(capsys):
@@ -82,4 +82,4 @@ def test_no_args(capsys):
 
     captured = capsys.readouterr().err
 
-    assert captured == 'Error: No name provided for the experiment.\n'
+    assert captured == "Error: No name provided for the experiment.\n"

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -22,14 +22,22 @@ def test_insert_invalid_experiment(database, monkeypatch, capsys):
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
     returncode = orion.core.cli.main(
-        ["insert", "-n", "dumb_experiment",
-         "-c", "./orion_config_random.yaml", "./black_box.py", "-x=1"])
+        [
+            "insert",
+            "-n",
+            "dumb_experiment",
+            "-c",
+            "./orion_config_random.yaml",
+            "./black_box.py",
+            "-x=1",
+        ]
+    )
 
     assert returncode == 1
 
     captured = capsys.readouterr().err
 
-    assert ("Error: No experiment with given name 'dumb_experiment'")
+    assert "Error: No experiment with given name 'dumb_experiment'"
 
 
 @pytest.mark.usefixtures("only_experiments_db")
@@ -39,22 +47,31 @@ def test_insert_single_trial(database, monkeypatch, script_path):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
-    orion.core.cli.main(["insert", "-n", "test_insert_normal",
-                         "-c", "./orion_config_random.yaml", script_path, "-x=1"])
+    orion.core.cli.main(
+        [
+            "insert",
+            "-n",
+            "test_insert_normal",
+            "-c",
+            "./orion_config_random.yaml",
+            script_path,
+            "-x=1",
+        ]
+    )
 
     exp = list(database.experiments.find({"name": "test_insert_normal"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
+    assert "_id" in exp
 
-    trials = list(database.trials.find({"experiment": exp['_id']}))
+    trials = list(database.trials.find({"experiment": exp["_id"]}))
 
     assert len(trials) == 1
 
     trial = trials[0]
 
-    assert trial['status'] == 'new'
-    assert trial['params'][0]['value'] == 1
+    assert trial["status"] == "new"
+    assert trial["params"][0]["value"] == 1
 
 
 @pytest.mark.usefixtures("only_experiments_db")
@@ -64,22 +81,30 @@ def test_insert_single_trial_default_value(database, monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
-    orion.core.cli.main(["insert", "-n", "test_insert_normal",
-                         "-c", "./orion_config_random.yaml", "./black_box.py"])
+    orion.core.cli.main(
+        [
+            "insert",
+            "-n",
+            "test_insert_normal",
+            "-c",
+            "./orion_config_random.yaml",
+            "./black_box.py",
+        ]
+    )
 
     exp = list(database.experiments.find({"name": "test_insert_normal"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
+    assert "_id" in exp
 
-    trials = list(database.trials.find({"experiment": exp['_id']}))
+    trials = list(database.trials.find({"experiment": exp["_id"]}))
 
     assert len(trials) == 1
 
     trial = trials[0]
 
-    assert trial['status'] == 'new'
-    assert trial['params'][0]['value'] == 1
+    assert trial["status"] == "new"
+    assert trial["params"][0]["value"] == 1
 
 
 @pytest.mark.usefixtures("only_experiments_db")
@@ -90,8 +115,16 @@ def test_insert_with_no_default_value(database, monkeypatch):
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
     with pytest.raises(ValueError) as exc_info:
-        orion.core.cli.main(["insert", "-n", "test_insert_missing_default_value",
-                             "-c", "./orion_config_random.yaml", "./black_box.py"])
+        orion.core.cli.main(
+            [
+                "insert",
+                "-n",
+                "test_insert_missing_default_value",
+                "-c",
+                "./orion_config_random.yaml",
+                "./black_box.py",
+            ]
+        )
 
     assert "Dimension /x is unspecified and has no default value" in str(exc_info.value)
 
@@ -104,9 +137,17 @@ def test_insert_with_incorrect_namespace(database, monkeypatch):
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
     with pytest.raises(ValueError) as exc_info:
-        orion.core.cli.main(["insert", "-n", "test_insert_normal",
-                             "-c", "./orion_config_random.yaml",
-                             "./black_box.py", "-p=4"])
+        orion.core.cli.main(
+            [
+                "insert",
+                "-n",
+                "test_insert_normal",
+                "-c",
+                "./orion_config_random.yaml",
+                "./black_box.py",
+                "-p=4",
+            ]
+        )
 
     assert "Found namespace outside of experiment space : /p" in str(exc_info.value)
 
@@ -119,9 +160,18 @@ def test_insert_with_outside_bound_value(database, monkeypatch):
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
 
     with pytest.raises(ValueError) as exc_info:
-        orion.core.cli.main(["insert", "-n", "test_insert_two_hyperparameters",
-                             "-c", "./orion_config_random.yaml",
-                             "./black_box.py", "-x=4", "-y=100"])
+        orion.core.cli.main(
+            [
+                "insert",
+                "-n",
+                "test_insert_two_hyperparameters",
+                "-c",
+                "./orion_config_random.yaml",
+                "./black_box.py",
+                "-x=4",
+                "-y=100",
+            ]
+        )
     assert "Value 100 is outside of" in str(exc_info.value)
 
 
@@ -131,47 +181,88 @@ def test_insert_two_hyperparameters(database, monkeypatch):
     """Try to insert a single trial with two hyperparameters"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     monkeypatch.setattr("getpass.getuser", get_user_corneau)
-    orion.core.cli.main(["insert", "-n", "test_insert_two_hyperparameters",
-                         "-c", "./orion_config_random.yaml", "./black_box.py", "-x=1", "-y=2"])
+    orion.core.cli.main(
+        [
+            "insert",
+            "-n",
+            "test_insert_two_hyperparameters",
+            "-c",
+            "./orion_config_random.yaml",
+            "./black_box.py",
+            "-x=1",
+            "-y=2",
+        ]
+    )
 
     exp = list(database.experiments.find({"name": "test_insert_two_hyperparameters"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
+    assert "_id" in exp
 
-    trials = list(database.trials.find({"experiment": exp['_id']}))
+    trials = list(database.trials.find({"experiment": exp["_id"]}))
 
     assert len(trials) == 1
 
     trial = trials[0]
 
-    assert trial['status'] == 'new'
-    assert trial['params'][0]['value'] == 1
-    assert trial['params'][1]['value'] == 2
+    assert trial["status"] == "new"
+    assert trial["params"][0]["value"] == 1
+    assert trial["params"][1]["value"] == 2
 
 
 @pytest.mark.usefixtures("clean_db")
 def test_insert_with_version(create_db_instance, monkeypatch, script_path):
     """Try to insert a single trial inside a specific version"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "--init-only", "-n", "experiment",
-                         "-c", "./orion_config_random.yaml", script_path, "-x~normal(0,1)"])
-    orion.core.cli.main(["hunt", "--init-only", "-n", "experiment",
-                         "-c", "./orion_config_random.yaml", script_path, "-x~normal(0,1)",
-                         "-y~+normal(0,1)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "experiment",
+            "-c",
+            "./orion_config_random.yaml",
+            script_path,
+            "-x~normal(0,1)",
+        ]
+    )
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "-n",
+            "experiment",
+            "-c",
+            "./orion_config_random.yaml",
+            script_path,
+            "-x~normal(0,1)",
+            "-y~+normal(0,1)",
+        ]
+    )
 
     exp = list(get_storage().fetch_experiments({"name": "experiment", "version": 1}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
+    assert "_id" in exp
 
-    trials = list(get_storage().fetch_trials(uid=exp['_id']))
+    trials = list(get_storage().fetch_trials(uid=exp["_id"]))
     assert len(trials) == 0
 
-    orion.core.cli.main(["insert", "-n", "experiment", "--version", "1",
-                         "-c", "./orion_config_random.yaml", script_path, "-x=1"])
+    orion.core.cli.main(
+        [
+            "insert",
+            "-n",
+            "experiment",
+            "--version",
+            "1",
+            "-c",
+            "./orion_config_random.yaml",
+            script_path,
+            "-x=1",
+        ]
+    )
 
-    trials = list(get_storage().fetch_trials(uid=exp['_id']))
+    trials = list(get_storage().fetch_trials(uid=exp["_id"]))
 
     assert len(trials) == 1
 
@@ -179,12 +270,12 @@ def test_insert_with_version(create_db_instance, monkeypatch, script_path):
 def test_no_args(capsys):
     """Test that help is printed when no args are given."""
     with pytest.raises(SystemExit):
-        orion.core.cli.main(['insert'])
+        orion.core.cli.main(["insert"])
 
     captured = capsys.readouterr().out
 
-    assert 'usage:' in captured
-    assert 'Traceback' not in captured
+    assert "usage:" in captured
+    assert "Traceback" not in captured
 
 
 def test_no_name(capsys):
@@ -194,4 +285,4 @@ def test_no_name(capsys):
 
     captured = capsys.readouterr().err
 
-    assert captured == 'Error: No name provided for the experiment.\n'
+    assert captured == "Error: No name provided for the experiment.\n"

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -9,7 +9,7 @@ import orion.core.cli
 def test_no_exp(monkeypatch, clean_db, capsys):
     """Test that nothing is printed when there are no experiments."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -18,7 +18,7 @@ def test_no_exp(monkeypatch, clean_db, capsys):
 
 def test_single_exp(clean_db, one_experiment, capsys):
     """Test that the name of the experiment is printed when there is one experiment."""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -27,7 +27,7 @@ def test_single_exp(clean_db, one_experiment, capsys):
 
 def test_no_version_backward_compatible(clean_db, one_experiment_no_version, capsys):
     """Test status with no experiments."""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -36,7 +36,7 @@ def test_no_version_backward_compatible(clean_db, one_experiment_no_version, cap
 
 def test_broken_refers(clean_db, broken_refers, capsys):
     """Test that experiment without refers dict can be handled properly."""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -45,7 +45,7 @@ def test_broken_refers(clean_db, broken_refers, capsys):
 
 def test_python_api(clean_db, with_experiment_using_python_api, capsys):
     """Test list if containing exps from cmdline api and python api"""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -54,7 +54,7 @@ def test_python_api(clean_db, with_experiment_using_python_api, capsys):
 
 def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
     """Test list can handle experiments when the user script config file is missing"""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -63,33 +63,39 @@ def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
 
 def test_two_exp(capsys, clean_db, two_experiments):
     """Test that experiment and child are printed."""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
-    assert captured == """\
+    assert (
+        captured
+        == """\
  test_double_exp-v1┐
                    └test_double_exp_child-v1
 """
+    )
 
 
 def test_three_exp(capsys, clean_db, three_experiments):
     """Test that experiment, child  and grand-child are printed."""
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
-    assert captured == """\
+    assert (
+        captured
+        == """\
  test_double_exp-v1┐
                    └test_double_exp_child-v1
  test_single_exp-v1
 """
+    )
 
 
 def test_no_exp_name(clean_db, three_experiments, monkeypatch, capsys):
     """Test that nothing is printed when there are no experiments with a given name."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list', '--name', 'I don\'t exist'])
+    orion.core.cli.main(["list", "--name", "I don't exist"])
 
     captured = capsys.readouterr().out
 
@@ -99,7 +105,7 @@ def test_no_exp_name(clean_db, three_experiments, monkeypatch, capsys):
 def test_exp_name(clean_db, three_experiments, monkeypatch, capsys):
     """Test that only the specified experiment is printed."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list', '--name', 'test_single_exp'])
+    orion.core.cli.main(["list", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
@@ -109,20 +115,23 @@ def test_exp_name(clean_db, three_experiments, monkeypatch, capsys):
 def test_exp_name_with_child(clean_db, three_experiments, monkeypatch, capsys):
     """Test that only the specified experiment is printed, and with its child."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list', '--name', 'test_double_exp'])
+    orion.core.cli.main(["list", "--name", "test_double_exp"])
 
     captured = capsys.readouterr().out
 
-    assert captured == """\
+    assert (
+        captured
+        == """\
  test_double_exp-v1┐
                    └test_double_exp_child-v1
 """
+    )
 
 
 def test_exp_name_child(clean_db, three_experiments, monkeypatch, capsys):
     """Test that only the specified child experiment is printed."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list', '--name', 'test_double_exp_child'])
+    orion.core.cli.main(["list", "--name", "test_double_exp_child"])
 
     captured = capsys.readouterr().out
 
@@ -132,44 +141,56 @@ def test_exp_name_child(clean_db, three_experiments, monkeypatch, capsys):
 def test_exp_same_name(clean_db, two_experiments_same_name, monkeypatch, capsys):
     """Test that two experiments with the same name and different versions are correctly printed."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
-    assert captured == """\
+    assert (
+        captured
+        == """\
  test_single_exp-v1┐
                    └test_single_exp-v2
 """
+    )
 
 
-def test_exp_family_same_name(clean_db, three_experiments_family_same_name, monkeypatch, capsys):
+def test_exp_family_same_name(
+    clean_db, three_experiments_family_same_name, monkeypatch, capsys
+):
     """Test that two experiments with the same name and different versions are correctly printed
     even when one of them has a child.
     """
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
-    assert captured == """\
+    assert (
+        captured
+        == """\
                    ┌test_single_exp-v2
  test_single_exp-v1┤
                    └test_single_exp_child-v1
 """
+    )
 
 
-def test_exp_family_branch_same_name(clean_db, three_experiments_branch_same_name,
-                                     monkeypatch, capsys):
+def test_exp_family_branch_same_name(
+    clean_db, three_experiments_branch_same_name, monkeypatch, capsys
+):
     """Test that two experiments with the same name and different versions are correctly printed
     even when last one has a child.
     """
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
-    assert captured == """\
+    assert (
+        captured
+        == """\
  test_single_exp-v1┐
                    └test_single_exp-v2┐
                                       └test_single_exp_child-v1
 """
+    )

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -26,7 +26,7 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
     """Test if a configuration file is created when it does not exist."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(['type', 'name', 'host']))
+    monkeypatch.setattr(builtins, "input", _mock_input(["type", "name", "host"]))
 
     try:
         os.remove(config_path)
@@ -37,7 +37,7 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
 
     assert os.path.exists(config_path)
 
-    with open(config_path, 'r') as output:
+    with open(config_path, "r") as output:
         content = yaml.safe_load(output)
 
     assert content == {"database": {"type": "type", "name": "name", "host": "host"}}
@@ -47,16 +47,16 @@ def test_creation_when_exists(monkeypatch, tmp_path):
     """Test if the configuration file is overwritten when it exists."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(['y', 'type', 'name', 'host']))
+    monkeypatch.setattr(builtins, "input", _mock_input(["y", "type", "name", "host"]))
 
     dump = {"database": {"type": "allo2", "name": "allo2", "host": "allo2"}}
 
-    with open(config_path, 'w') as output:
+    with open(config_path, "w") as output:
         yaml.dump(dump, output)
 
     orion.core.cli.main(["db", "setup"])
 
-    with open(config_path, 'r') as output:
+    with open(config_path, "r") as output:
         content = yaml.safe_load(output)
 
     assert content != dump
@@ -66,16 +66,16 @@ def test_stop_creation_when_exists(monkeypatch, tmp_path):
     """Test if the configuration file is overwritten when it exists."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(['n']))
+    monkeypatch.setattr(builtins, "input", _mock_input(["n"]))
 
     dump = {"database": {"type": "allo2", "name": "allo2", "host": "allo2"}}
 
-    with open(config_path, 'w') as output:
+    with open(config_path, "w") as output:
         yaml.dump(dump, output)
 
     orion.core.cli.main(["db", "setup"])
 
-    with open(config_path, 'r') as output:
+    with open(config_path, "r") as output:
         content = yaml.safe_load(output)
 
     assert content == dump
@@ -85,11 +85,13 @@ def test_defaults(monkeypatch, tmp_path):
     """Test if the default values are used when nothing user enters nothing."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(['', '', '']))
+    monkeypatch.setattr(builtins, "input", _mock_input(["", "", ""]))
 
     orion.core.cli.main(["db", "setup"])
 
-    with open(config_path, 'r') as output:
+    with open(config_path, "r") as output:
         content = yaml.safe_load(output)
 
-    assert content == {"database": {"type": "mongodb", "name": "test", "host": "localhost"}}
+    assert content == {
+        "database": {"type": "mongodb", "name": "test", "host": "localhost"}
+    }

--- a/tests/functional/commands/test_status_command.py
+++ b/tests/functional/commands/test_status_command.py
@@ -11,7 +11,7 @@ import orion.core.cli
 def test_no_experiments(clean_db, monkeypatch, capsys):
     """Test status with no experiments."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -20,7 +20,7 @@ def test_no_experiments(clean_db, monkeypatch, capsys):
 
 def test_no_version_backward_compatible(clean_db, one_experiment_no_version, capsys):
     """Test status with no experiments."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -36,7 +36,7 @@ empty
 
 def test_python_api(clean_db, with_experiment_using_python_api, capsys):
     """Test status with experiments built using python api."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -57,7 +57,7 @@ empty
 
 def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
     """Test status can handle experiments when the user script config file is missing"""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -73,7 +73,7 @@ empty
 
 def test_experiment_without_trials_wout_ac(clean_db, one_experiment, capsys):
     """Test status with only one experiment and no trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -89,7 +89,7 @@ empty
 
 def test_experiment_wout_success_wout_ac(clean_db, single_without_success, capsys):
     """Test status with only one experiment and no successful trial."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -109,10 +109,9 @@ suspended             1
     assert captured == expected
 
 
-def test_experiment_number_same_list_status(clean_db,
-                                            single_without_success, capsys):
+def test_experiment_number_same_list_status(clean_db, single_without_success, capsys):
     """Test status and list command output the consistent number of experiments"""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -131,7 +130,7 @@ suspended             1
 """
     assert captured == expected
 
-    orion.core.cli.main(['list'])
+    orion.core.cli.main(["list"])
 
     captured = capsys.readouterr().out
 
@@ -140,7 +139,7 @@ suspended             1
 
 def test_experiment_w_trials_wout_ac(clean_db, single_with_trials, capsys):
     """Test status with only one experiment and all trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -163,7 +162,7 @@ suspended             1
 
 def test_two_unrelated_w_trials_wout_ac(clean_db, unrelated_with_trials, capsys):
     """Test two unrelated experiments, with all types of trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -199,7 +198,7 @@ suspended             1
 
 def test_two_related_w_trials_wout_ac(clean_db, family_with_trials, capsys):
     """Test two related experiments, with all types of trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -235,7 +234,7 @@ suspended             1
 
 def test_three_unrelated_wout_ac(clean_db, three_experiments_with_trials, capsys):
     """Test three unrelated experiments with all types of trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -283,7 +282,7 @@ suspended             1
 
 def test_three_related_wout_ac(clean_db, three_family_with_trials, capsys):
     """Test three related experiments with all types of trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -329,9 +328,11 @@ suspended             1
     assert captured == expected
 
 
-def test_three_related_branch_wout_ac(clean_db, three_family_branch_with_trials, capsys):
+def test_three_related_branch_wout_ac(
+    clean_db, three_family_branch_with_trials, capsys
+):
     """Test three related experiments with all types of trials."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -379,7 +380,7 @@ suspended             1
 
 def test_one_wout_trials_w_a_wout_c(clean_db, one_experiment, capsys):
     """Test experiments, without trials, with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -398,7 +399,7 @@ empty
 
 def test_one_w_trials_w_a_wout_c(clean_db, single_with_trials, capsys):
     """Test experiment, with all trials, with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -422,7 +423,7 @@ b49e902aebccce14e834d96e411f896e  suspended
 
 def test_one_wout_success_w_a_wout_c(clean_db, single_without_success, capsys):
     """Test experiment, without success, with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -445,7 +446,7 @@ b49e902aebccce14e834d96e411f896e  suspended
 
 def test_two_unrelated_w_a_wout_c(clean_db, unrelated_with_trials, capsys):
     """Test two unrelated experiments with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -481,7 +482,7 @@ b49e902aebccce14e834d96e411f896e  suspended
 
 def test_two_related_w_a_wout_c(clean_db, family_with_trials, capsys):
     """Test two related experiments with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -517,7 +518,7 @@ b849f69cc3a77f39382d7435d0d41b14  interrupted
 
 def test_three_unrelated_w_a_wout_c(clean_db, three_experiments_with_trials, capsys):
     """Test three unrelated experiments with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -565,7 +566,7 @@ b49e902aebccce14e834d96e411f896e  suspended
 
 def test_three_related_w_a_wout_c(clean_db, three_family_with_trials, capsys):
     """Test three related experiments with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -611,9 +612,11 @@ b849f69cc3a77f39382d7435d0d41b14  interrupted
     assert captured == expected
 
 
-def test_three_related_branch_w_a_wout_c(clean_db, three_family_branch_with_trials, capsys):
+def test_three_related_branch_w_a_wout_c(
+    clean_db, three_family_branch_with_trials, capsys
+):
     """Test three related experiments in a branch with --all."""
-    orion.core.cli.main(['status', '--all'])
+    orion.core.cli.main(["status", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -661,7 +664,7 @@ b849f69cc3a77f39382d7435d0d41b14  interrupted
 
 def test_two_unrelated_w_c_wout_a(clean_db, unrelated_with_trials, capsys):
     """Test two unrelated experiments with --collapse."""
-    orion.core.cli.main(['status', '--collapse'])
+    orion.core.cli.main(["status", "--collapse"])
 
     captured = capsys.readouterr().out
 
@@ -697,7 +700,7 @@ suspended             1
 
 def test_two_related_w_c_wout_a(clean_db, family_with_trials, capsys):
     """Test two related experiments with --collapse."""
-    orion.core.cli.main(['status', '--collapse'])
+    orion.core.cli.main(["status", "--collapse"])
 
     captured = capsys.readouterr().out
 
@@ -721,7 +724,7 @@ suspended             1
 
 def test_three_unrelated_w_c_wout_a(clean_db, three_experiments_with_trials, capsys):
     """Test three unrelated experiments with --collapse."""
-    orion.core.cli.main(['status', '--collapse'])
+    orion.core.cli.main(["status", "--collapse"])
 
     captured = capsys.readouterr().out
 
@@ -757,7 +760,7 @@ suspended             1
 
 def test_three_related_w_c_wout_a(clean_db, three_family_with_trials, capsys):
     """Test three related experiments with --collapse."""
-    orion.core.cli.main(['status', '--collapse'])
+    orion.core.cli.main(["status", "--collapse"])
 
     captured = capsys.readouterr().out
 
@@ -779,9 +782,11 @@ suspended             1
     assert captured == expected
 
 
-def test_three_related_branch_w_c_wout_a(clean_db, three_family_branch_with_trials, capsys):
+def test_three_related_branch_w_c_wout_a(
+    clean_db, three_family_branch_with_trials, capsys
+):
     """Test three related experiments with --collapse."""
-    orion.core.cli.main(['status', '--collapse'])
+    orion.core.cli.main(["status", "--collapse"])
 
     captured = capsys.readouterr().out
 
@@ -805,7 +810,7 @@ suspended             1
 
 def test_two_unrelated_w_ac(clean_db, unrelated_with_trials, capsys):
     """Test two unrelated experiments with --collapse and --all."""
-    orion.core.cli.main(['status', '--collapse', '--all'])
+    orion.core.cli.main(["status", "--collapse", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -841,7 +846,7 @@ b49e902aebccce14e834d96e411f896e  suspended
 
 def test_two_related_w_ac(clean_db, family_with_trials, capsys):
     """Test two related experiments with --collapse and --all."""
-    orion.core.cli.main(['status', '--collapse', '--all'])
+    orion.core.cli.main(["status", "--collapse", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -866,7 +871,7 @@ d5f1c1cae188608b581ded20cd198679  new
 
 def test_three_unrelated_w_ac(clean_db, three_experiments_with_trials, capsys):
     """Test three unrelated experiments with --collapse and --all."""
-    orion.core.cli.main(['status', '--collapse', '--all'])
+    orion.core.cli.main(["status", "--collapse", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -903,7 +908,7 @@ b49e902aebccce14e834d96e411f896e  suspended
 
 def test_three_related_w_ac(clean_db, three_family_with_trials, capsys):
     """Test three related experiments with --collapse and --all."""
-    orion.core.cli.main(['status', '--collapse', '--all'])
+    orion.core.cli.main(["status", "--collapse", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -929,7 +934,7 @@ e5bf1dd6dec1a0c690ed62ff9146e5b8  new
 
 def test_three_related_branch_w_ac(clean_db, three_family_branch_with_trials, capsys):
     """Test three related experiments in a branch with --collapse and --all."""
-    orion.core.cli.main(['status', '--collapse', '--all'])
+    orion.core.cli.main(["status", "--collapse", "--all"])
 
     captured = capsys.readouterr().out
 
@@ -956,7 +961,7 @@ d5f1c1cae188608b581ded20cd198679  new
 def test_no_experiments_w_name(clean_db, monkeypatch, capsys):
     """Test status when --name <exp> does not exist."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(['status', '--name', 'test_ghost_exp'])
+    orion.core.cli.main(["status", "--name", "test_ghost_exp"])
 
     captured = capsys.readouterr().out
 
@@ -965,7 +970,7 @@ def test_no_experiments_w_name(clean_db, monkeypatch, capsys):
 
 def test_experiment_wout_child_w_name(clean_db, unrelated_with_trials, capsys):
     """Test status with the name argument and no child."""
-    orion.core.cli.main(['status', '--name', 'test_single_exp'])
+    orion.core.cli.main(["status", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
@@ -989,7 +994,7 @@ suspended             1
 
 def test_experiment_w_child_w_name(clean_db, three_experiments_with_trials, capsys):
     """Test status with the name argument and one child."""
-    orion.core.cli.main(['status', '--name', 'test_double_exp'])
+    orion.core.cli.main(["status", "--name", "test_double_exp"])
 
     captured = capsys.readouterr().out
 
@@ -1025,7 +1030,7 @@ suspended             1
 
 def test_experiment_w_parent_w_name(clean_db, three_experiments_with_trials, capsys):
     """Test status with the name argument and one parent."""
-    orion.core.cli.main(['status', '--name', 'test_double_exp_child'])
+    orion.core.cli.main(["status", "--name", "test_double_exp_child"])
 
     captured = capsys.readouterr().out
 
@@ -1049,7 +1054,7 @@ suspended             1
 
 def test_experiment_same_name_wout_exv(clean_db, three_experiments_same_name, capsys):
     """Test status with three experiments having the same name but different versions."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -1064,9 +1069,11 @@ empty
     assert captured == expected
 
 
-def test_experiment_same_name_wout_exv_w_name(clean_db, three_experiments_same_name, capsys):
+def test_experiment_same_name_wout_exv_w_name(
+    clean_db, three_experiments_same_name, capsys
+):
     """Test status with three experiments having the same name but different versions."""
-    orion.core.cli.main(['status', '--name', 'test_single_exp'])
+    orion.core.cli.main(["status", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
@@ -1081,10 +1088,11 @@ empty
     assert captured == expected
 
 
-def test_experiment_same_name_wout_exv_w_child_w_name(clean_db,
-                                                      three_experiments_family_same_name, capsys):
+def test_experiment_same_name_wout_exv_w_child_w_name(
+    clean_db, three_experiments_family_same_name, capsys
+):
     """Test status name with two experiments having the same name and one with a child."""
-    orion.core.cli.main(['status', '--name', 'test_single_exp'])
+    orion.core.cli.main(["status", "--name", "test_single_exp"])
 
     captured = capsys.readouterr().out
 
@@ -1110,9 +1118,10 @@ empty
 
 
 def test_experiment_same_name_wout_exv_w_c_w_child_w_name(
-        clean_db, three_experiments_family_same_name, capsys):
+    clean_db, three_experiments_family_same_name, capsys
+):
     """Test status name collapsed with two experiments having the same name and one with a child."""
-    orion.core.cli.main(['status', '--name', 'test_single_exp', '--collapse'])
+    orion.core.cli.main(["status", "--name", "test_single_exp", "--collapse"])
 
     captured = capsys.readouterr().out
 
@@ -1127,10 +1136,11 @@ empty
     assert captured == expected
 
 
-def test_experiment_same_name_wout_exv_w_child(clean_db,
-                                               three_experiments_family_same_name, capsys):
+def test_experiment_same_name_wout_exv_w_child(
+    clean_db, three_experiments_family_same_name, capsys
+):
     """Test status with two experiments having the same name and one with a child."""
-    orion.core.cli.main(['status'])
+    orion.core.cli.main(["status"])
 
     captured = capsys.readouterr().out
 
@@ -1157,7 +1167,7 @@ empty
 
 def test_experiment_same_name_w_exv(clean_db, three_experiments_same_name, capsys):
     """Test status with three experiments with the same name and `--expand-verions`."""
-    orion.core.cli.main(['status', '--expand-versions'])
+    orion.core.cli.main(["status", "--expand-versions"])
 
     captured = capsys.readouterr().out
 
@@ -1182,9 +1192,11 @@ empty
     assert captured == expected
 
 
-def test_experiment_same_name_w_exv_w_child(clean_db, three_experiments_family_same_name, capsys):
+def test_experiment_same_name_w_exv_w_child(
+    clean_db, three_experiments_family_same_name, capsys
+):
     """Test status with two experiments having the same name and one with a child."""
-    orion.core.cli.main(['status', '--expand-versions'])
+    orion.core.cli.main(["status", "--expand-versions"])
 
     captured = capsys.readouterr().out
 
@@ -1211,7 +1223,7 @@ empty
 
 def test_experiment_specific_version(clean_db, three_experiments_same_name, capsys):
     """Test status using `--version`."""
-    orion.core.cli.main(['status', '--version', '2'])
+    orion.core.cli.main(["status", "--version", "2"])
 
     captured = capsys.readouterr().out
 
@@ -1229,11 +1241,11 @@ empty
 def test_experiment_cant_use_version(clean_db, three_experiments_same_name):
     """Test status using `--version`."""
     with pytest.raises(RuntimeError) as ex:
-        orion.core.cli.main(['status', '--version', '2', '--collapse'])
+        orion.core.cli.main(["status", "--version", "2", "--collapse"])
 
-    assert 'collapse' in str(ex.value)
+    assert "collapse" in str(ex.value)
 
     with pytest.raises(RuntimeError) as ex:
-        orion.core.cli.main(['status', '--version', '2', '--expand-versions'])
+        orion.core.cli.main(["status", "--version", "2", "--expand-versions"])
 
-    assert 'expand-versions' in str(ex.value)
+    assert "expand-versions" in str(ex.value)

--- a/tests/functional/configuration/conftest.py
+++ b/tests/functional/configuration/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures and utils for configuration tests."""
-from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
-from orion.core.worker.strategy import (BaseParallelStrategy, Strategy)
+from orion.algo.base import BaseAlgorithm, OptimizationAlgorithm
+from orion.core.worker.strategy import BaseParallelStrategy, Strategy
 
 
 def __init__(self, *args, **params):
@@ -19,22 +19,18 @@ def configuration(self):
     return {self.__class__.__name__.lower(): self.params}
 
 
-for char in 'ABCDE':
-    algo_class = type(
-        f'A{char}',
-        (BaseAlgorithm, ),
-        {'suggest': stub, 'observe': stub})
+for char in "ABCDE":
+    algo_class = type(f"A{char}", (BaseAlgorithm,), {"suggest": stub, "observe": stub})
 
     # Hack it into being discoverable
     OptimizationAlgorithm.types.append(algo_class)
     OptimizationAlgorithm.typenames.append(algo_class.__name__.lower())
 
 
-for char in 'ABCDE':
+for char in "ABCDE":
     strategy_class = type(
-        f'S{char}',
-        (BaseParallelStrategy, ),
-        {'observe': stub, '__init__': __init__})
+        f"S{char}", (BaseParallelStrategy,), {"observe": stub, "__init__": __init__}
+    )
 
     strategy_class.configuration = property(configuration)
 

--- a/tests/functional/configuration/test_all_options.py
+++ b/tests/functional/configuration/test_all_options.py
@@ -21,17 +21,14 @@ from orion.storage.legacy import Legacy
 from orion.testing.state import OrionState
 
 
-class ConfigurationTestSuite():
+class ConfigurationTestSuite:
     """Test suite for the configuration groups"""
 
     database = {}
 
     default_storage = {
-        'type': 'legacy',
-        'database': {
-            'type': 'pickleddb',
-            'host': 'experiment.pkl'
-        }
+        "type": "legacy",
+        "database": {"type": "pickleddb", "host": "experiment.pkl"},
     }
 
     @contextmanager
@@ -102,7 +99,7 @@ class ConfigurationTestSuite():
         with self.setup_env_var_config(tmp_path):
             self.check_env_var_config(tmp_path, monkeypatch)
 
-    @pytest.mark.usefixtures('with_user_userxyz')
+    @pytest.mark.usefixtures("with_user_userxyz")
     def test_db_config(self, tmp_path):
         """Test that exp config in db overrides global config"""
         update_singletons()
@@ -110,7 +107,7 @@ class ConfigurationTestSuite():
         with self.setup_db_config(tmp_path):
             self.check_db_config()
 
-    @pytest.mark.usefixtures('with_user_userxyz')
+    @pytest.mark.usefixtures("with_user_userxyz")
     def test_local_config(self, tmp_path, monkeypatch):
         """Test that local config overrides db/global config"""
         update_singletons()
@@ -118,7 +115,7 @@ class ConfigurationTestSuite():
         with self.setup_local_config(tmp_path) as conf_file:
             self.check_local_config(tmp_path, conf_file, monkeypatch)
 
-    @pytest.mark.usefixtures('with_user_userxyz')
+    @pytest.mark.usefixtures("with_user_userxyz")
     def test_cmd_args_config(self, tmp_path, monkeypatch):
         """Test that cmd_args config overrides local config"""
         update_singletons()
@@ -131,73 +128,79 @@ class TestStorage(ConfigurationTestSuite):
     """Test suite for storage configuration"""
 
     config = {
-        'storage': {
-            'type': 'legacy',
-            'database': {
-                'name': 'test_name',
-                'type': 'pickleddb',
-                'host': 'here.pkl',
-                'port': 101}}}
+        "storage": {
+            "type": "legacy",
+            "database": {
+                "name": "test_name",
+                "type": "pickleddb",
+                "host": "here.pkl",
+                "port": 101,
+            },
+        }
+    }
 
     env_vars = {
-        'ORION_STORAGE_TYPE': 'legacy',
-        'ORION_DB_NAME': 'test_env_var_name',
-        'ORION_DB_TYPE': 'pickleddb',
-        'ORION_DB_ADDRESS': 'there.pkl',
-        'ORION_DB_PORT': '103'}
+        "ORION_STORAGE_TYPE": "legacy",
+        "ORION_DB_NAME": "test_env_var_name",
+        "ORION_DB_TYPE": "pickleddb",
+        "ORION_DB_ADDRESS": "there.pkl",
+        "ORION_DB_PORT": "103",
+    }
 
     local = {
-        'storage': {
-            'type': 'legacy',
-            'database': {
-                'type': 'pickleddb',
-                'host': 'local.pkl'}}}
+        "storage": {
+            "type": "legacy",
+            "database": {"type": "pickleddb", "host": "local.pkl"},
+        }
+    }
 
     def sanity_check(self):
         """Check that defaults are different than testing configuration"""
-        assert orion.core.config.storage.to_dict() != self.config['storage']
+        assert orion.core.config.storage.to_dict() != self.config["storage"]
 
     def check_global_config(self, tmp_path, monkeypatch):
         """Check that global configuration is set properly"""
         update_singletons()
 
-        assert orion.core.config.storage.to_dict() == self.config['storage']
+        assert orion.core.config.storage.to_dict() == self.config["storage"]
 
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
         assert isinstance(storage, Legacy)
         assert isinstance(storage._db, PickledDB)
-        assert storage._db.host == 'here.pkl'
+        assert storage._db.host == "here.pkl"
 
     def check_env_var_config(self, tmp_path, monkeypatch):
         """Check that env vars overrides global configuration"""
         update_singletons()
 
         assert orion.core.config.storage.to_dict() == {
-            'type': self.env_vars['ORION_STORAGE_TYPE'],
-            'database': {
-                'name': self.env_vars['ORION_DB_NAME'],
-                'type': self.env_vars['ORION_DB_TYPE'],
-                'host': self.env_vars['ORION_DB_ADDRESS'],
-                'port': int(self.env_vars['ORION_DB_PORT'])}}
+            "type": self.env_vars["ORION_STORAGE_TYPE"],
+            "database": {
+                "name": self.env_vars["ORION_DB_NAME"],
+                "type": self.env_vars["ORION_DB_TYPE"],
+                "host": self.env_vars["ORION_DB_ADDRESS"],
+                "port": int(self.env_vars["ORION_DB_PORT"]),
+            },
+        }
 
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
         assert isinstance(storage, Legacy)
         assert isinstance(storage._db, PickledDB)
-        assert storage._db.host == self.env_vars['ORION_DB_ADDRESS']
+        assert storage._db.host == self.env_vars["ORION_DB_ADDRESS"]
 
     def check_db_config(self):
         """No Storage config in DB, no test"""
@@ -208,24 +211,26 @@ class TestStorage(ConfigurationTestSuite):
         update_singletons()
 
         assert orion.core.config.storage.to_dict() == {
-            'type': self.env_vars['ORION_STORAGE_TYPE'],
-            'database': {
-                'name': self.env_vars['ORION_DB_NAME'],
-                'type': self.env_vars['ORION_DB_TYPE'],
-                'host': self.env_vars['ORION_DB_ADDRESS'],
-                'port': int(self.env_vars['ORION_DB_PORT'])}}
+            "type": self.env_vars["ORION_STORAGE_TYPE"],
+            "database": {
+                "name": self.env_vars["ORION_DB_NAME"],
+                "type": self.env_vars["ORION_DB_TYPE"],
+                "host": self.env_vars["ORION_DB_ADDRESS"],
+                "port": int(self.env_vars["ORION_DB_PORT"]),
+            },
+        }
 
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test -c {conf_file} python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test -c {conf_file} python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
         assert isinstance(storage, Legacy)
         assert isinstance(storage._db, PickledDB)
-        assert storage._db.host == 'local.pkl'
+        assert storage._db.host == "local.pkl"
 
     def check_cmd_args_config(self, tmp_path, conf_file, monkeypatch):
         """No Storage config in cmdline, no test"""
@@ -236,66 +241,67 @@ class TestDatabaseDeprecated(ConfigurationTestSuite):
     """Test suite for deprecated database configuration."""
 
     config = {
-        'database': {
-            'name': 'test_name',
-            'type': 'pickleddb',
-            'host': 'dbhere.pkl',
-            'port': 101}}
+        "database": {
+            "name": "test_name",
+            "type": "pickleddb",
+            "host": "dbhere.pkl",
+            "port": 101,
+        }
+    }
 
     env_vars = {
-        'ORION_DB_NAME': 'test_env_var_name',
-        'ORION_DB_TYPE': 'pickleddb',
-        'ORION_DB_ADDRESS': 'there.pkl',
-        'ORION_DB_PORT': '103'}
+        "ORION_DB_NAME": "test_env_var_name",
+        "ORION_DB_TYPE": "pickleddb",
+        "ORION_DB_ADDRESS": "there.pkl",
+        "ORION_DB_PORT": "103",
+    }
 
-    local = {
-        'database': {
-            'type': 'pickleddb',
-            'host': 'dblocal.pkl'}}
+    local = {"database": {"type": "pickleddb", "host": "dblocal.pkl"}}
 
     def sanity_check(self):
         """Check that defaults are different than testing configuration"""
-        assert orion.core.config.database.to_dict() != self.config['database']
+        assert orion.core.config.database.to_dict() != self.config["database"]
 
     def check_global_config(self, tmp_path, monkeypatch):
         """Check that global configuration is set properly"""
         update_singletons()
 
-        assert orion.core.config.database.to_dict() == self.config['database']
+        assert orion.core.config.database.to_dict() == self.config["database"]
 
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
         assert isinstance(storage, Legacy)
         assert isinstance(storage._db, PickledDB)
-        assert storage._db.host == 'dbhere.pkl'
+        assert storage._db.host == "dbhere.pkl"
 
     def check_env_var_config(self, tmp_path, monkeypatch):
         """Check that env vars overrides global configuration"""
         update_singletons()
 
         assert orion.core.config.database.to_dict() == {
-            'name': self.env_vars['ORION_DB_NAME'],
-            'type': self.env_vars['ORION_DB_TYPE'],
-            'host': self.env_vars['ORION_DB_ADDRESS'],
-            'port': int(self.env_vars['ORION_DB_PORT'])}
+            "name": self.env_vars["ORION_DB_NAME"],
+            "type": self.env_vars["ORION_DB_TYPE"],
+            "host": self.env_vars["ORION_DB_ADDRESS"],
+            "port": int(self.env_vars["ORION_DB_PORT"]),
+        }
 
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
         assert isinstance(storage, Legacy)
         assert isinstance(storage._db, PickledDB)
-        assert storage._db.host == self.env_vars['ORION_DB_ADDRESS']
+        assert storage._db.host == self.env_vars["ORION_DB_ADDRESS"]
 
     def check_db_config(self):
         """No Storage config in DB, no test"""
@@ -306,22 +312,23 @@ class TestDatabaseDeprecated(ConfigurationTestSuite):
         update_singletons()
 
         assert orion.core.config.database.to_dict() == {
-            'name': self.env_vars['ORION_DB_NAME'],
-            'type': self.env_vars['ORION_DB_TYPE'],
-            'host': self.env_vars['ORION_DB_ADDRESS'],
-            'port': int(self.env_vars['ORION_DB_PORT'])}
+            "name": self.env_vars["ORION_DB_NAME"],
+            "type": self.env_vars["ORION_DB_TYPE"],
+            "host": self.env_vars["ORION_DB_ADDRESS"],
+            "port": int(self.env_vars["ORION_DB_PORT"]),
+        }
 
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test -c {conf_file} python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test -c {conf_file} python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
         assert isinstance(storage, Legacy)
         assert isinstance(storage._db, PickledDB)
-        assert storage._db.host == 'dblocal.pkl'
+        assert storage._db.host == "dblocal.pkl"
 
     def check_cmd_args_config(self, tmp_path, conf_file, monkeypatch):
         """No Storage config in cmdline, no test"""
@@ -332,118 +339,85 @@ class TestExperimentConfig(ConfigurationTestSuite):
     """Test suite for experiment configuration"""
 
     config = {
-        'experiment': {
-            'max_trials': 10,
-            'max_broken': 5,
-            'working_dir': 'here',
-            'pool_size': 2,
-            'worker_trials': 5,
-            'algorithms': {
-                'aa': {
-                    'b': 'c',
-                    'd': {'e': 'f'}
-                }
-            },
-            'strategy': {
-                'sa': {
-                    'c': 'd',
-                    'e': {'f': 'g'}
-                }
-            }
+        "experiment": {
+            "max_trials": 10,
+            "max_broken": 5,
+            "working_dir": "here",
+            "pool_size": 2,
+            "worker_trials": 5,
+            "algorithms": {"aa": {"b": "c", "d": {"e": "f"}}},
+            "strategy": {"sa": {"c": "d", "e": {"f": "g"}}},
         }
     }
 
     env_vars = {
-        'ORION_EXP_MAX_TRIALS': 20,
-        'ORION_EXP_MAX_BROKEN': 12,
-        'ORION_WORKING_DIR': 'over_there'}
+        "ORION_EXP_MAX_TRIALS": 20,
+        "ORION_EXP_MAX_BROKEN": 12,
+        "ORION_WORKING_DIR": "over_there",
+    }
 
     database = {
-        'name': 'test-name',
-        'version': 1,
-        'max_trials': 75,
-        'max_broken': 16,
-        'working_dir': 'in_db?',
-        'algorithms': {
-            'ab': {
-                'd': 'i',
-                'f': 'g'}
-        },
-        'producer': {
-            'strategy': {
-                'sb': {
-                    'e': 'c',
-                    'd': 'g'}
-            }
-        },
-        'space': {
-            '/x': 'uniform(0, 1)'
-        },
-        'metadata': {
-            'VCS': {},
-            'datetime': datetime.datetime.utcnow(),
-            'orion_version': orion.core.__version__,
-            'parser': {
-                'cmd_priors': [['/x', 'uniform(0, 1)']],
-                'config_file_data': {},
-                'config_prefix': 'config',
-                'converter': None,
-                'file_config_path': None,
-                'file_priors': [],
-                'parser': {
-                    'arguments': [
-                        ['_pos_0', 'python'],
-                        ['_pos_1', os.path.abspath(__file__)],
-                        ['x', 'orion~uniform(0, 1)']
+        "name": "test-name",
+        "version": 1,
+        "max_trials": 75,
+        "max_broken": 16,
+        "working_dir": "in_db?",
+        "algorithms": {"ab": {"d": "i", "f": "g"}},
+        "producer": {"strategy": {"sb": {"e": "c", "d": "g"}}},
+        "space": {"/x": "uniform(0, 1)"},
+        "metadata": {
+            "VCS": {},
+            "datetime": datetime.datetime.utcnow(),
+            "orion_version": orion.core.__version__,
+            "parser": {
+                "cmd_priors": [["/x", "uniform(0, 1)"]],
+                "config_file_data": {},
+                "config_prefix": "config",
+                "converter": None,
+                "file_config_path": None,
+                "file_priors": [],
+                "parser": {
+                    "arguments": [
+                        ["_pos_0", "python"],
+                        ["_pos_1", os.path.abspath(__file__)],
+                        ["x", "orion~uniform(0, 1)"],
                     ],
-                    'keys': [
-                        ['_pos_0', '_pos_0'],
-                        ['_pos_1', '_pos_1'],
-                        ['x', '-x']
-                    ],
-                    'template': ['{_pos_0}', '{_pos_1}', '-x', '{x}']
-                }
+                    "keys": [["_pos_0", "_pos_0"], ["_pos_1", "_pos_1"], ["x", "-x"]],
+                    "template": ["{_pos_0}", "{_pos_1}", "-x", "{x}"],
+                },
             },
-            'priors': {'/x': 'uniform(0, 1)'},
-            'user': 'userxyz',
-            'user_args': ['python', os.path.abspath(__file__), '-x~uniform(0, 1)'],
-            'user_script': os.path.abspath(__file__)
+            "priors": {"/x": "uniform(0, 1)"},
+            "user": "userxyz",
+            "user_args": ["python", os.path.abspath(__file__), "-x~uniform(0, 1)"],
+            "user_script": os.path.abspath(__file__),
         },
-        'refers': {'adapter': [], 'parent_id': None, 'root_id': 1}
+        "refers": {"adapter": [], "parent_id": None, "root_id": 1},
     }
 
     local = {
-        'experiment': {
-            'name': 'test-name',
-            'user': 'useruvt',
-            'max_trials': 50,
-            'max_broken': 15,
-            'working_dir': 'here_again',
-            'algorithms': {
-                'ac': {
-                    'd': 'e',
-                    'f': 'g'}
-            },
-            'strategy': {
-                'sd': {
-                    'b': 'c',
-                    'd': 'e'}
-            }
+        "experiment": {
+            "name": "test-name",
+            "user": "useruvt",
+            "max_trials": 50,
+            "max_broken": 15,
+            "working_dir": "here_again",
+            "algorithms": {"ac": {"d": "e", "f": "g"}},
+            "strategy": {"sd": {"b": "c", "d": "e"}},
         }
     }
 
     cmdargs = {
-        'name': 'exp-name',
-        'user': 'userabc',
-        'version': 1,
-        'exp-max-trials': 100,
-        'exp-max-broken': 50,
-        'working-dir': 'cmdline-working-dir',
+        "name": "exp-name",
+        "user": "userabc",
+        "version": 1,
+        "exp-max-trials": 100,
+        "exp-max-broken": 50,
+        "working-dir": "cmdline-working-dir",
     }
 
     def sanity_check(self):
         """Check that defaults are different than testing configuration"""
-        assert orion.core.config.to_dict()['experiment'] != self.config['experiment']
+        assert orion.core.config.to_dict()["experiment"] != self.config["experiment"]
 
     def _compare(self, base_config, experiment_config, ignore=tuple()):
         def _prune(config):
@@ -451,11 +425,11 @@ class TestExperimentConfig(ConfigurationTestSuite):
             for key in ignore:
                 config.pop(key, None)
 
-            if 'producer' in config:
-                config['strategy'] = config.pop('producer')['strategy']
+            if "producer" in config:
+                config["strategy"] = config.pop("producer")["strategy"]
 
-            if 'metadata' in config and 'user' in config['metadata']:
-                config['user'] = config['metadata']['user']
+            if "metadata" in config and "user" in config["metadata"]:
+                config["user"] = config["metadata"]["user"]
 
             return config
 
@@ -470,121 +444,138 @@ class TestExperimentConfig(ConfigurationTestSuite):
 
     def check_global_config(self, tmp_path, monkeypatch):
         """Check that global configuration is set properly"""
-        self._compare(self.config['experiment'], orion.core.config.to_dict()['experiment'])
+        self._compare(
+            self.config["experiment"], orion.core.config.to_dict()["experiment"]
+        )
 
         script = os.path.abspath(__file__)
-        command = f'hunt --init-only -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --init-only -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
 
-        experiment = get_experiment('test')
-        self._compare(self.config['experiment'], experiment.configuration, ignore=['worker_trials'])
+        experiment = get_experiment("test")
+        self._compare(
+            self.config["experiment"],
+            experiment.configuration,
+            ignore=["worker_trials"],
+        )
 
     def check_env_var_config(self, tmp_path, monkeypatch):
         """Check that env vars overrides global configuration"""
-        assert orion.core.config.experiment.max_trials == self.env_vars['ORION_EXP_MAX_TRIALS']
-        assert orion.core.config.experiment.max_broken == self.env_vars['ORION_EXP_MAX_BROKEN']
-        assert orion.core.config.experiment.working_dir == self.env_vars['ORION_WORKING_DIR']
+        assert (
+            orion.core.config.experiment.max_trials
+            == self.env_vars["ORION_EXP_MAX_TRIALS"]
+        )
+        assert (
+            orion.core.config.experiment.max_broken
+            == self.env_vars["ORION_EXP_MAX_BROKEN"]
+        )
+        assert (
+            orion.core.config.experiment.working_dir
+            == self.env_vars["ORION_WORKING_DIR"]
+        )
 
         script = os.path.abspath(__file__)
-        command = f'hunt --init-only -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --init-only -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
-        experiment = get_experiment('test')
+        experiment = get_experiment("test")
 
-        assert experiment.max_trials == self.env_vars['ORION_EXP_MAX_TRIALS']
-        assert experiment.max_broken == self.env_vars['ORION_EXP_MAX_BROKEN']
-        assert experiment.working_dir == self.env_vars['ORION_WORKING_DIR']
+        assert experiment.max_trials == self.env_vars["ORION_EXP_MAX_TRIALS"]
+        assert experiment.max_broken == self.env_vars["ORION_EXP_MAX_BROKEN"]
+        assert experiment.working_dir == self.env_vars["ORION_WORKING_DIR"]
 
     def check_db_config(self):
         """Check that db config overrides global/envvar config"""
         script = os.path.abspath(__file__)
-        name = 'test-name'
-        command = f'hunt --worker-max-trials 0 -n {name}'
-        orion.core.cli.main(command.split(' '))
+        name = "test-name"
+        command = f"hunt --worker-max-trials 0 -n {name}"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
 
         experiment = get_experiment(name)
-        self._compare(self.database, experiment.configuration, ignore=['worker_trials'])
+        self._compare(self.database, experiment.configuration, ignore=["worker_trials"])
 
     def check_local_config(self, tmp_path, conf_file, monkeypatch):
         """Check that local configuration overrides global/envvars configuration"""
         script = os.path.abspath(__file__)
-        command = f'hunt --worker-trials 0 -c {conf_file}'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --worker-trials 0 -c {conf_file}"
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
 
-        experiment = get_experiment('test-name')
-        self._compare(self.local['experiment'], experiment.configuration)
+        experiment = get_experiment("test-name")
+        self._compare(self.local["experiment"], experiment.configuration)
 
     def check_cmd_args_config(self, tmp_path, conf_file, monkeypatch):
         """Check that cmdargs configuration overrides global/envvars/local configuration"""
         script = os.path.abspath(__file__)
-        command = f'hunt --worker-trials 0 -c {conf_file} --branch-from test-name'
-        command += ' ' + ' '.join('--{} {}'.format(name, value)
-                                  for name, value in self.cmdargs.items())
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --worker-trials 0 -c {conf_file} --branch-from test-name"
+        command += " " + " ".join(
+            "--{} {}".format(name, value) for name, value in self.cmdargs.items()
+        )
+        orion.core.cli.main(command.split(" "))
 
         storage = get_storage()
 
-        experiment = get_experiment('exp-name')
-        assert experiment.name == 'exp-name'
-        assert experiment.node.parent.name == 'test-name'
+        experiment = get_experiment("exp-name")
+        assert experiment.name == "exp-name"
+        assert experiment.node.parent.name == "test-name"
         assert experiment.version == 1
-        assert experiment.metadata['user'] == self.cmdargs['user']
-        assert experiment.max_trials == self.cmdargs['exp-max-trials']
-        assert experiment.max_broken == self.cmdargs['exp-max-broken']
-        assert experiment.working_dir == self.cmdargs['working-dir']
+        assert experiment.metadata["user"] == self.cmdargs["user"]
+        assert experiment.max_trials == self.cmdargs["exp-max-trials"]
+        assert experiment.max_broken == self.cmdargs["exp-max-broken"]
+        assert experiment.working_dir == self.cmdargs["working-dir"]
 
 
 class TestWorkerConfig(ConfigurationTestSuite):
     """Test suite for worker configuration"""
 
     config = {
-        'worker': {
-            'heartbeat': 30,
-            'max_trials': 10,
-            'max_broken': 5,
-            'max_idle_time': 15,
-            'interrupt_signal_code': 131,
-            'user_script_config': 'cfg',
+        "worker": {
+            "heartbeat": 30,
+            "max_trials": 10,
+            "max_broken": 5,
+            "max_idle_time": 15,
+            "interrupt_signal_code": 131,
+            "user_script_config": "cfg",
         }
     }
 
     env_vars = {
-        'ORION_HEARTBEAT': 40,
-        'ORION_WORKER_MAX_TRIALS': 20,
-        'ORION_WORKER_MAX_BROKEN': 6,
-        'ORION_MAX_IDLE_TIME': 16,
-        'ORION_INTERRUPT_CODE': 132,
-        'ORION_USER_SCRIPT_CONFIG': 'envcfg'}
+        "ORION_HEARTBEAT": 40,
+        "ORION_WORKER_MAX_TRIALS": 20,
+        "ORION_WORKER_MAX_BROKEN": 6,
+        "ORION_MAX_IDLE_TIME": 16,
+        "ORION_INTERRUPT_CODE": 132,
+        "ORION_USER_SCRIPT_CONFIG": "envcfg",
+    }
 
     local = {
-        'worker': {
-            'heartbeat': 50,
-            'max_trials': 30,
-            'max_broken': 7,
-            'max_idle_time': 17,
-            'interrupt_signal_code': 133,
-            'user_script_config': 'lclcfg',
+        "worker": {
+            "heartbeat": 50,
+            "max_trials": 30,
+            "max_broken": 7,
+            "max_idle_time": 17,
+            "interrupt_signal_code": 133,
+            "user_script_config": "lclcfg",
         }
     }
 
     cmdargs = {
-        'heartbeat': 70,
-        'worker-max-trials': 40,
-        'worker-max-broken': 8,
-        'max-idle-time': 18,
-        'interrupt-signal-code': 134,
-        'user-script-config': 'cmdcfg',
+        "heartbeat": 70,
+        "worker-max-trials": 40,
+        "worker-max-broken": 8,
+        "max-idle-time": 18,
+        "interrupt-signal-code": 134,
+        "user-script-config": "cmdcfg",
     }
 
     def sanity_check(self):
         """Check that defaults are different than testing configuration"""
-        assert orion.core.config.to_dict()['worker'] != self.config['worker']
+        assert orion.core.config.to_dict()["worker"] != self.config["worker"]
 
     def _mock_consumer(self, monkeypatch):
         self.consumer = None
@@ -594,7 +585,7 @@ class TestWorkerConfig(ConfigurationTestSuite):
             old_init(c_self, *args, **kwargs)
             self.consumer = c_self
 
-        monkeypatch.setattr(orion.core.worker.Consumer, '__init__', init)
+        monkeypatch.setattr(orion.core.worker.Consumer, "__init__", init)
 
     def _mock_producer(self, monkeypatch):
         self.producer = None
@@ -604,7 +595,7 @@ class TestWorkerConfig(ConfigurationTestSuite):
             old_init(p_self, *args, **kwargs)
             self.producer = p_self
 
-        monkeypatch.setattr(orion.core.worker.Producer, '__init__', init)
+        monkeypatch.setattr(orion.core.worker.Producer, "__init__", init)
 
     def _mock_workon(self, monkeypatch):
         workon = orion.core.worker.workon
@@ -615,56 +606,58 @@ class TestWorkerConfig(ConfigurationTestSuite):
             self.workon_kwargs = kwargs
             return workon(experiment, **kwargs)
 
-        monkeypatch.setattr('orion.core.cli.hunt.workon', mocked_workon)
+        monkeypatch.setattr("orion.core.cli.hunt.workon", mocked_workon)
 
     def _check_consumer(self, config):
-        assert self.consumer.heartbeat == config['heartbeat']
-        assert self.consumer.template_builder.config_prefix == config['user_script_config']
-        assert self.consumer.interrupt_signal_code == config['interrupt_signal_code']
+        assert self.consumer.heartbeat == config["heartbeat"]
+        assert (
+            self.consumer.template_builder.config_prefix == config["user_script_config"]
+        )
+        assert self.consumer.interrupt_signal_code == config["interrupt_signal_code"]
 
     def _check_producer(self, config):
-        assert self.producer.max_idle_time == config['max_idle_time']
+        assert self.producer.max_idle_time == config["max_idle_time"]
 
     def _check_workon(self, config):
-        assert self.workon_kwargs['max_trials'] == config['max_trials']
-        assert self.workon_kwargs['max_broken'] == config['max_broken']
+        assert self.workon_kwargs["max_trials"] == config["max_trials"]
+        assert self.workon_kwargs["max_broken"] == config["max_broken"]
 
     def check_global_config(self, tmp_path, monkeypatch):
         """Check that global configuration is set properly"""
-        assert orion.core.config.to_dict()['worker'] == self.config['worker']
+        assert orion.core.config.to_dict()["worker"] == self.config["worker"]
 
         self._mock_consumer(monkeypatch)
         self._mock_producer(monkeypatch)
         self._mock_workon(monkeypatch)
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
-        self._check_consumer(self.config['worker'])
-        self._check_producer(self.config['worker'])
-        self._check_workon(self.config['worker'])
+        self._check_consumer(self.config["worker"])
+        self._check_producer(self.config["worker"])
+        self._check_workon(self.config["worker"])
 
     def check_env_var_config(self, tmp_path, monkeypatch):
         """Check that env vars overrides global configuration"""
         env_var_config = {
-            'heartbeat': self.env_vars['ORION_HEARTBEAT'],
-            'max_trials': self.env_vars['ORION_WORKER_MAX_TRIALS'],
-            'max_broken': self.env_vars['ORION_WORKER_MAX_BROKEN'],
-            'max_idle_time': self.env_vars['ORION_MAX_IDLE_TIME'],
-            'interrupt_signal_code': self.env_vars['ORION_INTERRUPT_CODE'],
-            'user_script_config': self.env_vars['ORION_USER_SCRIPT_CONFIG']
+            "heartbeat": self.env_vars["ORION_HEARTBEAT"],
+            "max_trials": self.env_vars["ORION_WORKER_MAX_TRIALS"],
+            "max_broken": self.env_vars["ORION_WORKER_MAX_BROKEN"],
+            "max_idle_time": self.env_vars["ORION_MAX_IDLE_TIME"],
+            "interrupt_signal_code": self.env_vars["ORION_INTERRUPT_CODE"],
+            "user_script_config": self.env_vars["ORION_USER_SCRIPT_CONFIG"],
         }
 
-        assert orion.core.config.to_dict()['worker'] == env_var_config
+        assert orion.core.config.to_dict()["worker"] == env_var_config
 
         self._mock_consumer(monkeypatch)
         self._mock_producer(monkeypatch)
         self._mock_workon(monkeypatch)
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         self._check_consumer(env_var_config)
         self._check_producer(env_var_config)
@@ -681,22 +674,22 @@ class TestWorkerConfig(ConfigurationTestSuite):
         self._mock_workon(monkeypatch)
 
         script = os.path.abspath(__file__)
-        command = f'hunt --exp-max-trials 0 -n test -c {conf_file} python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --exp-max-trials 0 -n test -c {conf_file} python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
-        self._check_consumer(self.local['worker'])
-        self._check_producer(self.local['worker'])
-        self._check_workon(self.local['worker'])
+        self._check_consumer(self.local["worker"])
+        self._check_producer(self.local["worker"])
+        self._check_workon(self.local["worker"])
 
     def check_cmd_args_config(self, tmp_path, conf_file, monkeypatch):
         """Check that cmdargs configuration overrides global/envvars/local configuration"""
         config = {
-            'heartbeat': self.cmdargs['heartbeat'],
-            'max_trials': self.cmdargs['worker-max-trials'],
-            'max_broken': self.cmdargs['worker-max-broken'],
-            'max_idle_time': self.cmdargs['max-idle-time'],
-            'interrupt_signal_code': self.cmdargs['interrupt-signal-code'],
-            'user_script_config': self.cmdargs['user-script-config'],
+            "heartbeat": self.cmdargs["heartbeat"],
+            "max_trials": self.cmdargs["worker-max-trials"],
+            "max_broken": self.cmdargs["worker-max-broken"],
+            "max_idle_time": self.cmdargs["max-idle-time"],
+            "interrupt_signal_code": self.cmdargs["interrupt-signal-code"],
+            "user_script_config": self.cmdargs["user-script-config"],
         }
 
         self._mock_consumer(monkeypatch)
@@ -704,11 +697,12 @@ class TestWorkerConfig(ConfigurationTestSuite):
         self._mock_workon(monkeypatch)
 
         script = os.path.abspath(__file__)
-        command = f'hunt --worker-trials 0 -c {conf_file} -n cmd-test'
-        command += ' ' + ' '.join('--{} {}'.format(name, value)
-                                  for name, value in self.cmdargs.items())
-        command += f' python {script} -x~uniform(0,1)'
-        orion.core.cli.main(command.split(' '))
+        command = f"hunt --worker-trials 0 -c {conf_file} -n cmd-test"
+        command += " " + " ".join(
+            "--{} {}".format(name, value) for name, value in self.cmdargs.items()
+        )
+        command += f" python {script} -x~uniform(0,1)"
+        orion.core.cli.main(command.split(" "))
 
         self._check_consumer(config)
         self._check_producer(config)
@@ -719,53 +713,53 @@ class TestEVCConfig(ConfigurationTestSuite):
     """Test for EVC configuration"""
 
     config = {
-        'evc': {
-            'auto_resolution': False,
-            'manual_resolution': True,
-            'non_monitored_arguments': ['test', 'one'],
-            'ignore_code_changes': True,
-            'algorithm_change': True,
-            'code_change_type': 'noeffect',
-            'cli_change_type': 'noeffect',
-            'config_change_type': 'noeffect',
+        "evc": {
+            "auto_resolution": False,
+            "manual_resolution": True,
+            "non_monitored_arguments": ["test", "one"],
+            "ignore_code_changes": True,
+            "algorithm_change": True,
+            "code_change_type": "noeffect",
+            "cli_change_type": "noeffect",
+            "config_change_type": "noeffect",
         }
     }
 
     env_vars = {
-        'ORION_EVC_MANUAL_RESOLUTION': '',
-        'ORION_EVC_NON_MONITORED_ARGUMENTS': 'test:two:others',
-        'ORION_EVC_IGNORE_CODE_CHANGES': '',
-        'ORION_EVC_ALGO_CHANGE': '',
-        'ORION_EVC_CODE_CHANGE': 'unsure',
-        'ORION_EVC_CMDLINE_CHANGE': 'unsure',
-        'ORION_EVC_CONFIG_CHANGE': 'unsure'
+        "ORION_EVC_MANUAL_RESOLUTION": "",
+        "ORION_EVC_NON_MONITORED_ARGUMENTS": "test:two:others",
+        "ORION_EVC_IGNORE_CODE_CHANGES": "",
+        "ORION_EVC_ALGO_CHANGE": "",
+        "ORION_EVC_CODE_CHANGE": "unsure",
+        "ORION_EVC_CMDLINE_CHANGE": "unsure",
+        "ORION_EVC_CONFIG_CHANGE": "unsure",
     }
 
     local = {
-        'evc': {
-            'manual_resolution': True,
-            'non_monitored_arguments': ['test', 'local'],
-            'ignore_code_changes': True,
-            'algorithm_change': True,
-            'code_change_type': 'break',
-            'cli_change_type': 'break',
-            'config_change_type': 'noeffect',
+        "evc": {
+            "manual_resolution": True,
+            "non_monitored_arguments": ["test", "local"],
+            "ignore_code_changes": True,
+            "algorithm_change": True,
+            "code_change_type": "break",
+            "cli_change_type": "break",
+            "config_change_type": "noeffect",
         }
     }
 
     cmdargs = {
-        'manual-resolution': False,
-        'non-monitored-arguments': 'test:cmdargs',
-        'ignore-code-changes': False,
-        'algorithm-change': False,
-        'code-change-type': 'noeffect',
-        'cli-change-type': 'unsure',
-        'config-change-type': 'break',
+        "manual-resolution": False,
+        "non-monitored-arguments": "test:cmdargs",
+        "ignore-code-changes": False,
+        "algorithm-change": False,
+        "code-change-type": "noeffect",
+        "cli-change-type": "unsure",
+        "config-change-type": "break",
     }
 
     def sanity_check(self):
         """Check that defaults are different than testing configuration"""
-        assert orion.core.config.to_dict()['evc'] != self.config['evc']
+        assert orion.core.config.to_dict()["evc"] != self.config["evc"]
 
     def _mock_consumer(self, monkeypatch):
 
@@ -776,7 +770,7 @@ class TestEVCConfig(ConfigurationTestSuite):
             self.consumer = obj
             return obj
 
-        monkeypatch.setattr(orion.core.worker.Consumer, '__new__', register)
+        monkeypatch.setattr(orion.core.worker.Consumer, "__new__", register)
 
     def _mock_producer(self, monkeypatch):
 
@@ -787,7 +781,7 @@ class TestEVCConfig(ConfigurationTestSuite):
             self.producer = obj
             return obj
 
-        monkeypatch.setattr(orion.core.worker.Producer, '__new__', register)
+        monkeypatch.setattr(orion.core.worker.Producer, "__new__", register)
 
     def _mock_workon(self, monkeypatch):
         workon = orion.core.worker.workon
@@ -798,77 +792,93 @@ class TestEVCConfig(ConfigurationTestSuite):
             self.workon_kwargs = kwargs
             return workon(experiment, **kwargs)
 
-        monkeypatch.setattr('orion.core.cli.hunt.workon', mocked_workon)
+        monkeypatch.setattr("orion.core.cli.hunt.workon", mocked_workon)
 
     def _check_consumer(self, config):
 
-        assert self.consumer.heartbeat == config['heartbeat']
-        assert self.consumer.template_builder.config_prefix == config['user_script_config']
-        assert self.consumer.interrupt_signal_code == config['interrupt_signal_code']
+        assert self.consumer.heartbeat == config["heartbeat"]
+        assert (
+            self.consumer.template_builder.config_prefix == config["user_script_config"]
+        )
+        assert self.consumer.interrupt_signal_code == config["interrupt_signal_code"]
 
     def _check_producer(self, config):
 
-        assert self.producer.max_idle_time == config['max_idle_time']
+        assert self.producer.max_idle_time == config["max_idle_time"]
 
     def _check_workon(self, config):
 
-        assert self.workon_kwargs['max_trials'] == config['max_trials']
-        assert self.workon_kwargs['max_broken'] == config['max_broken']
+        assert self.workon_kwargs["max_trials"] == config["max_trials"]
+        assert self.workon_kwargs["max_broken"] == config["max_broken"]
 
     def check_global_config(self, tmp_path, monkeypatch):
         """Check that global configuration is set properly"""
-        assert orion.core.config.to_dict()['evc'] == self.config['evc']
+        assert orion.core.config.to_dict()["evc"] == self.config["evc"]
 
         script = os.path.abspath(__file__)
-        name = 'global-test'
-        command = f'hunt --init-only -n {name} python {script} -x~uniform(0,1)'
-        assert orion.core.cli.main(command.split(' ')) == 0
+        name = "global-test"
+        command = f"hunt --init-only -n {name} python {script} -x~uniform(0,1)"
+        assert orion.core.cli.main(command.split(" ")) == 0
 
         # Test that manual_resolution is True and it branches when changing cli
-        assert orion.core.cli.main(f'{command} --cli-change '.split(' ')) == 1
+        assert orion.core.cli.main(f"{command} --cli-change ".split(" ")) == 1
 
-        command = 'hunt --auto-resolution ' + command[5:]
+        command = "hunt --auto-resolution " + command[5:]
 
         command = self._check_cli_change(
-            name, command, version=1, change_type='noeffect')
+            name, command, version=1, change_type="noeffect"
+        )
         command = self._check_non_monitored_arguments(
-            name, command, version=2,
-            non_monitored_arguments=['test', 'one'])
+            name, command, version=2, non_monitored_arguments=["test", "one"]
+        )
         self._check_script_config_change(
-            tmp_path, name, command, version=2, change_type='noeffect')
+            tmp_path, name, command, version=2, change_type="noeffect"
+        )
         self._check_code_change(
-            monkeypatch, name, command, version=3,
+            monkeypatch,
+            name,
+            command,
+            version=3,
             ignore_code_change=None,
-            change_type='noeffect')
+            change_type="noeffect",
+        )
 
     def check_env_var_config(self, tmp_path, monkeypatch):
         """Check that env vars overrides global configuration"""
         assert not orion.core.config.evc.manual_resolution
         assert not orion.core.config.evc.ignore_code_changes
         assert not orion.core.config.evc.algorithm_change
-        assert orion.core.config.evc.non_monitored_arguments == ['test', 'two', 'others']
-        assert orion.core.config.evc.code_change_type == 'unsure'
-        assert orion.core.config.evc.cli_change_type == 'unsure'
-        assert orion.core.config.evc.config_change_type == 'unsure'
+        assert orion.core.config.evc.non_monitored_arguments == [
+            "test",
+            "two",
+            "others",
+        ]
+        assert orion.core.config.evc.code_change_type == "unsure"
+        assert orion.core.config.evc.cli_change_type == "unsure"
+        assert orion.core.config.evc.config_change_type == "unsure"
 
         script = os.path.abspath(__file__)
-        name = 'env-var-test'
-        command = f'hunt --init-only -n {name} python {script} -x~uniform(0,1)'
-        assert orion.core.cli.main(command.split(' ')) == 0
+        name = "env-var-test"
+        command = f"hunt --init-only -n {name} python {script} -x~uniform(0,1)"
+        assert orion.core.cli.main(command.split(" ")) == 0
 
         # TODO: Anything to test still???
-        command = self._check_cli_change(
-            name, command, version=1, change_type='unsure')
+        command = self._check_cli_change(name, command, version=1, change_type="unsure")
         command = self._check_non_monitored_arguments(
-            name, command, version=2,
-            non_monitored_arguments=['test', 'two', 'others'])
+            name, command, version=2, non_monitored_arguments=["test", "two", "others"]
+        )
         self._check_script_config_change(
-            tmp_path, name, command, version=2, change_type='unsure')
+            tmp_path, name, command, version=2, change_type="unsure"
+        )
 
         self._check_code_change(
-            monkeypatch, name, command, version=3,
+            monkeypatch,
+            name,
+            command,
+            version=3,
             ignore_code_change=None,
-            change_type='unsure')
+            change_type="unsure",
+        )
 
     def check_db_config(self):
         """No Storage config in DB, no test"""
@@ -877,150 +887,199 @@ class TestEVCConfig(ConfigurationTestSuite):
     def check_local_config(self, tmp_path, conf_file, monkeypatch):
         """Check that local configuration overrides global/envvars configuration"""
         script = os.path.abspath(__file__)
-        name = 'local-test'
-        command = f'hunt --init-only -n {name} -c {conf_file} python {script} -x~uniform(0,1)'
-        assert orion.core.cli.main(command.split(' ')) == 0
+        name = "local-test"
+        command = (
+            f"hunt --init-only -n {name} -c {conf_file} python {script} -x~uniform(0,1)"
+        )
+        assert orion.core.cli.main(command.split(" ")) == 0
 
         # Test that manual_resolution is True and it branches when changing cli
-        assert orion.core.cli.main(f'{command} --cli-change '.split(' ')) == 1
+        assert orion.core.cli.main(f"{command} --cli-change ".split(" ")) == 1
 
-        command = 'hunt --auto-resolution ' + command[5:]
+        command = "hunt --auto-resolution " + command[5:]
 
         command = self._check_cli_change(
-            name, command, version=1, change_type=self.local['evc']['cli_change_type'])
+            name, command, version=1, change_type=self.local["evc"]["cli_change_type"]
+        )
         command = self._check_non_monitored_arguments(
-            name, command, version=2,
-            non_monitored_arguments=self.local['evc']['non_monitored_arguments'])
+            name,
+            command,
+            version=2,
+            non_monitored_arguments=self.local["evc"]["non_monitored_arguments"],
+        )
         self._check_script_config_change(
-            tmp_path, name, command, version=2, change_type=self.local['evc']['config_change_type'])
+            tmp_path,
+            name,
+            command,
+            version=2,
+            change_type=self.local["evc"]["config_change_type"],
+        )
         self._check_code_change(
-            monkeypatch, name, command, version=3,
+            monkeypatch,
+            name,
+            command,
+            version=3,
             ignore_code_change=True,
-            change_type=self.local['evc']['code_change_type'])
+            change_type=self.local["evc"]["code_change_type"],
+        )
 
     def check_cmd_args_config(self, tmp_path, conf_file, monkeypatch):
         """Check that cmdargs configuration overrides global/envvars/local configuration"""
         script = os.path.abspath(__file__)
-        name = 'cmd-test'
-        command = (f'hunt --init-only -c {conf_file} -n {name} '
-                   '--auto-resolution '
-                   '--non-monitored-arguments test:cmdargs '
-                   '--code-change-type noeffect '
-                   '--cli-change-type unsure '
-                   '--config-change-type break '
-                   f'python {script} -x~uniform(0,1)')
-        assert orion.core.cli.main(command.split(' ')) == 0
+        name = "cmd-test"
+        command = (
+            f"hunt --init-only -c {conf_file} -n {name} "
+            "--auto-resolution "
+            "--non-monitored-arguments test:cmdargs "
+            "--code-change-type noeffect "
+            "--cli-change-type unsure "
+            "--config-change-type break "
+            f"python {script} -x~uniform(0,1)"
+        )
+        assert orion.core.cli.main(command.split(" ")) == 0
 
         command = self._check_cli_change(
-            name, command, version=1, change_type=self.cmdargs['cli-change-type'])
+            name, command, version=1, change_type=self.cmdargs["cli-change-type"]
+        )
         command = self._check_non_monitored_arguments(
-            name, command, version=2,
-            non_monitored_arguments=self.cmdargs['non-monitored-arguments'].split(':'))
+            name,
+            command,
+            version=2,
+            non_monitored_arguments=self.cmdargs["non-monitored-arguments"].split(":"),
+        )
 
         self._check_script_config_change(
-            tmp_path, name, command, version=2, change_type=self.cmdargs['config-change-type'])
+            tmp_path,
+            name,
+            command,
+            version=2,
+            change_type=self.cmdargs["config-change-type"],
+        )
 
         # Mock local to ignore_code_changes=False
         fetch_config = orion.core.io.resolve_config.fetch_config
 
         def mock_local(cmdargs):
             config = fetch_config(cmdargs)
-            config['evc']['ignore_code_changes'] = False
+            config["evc"]["ignore_code_changes"] = False
             return config
 
-        monkeypatch.setattr(orion.core.io.resolve_config, 'fetch_config', mock_local)
+        monkeypatch.setattr(orion.core.io.resolve_config, "fetch_config", mock_local)
 
         # Check that ignore_code_changes is rightly False
         self._check_code_change(
-            monkeypatch, name, command, version=3,
+            monkeypatch,
+            name,
+            command,
+            version=3,
             ignore_code_change=False,
-            change_type=self.cmdargs['code-change-type'])
+            change_type=self.cmdargs["code-change-type"],
+        )
 
-        command = 'hunt --ignore-code-changes ' + command[5:]
+        command = "hunt --ignore-code-changes " + command[5:]
 
         # Check that ignore_code_changes is now True
         self._check_code_change(
-            monkeypatch, name, command, version=4,
+            monkeypatch,
+            name,
+            command,
+            version=4,
             ignore_code_change=True,
-            change_type=self.cmdargs['code-change-type'])
+            change_type=self.cmdargs["code-change-type"],
+        )
 
     def _check_cli_change(self, name, command, version, change_type):
-        command += ' --cli-change'
+        command += " --cli-change"
 
         # Test that manual_resolution is False and it branches when changing cli
-        assert orion.core.cli.main(command.split(' ')) == 0
+        assert orion.core.cli.main(command.split(" ")) == 0
 
         experiment = get_experiment(name, version=version + 1)
         assert experiment.version == version + 1
-        assert (experiment.refers['adapter'].configuration[0] ==
-                {'of_type': 'commandlinechange', 'change_type': change_type})
+        assert experiment.refers["adapter"].configuration[0] == {
+            "of_type": "commandlinechange",
+            "change_type": change_type,
+        }
 
         return command
 
-    def _check_non_monitored_arguments(self, name, command, version, non_monitored_arguments):
+    def _check_non_monitored_arguments(
+        self, name, command, version, non_monitored_arguments
+    ):
         for argument in non_monitored_arguments:
-            command += f' --{argument} '
+            command += f" --{argument} "
 
         # Test that cli change with non-monitored args do not cause branching
-        assert orion.core.cli.main(command.split(' ')) == 0
+        assert orion.core.cli.main(command.split(" ")) == 0
 
         experiment = get_experiment(name, version=version + 1)
         assert experiment.version == version
 
         return command
 
-    def _check_code_change(self, monkeypatch, name, command, version, ignore_code_change,
-                           change_type):
+    def _check_code_change(
+        self, monkeypatch, name, command, version, ignore_code_change, change_type
+    ):
 
         # Test that code change is handled with 'no-effect'
         def fixed_dictionary(user_script):
             """Create VCS"""
             vcs = {}
-            vcs['type'] = 'git'
-            vcs['is_dirty'] = False
-            vcs['HEAD_sha'] = "test " + str(random.random())
-            vcs['active_branch'] = None
-            vcs['diff_sha'] = "diff"
+            vcs["type"] = "git"
+            vcs["is_dirty"] = False
+            vcs["HEAD_sha"] = "test " + str(random.random())
+            vcs["active_branch"] = None
+            vcs["diff_sha"] = "diff"
             return vcs
+
         monkeypatch.setattr(
-            orion.core.io.resolve_config, "infer_versioning_metadata", fixed_dictionary)
+            orion.core.io.resolve_config, "infer_versioning_metadata", fixed_dictionary
+        )
 
         detect = orion.core.evc.conflicts.CodeConflict.detect
 
         def mock_detect(old_config, new_config, branching_config):
-            if 'ignore_code_changes' in branching_config:
-                assert branching_config['ignore_code_changes'] is ignore_code_change
-                branching_config['ignore_code_changes'] = False
+            if "ignore_code_changes" in branching_config:
+                assert branching_config["ignore_code_changes"] is ignore_code_change
+                branching_config["ignore_code_changes"] = False
             return detect(old_config, new_config, branching_config)
 
-        monkeypatch.setattr(orion.core.evc.conflicts.CodeConflict, 'detect', mock_detect)
-        assert orion.core.cli.main(command.split(' ')) == 0
+        monkeypatch.setattr(
+            orion.core.evc.conflicts.CodeConflict, "detect", mock_detect
+        )
+        assert orion.core.cli.main(command.split(" ")) == 0
         experiment = get_experiment(name, version=version + 1)
         assert experiment.version == version + 1
-        assert (experiment.refers['adapter'].configuration[0] ==
-                {'of_type': 'codechange', 'change_type': change_type})
+        assert experiment.refers["adapter"].configuration[0] == {
+            "of_type": "codechange",
+            "change_type": change_type,
+        }
 
         monkeypatch.undo()
 
-    def _check_script_config_change(self, tmp_path, name, command, version, change_type):
+    def _check_script_config_change(
+        self, tmp_path, name, command, version, change_type
+    ):
 
         # Test that config change is handled with 'break'
         with self.setup_user_script_config(tmp_path) as user_script_config:
 
-            command += f' --config {user_script_config}'
-            assert orion.core.cli.main(command.split(' ')) == 0
+            command += f" --config {user_script_config}"
+            assert orion.core.cli.main(command.split(" ")) == 0
 
         experiment = get_experiment(name, version=version + 1)
         assert experiment.version == version + 1
-        print(experiment.refers['adapter'].configuration)
-        assert len(experiment.refers['adapter'].configuration) == 2
-        assert (experiment.refers['adapter'].configuration[1] ==
-                {'of_type': 'scriptconfigchange', 'change_type': change_type})
+        print(experiment.refers["adapter"].configuration)
+        assert len(experiment.refers["adapter"].configuration) == 2
+        assert experiment.refers["adapter"].configuration[1] == {
+            "of_type": "scriptconfigchange",
+            "change_type": change_type,
+        }
 
     @contextmanager
     def setup_user_script_config(self, tmp_path):
         """Setup temporary dummy user script config"""
         conf_file = tmp_path / "user_script_config.yaml"
-        config = {'what': 'ever'}
+        config = {"what": "ever"}
         conf_file.write_text(yaml.dump(config))
         yield conf_file

--- a/tests/functional/demo/black_box.py
+++ b/tests/functional/demo/black_box.py
@@ -10,43 +10,37 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     z = x - 34.56789
-    return 4 * z**2 + 23.4, 8 * z
+    return 4 * z ** 2 + 23.4, 8 * z
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('--test-env', action='store_true')
-    parser.add_argument('--experiment-id', type=str)
-    parser.add_argument('--experiment-name', type=str)
-    parser.add_argument('--experiment-version', type=str)
-    parser.add_argument('--trial-id', type=str)
-    parser.add_argument('--working-dir', type=str)
+    parser.add_argument("-x", type=float, required=True)
+    parser.add_argument("--test-env", action="store_true")
+    parser.add_argument("--experiment-id", type=str)
+    parser.add_argument("--experiment-name", type=str)
+    parser.add_argument("--experiment-version", type=str)
+    parser.add_argument("--trial-id", type=str)
+    parser.add_argument("--working-dir", type=str)
 
     inputs = parser.parse_args()
 
     if inputs.test_env:
-        assert inputs.experiment_id == os.environ['ORION_EXPERIMENT_ID']
-        assert inputs.experiment_name == os.environ['ORION_EXPERIMENT_NAME']
-        assert inputs.experiment_version == os.environ['ORION_EXPERIMENT_VERSION']
-        assert inputs.trial_id == os.environ['ORION_TRIAL_ID']
-        assert inputs.working_dir == os.environ['ORION_WORKING_DIR']
+        assert inputs.experiment_id == os.environ["ORION_EXPERIMENT_ID"]
+        assert inputs.experiment_name == os.environ["ORION_EXPERIMENT_NAME"]
+        assert inputs.experiment_version == os.environ["ORION_EXPERIMENT_VERSION"]
+        assert inputs.trial_id == os.environ["ORION_TRIAL_ID"]
+        assert inputs.working_dir == os.environ["ORION_WORKING_DIR"]
 
     # 2. Perform computations
     y, dy = function(inputs.x)
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/demo/black_box_w_config.py
+++ b/tests/functional/demo/black_box_w_config.py
@@ -11,32 +11,26 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     z = x - 34.56789
-    return 4 * z**2 + 23.4, 8 * z
+    return 4 * z ** 2 + 23.4, 8 * z
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('--config', required=True)
+    parser.add_argument("--config", required=True)
     inputs = parser.parse_args()
 
-    with open(inputs.config, 'r') as f:
+    with open(inputs.config, "r") as f:
         config = yaml.safe_load(f)
 
     # 2. Perform computations
-    y, dy = function(config['x'])
+    y, dy = function(config["x"])
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/demo/black_box_w_config_other.py
+++ b/tests/functional/demo/black_box_w_config_other.py
@@ -11,33 +11,27 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     z = x - 34.56789
-    return 4 * z**2 + 23.4, 8 * z
+    return 4 * z ** 2 + 23.4, 8 * z
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('--configuration', required=True)
+    parser.add_argument("--configuration", required=True)
     inputs = parser.parse_args()
 
-    with open(inputs.configuration, 'r') as f:
+    with open(inputs.configuration, "r") as f:
         config = yaml.safe_load(f)
 
     # 2. Perform computations
 
-    y, dy = function(config['x'])
+    y, dy = function(config["x"])
 
     # 3. Gather and report results
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/demo/broken_box.py
+++ b/tests/functional/demo/broken_box.py
@@ -8,7 +8,7 @@ def execute():
     """Execute a simple pipeline as an example."""
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument("-x", type=float, required=True)
 
     raise RuntimeError
 

--- a/tests/functional/demo/dir_per_trial.py
+++ b/tests/functional/demo/dir_per_trial.py
@@ -12,33 +12,29 @@ from orion.client import report_results
 def function(x):
     """Evaluate partial information of a quadratic."""
     z = x - 34.56789168765984988448213179176
-    return 4 * z**2 + 23.4, 8 * z
+    return 4 * z ** 2 + 23.4, 8 * z
 
 
 def execute():
     """Execute a simple pipeline as an example."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('--dir', type=str, required=True)
-    parser.add_argument('--name', type=str, required=True)
-    parser.add_argument('--other-name', type=str, required=True)
+    parser.add_argument("-x", type=float, required=True)
+    parser.add_argument("--dir", type=str, required=True)
+    parser.add_argument("--name", type=str, required=True)
+    parser.add_argument("--other-name", type=str, required=True)
     inputs = parser.parse_args()
 
     # That's what is expected to happen
-    os.makedirs(os.path.join(inputs.dir, inputs.other_name, "my-exp-{}".format(inputs.name)),
-                exist_ok=False)  # Raise OSError if it exists
+    os.makedirs(
+        os.path.join(inputs.dir, inputs.other_name, "my-exp-{}".format(inputs.name)),
+        exist_ok=False,
+    )  # Raise OSError if it exists
 
     y, dy = function(inputs.x)
 
     results = list()
-    results.append(dict(
-        name='example_objective',
-        type='objective',
-        value=y))
-    results.append(dict(
-        name='example_gradient',
-        type='gradient',
-        value=[dy]))
+    results.append(dict(name="example_objective", type="objective", value=y))
+    results.append(dict(name="example_gradient", type="gradient", value=[dy]))
 
     report_results(results)
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -25,27 +25,35 @@ from orion.testing import OrionState
 def test_demo_with_default_algo_cli_config_only(database, monkeypatch):
     """Check that random algorithm is used, when no algo is chosen explicitly."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    monkeypatch.setenv('ORION_DB_NAME', 'orion_test')
-    monkeypatch.setenv('ORION_DB_ADDRESS', 'mongodb://user:pass@localhost')
+    monkeypatch.setenv("ORION_DB_NAME", "orion_test")
+    monkeypatch.setenv("ORION_DB_ADDRESS", "mongodb://user:pass@localhost")
 
-    orion.core.cli.main(["hunt", "-n", "default_algo",
-                         "--max-trials", "30",
-                         "./black_box.py", "-x~uniform(-50, 50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "-n",
+            "default_algo",
+            "--max-trials",
+            "30",
+            "./black_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'default_algo'}))
+    exp = list(database.experiments.find({"name": "default_algo"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    assert exp['name'] == 'default_algo'
-    assert exp['pool_size'] == 1
-    assert exp['max_trials'] == 30
-    assert exp['max_broken'] == 3
-    assert exp['algorithms'] == {'random': {'seed': None}}
-    assert 'user' in exp['metadata']
-    assert 'datetime' in exp['metadata']
-    assert 'orion_version' in exp['metadata']
-    assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ["./black_box.py", '-x~uniform(-50, 50)']
+    assert "_id" in exp
+    assert exp["name"] == "default_algo"
+    assert exp["pool_size"] == 1
+    assert exp["max_trials"] == 30
+    assert exp["max_broken"] == 3
+    assert exp["algorithms"] == {"random": {"seed": None}}
+    assert "user" in exp["metadata"]
+    assert "datetime" in exp["metadata"]
+    assert "orion_version" in exp["metadata"]
+    assert "user_script" in exp["metadata"]
+    assert exp["metadata"]["user_args"] == ["./black_box.py", "-x~uniform(-50, 50)"]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -58,49 +66,55 @@ def test_demo(database, monkeypatch):
         "./black_box.py",
         "-x~uniform(-50, 50, precision=None)",
         "--test-env",
-        "--experiment-id", '{exp.id}',
-        "--experiment-name", '{exp.name}',
-        "--experiment-version", '{exp.version}',
-        "--trial-id", '{trial.id}',
-        "--working-dir", '{trial.working_dir}']
+        "--experiment-id",
+        "{exp.id}",
+        "--experiment-name",
+        "{exp.name}",
+        "--experiment-version",
+        "{exp.version}",
+        "--trial-id",
+        "{trial.id}",
+        "--working-dir",
+        "{trial.working_dir}",
+    ]
 
-    orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml"] + user_args)
+    orion.core.cli.main(["hunt", "--config", "./orion_config.yaml"] + user_args)
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    assert exp['name'] == 'voila_voici'
-    assert exp['pool_size'] == 1
-    assert exp['max_trials'] == 100
-    assert exp['max_broken'] == 5
-    assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
-                                                      'dx_tolerance': 1e-7}}
-    assert 'user' in exp['metadata']
-    assert 'datetime' in exp['metadata']
-    assert 'orion_version' in exp['metadata']
-    assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == user_args
-    trials = list(database.trials.find({'experiment': exp_id}))
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    assert exp["name"] == "voila_voici"
+    assert exp["pool_size"] == 1
+    assert exp["max_trials"] == 100
+    assert exp["max_broken"] == 5
+    assert exp["algorithms"] == {
+        "gradient_descent": {"learning_rate": 0.1, "dx_tolerance": 1e-7}
+    }
+    assert "user" in exp["metadata"]
+    assert "datetime" in exp["metadata"]
+    assert "orion_version" in exp["metadata"]
+    assert "user_script" in exp["metadata"]
+    assert exp["metadata"]["user_args"] == user_args
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) <= 15
-    assert trials[-1]['status'] == 'completed'
-    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
-    for result in trials[-1]['results']:
-        assert result['type'] != 'constraint'
-        if result['type'] == 'objective':
-            assert abs(result['value'] - 23.4) < 1e-6
-            assert result['name'] == 'example_objective'
-        elif result['type'] == 'gradient':
-            res = numpy.asarray(result['value'])
+    assert trials[-1]["status"] == "completed"
+    trials = list(sorted(trials, key=lambda trial: trial["submit_time"]))
+    for result in trials[-1]["results"]:
+        assert result["type"] != "constraint"
+        if result["type"] == "objective":
+            assert abs(result["value"] - 23.4) < 1e-6
+            assert result["name"] == "example_objective"
+        elif result["type"] == "gradient":
+            res = numpy.asarray(result["value"])
             assert 0.1 * numpy.sqrt(res.dot(res)) < 1e-7
-            assert result['name'] == 'example_gradient'
-    params = trials[-1]['params']
+            assert result["name"] == "example_gradient"
+    params = trials[-1]["params"]
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params[0]["name"] == "/x"
+    assert params[0]["type"] == "real"
+    assert (params[0]["value"] - 34.56789) < 1e-5
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -108,45 +122,57 @@ def test_demo(database, monkeypatch):
 def test_demo_with_script_config(database, monkeypatch):
     """Test a simple usage scenario."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "--config", "./orion_config.yaml",
-                         "./black_box_w_config.py", "--config", "script_config.yaml"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "./black_box_w_config.py",
+            "--config",
+            "script_config.yaml",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    assert exp['name'] == 'voila_voici'
-    assert exp['pool_size'] == 1
-    assert exp['max_trials'] == 100
-    assert exp['max_broken'] == 5
-    assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
-                                                      'dx_tolerance': 1e-7}}
-    assert 'user' in exp['metadata']
-    assert 'datetime' in exp['metadata']
-    assert 'orion_version' in exp['metadata']
-    assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['./black_box_w_config.py', '--config',
-                                            'script_config.yaml']
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    assert exp["name"] == "voila_voici"
+    assert exp["pool_size"] == 1
+    assert exp["max_trials"] == 100
+    assert exp["max_broken"] == 5
+    assert exp["algorithms"] == {
+        "gradient_descent": {"learning_rate": 0.1, "dx_tolerance": 1e-7}
+    }
+    assert "user" in exp["metadata"]
+    assert "datetime" in exp["metadata"]
+    assert "orion_version" in exp["metadata"]
+    assert "user_script" in exp["metadata"]
+    assert exp["metadata"]["user_args"] == [
+        "./black_box_w_config.py",
+        "--config",
+        "script_config.yaml",
+    ]
 
-    trials = list(database.trials.find({'experiment': exp_id}))
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) <= 15
-    assert trials[-1]['status'] == 'completed'
-    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
-    for result in trials[-1]['results']:
-        assert result['type'] != 'constraint'
-        if result['type'] == 'objective':
-            assert abs(result['value'] - 23.4) < 1e-6
-            assert result['name'] == 'example_objective'
-        elif result['type'] == 'gradient':
-            res = numpy.asarray(result['value'])
+    assert trials[-1]["status"] == "completed"
+    trials = list(sorted(trials, key=lambda trial: trial["submit_time"]))
+    for result in trials[-1]["results"]:
+        assert result["type"] != "constraint"
+        if result["type"] == "objective":
+            assert abs(result["value"] - 23.4) < 1e-6
+            assert result["name"] == "example_objective"
+        elif result["type"] == "gradient":
+            res = numpy.asarray(result["value"])
             assert 0.1 * numpy.sqrt(res.dot(res)) < 1e-7
-            assert result['name'] == 'example_gradient'
-    params = trials[-1]['params']
+            assert result["name"] == "example_gradient"
+    params = trials[-1]["params"]
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params[0]["name"] == "/x"
+    assert params[0]["type"] == "real"
+    assert (params[0]["value"] - 34.56789) < 1e-5
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -154,45 +180,59 @@ def test_demo_with_script_config(database, monkeypatch):
 def test_demo_with_python_and_script(database, monkeypatch):
     """Test a simple usage scenario."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "--config", "./orion_config.yaml",
-                         "python", "black_box_w_config.py", "--config", "script_config.yaml"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "python",
+            "black_box_w_config.py",
+            "--config",
+            "script_config.yaml",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    assert exp['name'] == 'voila_voici'
-    assert exp['pool_size'] == 1
-    assert exp['max_trials'] == 100
-    assert exp['max_broken'] == 5
-    assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
-                                                      'dx_tolerance': 1e-7}}
-    assert 'user' in exp['metadata']
-    assert 'datetime' in exp['metadata']
-    assert 'orion_version' in exp['metadata']
-    assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['python', 'black_box_w_config.py',
-                                            '--config', 'script_config.yaml']
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    assert exp["name"] == "voila_voici"
+    assert exp["pool_size"] == 1
+    assert exp["max_trials"] == 100
+    assert exp["max_broken"] == 5
+    assert exp["algorithms"] == {
+        "gradient_descent": {"learning_rate": 0.1, "dx_tolerance": 1e-7}
+    }
+    assert "user" in exp["metadata"]
+    assert "datetime" in exp["metadata"]
+    assert "orion_version" in exp["metadata"]
+    assert "user_script" in exp["metadata"]
+    assert exp["metadata"]["user_args"] == [
+        "python",
+        "black_box_w_config.py",
+        "--config",
+        "script_config.yaml",
+    ]
 
-    trials = list(database.trials.find({'experiment': exp_id}))
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) <= 15
-    assert trials[-1]['status'] == 'completed'
-    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
-    for result in trials[-1]['results']:
-        assert result['type'] != 'constraint'
-        if result['type'] == 'objective':
-            assert abs(result['value'] - 23.4) < 1e-6
-            assert result['name'] == 'example_objective'
-        elif result['type'] == 'gradient':
-            res = numpy.asarray(result['value'])
+    assert trials[-1]["status"] == "completed"
+    trials = list(sorted(trials, key=lambda trial: trial["submit_time"]))
+    for result in trials[-1]["results"]:
+        assert result["type"] != "constraint"
+        if result["type"] == "objective":
+            assert abs(result["value"] - 23.4) < 1e-6
+            assert result["name"] == "example_objective"
+        elif result["type"] == "gradient":
+            res = numpy.asarray(result["value"])
             assert 0.1 * numpy.sqrt(res.dot(res)) < 1e-7
-            assert result['name'] == 'example_gradient'
-    params = trials[-1]['params']
+            assert result["name"] == "example_gradient"
+    params = trials[-1]["params"]
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params[0]["name"] == "/x"
+    assert params[0]["type"] == "real"
+    assert (params[0]["value"] - 34.56789) < 1e-5
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -200,11 +240,19 @@ def test_demo_inexecutable_script(database, monkeypatch, capsys):
     """Test error message when user script is not executable."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     script = tempfile.NamedTemporaryFile()
-    orion.core.cli.main(["hunt", "--config", "./orion_config.yaml",
-                         script.name, "--config", "script_config.yaml"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            script.name,
+            "--config",
+            "script_config.yaml",
+        ]
+    )
 
     captured = capsys.readouterr().err
-    assert 'User script is not executable' in captured
+    assert "User script is not executable" in captured
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -213,59 +261,66 @@ def test_demo_two_workers(database, monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     processes = []
     for _ in range(2):
-        process = subprocess.Popen(["orion", "hunt", "-n", "two_workers_demo",
-                                    "--config", "./orion_config_random.yaml",
-                                    "--max-trials", "100",
-                                    "./black_box.py", "-x~norm(34, 3)"])
+        process = subprocess.Popen(
+            [
+                "orion",
+                "hunt",
+                "-n",
+                "two_workers_demo",
+                "--config",
+                "./orion_config_random.yaml",
+                "--max-trials",
+                "100",
+                "./black_box.py",
+                "-x~norm(34, 3)",
+            ]
+        )
         processes.append(process)
 
     for process in processes:
         rcode = process.wait()
         assert rcode == 0
 
-    exp = list(database.experiments.find({'name': 'two_workers_demo'}))
+    exp = list(database.experiments.find({"name": "two_workers_demo"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    assert exp['name'] == 'two_workers_demo'
-    assert exp['pool_size'] == 2
-    assert exp['max_trials'] == 100
-    assert exp['max_broken'] == 5
-    assert exp['algorithms'] == {'random': {'seed': None}}
-    assert 'user' in exp['metadata']
-    assert 'datetime' in exp['metadata']
-    assert 'orion_version' in exp['metadata']
-    assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['./black_box.py', '-x~norm(34, 3)']
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    assert exp["name"] == "two_workers_demo"
+    assert exp["pool_size"] == 2
+    assert exp["max_trials"] == 100
+    assert exp["max_broken"] == 5
+    assert exp["algorithms"] == {"random": {"seed": None}}
+    assert "user" in exp["metadata"]
+    assert "datetime" in exp["metadata"]
+    assert "orion_version" in exp["metadata"]
+    assert "user_script" in exp["metadata"]
+    assert exp["metadata"]["user_args"] == ["./black_box.py", "-x~norm(34, 3)"]
 
-    trials = list(database.trials.find({'experiment': exp_id}))
+    trials = list(database.trials.find({"experiment": exp_id}))
     status = defaultdict(int)
     for trial in trials:
-        status[trial['status']] += 1
-    assert 100 <= status['completed'] <= 101
-    assert status['new'] < 5
-    params = trials[-1]['params']
+        status[trial["status"]] += 1
+    assert 100 <= status["completed"] <= 101
+    assert status["new"] < 5
+    params = trials[-1]["params"]
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
+    assert params[0]["name"] == "/x"
+    assert params[0]["type"] == "real"
 
 
 def test_workon():
     """Test scenario having a configured experiment already setup."""
-    name = 'voici_voila'
-    config = {'name': name}
-    config['algorithms'] = {
-        'gradient_descent': {
-            'learning_rate': 0.1
-            }
-        }
-    config['pool_size'] = 1
-    config['max_trials'] = 100
-    config['exp_max_broken'] = 5
-    config['user_args'] = [
+    name = "voici_voila"
+    config = {"name": name}
+    config["algorithms"] = {"gradient_descent": {"learning_rate": 0.1}}
+    config["pool_size"] = 1
+    config["max_trials"] = 100
+    config["exp_max_broken"] = 5
+    config["user_args"] = [
         os.path.abspath(os.path.join(os.path.dirname(__file__), "black_box.py")),
-        "-x~uniform(-50, 50, precision=None)"]
+        "-x~uniform(-50, 50, precision=None)",
+    ]
 
     with OrionState():
         experiment = experiment_builder.build_from_args(config)
@@ -274,38 +329,39 @@ def test_workon():
 
         storage = get_storage()
 
-        exp = list(storage.fetch_experiments({'name': name}))
+        exp = list(storage.fetch_experiments({"name": name}))
         assert len(exp) == 1
         exp = exp[0]
-        assert '_id' in exp
-        assert exp['name'] == name
-        assert exp['pool_size'] == 1
-        assert exp['max_trials'] == 100
-        assert exp['max_broken'] == 5
-        assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
-                                                          'dx_tolerance': 1e-7}}
-        assert 'user' in exp['metadata']
-        assert 'datetime' in exp['metadata']
-        assert 'user_script' in exp['metadata']
-        assert exp['metadata']['user_args'] == config['user_args']
+        assert "_id" in exp
+        assert exp["name"] == name
+        assert exp["pool_size"] == 1
+        assert exp["max_trials"] == 100
+        assert exp["max_broken"] == 5
+        assert exp["algorithms"] == {
+            "gradient_descent": {"learning_rate": 0.1, "dx_tolerance": 1e-7}
+        }
+        assert "user" in exp["metadata"]
+        assert "datetime" in exp["metadata"]
+        assert "user_script" in exp["metadata"]
+        assert exp["metadata"]["user_args"] == config["user_args"]
 
         trials = list(storage.fetch_trials(experiment))
         assert len(trials) <= 15
         trials = list(sorted(trials, key=lambda trial: trial.submit_time))
-        assert trials[-1].status == 'completed'
+        assert trials[-1].status == "completed"
         for result in trials[-1].results:
-            assert result.type != 'constraint'
-            if result.type == 'objective':
+            assert result.type != "constraint"
+            if result.type == "objective":
                 assert abs(result.value - 23.4) < 1e-6
-                assert result.name == 'example_objective'
-            elif result.type == 'gradient':
+                assert result.name == "example_objective"
+            elif result.type == "gradient":
                 res = numpy.asarray(result.value)
                 assert 0.1 * numpy.sqrt(res.dot(res)) < 1e-7
-                assert result.name == 'example_gradient'
+                assert result.name == "example_gradient"
         params = trials[-1]._params
         assert len(params) == 1
-        assert params[0].name == '/x'
-        assert params[0].type == 'real'
+        assert params[0].name == "/x"
+        assert params[0].type == "real"
         assert (params[0].value - 34.56789) < 1e-5
 
 
@@ -319,21 +375,29 @@ def test_stress_unique_folder_creation(database, monkeypatch, tmpdir, capfd):
     # seed of Oríon
     how_many = 2
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "--max-trials={}".format(how_many),
-                         "--pool-size=1",
-                         "--name=lalala",
-                         "--config", "./stress_gradient.yaml",
-                         "./dir_per_trial.py",
-                         "--dir={}".format(str(tmpdir)),
-                         "--other-name", "{exp.name}",
-                         "--name", "{trial.hash_name}",
-                         "-x~gaussian(30, 10)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--max-trials={}".format(how_many),
+            "--pool-size=1",
+            "--name=lalala",
+            "--config",
+            "./stress_gradient.yaml",
+            "./dir_per_trial.py",
+            "--dir={}".format(str(tmpdir)),
+            "--other-name",
+            "{exp.name}",
+            "--name",
+            "{trial.hash_name}",
+            "-x~gaussian(30, 10)",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'lalala'}))
+    exp = list(database.experiments.find({"name": "lalala"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
+    assert "_id" in exp
+    exp_id = exp["_id"]
 
     # For contingent broken trials, which in this test means that a existing
     # directory was attempted to be created, it means that it's not md5 or
@@ -344,10 +408,10 @@ def test_stress_unique_folder_creation(database, monkeypatch, tmpdir, capfd):
     # test to create underdamped behaviour), that it begins to suggest same
     # things from the past. This is intended to be shown with the assertions
     # in the for-loop below.
-    trials_c = list(database.trials.find({'experiment': exp_id, 'status': 'completed'}))
-    list_of_cx = [trial['params'][0]['value'] for trial in trials_c]
-    trials_b = list(database.trials.find({'experiment': exp_id, 'status': 'broken'}))
-    list_of_bx = [trial['params'][0]['value'] for trial in trials_b]
+    trials_c = list(database.trials.find({"experiment": exp_id, "status": "completed"}))
+    list_of_cx = [trial["params"][0]["value"] for trial in trials_c]
+    trials_b = list(database.trials.find({"experiment": exp_id, "status": "broken"}))
+    list_of_bx = [trial["params"][0]["value"] for trial in trials_b]
     for bx in list_of_bx:
         assert bx in list_of_cx
 
@@ -355,7 +419,7 @@ def test_stress_unique_folder_creation(database, monkeypatch, tmpdir, capfd):
     assert len(os.listdir(str(tmpdir))) == 1
     # Also, because of the way the demo gradient descent works `how_many` trials
     # can be completed
-    assert len(os.listdir(str(tmpdir.join('lalala')))) == how_many
+    assert len(os.listdir(str(tmpdir.join("lalala")))) == how_many
     assert len(trials_c) == how_many
     capfd.readouterr()  # Suppress fd level 1 & 2
 
@@ -367,12 +431,24 @@ def test_working_dir_argument_cmdline(database, monkeypatch, tmp_path):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     path = str(tmp_path) + "/test"
     assert not os.path.exists(path)
-    orion.core.cli.main(["hunt", "-n", "allo", "--working-dir", path,
-                         "--max-trials", "2", "--config", "./database_config.yaml",
-                         "./black_box.py", "-x~uniform(-50,50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "-n",
+            "allo",
+            "--working-dir",
+            path,
+            "--max-trials",
+            "2",
+            "--config",
+            "./database_config.yaml",
+            "./black_box.py",
+            "-x~uniform(-50,50)",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'allo'}))[0]
-    assert exp['working_dir'] == path
+    exp = list(database.experiments.find({"name": "allo"}))[0]
+    assert exp["working_dir"] == path
     assert os.path.exists(path)
     assert os.listdir(path)
 
@@ -383,13 +459,24 @@ def test_working_dir_argument_cmdline(database, monkeypatch, tmp_path):
 @pytest.mark.usefixtures("null_db_instances")
 def test_tmpdir_is_deleted(database, monkeypatch, tmp_path):
     """Check that temporary directory is deletid tmpdir"""
-    tmp_path = os.path.join(tempfile.gettempdir(), 'orion')
+    tmp_path = os.path.join(tempfile.gettempdir(), "orion")
     if os.path.exists(tmp_path):
         shutil.rmtree(tmp_path)
 
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "-n", "allo", "--max-trials", "2", "--config",
-                         "./database_config.yaml", "./black_box.py", "-x~uniform(-50,50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "-n",
+            "allo",
+            "--max-trials",
+            "2",
+            "--config",
+            "./database_config.yaml",
+            "./black_box.py",
+            "-x~uniform(-50,50)",
+        ]
+    )
 
     assert not os.listdir(tmp_path)
 
@@ -399,16 +486,26 @@ def test_tmpdir_is_deleted(database, monkeypatch, tmp_path):
 def test_working_dir_argument_config(database, monkeypatch):
     """Check that workning dir argument is handled properly"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    dir_path = os.path.join('orion', 'test')
+    dir_path = os.path.join("orion", "test")
     if os.path.exists(dir_path):
         shutil.rmtree(dir_path)
 
-    orion.core.cli.main(["hunt", "-n", "allo", "--max-trials", "2",
-                         "--config", "./working_dir_config.yaml", "./black_box.py",
-                         "-x~uniform(-50,50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "-n",
+            "allo",
+            "--max-trials",
+            "2",
+            "--config",
+            "./working_dir_config.yaml",
+            "./black_box.py",
+            "-x~uniform(-50,50)",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'allo'}))[0]
-    assert exp['working_dir'] == dir_path
+    exp = list(database.experiments.find({"name": "allo"}))[0]
+    assert exp["working_dir"] == dir_path
     assert os.path.exists(dir_path)
     assert os.listdir(dir_path)
 
@@ -420,17 +517,27 @@ def test_working_dir_argument_config(database, monkeypatch):
 def test_run_with_name_only(database, monkeypatch):
     """Test hunt can be executed with experiment name only"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "--init-only", "--config", "./orion_config_random.yaml",
-                         "./black_box.py", "-x~uniform(-50, 50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "--config",
+            "./orion_config_random.yaml",
+            "./black_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
-    orion.core.cli.main(["hunt", "--max-trials", "20", "--config", "./orion_config_random.yaml"])
+    orion.core.cli.main(
+        ["hunt", "--max-trials", "20", "--config", "./orion_config_random.yaml"]
+    )
 
-    exp = list(database.experiments.find({'name': 'demo_random_search'}))
+    exp = list(database.experiments.find({"name": "demo_random_search"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 20
 
 
@@ -439,50 +546,69 @@ def test_run_with_name_only(database, monkeypatch):
 def test_run_with_name_only_with_trailing_whitespace(database, monkeypatch):
     """Test hunt can be executed with experiment name and trailing whitespace"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.cli.main(["hunt", "--init-only", "--config", "./orion_config_random.yaml",
-                         "./black_box.py", "-x~uniform(-50, 50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--init-only",
+            "--config",
+            "./orion_config_random.yaml",
+            "./black_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
-    orion.core.cli.main(["hunt", "--max-trials", "20",
-                         "--config", "./orion_config_random.yaml", ""])
+    orion.core.cli.main(
+        ["hunt", "--max-trials", "20", "--config", "./orion_config_random.yaml", ""]
+    )
 
-    exp = list(database.experiments.find({'name': 'demo_random_search'}))
+    exp = list(database.experiments.find({"name": "demo_random_search"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 20
 
 
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.parametrize("strategy", ['MaxParallelStrategy', 'MeanParallelStrategy'])
+@pytest.mark.parametrize("strategy", ["MaxParallelStrategy", "MeanParallelStrategy"])
 def test_run_with_parallel_strategy(database, monkeypatch, strategy):
     """Test hunt can be executed with max parallel strategies"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    with open('strategy_config.yaml') as f:
+    with open("strategy_config.yaml") as f:
         config = yaml.safe_load(f.read())
 
-    config_file = '{}_strategy_config.yaml'.format(strategy)
+    config_file = "{}_strategy_config.yaml".format(strategy)
 
-    with open(config_file, 'w') as f:
-        config['producer']['strategy'] = strategy
+    with open(config_file, "w") as f:
+        config["producer"]["strategy"] = strategy
         f.write(yaml.dump(config))
 
-    orion.core.cli.main(["hunt", "--max-trials", "20", "--pool-size", "1",
-                         "--config", config_file,
-                         "./black_box.py", "-x~uniform(-50, 50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--max-trials",
+            "20",
+            "--pool-size",
+            "1",
+            "--config",
+            config_file,
+            "./black_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
     os.remove(config_file)
 
-    exp = list(database.experiments.find({'name': 'strategy_demo'}))
+    exp = list(database.experiments.find({"name": "strategy_demo"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert exp['producer']['strategy'] == {strategy: {'default_result': float('inf')}}
-    assert '_id' in exp
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
+    assert exp["producer"]["strategy"] == {strategy: {"default_result": float("inf")}}
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) == 20
 
 
@@ -492,35 +618,58 @@ def test_worker_trials(database, monkeypatch):
     """Test number of trials executed is limited based on worker-trials"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    assert len(list(database.experiments.find({'name': 'demo_random_search'}))) == 0
+    assert len(list(database.experiments.find({"name": "demo_random_search"}))) == 0
 
-    orion.core.cli.main(["hunt", "--config", "./orion_config_random.yaml", "--pool-size", "1",
-                         "--worker-trials", "0",
-                         "./black_box.py", "-x~uniform(-50, 50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config_random.yaml",
+            "--pool-size",
+            "1",
+            "--worker-trials",
+            "0",
+            "./black_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'demo_random_search'}))
+    exp = list(database.experiments.find({"name": "demo_random_search"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
+    assert "_id" in exp
+    exp_id = exp["_id"]
 
-    assert len(list(database.trials.find({'experiment': exp_id}))) == 0
+    assert len(list(database.trials.find({"experiment": exp_id}))) == 0
 
     # Test only executes 2 trials
-    orion.core.cli.main(["hunt", "--name", "demo_random_search", "--worker-trials", "2"])
+    orion.core.cli.main(
+        ["hunt", "--name", "demo_random_search", "--worker-trials", "2"]
+    )
 
-    assert len(list(database.trials.find({'experiment': exp_id}))) == 2
+    assert len(list(database.trials.find({"experiment": exp_id}))) == 2
 
     # Test only executes 3 more trials
-    orion.core.cli.main(["hunt", "--name", "demo_random_search", "--worker-trials", "3"])
+    orion.core.cli.main(
+        ["hunt", "--name", "demo_random_search", "--worker-trials", "3"]
+    )
 
-    assert len(list(database.trials.find({'experiment': exp_id}))) == 5
+    assert len(list(database.trials.find({"experiment": exp_id}))) == 5
 
     # Test that max-trials has precedence over worker-trials
-    orion.core.cli.main(["hunt", "--name", "demo_random_search", "--worker-trials", "5",
-                         "--max-trials", "6"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--name",
+            "demo_random_search",
+            "--worker-trials",
+            "5",
+            "--max-trials",
+            "6",
+        ]
+    )
 
-    assert len(list(database.trials.find({'experiment': exp_id}))) == 6
+    assert len(list(database.trials.find({"experiment": exp_id}))) == 6
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -532,11 +681,18 @@ def test_resilience(monkeypatch):
     MAX_BROKEN = 3
     orion.core.config.worker.max_broken = 3
 
-    orion.core.cli.main(["hunt", "--config", "./orion_config_random.yaml", "./broken_box.py",
-                         "-x~uniform(-50, 50)"])
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config_random.yaml",
+            "./broken_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
-    exp = experiment_builder.build(name='demo_random_search')
-    assert len(exp.fetch_trials_by_status('broken')) == MAX_BROKEN
+    exp = experiment_builder.build(name="demo_random_search")
+    assert len(exp.fetch_trials_by_status("broken")) == MAX_BROKEN
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -545,11 +701,20 @@ def test_demo_with_shutdown_quickly(monkeypatch):
     """Check simple pipeline with random search is reasonably fast."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    monkeypatch.setattr(orion.core.config.worker, 'heartbeat', 120)
+    monkeypatch.setattr(orion.core.config.worker, "heartbeat", 120)
 
     process = subprocess.Popen(
-        ["orion", "hunt", "--config", "./orion_config_random.yaml", "--max-trials", "10",
-         "./black_box.py", "-x~uniform(-50, 50)"])
+        [
+            "orion",
+            "hunt",
+            "--config",
+            "./orion_config_random.yaml",
+            "--max-trials",
+            "10",
+            "./black_box.py",
+            "-x~uniform(-50, 50)",
+        ]
+    )
 
     assert process.wait(timeout=40) == 0
 
@@ -559,47 +724,59 @@ def test_demo_with_shutdown_quickly(monkeypatch):
 def test_demo_with_nondefault_config_keyword(database, monkeypatch):
     """Check that the user script configuration file is correctly used with a new keyword."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
-    orion.core.config.worker.user_script_config = 'configuration'
-    orion.core.cli.main(["hunt", "--config", "./orion_config_other.yaml",
-                         "./black_box_w_config_other.py", "--configuration", "script_config.yaml"])
+    orion.core.config.worker.user_script_config = "configuration"
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config_other.yaml",
+            "./black_box_w_config_other.py",
+            "--configuration",
+            "script_config.yaml",
+        ]
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     assert len(exp) == 1
     exp = exp[0]
-    assert '_id' in exp
-    exp_id = exp['_id']
-    assert exp['name'] == 'voila_voici'
-    assert exp['pool_size'] == 1
-    assert exp['max_trials'] == 100
-    assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
-                                                      'dx_tolerance': 1e-7}}
-    assert 'user' in exp['metadata']
-    assert 'datetime' in exp['metadata']
-    assert 'orion_version' in exp['metadata']
-    assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['./black_box_w_config_other.py', '--configuration',
-                                            'script_config.yaml']
+    assert "_id" in exp
+    exp_id = exp["_id"]
+    assert exp["name"] == "voila_voici"
+    assert exp["pool_size"] == 1
+    assert exp["max_trials"] == 100
+    assert exp["algorithms"] == {
+        "gradient_descent": {"learning_rate": 0.1, "dx_tolerance": 1e-7}
+    }
+    assert "user" in exp["metadata"]
+    assert "datetime" in exp["metadata"]
+    assert "orion_version" in exp["metadata"]
+    assert "user_script" in exp["metadata"]
+    assert exp["metadata"]["user_args"] == [
+        "./black_box_w_config_other.py",
+        "--configuration",
+        "script_config.yaml",
+    ]
 
-    trials = list(database.trials.find({'experiment': exp_id}))
+    trials = list(database.trials.find({"experiment": exp_id}))
     assert len(trials) <= 15
-    assert trials[-1]['status'] == 'completed'
-    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
-    for result in trials[-1]['results']:
-        assert result['type'] != 'constraint'
-        if result['type'] == 'objective':
-            assert abs(result['value'] - 23.4) < 1e-6
-            assert result['name'] == 'example_objective'
-        elif result['type'] == 'gradient':
-            res = numpy.asarray(result['value'])
+    assert trials[-1]["status"] == "completed"
+    trials = list(sorted(trials, key=lambda trial: trial["submit_time"]))
+    for result in trials[-1]["results"]:
+        assert result["type"] != "constraint"
+        if result["type"] == "objective":
+            assert abs(result["value"] - 23.4) < 1e-6
+            assert result["name"] == "example_objective"
+        elif result["type"] == "gradient":
+            res = numpy.asarray(result["value"])
             assert 0.1 * numpy.sqrt(res.dot(res)) < 1e-7
-            assert result['name'] == 'example_gradient'
-    params = trials[-1]['params']
+            assert result["name"] == "example_gradient"
+    params = trials[-1]["params"]
     assert len(params) == 1
-    assert params[0]['name'] == '/x'
-    assert params[0]['type'] == 'real'
-    assert (params[0]['value'] - 34.56789) < 1e-5
+    assert params[0]["name"] == "/x"
+    assert params[0]["type"] == "real"
+    assert (params[0]["value"] - 34.56789) < 1e-5
 
-    orion.core.config.worker.user_script_config = 'config'
+    orion.core.config.worker.user_script_config = "config"
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -608,20 +785,27 @@ def test_demo_precision(database, monkeypatch):
     """Test a simple usage scenario."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "--max-trials", "2",
-                            "./black_box.py"] + user_args)
+    orion.core.cli.main(
+        [
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--max-trials",
+            "2",
+            "./black_box.py",
+        ]
+        + user_args
+    )
 
-    exp = list(database.experiments.find({'name': 'voila_voici'}))
+    exp = list(database.experiments.find({"name": "voila_voici"}))
     exp = exp[0]
-    exp_id = exp['_id']
-    trials = list(database.trials.find({'experiment': exp_id}))
-    trials = list(sorted(trials, key=lambda trial: trial['submit_time']))
-    params = trials[-1]['params']
-    value = params[0]['value']
+    exp_id = exp["_id"]
+    trials = list(database.trials.find({"experiment": exp_id}))
+    trials = list(sorted(trials, key=lambda trial: trial["submit_time"]))
+    params = trials[-1]["params"]
+    value = params[0]["value"]
 
     assert value == float(numpy.format_float_scientific(value, precision=4))
 
@@ -631,12 +815,20 @@ def test_debug_mode(monkeypatch):
     """Test debug mode."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    user_args = [
-        "-x~uniform(-50, 50, precision=5)"]
+    user_args = ["-x~uniform(-50, 50, precision=5)"]
 
-    orion.core.cli.main([
-        "--debug", "hunt", "--config", "./orion_config.yaml", "--max-trials", "2",
-        "./black_box.py"] + user_args)
+    orion.core.cli.main(
+        [
+            "--debug",
+            "hunt",
+            "--config",
+            "./orion_config.yaml",
+            "--max-trials",
+            "2",
+            "./black_box.py",
+        ]
+        + user_args
+    )
 
     storage = get_storage()
 
@@ -651,5 +843,5 @@ def test_no_args(capsys):
 
     captured = capsys.readouterr().out
 
-    assert 'usage:' in captured
-    assert 'Traceback' not in captured
+    assert "usage:" in captured
+    assert "Traceback" not in captured

--- a/tests/functional/example/test_scikit_learn.py
+++ b/tests/functional/example/test_scikit_learn.py
@@ -13,12 +13,13 @@ def test_script_integrity(capsys):
     """Verifies the example script can run in standalone via `python ...`."""
     script = os.path.abspath("examples/scikitlearn-iris/main.py")
 
-    return_code = subprocess.call(["python", script, '0.1'])
+    return_code = subprocess.call(["python", script, "0.1"])
 
     assert return_code != 2, "The example script does not exists."
     assert return_code != 1, "The example script did not terminates its execution."
-    assert return_code == 0 and not capsys.readouterr().err, \
-        "The example script encountered an error during its execution."
+    assert (
+        return_code == 0 and not capsys.readouterr().err
+    ), "The example script encountered an error during its execution."
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
@@ -28,8 +29,9 @@ def test_orion_runs_script(monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     config = "orion_config.yaml"
 
-    orion.core.cli.main(["hunt", "--config", config, "python", script,
-                         "orion~choices([0.1])"])
+    orion.core.cli.main(
+        ["hunt", "--config", config, "python", script, "orion~choices([0.1])"]
+    )
 
     experiment = create_experiment(name="scikit-iris-tutorial")
     assert experiment is not None
@@ -37,15 +39,15 @@ def test_orion_runs_script(monkeypatch):
 
     keys = experiment.space.keys()
     assert len(keys) == 1
-    assert '/_pos_2' in keys
+    assert "/_pos_2" in keys
 
     storage = get_storage()
     trials = storage.fetch_trials(uid=experiment.id)
     assert len(trials) == 1
 
     trial = trials[0]
-    assert trial.status == 'completed'
-    assert trial.params['/_pos_2'] == 0.1
+    assert trial.status == "completed"
+    assert trial.params["/_pos_2"] == 0.1
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
@@ -55,9 +57,10 @@ def test_result_reproducibility(monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     config = "orion_config.yaml"
 
-    orion.core.cli.main(["hunt", "--config", config, "python", script,
-                         "orion~choices([0.1])"])
+    orion.core.cli.main(
+        ["hunt", "--config", config, "python", script, "orion~choices([0.1])"]
+    )
 
     experiment = create_experiment(name="scikit-iris-tutorial")
-    assert 'best_evaluation' in experiment.stats
-    assert experiment.stats['best_evaluation'] == 0.6666666666666667
+    assert "best_evaluation" in experiment.stats
+    assert experiment.stats["best_evaluation"] == 0.6666666666666667

--- a/tests/functional/gradient_descent_algo/setup.py
+++ b/tests/functional/gradient_descent_algo/setup.py
@@ -4,50 +4,49 @@
 from setuptools import setup
 
 setup_args = dict(
-    name='orion.algo.gradient_descent',
+    name="orion.algo.gradient_descent",
     version=0.1,
     description="Implement a gradient descent algorithm, for demo and testing.",
-    license='BSD-3-Clause',
-    author='Christos Tsirigotis',
-    author_email='tsirif@gmail.com',
-    url='https://github.com/epistimio/orion',
-    packages=['orion.algo'],
-    package_dir={'': 'src'},
+    license="BSD-3-Clause",
+    author="Christos Tsirigotis",
+    author_email="tsirif@gmail.com",
+    url="https://github.com/epistimio/orion",
+    packages=["orion.algo"],
+    package_dir={"": "src"},
     include_package_data=True,
     entry_points={
-        'OptimizationAlgorithm': [
-            'gradient_descent = orion.algo.gradient_descent:Gradient_Descent'
-            ],
-        },
-    install_requires=['orion'],
-    setup_requires=['setuptools'],
+        "OptimizationAlgorithm": [
+            "gradient_descent = orion.algo.gradient_descent:Gradient_Descent"
+        ],
+    },
+    install_requires=["orion"],
+    setup_requires=["setuptools"],
     # "Zipped eggs don't play nicely with namespace packaging"
     # from https://github.com/pypa/sample-namespace-packages
-    zip_safe=False
-    )
+    zip_safe=False,
+)
 
-setup_args['keywords'] = [
-    'Machine Learning',
-    'Deep Learning',
-    'Distributed',
-    'Optimization',
-    ]
+setup_args["keywords"] = [
+    "Machine Learning",
+    "Deep Learning",
+    "Distributed",
+    "Optimization",
+]
 
-setup_args['platforms'] = ['Linux']
+setup_args["platforms"] = ["Linux"]
 
-setup_args['classifiers'] = [
-    'Development Status :: 1 - Planning',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Education',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: POSIX',
-    'Operating System :: Unix',
-    'Programming Language :: Python',
-    'Topic :: Scientific/Engineering',
-    'Topic :: Scientific/Engineering :: Artificial Intelligence',
-] + [('Programming Language :: Python :: %s' % x)
-     for x in '3 3.6 3.7 3.8'.split()]
+setup_args["classifiers"] = [
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+] + [("Programming Language :: Python :: %s" % x) for x in "3 3.6 3.7 3.8".split()]
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(**setup_args)

--- a/tests/functional/gradient_descent_algo/src/orion/algo/gradient_descent.py
+++ b/tests/functional/gradient_descent_algo/src/orion/algo/gradient_descent.py
@@ -16,13 +16,13 @@ from orion.algo.base import BaseAlgorithm
 class Gradient_Descent(BaseAlgorithm):
     """Implement a gradient descent algorithm."""
 
-    requires = 'real'
+    requires = "real"
 
-    def __init__(self, space, learning_rate=1., dx_tolerance=1e-7):
+    def __init__(self, space, learning_rate=1.0, dx_tolerance=1e-7):
         """Declare `learning_rate` as a hyperparameter of this algorithm."""
-        super(Gradient_Descent, self).__init__(space,
-                                               learning_rate=learning_rate,
-                                               dx_tolerance=dx_tolerance)
+        super(Gradient_Descent, self).__init__(
+            space, learning_rate=learning_rate, dx_tolerance=dx_tolerance
+        )
         self.has_observed_once = False
         self.current_point = None
         self.gradient = numpy.array([numpy.inf])
@@ -48,7 +48,7 @@ class Gradient_Descent(BaseAlgorithm):
 
         """
         self.current_point = numpy.asarray(points[-1])
-        self.gradient = numpy.asarray(results[-1]['gradient'])
+        self.gradient = numpy.asarray(results[-1]["gradient"])
         self.has_observed_once = True
 
     @property

--- a/tests/functional/parsing/test_parsing_base.py
+++ b/tests/functional/parsing/test_parsing_base.py
@@ -28,8 +28,8 @@ def test_common_group_arguments(database, monkeypatch):
 
     cli.get_basic_args_group(parser)
     args = vars(parser.parse_args(args_list))
-    assert args['name'] == 'test'
-    assert args['config'].name == "./orion_config_random.yaml"
+    assert args["name"] == "test"
+    assert args["config"].name == "./orion_config_random.yaml"
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -41,8 +41,8 @@ def test_user_group_arguments(database, monkeypatch):
 
     cli.get_user_args_group(parser)
     args = vars(parser.parse_args(args_list))
-    assert len(args['user_args']) == 2
-    assert args['user_args'] == ['./black_box.py', '-x~normal(50,50)']
+    assert len(args["user_args"]) == 2
+    assert args["user_args"] == ["./black_box.py", "-x~normal(50,50)"]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -50,13 +50,19 @@ def test_common_and_user_group_arguments(database, monkeypatch):
     """Test the parsing of the command and user groups"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     parser = _create_parser(False)
-    args_list = ["-n", "test", "-c", "./orion_config_random.yaml",
-                 "./black_box.py", "-x~normal(50,50)"]
+    args_list = [
+        "-n",
+        "test",
+        "-c",
+        "./orion_config_random.yaml",
+        "./black_box.py",
+        "-x~normal(50,50)",
+    ]
 
     cli.get_basic_args_group(parser)
     cli.get_user_args_group(parser)
     args = vars(parser.parse_args(args_list))
-    assert args['name'] == 'test'
-    assert args['config'].name == './orion_config_random.yaml'
-    assert len(args['user_args']) == 2
-    assert args['user_args'] == ['./black_box.py', '-x~normal(50,50)']
+    assert args["name"] == "test"
+    assert args["config"].name == "./orion_config_random.yaml"
+    assert len(args["user_args"]) == 2
+    assert args["user_args"] == ["./black_box.py", "-x~normal(50,50)"]

--- a/tests/functional/parsing/test_parsing_hunt.py
+++ b/tests/functional/parsing/test_parsing_hunt.py
@@ -24,18 +24,29 @@ def test_hunt_command_full_parsing(database, monkeypatch):
     """Test the parsing of the `hunt` command"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     parser, subparsers = _create_parser()
-    args_list = ["hunt", "-n", "test",
-                 "--config", "./orion_config_random.yaml",
-                 "--max-trials", "400", "--pool-size", "4", "--worker-trials", "5",
-                 "./black_box.py", "-x~normal(1,1)"]
+    args_list = [
+        "hunt",
+        "-n",
+        "test",
+        "--config",
+        "./orion_config_random.yaml",
+        "--max-trials",
+        "400",
+        "--pool-size",
+        "4",
+        "--worker-trials",
+        "5",
+        "./black_box.py",
+        "-x~normal(1,1)",
+    ]
 
     hunt.add_subparser(subparsers)
-    subparsers.choices['hunt'].set_defaults(func='')
+    subparsers.choices["hunt"].set_defaults(func="")
 
     args = vars(parser.parse_args(args_list))
-    assert args['name'] == 'test'
-    assert args['config'].name == './orion_config_random.yaml'
-    assert args['user_args'] == ['./black_box.py', '-x~normal(1,1)']
-    assert args['pool_size'] == 4
-    assert args['max_trials'] == 400
-    assert args['worker_trials'] == 5
+    assert args["name"] == "test"
+    assert args["config"].name == "./orion_config_random.yaml"
+    assert args["user_args"] == ["./black_box.py", "-x~normal(1,1)"]
+    assert args["pool_size"] == 4
+    assert args["max_trials"] == 400
+    assert args["worker_trials"] == 5

--- a/tests/functional/parsing/test_parsing_insert.py
+++ b/tests/functional/parsing/test_parsing_insert.py
@@ -24,13 +24,20 @@ def test_insert_command_full_parsing(database, monkeypatch):
     """Test the parsing of all the options of insert"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     parser, subparsers = _create_parser()
-    args_list = ["insert", "-n", "test", "--config",
-                 "./orion_config_random.yaml", "./black_box.py", "-x=1"]
+    args_list = [
+        "insert",
+        "-n",
+        "test",
+        "--config",
+        "./orion_config_random.yaml",
+        "./black_box.py",
+        "-x=1",
+    ]
 
     insert.add_subparser(subparsers)
-    subparsers.choices['insert'].set_defaults(func='')
+    subparsers.choices["insert"].set_defaults(func="")
 
     args = vars(parser.parse_args(args_list))
-    assert args['name'] == 'test'
-    assert args['config'].name == './orion_config_random.yaml'
-    assert args['user_args'] == ['./black_box.py', '-x=1']
+    assert args["name"] == "test"
+    assert args["config"].name == "./orion_config_random.yaml"
+    assert args["user_args"] == ["./black_box.py", "-x=1"]

--- a/tests/functional/serving/conftest.py
+++ b/tests/functional/serving/conftest.py
@@ -11,6 +11,6 @@ from orion.testing import OrionState
 @pytest.fixture()
 def client():
     """Mock the falcon.API instance for testing with an in memory database"""
-    storage = {'type': 'legacy', 'database': {'type': 'EphemeralDB'}}
+    storage = {"type": "legacy", "database": {"type": "EphemeralDB"}}
     with OrionState(storage=storage):
-        yield testing.TestClient(WebApi({'storage': storage}))
+        yield testing.TestClient(WebApi({"storage": storage}))

--- a/tests/functional/serving/test_experiments_resource.py
+++ b/tests/functional/serving/test_experiments_resource.py
@@ -9,42 +9,44 @@ from orion.storage.base import get_storage
 current_id = 0
 
 base_experiment = dict(
-    name='experiment-name',
-    space={'x': 'uniform(0, 200)'},
-    metadata={'user': 'test-user',
-              'orion_version': 'x.y.z',
-              'datetime': datetime.datetime(1, 1, 1),
-              'VCS': {"type": "git",
-                      "is_dirty": False,
-                      "HEAD_sha": "test",
-                      "active_branch": None,
-                      "diff_sha": "diff"}},
+    name="experiment-name",
+    space={"x": "uniform(0, 200)"},
+    metadata={
+        "user": "test-user",
+        "orion_version": "x.y.z",
+        "datetime": datetime.datetime(1, 1, 1),
+        "VCS": {
+            "type": "git",
+            "is_dirty": False,
+            "HEAD_sha": "test",
+            "active_branch": None,
+            "diff_sha": "diff",
+        },
+    },
     version=1,
     pool_size=1,
     max_trials=10,
     max_broken=7,
-    working_dir='',
-    algorithms={'random': {'seed': 1}},
-    producer={'strategy': 'NoParallelStrategy'},
+    working_dir="",
+    algorithms={"random": {"seed": 1}},
+    producer={"strategy": "NoParallelStrategy"},
 )
 
 base_trial = {
-    'experiment': None,
-    'status': 'new',
-    'worker': None,
-    'submit_time': datetime.datetime(1, 1, 1),
-    'start_time': datetime.datetime(1, 1, 1, second=10),
-    'end_time': datetime.datetime(1, 1, 2),
-    'heartbeat': None,
-    'results': [
-        {'name': 'loss', 'type': 'objective', 'value': 0.05},
-        {'name': 'a', 'type': 'statistic', 'value': 10},
-        {'name': 'b', 'type': 'statistic', 'value': 5},
+    "experiment": None,
+    "status": "new",
+    "worker": None,
+    "submit_time": datetime.datetime(1, 1, 1),
+    "start_time": datetime.datetime(1, 1, 1, second=10),
+    "end_time": datetime.datetime(1, 1, 2),
+    "heartbeat": None,
+    "results": [
+        {"name": "loss", "type": "objective", "value": 0.05},
+        {"name": "a", "type": "statistic", "value": 10},
+        {"name": "b", "type": "statistic", "value": 5},
     ],
-    'params': [
-        {'name': 'x',
-         'type': 'real',
-         'value': 10.0},
+    "params": [
+        {"name": "x", "type": "real", "value": 10.0},
     ],
 }
 
@@ -54,39 +56,33 @@ class TestCollection:
 
     def test_no_experiments(self, client):
         """Tests that the API returns a positive response when no experiments are present"""
-        response = client.simulate_get('/experiments')
+        response = client.simulate_get("/experiments")
 
         assert response.json == []
         assert response.status == "200 OK"
 
     def test_send_name_and_versions(self, client):
         """Tests that the API returns all the experiments with their name and version"""
-        expected = [
-            {'name': 'a', 'version': 1},
-            {'name': 'b', 'version': 1}
-        ]
+        expected = [{"name": "a", "version": 1}, {"name": "b", "version": 1}]
 
-        _add_experiment(name='a', version=1, _id=1)
-        _add_experiment(name='b', version=1, _id=2)
+        _add_experiment(name="a", version=1, _id=1)
+        _add_experiment(name="b", version=1, _id=2)
 
-        response = client.simulate_get('/experiments')
+        response = client.simulate_get("/experiments")
 
         assert response.json == expected
         assert response.status == "200 OK"
 
     def test_latest_versions(self, client):
         """Tests that the API return the latest versions of each experiment"""
-        expected = [
-            {'name': 'a', 'version': 3},
-            {'name': 'b', 'version': 1}
-        ]
+        expected = [{"name": "a", "version": 3}, {"name": "b", "version": 1}]
 
-        _add_experiment(name='a', version=1, _id=1)
-        _add_experiment(name='a', version=3, _id=2)
-        _add_experiment(name='a', version=2, _id=3)
-        _add_experiment(name='b', version=1, _id=4)
+        _add_experiment(name="a", version=1, _id=1)
+        _add_experiment(name="a", version=3, _id=2)
+        _add_experiment(name="a", version=2, _id=3)
+        _add_experiment(name="b", version=1, _id=4)
 
-        response = client.simulate_get('/experiments')
+        response = client.simulate_get("/experiments")
 
         assert response.json == expected
         assert response.status == "200 OK"
@@ -100,87 +96,87 @@ class TestItem:
         Tests that a 404 response is returned when the experiment
         doesn't exist in the database
         """
-        response = client.simulate_get('/experiments/a')
+        response = client.simulate_get("/experiments/a")
 
         assert response.status == "404 Not Found"
         assert response.json == {
-            'title': 'Experiment not found',
-            'description': 'Experiment "a" does not exist'
+            "title": "Experiment not found",
+            "description": 'Experiment "a" does not exist',
         }
 
-        _add_experiment(name='a', version=1, _id=1)
-        response = client.simulate_get('/experiments/b')
+        _add_experiment(name="a", version=1, _id=1)
+        response = client.simulate_get("/experiments/b")
 
         assert response.status == "404 Not Found"
         assert response.json == {
-            'title': 'Experiment not found',
-            'description': 'Experiment "b" does not exist'
+            "title": "Experiment not found",
+            "description": 'Experiment "b" does not exist',
         }
 
     def test_experiment_specification(self, client):
         """Tests that the experiment returned is following the specification"""
-        _add_experiment(name='a', version=1, _id=1)
-        _add_trial(experiment=1, id_override="ae8", status='completed')
+        _add_experiment(name="a", version=1, _id=1)
+        _add_trial(experiment=1, id_override="ae8", status="completed")
 
-        response = client.simulate_get('/experiments/a')
+        response = client.simulate_get("/experiments/a")
 
         assert response.status == "200 OK"
 
-        assert response.json['name'] == "a"
-        assert response.json['version'] == 1
-        assert response.json['status'] == "not done"
-        assert response.json['trialsCompleted'] == 1
-        assert response.json['startTime'] == "0001-01-01 00:00:00"  # TODO
-        assert response.json['endTime'] == "0001-01-02 00:00:00"  # TODO
-        assert len(response.json['user'])
-        assert response.json['orionVersion'] == "x.y.z"
+        assert response.json["name"] == "a"
+        assert response.json["version"] == 1
+        assert response.json["status"] == "not done"
+        assert response.json["trialsCompleted"] == 1
+        assert response.json["startTime"] == "0001-01-01 00:00:00"  # TODO
+        assert response.json["endTime"] == "0001-01-02 00:00:00"  # TODO
+        assert len(response.json["user"])
+        assert response.json["orionVersion"] == "x.y.z"
 
-        _assert_config(response.json['config'])
-        _assert_best_trial(response.json['bestTrial'])
+        _assert_config(response.json["config"])
+        _assert_best_trial(response.json["bestTrial"])
 
     def test_default_is_latest_version(self, client):
         """Tests that the latest experiment is returned when no version parameter exists"""
-        _add_experiment(name='a', version=1, _id=1)
-        _add_experiment(name='a', version=3, _id=2)
-        _add_experiment(name='a', version=2, _id=3)
+        _add_experiment(name="a", version=1, _id=1)
+        _add_experiment(name="a", version=3, _id=2)
+        _add_experiment(name="a", version=2, _id=3)
 
-        response = client.simulate_get('/experiments/a')
+        response = client.simulate_get("/experiments/a")
 
         assert response.status == "200 OK"
-        assert response.json['version'] == 3
+        assert response.json["version"] == 3
 
     def test_specific_version(self, client):
         """Tests that the specified version of an experiment is returned"""
-        _add_experiment(name='a', version=1, _id=1)
-        _add_experiment(name='a', version=2, _id=2)
-        _add_experiment(name='a', version=3, _id=3)
+        _add_experiment(name="a", version=1, _id=1)
+        _add_experiment(name="a", version=2, _id=2)
+        _add_experiment(name="a", version=3, _id=3)
 
-        response = client.simulate_get('/experiments/a?version=2')
+        response = client.simulate_get("/experiments/a?version=2")
 
         assert response.status == "200 OK"
-        assert response.json['version'] == 2
+        assert response.json["version"] == 2
 
     def test_unknown_parameter(self, client):
         """
         Tests that if an unknown parameter is specified in
         the query string, an error is returned even if the experiment doesn't exist.
         """
-        response = client.simulate_get('/experiments/a?unknown=true')
+        response = client.simulate_get("/experiments/a?unknown=true")
 
         assert response.status == "400 Bad Request"
         assert response.json == {
-            'title': 'Invalid parameter',
-            'description': 'Parameter "unknown" is not supported. Expected parameter "version".'
+            "title": "Invalid parameter",
+            "description": 'Parameter "unknown" is not supported. Expected parameter "version".',
         }
 
-        _add_experiment(name='a', version=1, _id=1)
+        _add_experiment(name="a", version=1, _id=1)
 
-        response = client.simulate_get('/experiments/a?unknown=true')
+        response = client.simulate_get("/experiments/a?unknown=true")
 
         assert response.status == "400 Bad Request"
         assert response.json == {
-            'title': 'Invalid parameter',
-            'description': 'Parameter "unknown" is not supported. Expected parameter "version".'
+            "title": "Invalid parameter",
+            "description": 'Parameter "unknown" is not supported. Expected parameter "version".',
         }
 
 
@@ -198,32 +194,32 @@ def _add_trial(**kwargs):
 
 def _assert_config(config):
     """Asserts properties of the ``config`` dictionary"""
-    assert config['poolSize'] == 1
-    assert config['maxTrials'] == 10
-    assert config['maxBroken'] == 7
+    assert config["poolSize"] == 1
+    assert config["maxTrials"] == 10
+    assert config["maxBroken"] == 7
 
-    algorithm = config['algorithm']
-    assert algorithm['name'] == 'random'
-    assert algorithm['seed'] == 1
+    algorithm = config["algorithm"]
+    assert algorithm["name"] == "random"
+    assert algorithm["seed"] == 1
 
-    space = config['space']
+    space = config["space"]
     assert len(space) == 1
-    assert space['x'] == 'uniform(0, 200)'
+    assert space["x"] == "uniform(0, 200)"
 
 
 def _assert_best_trial(best_trial):
     """Verifies properties of the best trial"""
-    assert best_trial['id'] == 'ae8'
-    assert best_trial['submitTime'] == '0001-01-01 00:00:00'
-    assert best_trial['startTime'] == '0001-01-01 00:00:10'
-    assert best_trial['endTime'] == '0001-01-02 00:00:00'
+    assert best_trial["id"] == "ae8"
+    assert best_trial["submitTime"] == "0001-01-01 00:00:00"
+    assert best_trial["startTime"] == "0001-01-01 00:00:10"
+    assert best_trial["endTime"] == "0001-01-02 00:00:00"
 
-    parameters = best_trial['parameters']
+    parameters = best_trial["parameters"]
     assert len(parameters) == 1
-    assert parameters['x'] == 10.0
+    assert parameters["x"] == 10.0
 
-    assert best_trial['objective'] == 0.05
+    assert best_trial["objective"] == 0.05
 
-    statistics = best_trial['statistics']
-    assert statistics['a'] == 10
-    assert statistics['b'] == 5
+    statistics = best_trial["statistics"]
+    assert statistics["a"] == 10
+    assert statistics["b"] == 5

--- a/tests/functional/serving/test_plots_resource.py
+++ b/tests/functional/serving/test_plots_resource.py
@@ -2,38 +2,42 @@
 from orion.testing import create_experiment
 
 config = dict(
-    name='experiment-name',
-    space={'x': 'uniform(0, 200)'},
-    metadata={'user': 'test-user',
-              'orion_version': 'XYZ',
-              'VCS': {"type": "git",
-                      "is_dirty": False,
-                      "HEAD_sha": "test",
-                      "active_branch": None,
-                      "diff_sha": "diff"}},
+    name="experiment-name",
+    space={"x": "uniform(0, 200)"},
+    metadata={
+        "user": "test-user",
+        "orion_version": "XYZ",
+        "VCS": {
+            "type": "git",
+            "is_dirty": False,
+            "HEAD_sha": "test",
+            "active_branch": None,
+            "diff_sha": "diff",
+        },
+    },
     version=1,
     pool_size=1,
     max_trials=10,
-    working_dir='',
-    algorithms={'random': {'seed': 1}},
-    producer={'strategy': 'NoParallelStrategy'},
+    working_dir="",
+    algorithms={"random": {"seed": 1}},
+    producer={"strategy": "NoParallelStrategy"},
 )
 
 trial_config = {
-    'experiment': 0,
-    'status': 'completed',
-    'worker': None,
-    'start_time': None,
-    'end_time': None,
-    'heartbeat': None,
-    'results': [],
-    'params': []
+    "experiment": 0,
+    "status": "completed",
+    "worker": None,
+    "start_time": None,
+    "end_time": None,
+    "heartbeat": None,
+    "results": [],
+    "params": [],
 }
 
 
 def test_root_not_available(client):
     """Tests that plots/regret is not available"""
-    response = client.simulate_get('/plots/regret')
+    response = client.simulate_get("/plots/regret")
 
     assert response.status == "404 Not Found"
 
@@ -43,20 +47,26 @@ class TestRegretPlots:
 
     def test_unknown_experiment(self, client):
         """Tests that the API returns a 404 Not Found when an unknown experiment is queried."""
-        response = client.simulate_get('/plots/regret/unknown-experiment')
+        response = client.simulate_get("/plots/regret/unknown-experiment")
 
         assert response.status == "404 Not Found"
-        assert response.json == {'title': 'Experiment not found',
-                                 'description': 'Experiment "unknown-experiment" does not exist'}
+        assert response.json == {
+            "title": "Experiment not found",
+            "description": 'Experiment "unknown-experiment" does not exist',
+        }
 
     def test_plot(self, client):
         """Tests that the API returns the plot in json format."""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
-            response = client.simulate_get('/plots/regret/experiment-name')
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
+            response = client.simulate_get("/plots/regret/experiment-name")
 
         assert response.status == "200 OK"
         assert response.json
-        assert list(response.json.keys()) == ['data', 'layout']
+        assert list(response.json.keys()) == ["data", "layout"]
 
 
 class TestParallelCoordinatesPlots:
@@ -64,17 +74,25 @@ class TestParallelCoordinatesPlots:
 
     def test_unknown_experiment(self, client):
         """Tests that the API returns a 404 Not Found when an unknown experiment is queried."""
-        response = client.simulate_get('/plots/parallel_coordinates/unknown-experiment')
+        response = client.simulate_get("/plots/parallel_coordinates/unknown-experiment")
 
         assert response.status == "404 Not Found"
-        assert response.json == {'title': 'Experiment not found',
-                                 'description': 'Experiment "unknown-experiment" does not exist'}
+        assert response.json == {
+            "title": "Experiment not found",
+            "description": 'Experiment "unknown-experiment" does not exist',
+        }
 
     def test_plot(self, client):
         """Tests that the API returns the plot in json format."""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
-            response = client.simulate_get('/plots/parallel_coordinates/experiment-name')
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
+            response = client.simulate_get(
+                "/plots/parallel_coordinates/experiment-name"
+            )
 
         assert response.status == "200 OK"
         assert response.json
-        assert list(response.json.keys()) == ['data', 'layout']
+        assert list(response.json.keys()) == ["data", "layout"]

--- a/tests/functional/serving/test_root.py
+++ b/tests/functional/serving/test_root.py
@@ -4,9 +4,9 @@
 
 def test_runtime_summary(client):
     """Tests if the instance's meta-summary is present"""
-    response = client.simulate_get('/')
+    response = client.simulate_get("/")
 
-    assert response.json['orion']
-    assert response.json['server'] == 'gunicorn'
-    assert response.json['database'] == 'EphemeralDB'
+    assert response.json["orion"]
+    assert response.json["server"] == "gunicorn"
+    assert response.json["database"] == "EphemeralDB"
     assert response.status == "200 OK"

--- a/tests/functional/serving/test_trials_resource.py
+++ b/tests/functional/serving/test_trials_resource.py
@@ -8,41 +8,43 @@ from orion.core.worker.trial import Trial
 from orion.storage.base import get_storage
 
 base_experiment = dict(
-    name='experiment-name',
-    space={'x': 'uniform(0, 200)'},
-    metadata={'user': 'test-user',
-              'orion_version': 'x.y.z',
-              'datetime': datetime.datetime(1, 1, 1),
-              'VCS': {"type": "git",
-                      "is_dirty": False,
-                      "HEAD_sha": "test",
-                      "active_branch": None,
-                      "diff_sha": "diff"}},
+    name="experiment-name",
+    space={"x": "uniform(0, 200)"},
+    metadata={
+        "user": "test-user",
+        "orion_version": "x.y.z",
+        "datetime": datetime.datetime(1, 1, 1),
+        "VCS": {
+            "type": "git",
+            "is_dirty": False,
+            "HEAD_sha": "test",
+            "active_branch": None,
+            "diff_sha": "diff",
+        },
+    },
     refers={},
     version=1,
     pool_size=1,
     max_trials=10,
-    working_dir='',
-    algorithms={'random': {'seed': 1}},
+    working_dir="",
+    algorithms={"random": {"seed": 1}},
 )
 
 base_trial = {
-    'experiment': None,
-    'status': 'new',
-    'worker': None,
-    'submit_time': datetime.datetime(1, 1, 1),
-    'start_time': datetime.datetime(1, 1, 1, second=10),
-    'end_time': datetime.datetime(1, 1, 2),
-    'heartbeat': None,
-    'results': [
-        {'name': 'loss', 'type': 'objective', 'value': 0.05},
-        {'name': 'a', 'type': 'statistic', 'value': 10},
-        {'name': 'b', 'type': 'statistic', 'value': 5},
+    "experiment": None,
+    "status": "new",
+    "worker": None,
+    "submit_time": datetime.datetime(1, 1, 1),
+    "start_time": datetime.datetime(1, 1, 1, second=10),
+    "end_time": datetime.datetime(1, 1, 2),
+    "heartbeat": None,
+    "results": [
+        {"name": "loss", "type": "objective", "value": 0.05},
+        {"name": "a", "type": "statistic", "value": 10},
+        {"name": "b", "type": "statistic", "value": 5},
     ],
-    'params': [
-        {'name': 'x',
-         'type': 'real',
-         'value': 10.0},
+    "params": [
+        {"name": "x", "type": "real", "value": 10.0},
     ],
 }
 
@@ -50,7 +52,9 @@ base_trial = {
 def add_experiment(**kwargs):
     """Adds experiment to the dummy orion instance"""
     base_experiment.update(copy.deepcopy(kwargs))
-    experiment_builder.build(branching=dict(branch_from=base_experiment['name']), **base_experiment)
+    experiment_builder.build(
+        branching=dict(branch_from=base_experiment["name"]), **base_experiment
+    )
 
 
 def add_trial(experiment: int, status: str = None, **kwargs):
@@ -69,8 +73,8 @@ def add_trial(experiment: int, status: str = None, **kwargs):
     if not status:
         status = random.choice(Trial.allowed_stati)
 
-    kwargs['experiment'] = experiment
-    kwargs['status'] = status
+    kwargs["experiment"] = experiment
+    kwargs["status"] = status
 
     base_trial.update(copy.deepcopy(kwargs))
     get_storage().register_trial(Trial(**base_trial))
@@ -78,7 +82,7 @@ def add_trial(experiment: int, status: str = None, **kwargs):
 
 def test_root_endpoint_not_supported(client):
     """Tests that the server return a 404 when accessing trials/ with no experiment"""
-    response = client.simulate_get('/trials')
+    response = client.simulate_get("/trials")
 
     assert response.status == "404 Not Found"
     assert not response.json
@@ -89,112 +93,120 @@ class TestTrialCollection:
 
     def test_trials_for_unknown_experiment(self, client):
         """Tests that an unknown experiment returns a not found error"""
-        response = client.simulate_get('/trials/unknown-experiment')
+        response = client.simulate_get("/trials/unknown-experiment")
 
         assert response.status == "404 Not Found"
-        assert response.json == {'title': 'Experiment not found',
-                                 'description': 'Experiment "unknown-experiment" does not exist'}
+        assert response.json == {
+            "title": "Experiment not found",
+            "description": 'Experiment "unknown-experiment" does not exist',
+        }
 
     def test_unknown_parameter(self, client):
         """
         Tests that if an unknown parameter is specified in
         the query string, an error is returned even if the experiment doesn't exist.
         """
-        expected_error_message = 'Parameter "unknown" is not supported. ' \
-                                 'Expected one of [\'ancestors\', \'status\', \'version\'].'
+        expected_error_message = (
+            'Parameter "unknown" is not supported. '
+            "Expected one of ['ancestors', 'status', 'version']."
+        )
 
-        response = client.simulate_get('/trials/a?unknown=true')
-
-        assert response.status == "400 Bad Request"
-        assert response.json == {'title': 'Invalid parameter',
-                                 'description': expected_error_message}
-
-        add_experiment(name='a', version=1, _id=1)
-
-        response = client.simulate_get('/trials/a?unknown=true')
+        response = client.simulate_get("/trials/a?unknown=true")
 
         assert response.status == "400 Bad Request"
-        assert response.json == {'title': 'Invalid parameter',
-                                 'description': expected_error_message}
+        assert response.json == {
+            "title": "Invalid parameter",
+            "description": expected_error_message,
+        }
+
+        add_experiment(name="a", version=1, _id=1)
+
+        response = client.simulate_get("/trials/a?unknown=true")
+
+        assert response.status == "400 Bad Request"
+        assert response.json == {
+            "title": "Invalid parameter",
+            "description": expected_error_message,
+        }
 
     def test_trials_for_latest_version(self, client):
         """Tests that it returns the trials of the latest version of the experiment"""
-        add_experiment(name='a', version=1, _id=1)
-        add_experiment(name='a', version=2, _id=2)
+        add_experiment(name="a", version=1, _id=1)
+        add_experiment(name="a", version=2, _id=2)
 
         add_trial(experiment=1, id_override="00")
         add_trial(experiment=2, id_override="01")
         add_trial(experiment=1, id_override="02")
         add_trial(experiment=2, id_override="03")
 
-        response = client.simulate_get('/trials/a')
+        response = client.simulate_get("/trials/a")
 
         assert response.status == "200 OK"
-        assert response.json == [{'id': '01'}, {'id': '03'}]
+        assert response.json == [{"id": "01"}, {"id": "03"}]
 
     def test_trials_for_specific_version(self, client):
         """Tests specific version of experiment"""
-        add_experiment(name='a', version=1, _id=1)
-        add_experiment(name='a', version=2, _id=2)
-        add_experiment(name='a', version=3, _id=3)
+        add_experiment(name="a", version=1, _id=1)
+        add_experiment(name="a", version=2, _id=2)
+        add_experiment(name="a", version=3, _id=3)
 
         add_trial(experiment=1, id_override="00")
         add_trial(experiment=2, id_override="01")
         add_trial(experiment=3, id_override="02")
 
         # Happy case
-        response = client.simulate_get('/trials/a?version=2')
+        response = client.simulate_get("/trials/a?version=2")
 
         assert response.status == "200 OK"
-        assert response.json == [{'id': '01'}]
+        assert response.json == [{"id": "01"}]
 
         # Version doesn't exist
-        response = client.simulate_get('/trials/a?version=4')
+        response = client.simulate_get("/trials/a?version=4")
 
         assert response.status == "404 Not Found"
         assert response.json == {
-            'title': 'Experiment not found',
-            'description': 'Experiment "a" has no version "4"'
+            "title": "Experiment not found",
+            "description": 'Experiment "a" has no version "4"',
         }
 
     def test_trials_for_all_versions(self, client):
         """Tests that trials from all ancestors are shown"""
-        add_experiment(name='a', version=1, _id=1)
-        add_experiment(name='a', version=2, _id=2)
-        add_experiment(name='a', version=3, _id=3)
+        add_experiment(name="a", version=1, _id=1)
+        add_experiment(name="a", version=2, _id=2)
+        add_experiment(name="a", version=3, _id=3)
 
         add_trial(experiment=1, id_override="00")
         add_trial(experiment=2, id_override="01")
         add_trial(experiment=3, id_override="02")
 
         # Happy case default
-        response = client.simulate_get('/trials/a?ancestors=true')
+        response = client.simulate_get("/trials/a?ancestors=true")
 
         assert response.status == "200 OK"
-        assert response.json == [{'id': '00'}, {'id': '01'}, {'id': '02'}]
+        assert response.json == [{"id": "00"}, {"id": "01"}, {"id": "02"}]
 
         # Happy case explicitly false (call latest version test)
-        response = client.simulate_get('/trials/a?ancestors=false')
+        response = client.simulate_get("/trials/a?ancestors=false")
 
         assert response.status == "200 OK"
-        assert response.json == [{'id': '02'}]
+        assert response.json == [{"id": "02"}]
 
         # Not a boolean parameter
-        response = client.simulate_get('/trials/a?ancestors=42')
+        response = client.simulate_get("/trials/a?ancestors=42")
 
         assert response.status == "400 Bad Request"
         assert response.json == {
-            'title': 'Invalid parameter',
-            'description': 'The "ancestors" parameter is invalid. '
-                           'The value of the parameter must be "true" or "false".'
+            "title": "Invalid parameter",
+            "description": 'The "ancestors" parameter is invalid. '
+            'The value of the parameter must be "true" or "false".',
         }
 
     def test_trials_by_status(self, client):
         """Tests that trials are returned"""
-        add_experiment(name='a', version=1, _id=1)
+        add_experiment(name="a", version=1, _id=1)
 
         # There exist no trial of the given status in an empty experiment
-        response = client.simulate_get('/trials/a?status=completed')
+        response = client.simulate_get("/trials/a?status=completed")
 
         assert response.status == "200 OK"
         assert response.json == []
@@ -202,47 +214,53 @@ class TestTrialCollection:
         # There exist no trial of the given status while other status are present
         add_trial(experiment=1, id_override="00", status="broken")
 
-        response = client.simulate_get('/trials/a?status=completed')
+        response = client.simulate_get("/trials/a?status=completed")
         assert response.status == "200 OK"
         assert response.json == []
 
         # There exist at least one trial of the given status
         add_trial(experiment=1, id_override="01", status="completed")
 
-        response = client.simulate_get('/trials/a?status=completed')
+        response = client.simulate_get("/trials/a?status=completed")
 
         assert response.status == "200 OK"
-        assert response.json == [{'id': '01'}]
+        assert response.json == [{"id": "01"}]
 
         # Status doesn't exist
-        response = client.simulate_get('/trials/a?status=invalid')
+        response = client.simulate_get("/trials/a?status=invalid")
 
         assert response.status == "400 Bad Request"
-        error_message = "Invalid status value. " \
-                        "Expected one of " \
-                        "['new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken']"
-        assert response.json == {'title': 'Invalid parameter',
-                                 'description': "The \"status\" parameter is invalid. "
-                                                "The value of the parameter must be one of "
-                                                "['new', 'reserved', 'suspended', 'completed', "
-                                                "'interrupted', 'broken']"}
+        error_message = (
+            "Invalid status value. "
+            "Expected one of "
+            "['new', 'reserved', 'suspended', 'completed', 'interrupted', 'broken']"
+        )
+        assert response.json == {
+            "title": "Invalid parameter",
+            "description": 'The "status" parameter is invalid. '
+            "The value of the parameter must be one of "
+            "['new', 'reserved', 'suspended', 'completed', "
+            "'interrupted', 'broken']",
+        }
 
     def test_trials_by_from_specific_version_by_status_with_ancestors(self, client):
         """Tests that mixing parameters work as intended"""
-        add_experiment(name='a', version=1, _id=1)
-        add_experiment(name='b', version=1, _id=2)
-        add_experiment(name='a', version=2, _id=3)
-        add_experiment(name='a', version=3, _id=4)
+        add_experiment(name="a", version=1, _id=1)
+        add_experiment(name="b", version=1, _id=2)
+        add_experiment(name="a", version=2, _id=3)
+        add_experiment(name="a", version=3, _id=4)
 
-        add_trial(experiment=1, id_override="00", status='completed')
-        add_trial(experiment=3, id_override="01", status='broken')
-        add_trial(experiment=3, id_override="02", status='completed')
-        add_trial(experiment=2, id_override="03", status='completed')
+        add_trial(experiment=1, id_override="00", status="completed")
+        add_trial(experiment=3, id_override="01", status="broken")
+        add_trial(experiment=3, id_override="02", status="completed")
+        add_trial(experiment=2, id_override="03", status="completed")
 
-        response = client.simulate_get('/trials/a?ancestors=true&version=2&status=completed')
+        response = client.simulate_get(
+            "/trials/a?ancestors=true&version=2&status=completed"
+        )
 
         assert response.status == "200 OK"
-        assert response.json == [{'id': '00'}, {'id': '02'}]
+        assert response.json == [{"id": "00"}, {"id": "02"}]
 
 
 class TestTrialItem:
@@ -250,38 +268,41 @@ class TestTrialItem:
 
     def test_unknown_experiment(self, client):
         """Tests that an unknown experiment returns a not found error"""
-        response = client.simulate_get('/trials/unknown-experiment/a-trial')
+        response = client.simulate_get("/trials/unknown-experiment/a-trial")
 
         assert response.status == "404 Not Found"
-        assert response.json == {'title': 'Experiment not found',
-                                 'description': 'Experiment "unknown-experiment" does not exist'}
+        assert response.json == {
+            "title": "Experiment not found",
+            "description": 'Experiment "unknown-experiment" does not exist',
+        }
 
     def test_unknown_trial(self, client):
         """Tests that an unknown experiment returns a not found error"""
-        add_experiment(name='a', version=1, _id=1)
+        add_experiment(name="a", version=1, _id=1)
 
-        response = client.simulate_get('/trials/a/unknown-trial')
+        response = client.simulate_get("/trials/a/unknown-trial")
 
         assert response.status == "404 Not Found"
-        assert response.json == {'title': 'Trial not found',
-                                 'description': 'Trial "unknown-trial" does not exist'}
+        assert response.json == {
+            "title": "Trial not found",
+            "description": 'Trial "unknown-trial" does not exist',
+        }
 
     def test_get_trial(self, client):
         """Tests that an existing trial is returned according to the API specification"""
-        add_experiment(name='a', version=1, _id=1)
-        add_trial(experiment=1, id_override="00", status='completed')
-        add_trial(experiment=1, id_override="01", status='completed')
+        add_experiment(name="a", version=1, _id=1)
+        add_trial(experiment=1, id_override="00", status="completed")
+        add_trial(experiment=1, id_override="01", status="completed")
 
-        response = client.simulate_get('/trials/a/01')
+        response = client.simulate_get("/trials/a/01")
 
         assert response.status == "200 OK"
         assert response.json == {
-            'id': '01',
-            'submitTime': '0001-01-01 00:00:00',
-            'startTime': '0001-01-01 00:00:10',
-            'endTime': '0001-01-02 00:00:00',
-            'parameters': {'x': 10.0},
-            'objective': 0.05,
-            'statistics': {'a': 10,
-                           'b': 5},
+            "id": "01",
+            "submitTime": "0001-01-01 00:00:00",
+            "startTime": "0001-01-01 00:00:10",
+            "endTime": "0001-01-02 00:00:00",
+            "parameters": {"x": 10.0},
+            "objective": 0.05,
+            "statistics": {"a": 10, "b": 5},
         }

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -15,8 +15,8 @@ from orion.algo.space import Fidelity, Integer, Real, Space
 def space():
     """Create a Space with a real dimension and a fidelity value."""
     space = Space()
-    space.register(Real('lr', 'uniform', 0, 1))
-    space.register(Fidelity('epoch', 1, 9, 3))
+    space.register(Real("lr", "uniform", 0, 1))
+    space.register(Fidelity("epoch", 1, 9, 3))
     return space
 
 
@@ -28,8 +28,10 @@ def b_config(space):
     budgets = np.logspace(
         np.log(fidelity_dim.low) / np.log(fidelity_dim.base),
         np.log(fidelity_dim.high) / np.log(fidelity_dim.base),
-        num_rungs, base=fidelity_dim.base)
-    return {'reduction_factor': fidelity_dim.base, 'budgets': budgets}
+        num_rungs,
+        base=fidelity_dim.base,
+    )
+    return {"reduction_factor": fidelity_dim.base, "budgets": budgets}
 
 
 @pytest.fixture
@@ -41,29 +43,44 @@ def asha(b_config, space):
 @pytest.fixture
 def bracket(b_config):
     """Return a `Bracket` instance configured with `b_config`."""
-    return Bracket(None, b_config['reduction_factor'], b_config['budgets'])
+    return Bracket(None, b_config["reduction_factor"], b_config["budgets"])
 
 
 @pytest.fixture
 def rung_0():
     """Create fake points and objectives for rung 0."""
     points = np.linspace(0, 1, 9)
-    return (1, {hashlib.md5(str([point]).encode('utf-8')).hexdigest():
-            (point, (1, point)) for point in points})
+    return (
+        1,
+        {
+            hashlib.md5(str([point]).encode("utf-8")).hexdigest(): (point, (1, point))
+            for point in points
+        },
+    )
 
 
 @pytest.fixture
 def rung_1(rung_0):
     """Create fake points and objectives for rung 1."""
-    return (3, {hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value for value in
-            map(lambda v: (v[0], (3, v[0])), sorted(rung_0[1].values()))})
+    return (
+        3,
+        {
+            hashlib.md5(str([value[0]]).encode("utf-8")).hexdigest(): value
+            for value in map(lambda v: (v[0], (3, v[0])), sorted(rung_0[1].values()))
+        },
+    )
 
 
 @pytest.fixture
 def rung_2(rung_1):
     """Create fake points and objectives for rung 1."""
-    return (9, {hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value for value in
-            map(lambda v: (v[0], (9, v[0])), sorted(rung_1[1].values()))})
+    return (
+        9,
+        {
+            hashlib.md5(str([value[0]]).encode("utf-8")).hexdigest(): value
+            for value in map(lambda v: (v[0], (9, v[0])), sorted(rung_1[1].values()))
+        },
+    )
 
 
 def test_compute_budgets():
@@ -89,10 +106,10 @@ def test_compute_compressed_budgets():
     with pytest.raises(ValueError) as exc:
         compute_budgets(1, 2, 2, 10)
 
-    assert 'Cannot build budgets below max_resources' in str(exc.value)
+    assert "Cannot build budgets below max_resources" in str(exc.value)
 
 
-class TestBracket():
+class TestBracket:
     """Tests for the `Bracket` class."""
 
     def test_rungs_creation(self, bracket):
@@ -106,7 +123,7 @@ class TestBracket():
         """Check that a point is correctly registered inside a bracket."""
         bracket.asha = asha
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
         bracket.register(point, 0.0)
 
@@ -121,7 +138,7 @@ class TestBracket():
         with pytest.raises(IndexError) as ex:
             bracket.register((55, 0.0), 0.0)
 
-        assert 'Bad fidelity level 55' in str(ex.value)
+        assert "Bad fidelity level 55" in str(ex.value)
 
     def test_candidate_promotion(self, asha, bracket, rung_0):
         """Test that correct point is promoted."""
@@ -135,7 +152,7 @@ class TestBracket():
     def test_promotion_with_rung_1_hit(self, asha, bracket, rung_0):
         """Test that get_candidate gives us the next best thing if point is already in rung 1."""
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
         bracket.asha = asha
         bracket.rungs[0] = rung_0
         bracket.rungs[1][1][point_hash] = (0.0, point)
@@ -157,8 +174,10 @@ class TestBracket():
     def test_no_promotion_if_not_enough_points(self, asha, bracket):
         """Test the get_candidate return None if there is not enough points ready."""
         bracket.asha = asha
-        bracket.rungs[0] = (1, {hashlib.md5(str([0.0]).encode('utf-8')).hexdigest():
-                                (0.0, (1, 0.0))})
+        bracket.rungs[0] = (
+            1,
+            {hashlib.md5(str([0.0]).encode("utf-8")).hexdigest(): (0.0, (1, 0.0))},
+        )
 
         point = bracket.get_candidate(0)
 
@@ -184,7 +203,7 @@ class TestBracket():
         assert not bracket.is_done
 
         # Actual value of the point is not important here
-        bracket.rungs[2] = (9, {'1': (1, 0.0)})
+        bracket.rungs[2] = (9, {"1": (1, 0.0)})
 
         assert bracket.is_done
 
@@ -192,7 +211,7 @@ class TestBracket():
         """Check if a valid modified candidate is returned by update_rungs."""
         bracket.asha = asha
         bracket.rungs[1] = rung_1
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
         candidate = bracket.update_rungs()
 
@@ -214,10 +233,10 @@ class TestBracket():
         bracket.rungs[1] = rung_1
         bracket.rungs[2] = rung_2
 
-        assert str(bracket) == 'Bracket([1, 3, 9])'
+        assert str(bracket) == "Bracket([1, 3, 9])"
 
 
-class TestASHA():
+class TestASHA:
     """Tests for the algo ASHA."""
 
     def test_register(self, asha, bracket, rung_0, rung_1):
@@ -226,9 +245,9 @@ class TestASHA():
         bracket.asha = asha
         bracket.rungs = [rung_0, rung_1]
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
-        asha.observe([point], [{'objective': 0.0}])
+        asha.observe([point], [{"objective": 0.0}])
 
         assert len(bracket.rungs[0])
         assert point_hash in bracket.rungs[0][1]
@@ -241,9 +260,9 @@ class TestASHA():
         value = 50
         fidelity = 1
         point = (fidelity, value)
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        asha.observe([point], [{'objective': 0.0}])
+        asha.observe([point], [{"objective": 0.0}])
 
         bracket = asha.brackets[0]
 
@@ -253,9 +272,9 @@ class TestASHA():
 
         fidelity = 3
         point = [fidelity, value]
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        asha.observe([point], [{'objective': 0.0}])
+        asha.observe([point], [{"objective": 0.0}])
 
         assert len(bracket.rungs[0])
         assert point_hash in bracket.rungs[1][1]
@@ -269,9 +288,9 @@ class TestASHA():
         value = 50
         fidelity = 3
         point = (fidelity, value)
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        asha.observe([point], [{'objective': 0.0}])
+        asha.observe([point], [{"objective": 0.0}])
 
         assert sum(len(rung[1]) for rung in asha.brackets[0].rungs) == 0
         assert sum(len(rung[1]) for rung in asha.brackets[1].rungs) == 1
@@ -282,9 +301,9 @@ class TestASHA():
         value = 51
         fidelity = 9
         point = (fidelity, value)
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        asha.observe([point], [{'objective': 0.0}])
+        asha.observe([point], [{"objective": 0.0}])
 
         assert sum(len(rung[1]) for rung in asha.brackets[0].rungs) == 0
         assert sum(len(rung[1]) for rung in asha.brackets[1].rungs) == 1
@@ -301,9 +320,9 @@ class TestASHA():
         point = (fidelity, value)
 
         with pytest.raises(ValueError) as ex:
-            asha.observe([point], [{'objective': 0.0}])
+            asha.observe([point], [{"objective": 0.0}])
 
-        assert 'No bracket found for point' in str(ex.value)
+        assert "No bracket found for point" in str(ex.value)
 
     def test_register_corrupted_db(self, caplog, space, b_config):
         """Check that a point cannot registered if passed in order diff than fidelity."""
@@ -313,33 +332,33 @@ class TestASHA():
         fidelity = 3
         point = (fidelity, value)
 
-        asha.observe([point], [{'objective': 0.0}])
-        assert 'Point registered to wrong bracket' not in caplog.text
+        asha.observe([point], [{"objective": 0.0}])
+        assert "Point registered to wrong bracket" not in caplog.text
 
         fidelity = 1
         point = [fidelity, value]
 
         caplog.clear()
-        asha.observe([point], [{'objective': 0.0}])
-        assert 'Point registered to wrong bracket' in caplog.text
+        asha.observe([point], [{"objective": 0.0}])
+        assert "Point registered to wrong bracket" in caplog.text
 
     def test_get_id(self, space, b_config):
         """Test valid id of points"""
         asha = ASHA(space, num_brackets=3)
 
-        assert asha.get_id(['whatever', 1]) == asha.get_id(['is here', 1])
-        assert asha.get_id(['whatever', 1]) != asha.get_id(['is here', 2])
+        assert asha.get_id(["whatever", 1]) == asha.get_id(["is here", 1])
+        assert asha.get_id(["whatever", 1]) != asha.get_id(["is here", 2])
 
     def test_get_id_multidim(self, b_config):
         """Test valid id for points with dim of shape > 1"""
         space = Space()
-        space.register(Fidelity('epoch', 1, 9, 3))
-        space.register(Real('lr', 'uniform', 0, 1, shape=2))
+        space.register(Fidelity("epoch", 1, 9, 3))
+        space.register(Real("lr", "uniform", 0, 1, shape=2))
 
         asha = ASHA(space, num_brackets=3)
 
-        assert asha.get_id(['whatever', [1, 1]]) == asha.get_id(['is here', [1, 1]])
-        assert asha.get_id(['whatever', [1, 1]]) != asha.get_id(['is here', [2, 2]])
+        assert asha.get_id(["whatever", [1, 1]]) == asha.get_id(["is here", [1, 1]])
+        assert asha.get_id(["whatever", [1, 1]]) != asha.get_id(["is here", [2, 2]])
 
     def test_suggest_new(self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2):
         """Test that a new point is sampled."""
@@ -347,23 +366,25 @@ class TestASHA():
         bracket.asha = asha
 
         def sample(num=1, seed=None):
-            return [('fidelity', 0.5)]
+            return [("fidelity", 0.5)]
 
-        monkeypatch.setattr(asha.space, 'sample', sample)
+        monkeypatch.setattr(asha.space, "sample", sample)
 
         points = asha.suggest()
 
         assert points == [(1, 0.5)]
 
-    def test_suggest_duplicates(self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2):
+    def test_suggest_duplicates(
+        self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2
+    ):
         """Test that sampling collisions are handled."""
         asha.brackets = [bracket]
         bracket.asha = asha
 
-        duplicate_point = ('fidelity', 0.0)
-        new_point = ('fidelity', 0.5)
+        duplicate_point = ("fidelity", 0.0)
+        new_point = ("fidelity", 0.5)
 
-        duplicate_id = hashlib.md5(str([duplicate_point]).encode('utf-8')).hexdigest()
+        duplicate_id = hashlib.md5(str([duplicate_point]).encode("utf-8")).hexdigest()
         bracket.rungs[0] = (1, {duplicate_id: (0.0, duplicate_point)})
 
         asha.trial_info[asha.get_id(duplicate_point)] = bracket
@@ -373,41 +394,43 @@ class TestASHA():
         def sample(num=1, seed=None):
             return [points.pop(0)]
 
-        monkeypatch.setattr(asha.space, 'sample', sample)
+        monkeypatch.setattr(asha.space, "sample", sample)
 
         assert asha.suggest()[0][1] == new_point[1]
         assert len(points) == 0
 
-    def test_suggest_inf_duplicates(self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2):
+    def test_suggest_inf_duplicates(
+        self, monkeypatch, asha, bracket, rung_0, rung_1, rung_2
+    ):
         """Test that sampling inf collisions raises runtime error."""
         asha.brackets = [bracket]
         bracket.asha = asha
 
-        zhe_point = ('fidelity', 0.0)
+        zhe_point = ("fidelity", 0.0)
         asha.trial_info[asha.get_id(zhe_point)] = bracket
 
         def sample(num=1, seed=None):
             return [zhe_point]
 
-        monkeypatch.setattr(asha.space, 'sample', sample)
+        monkeypatch.setattr(asha.space, "sample", sample)
 
         with pytest.raises(RuntimeError) as exc:
             asha.suggest()
 
-        assert 'ASHA keeps sampling already existing points.' in str(exc.value)
+        assert "ASHA keeps sampling already existing points." in str(exc.value)
 
     def test_suggest_in_finite_cardinality(self):
         """Test that suggest None when search space is empty"""
         space = Space()
-        space.register(Integer('yolo1', 'uniform', 0, 5))
-        space.register(Fidelity('epoch', 1, 9, 3))
+        space.register(Integer("yolo1", "uniform", 0, 5))
+        space.register(Fidelity("epoch", 1, 9, 3))
 
         asha = ASHA(space)
         for i in range(6):
-            asha.observe([(1, i)], [{'objective': i}])
+            asha.observe([(1, i)], [{"objective": i}])
 
         for i in range(2):
-            asha.observe([(3, i)], [{'objective': i}])
+            asha.observe([(3, i)], [{"objective": i}])
 
         assert asha.suggest() is None
 

--- a/tests/unittests/algo/test_base.py
+++ b/tests/unittests/algo/test_base.py
@@ -8,10 +8,7 @@ from orion.algo.space import Integer, Real, Space
 
 def test_init(dumbalgo):
     """Check if initialization works for nested algos."""
-    nested_algo = {'DumbAlgo': dict(
-        value=6,
-        scoring=5
-        )}
+    nested_algo = {"DumbAlgo": dict(value=6, scoring=5)}
     algo = dumbalgo(8, value=1, subone=nested_algo)
     assert algo.space == 8
     assert algo.value == 1
@@ -27,106 +24,104 @@ def test_init(dumbalgo):
 
 def test_configuration(dumbalgo):
     """Check configuration getter works for nested algos."""
-    nested_algo = {'DumbAlgo': dict(
-        value=6,
-        scoring=5
-        )}
+    nested_algo = {"DumbAlgo": dict(value=6, scoring=5)}
     algo = dumbalgo(8, value=1, subone=nested_algo)
     config = algo.configuration
     assert config == {
-        'dumbalgo': {
-            'seed': None,
-            'value': 1,
-            'scoring': 0,
-            'judgement': None,
-            'suspend': False,
-            'done': False,
-            'subone': {
-                'dumbalgo': {
-                    'seed': None,
-                    'value': 6,
-                    'scoring': 5,
-                    'judgement': None,
-                    'suspend': False,
-                    'done': False,
-                    }
+        "dumbalgo": {
+            "seed": None,
+            "value": 1,
+            "scoring": 0,
+            "judgement": None,
+            "suspend": False,
+            "done": False,
+            "subone": {
+                "dumbalgo": {
+                    "seed": None,
+                    "value": 6,
+                    "scoring": 5,
+                    "judgement": None,
+                    "suspend": False,
+                    "done": False,
                 }
-            }
+            },
         }
+    }
 
 
 def test_space_setter(dumbalgo):
     """Check whether space setter works for nested algos."""
-    nested_algo = {'DumbAlgo': dict(
-        value=9,
-        )}
-    nested_algo2 = {'DumbAlgo': dict(
-        judgement=10,
-        )}
+    nested_algo = {
+        "DumbAlgo": dict(
+            value=9,
+        )
+    }
+    nested_algo2 = {
+        "DumbAlgo": dict(
+            judgement=10,
+        )
+    }
     algo = dumbalgo(8, value=1, naedw=nested_algo, naekei=nested_algo2)
-    algo.space = 'etsh'
-    assert algo.space == 'etsh'
-    assert algo.naedw.space == 'etsh'
+    algo.space = "etsh"
+    assert algo.space == "etsh"
+    assert algo.naedw.space == "etsh"
     assert algo.naedw.value == 9
-    assert algo.naekei.space == 'etsh'
+    assert algo.naekei.space == "etsh"
     assert algo.naekei.judgement == 10
 
 
 def test_state_dict(dumbalgo):
     """Check whether trials_info is in the state dict"""
-    nested_algo = {'DumbAlgo': dict(
-        value=6,
-        scoring=5
-        )}
+    nested_algo = {"DumbAlgo": dict(value=6, scoring=5)}
     algo = dumbalgo(8, value=1, subone=nested_algo)
     algo.suggest()
-    assert not algo.state_dict['_trials_info']
-    algo.observe([(1, 2)], [{'objective': 3}])
-    assert len(algo.state_dict['_trials_info']) == 1
-    algo.observe([(1, 2)], [{'objective': 3}])
-    assert len(algo.state_dict['_trials_info']) == 1
+    assert not algo.state_dict["_trials_info"]
+    algo.observe([(1, 2)], [{"objective": 3}])
+    assert len(algo.state_dict["_trials_info"]) == 1
+    algo.observe([(1, 2)], [{"objective": 3}])
+    assert len(algo.state_dict["_trials_info"]) == 1
 
 
 def test_is_done_cardinality(monkeypatch, dumbalgo):
     """Check whether algorithm will stop with base algorithm cardinality check"""
-    monkeypatch.delattr(dumbalgo, 'is_done')
+    monkeypatch.delattr(dumbalgo, "is_done")
 
     space = Space()
-    space.register(Integer('yolo1', 'uniform', 1, 4))
+    space.register(Integer("yolo1", "uniform", 1, 4))
 
     algo = dumbalgo(space)
     algo.suggest()
     for i in range(1, 6):
-        algo.observe([[i]], [{'objective': 3}])
+        algo.observe([[i]], [{"objective": 3}])
 
-    assert len(algo.state_dict['_trials_info']) == 5
+    assert len(algo.state_dict["_trials_info"]) == 5
     assert algo.is_done
 
     space = Space()
-    space.register(Real('yolo1', 'uniform', 1, 4))
+    space.register(Real("yolo1", "uniform", 1, 4))
 
     algo = dumbalgo(space)
     algo.suggest()
     for i in range(1, 6):
-        algo.observe([[i]], [{'objective': 3}])
+        algo.observe([[i]], [{"objective": 3}])
 
-    assert len(algo.state_dict['_trials_info']) == 5
+    assert len(algo.state_dict["_trials_info"]) == 5
     assert not algo.is_done
 
 
 def test_is_done_max_trials(monkeypatch, dumbalgo):
     """Check whether algorithm will stop with base algorithm max_trials check"""
-    monkeypatch.delattr(dumbalgo, 'is_done')
+    monkeypatch.delattr(dumbalgo, "is_done")
 
     space = Space()
-    space.register(Real('yolo1', 'uniform', 1, 4))
+    space.register(Real("yolo1", "uniform", 1, 4))
 
     algo = dumbalgo(space)
     algo.suggest()
     for i in range(1, 5):
-        algo.observe([[i]], [{'objective': 3}])
+        algo.observe([[i]], [{"objective": 3}])
 
-    assert len(algo.state_dict['_trials_info']) == 4
+    assert len(algo.state_dict["_trials_info"]) == 4
     assert not algo.is_done
 
     dumbalgo.max_trials = 4

--- a/tests/unittests/algo/test_evolution_es.py
+++ b/tests/unittests/algo/test_evolution_es.py
@@ -16,8 +16,8 @@ from orion.algo.space import Fidelity, Real, Space
 def space():
     """Create a Space with a real dimension and a fidelity value."""
     space = Space()
-    space.register(Real('lr', 'uniform', 0, 1))
-    space.register(Fidelity('epoch', 1, 9, 1))
+    space.register(Real("lr", "uniform", 0, 1))
+    space.register(Fidelity("epoch", 1, 9, 1))
     return space
 
 
@@ -25,9 +25,9 @@ def space():
 def space1():
     """Create a Space with two real dimensions and a fidelity value."""
     space = Space()
-    space.register(Real('lr', 'uniform', 0, 1))
-    space.register(Real('weight_decay', 'uniform', 0, 1))
-    space.register(Fidelity('epoch', 1, 8, 2))
+    space.register(Real("lr", "uniform", 0, 1))
+    space.register(Real("weight_decay", "uniform", 0, 1))
+    space.register(Fidelity("epoch", 1, 8, 2))
     return space
 
 
@@ -35,8 +35,8 @@ def space1():
 def space2():
     """Create a Space with two real dimensions."""
     space = Space()
-    space.register(Real('lr', 'uniform', 0, 1))
-    space.register(Real('weight_decay', 'uniform', 0, 1))
+    space.register(Real("lr", "uniform", 0, 1))
+    space.register(Real("weight_decay", "uniform", 0, 1))
     return space
 
 
@@ -61,8 +61,12 @@ def bracket(budgets, evolution, space1):
 @pytest.fixture
 def evolution_customer_mutate(space1):
     """Return an instance of EvolutionES."""
-    return EvolutionES(space1, repetitions=1, nums_population=4,
-                       mutate="orion.core.utils.tests.customized_mutate_example")
+    return EvolutionES(
+        space1,
+        repetitions=1,
+        nums_population=4,
+        mutate="orion.core.utils.tests.customized_mutate_example",
+    )
 
 
 @pytest.fixture
@@ -72,30 +76,43 @@ def rung_0():
     return dict(
         n_trials=9,
         resources=1,
-        results={hashlib.md5(str([point]).encode('utf-8')).hexdigest(): (point, (1, point))
-                 for point in points})
+        results={
+            hashlib.md5(str([point]).encode("utf-8")).hexdigest(): (point, (1, point))
+            for point in points
+        },
+    )
 
 
 @pytest.fixture
 def rung_1(rung_0):
     """Create fake points and objectives for rung 1."""
-    values = map(lambda v: (v[0], (3, v[0])), list(sorted(rung_0['results'].values()))[:3])
+    values = map(
+        lambda v: (v[0], (3, v[0])), list(sorted(rung_0["results"].values()))[:3]
+    )
     return dict(
         n_trials=3,
         resources=3,
-        results={hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value
-                 for value in values})
+        results={
+            hashlib.md5(str([value[0]]).encode("utf-8")).hexdigest(): value
+            for value in values
+        },
+    )
 
 
 @pytest.fixture
 def rung_2(rung_1):
     """Create fake points and objectives for rung 2."""
-    values = map(lambda v: (v[0], (9, v[0])), list(sorted(rung_1['results'].values()))[:1])
+    values = map(
+        lambda v: (v[0], (9, v[0])), list(sorted(rung_1["results"].values()))[:1]
+    )
     return dict(
         n_trials=1,
         resources=9,
-        results={hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value
-                 for value in values})
+        results={
+            hashlib.md5(str([value[0]]).encode("utf-8")).hexdigest(): value
+            for value in values
+        },
+    )
 
 
 @pytest.fixture
@@ -105,9 +122,14 @@ def rung_3():
     return dict(
         n_trials=4,
         resources=1,
-        results={hashlib.md5(str([point]).encode('utf-8')).hexdigest():
-                 (point, (np.power(2, (point - 1)), 1.0 / point, 1.0 / (point * point)))
-                 for point in points})
+        results={
+            hashlib.md5(str([point]).encode("utf-8")).hexdigest(): (
+                point,
+                (np.power(2, (point - 1)), 1.0 / point, 1.0 / (point * point)),
+            )
+            for point in points
+        },
+    )
 
 
 @pytest.fixture
@@ -117,9 +139,14 @@ def rung_4():
     return dict(
         n_trials=4,
         resources=1,
-        results={hashlib.md5(str([point]).encode('utf-8')).hexdigest():
-                 (point, (1, point // 2, point // 2))
-                 for point in points})
+        results={
+            hashlib.md5(str([point]).encode("utf-8")).hexdigest(): (
+                point,
+                (1, point // 2, point // 2),
+            )
+            for point in points
+        },
+    )
 
 
 def test_compute_budgets():
@@ -131,10 +158,14 @@ def test_compute_budgets():
 
 def test_customized_mutate_population(space1, rung_3, budgets):
     """Verify customized mutated candidates is generated correctly."""
-    customerized_dict = {'function': 'orion.testing.state.customized_mutate_example',
-                         'multiply_factor': 2.0, 'add_factor': 1}
-    algo = EvolutionES(space1, repetitions=1, nums_population=4,
-                       mutate=customerized_dict)
+    customerized_dict = {
+        "function": "orion.testing.state.customized_mutate_example",
+        "multiply_factor": 2.0,
+        "add_factor": 1,
+    }
+    algo = EvolutionES(
+        space1, repetitions=1, nums_population=4, mutate=customerized_dict
+    )
     algo.brackets[0] = BracketEVES(algo, budgets, 1, space1)
 
     red_team = [0, 2]
@@ -142,19 +173,32 @@ def test_customized_mutate_population(space1, rung_3, budgets):
     population_range = 4
     for i in range(4):
         for j in [1, 2]:
-            algo.brackets[0].eves.population[j][i] = list(rung_3["results"].values())[i][1][j]
+            algo.brackets[0].eves.population[j][i] = list(rung_3["results"].values())[
+                i
+            ][1][j]
         algo.brackets[0].eves.performance[i] = list(rung_3["results"].values())[i][0]
 
-    org_data = np.stack((list(algo.brackets[0].eves.population.values())[0],
-                         list(algo.brackets[0].eves.population.values())[1]), axis=0).T
+    org_data = np.stack(
+        (
+            list(algo.brackets[0].eves.population.values())[0],
+            list(algo.brackets[0].eves.population.values())[1],
+        ),
+        axis=0,
+    ).T
 
     org_data = copy.deepcopy(org_data)
 
-    algo.brackets[0]._mutate_population(red_team, blue_team,
-                                        rung_3["results"], population_range)
+    algo.brackets[0]._mutate_population(
+        red_team, blue_team, rung_3["results"], population_range
+    )
 
-    mutated_data = np.stack((list(algo.brackets[0].eves.population.values())[0],
-                             list(algo.brackets[0].eves.population.values())[1]), axis=0).T
+    mutated_data = np.stack(
+        (
+            list(algo.brackets[0].eves.population.values())[0],
+            list(algo.brackets[0].eves.population.values())[1],
+        ),
+        axis=0,
+    ).T
 
     # Winner team will be [0, 2], so [0, 2] will be remained, [1, 3] will be mutated.
     assert org_data.shape == mutated_data.shape
@@ -167,18 +211,22 @@ def test_customized_mutate_population(space1, rung_3, budgets):
 
     # For each individual, mutation occurs in only one dimension chosen from two.
     # Customized test mutation function is divided by 2 for real type.
-    if mutated_data[1][0] == org_data[0][0] / customerized_dict['multiply_factor']:
+    if mutated_data[1][0] == org_data[0][0] / customerized_dict["multiply_factor"]:
         assert mutated_data[1][1] == org_data[0][1]
     else:
-        assert mutated_data[1][1] == org_data[0][1] / customerized_dict['multiply_factor']
+        assert (
+            mutated_data[1][1] == org_data[0][1] / customerized_dict["multiply_factor"]
+        )
 
-    if mutated_data[3][0] == org_data[2][0] / customerized_dict['multiply_factor']:
+    if mutated_data[3][0] == org_data[2][0] / customerized_dict["multiply_factor"]:
         assert mutated_data[3][1] == org_data[2][1]
     else:
-        assert mutated_data[3][1] == org_data[2][1] / customerized_dict['multiply_factor']
+        assert (
+            mutated_data[3][1] == org_data[2][1] / customerized_dict["multiply_factor"]
+        )
 
 
-class TestEvolutionES():
+class TestEvolutionES:
     """Tests for the algo Evolution."""
 
     def test_register(self, evolution, bracket, rung_0, rung_1):
@@ -188,16 +236,16 @@ class TestEvolutionES():
         bracket.eves = evolution
         bracket.rungs = [rung_0, rung_1]
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
-        evolution.observe([point], [{'objective': 0.0}])
+        evolution.observe([point], [{"objective": 0.0}])
 
         assert len(bracket.rungs[0])
-        assert point_hash in bracket.rungs[0]['results']
-        assert (0.0, point) == bracket.rungs[0]['results'][point_hash]
+        assert point_hash in bracket.rungs[0]["results"]
+        assert (0.0, point) == bracket.rungs[0]["results"][point_hash]
 
 
-class TestBracketEVES():
+class TestBracketEVES:
     """Tests for `BracketEVES` class.."""
 
     def test_get_teams(self, bracket, rung_3):
@@ -217,19 +265,32 @@ class TestBracketEVES():
         population_range = 4
         for i in range(4):
             for j in [1, 2]:
-                bracket.eves.population[j][i] = list(rung_3["results"].values())[i][1][j]
+                bracket.eves.population[j][i] = list(rung_3["results"].values())[i][1][
+                    j
+                ]
             bracket.eves.performance[i] = list(rung_3["results"].values())[i][0]
 
-        org_data = np.stack((list(bracket.eves.population.values())[0],
-                             list(bracket.eves.population.values())[1]), axis=0).T
+        org_data = np.stack(
+            (
+                list(bracket.eves.population.values())[0],
+                list(bracket.eves.population.values())[1],
+            ),
+            axis=0,
+        ).T
 
         org_data = copy.deepcopy(org_data)
 
-        bracket._mutate_population(red_team, blue_team,
-                                   rung_3["results"], population_range)
+        bracket._mutate_population(
+            red_team, blue_team, rung_3["results"], population_range
+        )
 
-        mutated_data = np.stack((list(bracket.eves.population.values())[0],
-                                 list(bracket.eves.population.values())[1]), axis=0).T
+        mutated_data = np.stack(
+            (
+                list(bracket.eves.population.values())[0],
+                list(bracket.eves.population.values())[1],
+            ),
+            axis=0,
+        ).T
 
         # Winner team will be [0, 2], so [0, 2] will be remained, [1, 3] will be mutated.
         assert org_data.shape == mutated_data.shape
@@ -258,9 +319,12 @@ class TestBracketEVES():
         population_range = 4
         for i in range(4):
             for j in [1, 2]:
-                bracket.eves.population[j][i] = list(rung_4["results"].values())[i][1][j]
-        points, nums_all_equal = bracket._mutate_population(red_team, blue_team,
-                                                            rung_4["results"], population_range)
+                bracket.eves.population[j][i] = list(rung_4["results"].values())[i][1][
+                    j
+                ]
+        points, nums_all_equal = bracket._mutate_population(
+            red_team, blue_team, rung_4["results"], population_range
+        )
 
         # In this case, duplication will occur, and we can make it mutate one more time.
         # The points 1 and 2 should be different, while one of nums_all_equal should be 1.
@@ -281,9 +345,12 @@ class TestBracketEVES():
         population_range = 4
         for i in range(4):
             for j in [1, 2]:
-                bracket.eves.population[j][i] = list(rung_3["results"].values())[i][1][j]
-        points, nums_all_equal = bracket._mutate_population(red_team, blue_team,
-                                                            rung_3["results"], population_range)
+                bracket.eves.population[j][i] = list(rung_3["results"].values())[i][1][
+                    j
+                ]
+        points, nums_all_equal = bracket._mutate_population(
+            red_team, blue_team, rung_3["results"], population_range
+        )
         assert points[0] == (1.0, 1.0, 1.0)
         assert points[1] == (2, 1.0 / 2, 1.0 / 4)
         assert (nums_all_equal == 0).all()

--- a/tests/unittests/algo/test_hyperband.py
+++ b/tests/unittests/algo/test_hyperband.py
@@ -15,8 +15,8 @@ from orion.algo.space import Fidelity, Integer, Real, Space
 def space():
     """Create a Space with a real dimension and a fidelity value."""
     space = Space()
-    space.register(Real('lr', 'uniform', 0, 1))
-    space.register(Fidelity('epoch', 1, 9, 3))
+    space.register(Real("lr", "uniform", 0, 1))
+    space.register(Fidelity("epoch", 1, 9, 3))
     return space
 
 
@@ -45,44 +45,64 @@ def rung_0():
     return dict(
         n_trials=9,
         resources=1,
-        results={hashlib.md5(str([point]).encode('utf-8')).hexdigest(): (point, (1, point))
-                 for point in points})
+        results={
+            hashlib.md5(str([point]).encode("utf-8")).hexdigest(): (point, (1, point))
+            for point in points
+        },
+    )
 
 
 @pytest.fixture
 def rung_1(rung_0):
     """Create fake points and objectives for rung 1."""
-    values = map(lambda v: (v[0], (3, v[0])), list(sorted(rung_0['results'].values()))[:3])
+    values = map(
+        lambda v: (v[0], (3, v[0])), list(sorted(rung_0["results"].values()))[:3]
+    )
     return dict(
         n_trials=3,
         resources=3,
-        results={hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value
-                 for value in values})
+        results={
+            hashlib.md5(str([value[0]]).encode("utf-8")).hexdigest(): value
+            for value in values
+        },
+    )
 
 
 @pytest.fixture
 def rung_2(rung_1):
     """Create fake points and objectives for rung 1."""
-    values = map(lambda v: (v[0], (9, v[0])), list(sorted(rung_1['results'].values()))[:1])
+    values = map(
+        lambda v: (v[0], (9, v[0])), list(sorted(rung_1["results"].values()))[:1]
+    )
     return dict(
         n_trials=1,
         resources=9,
-        results={hashlib.md5(str([value[0]]).encode('utf-8')).hexdigest(): value
-                 for value in values})
+        results={
+            hashlib.md5(str([value[0]]).encode("utf-8")).hexdigest(): value
+            for value in values
+        },
+    )
 
 
 def test_compute_budgets():
     """Verify proper computation of budgets on a logarithmic scale"""
     # Check typical values
-    assert compute_budgets(81, 3) == [[(81, 1), (27, 3), (9, 9), (3, 27), (1, 81)],
-                                      [(27, 3), (9, 9), (3, 27), (1, 81)],
-                                      [(9, 9), (3, 27), (1, 81)],
-                                      [(6, 27), (2, 81)], [(5, 81)]]
-    assert compute_budgets(16, 4) == [[(16, 1), (4, 4), (1, 16)], [(4, 4), (1, 16)], [(3, 16)]]
+    assert compute_budgets(81, 3) == [
+        [(81, 1), (27, 3), (9, 9), (3, 27), (1, 81)],
+        [(27, 3), (9, 9), (3, 27), (1, 81)],
+        [(9, 9), (3, 27), (1, 81)],
+        [(6, 27), (2, 81)],
+        [(5, 81)],
+    ]
+    assert compute_budgets(16, 4) == [
+        [(16, 1), (4, 4), (1, 16)],
+        [(4, 4), (1, 16)],
+        [(3, 16)],
+    ]
     assert compute_budgets(16, 5) == [[(5, 3), (1, 16)], [(2, 16)]]
 
 
-class TestBracket():
+class TestBracket:
     """Tests for the `Bracket` class."""
 
     def test_rungs_creation(self, bracket):
@@ -96,13 +116,13 @@ class TestBracket():
         """Check that a point is correctly registered inside a bracket."""
         bracket.hyperband = hyperband
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
         bracket.register(point, 0.0)
 
         assert len(bracket.rungs[0])
-        assert point_hash in bracket.rungs[0]['results']
-        assert (0.0, point) == bracket.rungs[0]['results'][point_hash]
+        assert point_hash in bracket.rungs[0]["results"]
+        assert (0.0, point) == bracket.rungs[0]["results"][point_hash]
 
     def test_bad_register(self, hyperband, bracket):
         """Check that a non-valid point is not registered."""
@@ -111,7 +131,7 @@ class TestBracket():
         with pytest.raises(IndexError) as ex:
             bracket.register((55, 0.0), 0.0)
 
-        assert 'Bad fidelity level 55' in str(ex.value)
+        assert "Bad fidelity level 55" in str(ex.value)
 
     def test_candidate_promotion(self, hyperband, bracket, rung_0):
         """Test that correct point is promoted."""
@@ -125,10 +145,10 @@ class TestBracket():
     def test_promotion_with_rung_1_hit(self, hyperband, bracket, rung_0):
         """Test that get_candidate gives us the next best thing if point is already in rung 1."""
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
         bracket.hyperband = hyperband
         bracket.rungs[0] = rung_0
-        bracket.rungs[1]['results'][point_hash] = (0.0, point)
+        bracket.rungs[1]["results"][point_hash] = (0.0, point)
 
         points = bracket.get_candidates(0)
 
@@ -148,7 +168,7 @@ class TestBracket():
         """Test the get_candidate return None if trials are not completed."""
         bracket.hyperband = hyperband
         bracket.rungs[0] = rung_0
-        rung = bracket.rungs[0]['results']
+        rung = bracket.rungs[0]["results"]
 
         # points = bracket.get_candidates(0)
 
@@ -163,7 +183,7 @@ class TestBracket():
         assert not bracket.is_done
 
         # Actual value of the point is not important here
-        bracket.rungs[2]['results'] = {'1': (1, 0.0), '2': (1, 0.0), '3': (1, 0.0)}
+        bracket.rungs[2]["results"] = {"1": (1, 0.0), "2": (1, 0.0), "3": (1, 0.0)}
 
         assert bracket.is_done
 
@@ -171,12 +191,12 @@ class TestBracket():
         """Check if a valid modified candidate is returned by update_rungs."""
         bracket.hyperband = hyperband
         bracket.rungs[1] = rung_1
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
         candidates = bracket.promote()
 
-        assert point_hash in bracket.rungs[1]['results']
-        assert bracket.rungs[1]['results'][point_hash] == (0.0, (3, 0.0))
+        assert point_hash in bracket.rungs[1]["results"]
+        assert bracket.rungs[1]["results"][point_hash] == (0.0, (3, 0.0))
         assert candidates[0][0] == 9
 
     def test_update_rungs_return_no_candidate(self, hyperband, bracket, rung_1):
@@ -209,10 +229,10 @@ class TestBracket():
         bracket.rungs[1] = rung_1
         bracket.rungs[2] = rung_2
 
-        assert str(bracket) == 'Bracket(resource=[1, 3, 9], repetition id=1)'
+        assert str(bracket) == "Bracket(resource=[1, 3, 9], repetition id=1)"
 
 
-class TestHyperband():
+class TestHyperband:
     """Tests for the algo Hyperband."""
 
     def test_register(self, hyperband, bracket, rung_0, rung_1):
@@ -221,13 +241,13 @@ class TestHyperband():
         bracket.hyperband = hyperband
         bracket.rungs = [rung_0, rung_1]
         point = (1, 0.0)
-        point_hash = hashlib.md5(str([0.0]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([0.0]).encode("utf-8")).hexdigest()
 
-        hyperband.observe([point], [{'objective': 0.0}])
+        hyperband.observe([point], [{"objective": 0.0}])
 
         assert len(bracket.rungs[0])
-        assert point_hash in bracket.rungs[0]['results']
-        assert (0.0, point) == bracket.rungs[0]['results'][point_hash]
+        assert point_hash in bracket.rungs[0]["results"]
+        assert (0.0, point) == bracket.rungs[0]["results"][point_hash]
 
     def test_register_bracket_multi_fidelity(self, space):
         """Check that a point is registered inside the same bracket for diff fidelity."""
@@ -236,26 +256,26 @@ class TestHyperband():
         value = 50
         fidelity = 1
         point = (fidelity, value)
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        hyperband.observe([point], [{'objective': 0.0}])
+        hyperband.observe([point], [{"objective": 0.0}])
 
         bracket = hyperband.brackets[0]
 
         assert len(bracket.rungs[0])
-        assert point_hash in bracket.rungs[0]['results']
-        assert (0.0, point) == bracket.rungs[0]['results'][point_hash]
+        assert point_hash in bracket.rungs[0]["results"]
+        assert (0.0, point) == bracket.rungs[0]["results"][point_hash]
 
         fidelity = 3
         point = [fidelity, value]
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        hyperband.observe([point], [{'objective': 0.0}])
+        hyperband.observe([point], [{"objective": 0.0}])
 
         assert len(bracket.rungs[0])
-        assert point_hash in bracket.rungs[1]['results']
-        assert (0.0, point) != bracket.rungs[0]['results'][point_hash]
-        assert (0.0, point) == bracket.rungs[1]['results'][point_hash]
+        assert point_hash in bracket.rungs[1]["results"]
+        assert (0.0, point) != bracket.rungs[0]["results"][point_hash]
+        assert (0.0, point) == bracket.rungs[1]["results"][point_hash]
 
     def test_register_next_bracket(self, space):
         """Check that a point is registered inside the good bracket when higher fidelity."""
@@ -264,28 +284,28 @@ class TestHyperband():
         value = 50
         fidelity = 3
         point = (fidelity, value)
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        hyperband.observe([point], [{'objective': 0.0}])
+        hyperband.observe([point], [{"objective": 0.0}])
 
-        assert sum(len(rung['results']) for rung in hyperband.brackets[0].rungs) == 0
-        assert sum(len(rung['results']) for rung in hyperband.brackets[1].rungs) == 1
-        assert sum(len(rung['results']) for rung in hyperband.brackets[2].rungs) == 0
-        assert point_hash in hyperband.brackets[1].rungs[0]['results']
-        assert (0.0, point) == hyperband.brackets[1].rungs[0]['results'][point_hash]
+        assert sum(len(rung["results"]) for rung in hyperband.brackets[0].rungs) == 0
+        assert sum(len(rung["results"]) for rung in hyperband.brackets[1].rungs) == 1
+        assert sum(len(rung["results"]) for rung in hyperband.brackets[2].rungs) == 0
+        assert point_hash in hyperband.brackets[1].rungs[0]["results"]
+        assert (0.0, point) == hyperband.brackets[1].rungs[0]["results"][point_hash]
 
         value = 51
         fidelity = 9
         point = (fidelity, value)
-        point_hash = hashlib.md5(str([value]).encode('utf-8')).hexdigest()
+        point_hash = hashlib.md5(str([value]).encode("utf-8")).hexdigest()
 
-        hyperband.observe([point], [{'objective': 0.0}])
+        hyperband.observe([point], [{"objective": 0.0}])
 
-        assert sum(len(rung['results']) for rung in hyperband.brackets[0].rungs) == 0
-        assert sum(len(rung['results']) for rung in hyperband.brackets[1].rungs) == 1
-        assert sum(len(rung['results']) for rung in hyperband.brackets[2].rungs) == 1
-        assert point_hash in hyperband.brackets[2].rungs[0]['results']
-        assert (0.0, point) == hyperband.brackets[2].rungs[0]['results'][point_hash]
+        assert sum(len(rung["results"]) for rung in hyperband.brackets[0].rungs) == 0
+        assert sum(len(rung["results"]) for rung in hyperband.brackets[1].rungs) == 1
+        assert sum(len(rung["results"]) for rung in hyperband.brackets[2].rungs) == 1
+        assert point_hash in hyperband.brackets[2].rungs[0]["results"]
+        assert (0.0, point) == hyperband.brackets[2].rungs[0]["results"][point_hash]
 
     def test_register_invalid_fidelity(self, space):
         """Check that a point cannot registered if fidelity is invalid."""
@@ -296,9 +316,9 @@ class TestHyperband():
         point = (fidelity, value)
 
         with pytest.raises(ValueError) as ex:
-            hyperband.observe([point], [{'objective': 0.0}])
+            hyperband.observe([point], [{"objective": 0.0}])
 
-        assert 'No bracket found for point' in str(ex.value)
+        assert "No bracket found for point" in str(ex.value)
 
     def test_register_corrupted_db(self, caplog, space):
         """Check that a point cannot registered if passed in order diff than fidelity."""
@@ -308,49 +328,61 @@ class TestHyperband():
         fidelity = 3
         point = (fidelity, value)
 
-        hyperband.observe([point], [{'objective': 0.0}])
-        assert 'Point registered to wrong bracket' not in caplog.text
+        hyperband.observe([point], [{"objective": 0.0}])
+        assert "Point registered to wrong bracket" not in caplog.text
 
         fidelity = 1
         point = [fidelity, value]
 
         caplog.clear()
-        hyperband.observe([point], [{'objective': 0.0}])
-        assert 'Point registered to wrong bracket' in caplog.text
+        hyperband.observe([point], [{"objective": 0.0}])
+        assert "Point registered to wrong bracket" in caplog.text
 
     def test_get_id(self, space):
         """Test valid id of points"""
         hyperband = Hyperband(space)
 
-        assert hyperband.get_id(['whatever', 1]) == hyperband.get_id(['is here', 1])
-        assert hyperband.get_id(['whatever', 1]) != hyperband.get_id(['is here', 2])
-        assert hyperband.get_id(['whatever', 1], ignore_fidelity=False) != \
-            hyperband.get_id(['is here', 1], ignore_fidelity=False)
-        assert hyperband.get_id(['whatever', 1], ignore_fidelity=False) != \
-            hyperband.get_id(['is here', 2], ignore_fidelity=False)
-        assert hyperband.get_id(['same', 1], ignore_fidelity=False) == \
-            hyperband.get_id(['same', 1], ignore_fidelity=False)
-        assert hyperband.get_id(['same', 1], ignore_fidelity=False) != \
-            hyperband.get_id(['same', 1])
+        assert hyperband.get_id(["whatever", 1]) == hyperband.get_id(["is here", 1])
+        assert hyperband.get_id(["whatever", 1]) != hyperband.get_id(["is here", 2])
+        assert hyperband.get_id(
+            ["whatever", 1], ignore_fidelity=False
+        ) != hyperband.get_id(["is here", 1], ignore_fidelity=False)
+        assert hyperband.get_id(
+            ["whatever", 1], ignore_fidelity=False
+        ) != hyperband.get_id(["is here", 2], ignore_fidelity=False)
+        assert hyperband.get_id(["same", 1], ignore_fidelity=False) == hyperband.get_id(
+            ["same", 1], ignore_fidelity=False
+        )
+        assert hyperband.get_id(["same", 1], ignore_fidelity=False) != hyperband.get_id(
+            ["same", 1]
+        )
 
     def test_get_id_multidim(self):
         """Test valid id for points with dim of shape > 1"""
         space = Space()
-        space.register(Fidelity('epoch', 1, 9, 3))
-        space.register(Real('lr', 'uniform', 0, 1, shape=2))
+        space.register(Fidelity("epoch", 1, 9, 3))
+        space.register(Real("lr", "uniform", 0, 1, shape=2))
 
         hyperband = Hyperband(space)
 
-        assert hyperband.get_id(['whatever', [1, 1]]) == hyperband.get_id(['is here', [1, 1]])
-        assert hyperband.get_id(['whatever', [1, 1]]) != hyperband.get_id(['is here', [2, 2]])
-        assert hyperband.get_id(['whatever', [1, 1]], ignore_fidelity=False) != \
-            hyperband.get_id(['is here', [1, 1]], ignore_fidelity=False)
-        assert hyperband.get_id(['whatever', [1, 1]], ignore_fidelity=False) != \
-            hyperband.get_id(['is here', [2, 2]], ignore_fidelity=False)
-        assert hyperband.get_id(['same', [1, 1]], ignore_fidelity=False) == \
-            hyperband.get_id(['same', [1, 1]], ignore_fidelity=False)
-        assert hyperband.get_id(['same', [1, 1]], ignore_fidelity=False) != \
-            hyperband.get_id(['same', [1, 1]])
+        assert hyperband.get_id(["whatever", [1, 1]]) == hyperband.get_id(
+            ["is here", [1, 1]]
+        )
+        assert hyperband.get_id(["whatever", [1, 1]]) != hyperband.get_id(
+            ["is here", [2, 2]]
+        )
+        assert hyperband.get_id(
+            ["whatever", [1, 1]], ignore_fidelity=False
+        ) != hyperband.get_id(["is here", [1, 1]], ignore_fidelity=False)
+        assert hyperband.get_id(
+            ["whatever", [1, 1]], ignore_fidelity=False
+        ) != hyperband.get_id(["is here", [2, 2]], ignore_fidelity=False)
+        assert hyperband.get_id(
+            ["same", [1, 1]], ignore_fidelity=False
+        ) == hyperband.get_id(["same", [1, 1]], ignore_fidelity=False)
+        assert hyperband.get_id(
+            ["same", [1, 1]], ignore_fidelity=False
+        ) != hyperband.get_id(["same", [1, 1]])
 
     def test_suggest_new(self, monkeypatch, hyperband, bracket, rung_0, rung_1, rung_2):
         """Test that a new point is sampled."""
@@ -358,9 +390,9 @@ class TestHyperband():
         bracket.hyperband = hyperband
 
         def sample(num=1, seed=None):
-            return [('fidelity', i) for i in range(num)]
+            return [("fidelity", i) for i in range(num)]
 
-        monkeypatch.setattr(hyperband.space, 'sample', sample)
+        monkeypatch.setattr(hyperband.space, "sample", sample)
 
         points = hyperband.suggest()
 
@@ -374,20 +406,20 @@ class TestHyperband():
         hyperband.brackets = [bracket]
         bracket.hyperband = hyperband
 
-        duplicate_point = ('fidelity', 0.0)
-        new_point = ('fidelity', 0.5)
+        duplicate_point = ("fidelity", 0.0)
+        new_point = ("fidelity", 0.5)
 
-        duplicate_id = hashlib.md5(str([duplicate_point]).encode('utf-8')).hexdigest()
-        bracket.rungs[0]['results'] = {duplicate_id: (0.0, duplicate_point)}
+        duplicate_id = hashlib.md5(str([duplicate_point]).encode("utf-8")).hexdigest()
+        bracket.rungs[0]["results"] = {duplicate_id: (0.0, duplicate_point)}
 
         hyperband.trial_info_wo_fidelity[hyperband.get_id(duplicate_point)] = bracket
 
         points = [duplicate_point, new_point]
 
         def sample(num=1, seed=None):
-            return points + [('fidelity', i) for i in range(num - 2)]
+            return points + [("fidelity", i) for i in range(num - 2)]
 
-        monkeypatch.setattr(hyperband.space, 'sample', sample)
+        monkeypatch.setattr(hyperband.space, "sample", sample)
 
         assert hyperband.suggest()[0][1] == new_point[1]
 
@@ -403,7 +435,7 @@ class TestHyperband():
         def sample(num=1, seed=None):
             return zhe_point * num
 
-        monkeypatch.setattr(hyperband.space, 'sample', sample)
+        monkeypatch.setattr(hyperband.space, "sample", sample)
         zhe_samples = hyperband.suggest()
 
         assert zhe_samples[0][1] == 0.0
@@ -417,7 +449,9 @@ class TestHyperband():
         assert zhe_samples[0][1] == 5.0
         assert zhe_samples[1][1] == 4.0
 
-    def test_suggest_duplicates_between_execution(self, monkeypatch, hyperband, budgets):
+    def test_suggest_duplicates_between_execution(
+        self, monkeypatch, hyperband, budgets
+    ):
         """Test that sampling collisions are handled between different hyperband execution."""
         hyperband.repetitions = 2
         bracket = Bracket(hyperband, budgets, 1)
@@ -425,12 +459,12 @@ class TestHyperband():
         bracket.hyperband = hyperband
 
         for i in range(9):
-            hyperband.observe([(1, i)], [{'objective': i}])
+            hyperband.observe([(1, i)], [{"objective": i}])
 
         for i in range(3):
-            hyperband.observe([(3, i)], [{'objective': i}])
+            hyperband.observe([(3, i)], [{"objective": i}])
 
-        hyperband.observe([(9, 0)], [{'objective': 0}])
+        hyperband.observe([(9, 0)], [{"objective": 0}])
 
         assert not hyperband.is_done
 
@@ -439,34 +473,36 @@ class TestHyperband():
         def sample(num=1, seed=None):
             return zhe_point * num
 
-        monkeypatch.setattr(hyperband.space, 'sample', sample)
+        monkeypatch.setattr(hyperband.space, "sample", sample)
         zhe_samples = hyperband.suggest()
         assert zhe_samples == [(9, 1), (9, 2)]
 
-    def test_suggest_inf_duplicates(self, monkeypatch, hyperband, bracket, rung_0, rung_1, rung_2):
+    def test_suggest_inf_duplicates(
+        self, monkeypatch, hyperband, bracket, rung_0, rung_1, rung_2
+    ):
         """Test that sampling inf collisions will return None."""
         hyperband.brackets = [bracket]
         bracket.hyperband = hyperband
 
-        zhe_point = ('fidelity', 0.0)
+        zhe_point = ("fidelity", 0.0)
         hyperband.trial_info_wo_fidelity[hyperband.get_id(zhe_point)] = bracket
 
         def sample(num=1, seed=None):
             return [zhe_point] * num
 
-        monkeypatch.setattr(hyperband.space, 'sample', sample)
+        monkeypatch.setattr(hyperband.space, "sample", sample)
 
         assert hyperband.suggest() is None
 
     def test_suggest_in_finite_cardinality(self):
         """Test that suggest None when search space is empty"""
         space = Space()
-        space.register(Integer('yolo1', 'uniform', 0, 5))
-        space.register(Fidelity('epoch', 1, 9, 3))
+        space.register(Integer("yolo1", "uniform", 0, 5))
+        space.register(Fidelity("epoch", 1, 9, 3))
 
         hyperband = Hyperband(space, repetitions=1)
         for i in range(6):
-            hyperband.observe([(1, i)], [{'objective': i}])
+            hyperband.observe([(1, i)], [{"objective": i}])
 
         assert hyperband.suggest() is None
 
@@ -486,7 +522,7 @@ class TestHyperband():
         bracket.hyperband = hyperband
         bracket.rungs[0] = rung_0
 
-        rung = bracket.rungs[0]['results']
+        rung = bracket.rungs[0]["results"]
         trial_id = next(iter(rung.keys()))
         objective, point = rung.pop(trial_id)
 
@@ -502,7 +538,7 @@ class TestHyperband():
 
         bracket.rungs[1] = rung_1
 
-        rung = bracket.rungs[1]['results']
+        rung = bracket.rungs[1]["results"]
         trial_id = next(iter(rung.keys()))
         objective, point = rung.pop(trial_id)
 
@@ -519,7 +555,7 @@ class TestHyperband():
 
         bracket.rungs[2] = rung_2
 
-        rung = bracket.rungs[2]['results']
+        rung = bracket.rungs[2]["results"]
         trial_id = next(iter(rung.keys()))
         objective, point = rung.pop(trial_id)
 
@@ -541,7 +577,7 @@ class TestHyperband():
         bracket.hyperband = hyperband
         bracket.rungs[0] = rung_0
 
-        rung = bracket.rungs[0]['results']
+        rung = bracket.rungs[0]["results"]
         trial_id = next(iter(rung.keys()))
         objective, point = rung[trial_id]
         rung[trial_id] = (None, point)
@@ -558,7 +594,7 @@ class TestHyperband():
 
         bracket.rungs[1] = rung_1
 
-        rung = bracket.rungs[1]['results']
+        rung = bracket.rungs[1]["results"]
         trial_id = next(iter(rung.keys()))
         objective, point = rung[trial_id]
         rung[trial_id] = (None, point)
@@ -577,7 +613,7 @@ class TestHyperband():
 
         bracket.rungs[2] = rung_2
 
-        rung = bracket.rungs[2]['results']
+        rung = bracket.rungs[2]["results"]
         trial_id = next(iter(rung.keys()))
         objective, point = rung[trial_id]
         rung[trial_id] = (None, point)
@@ -601,9 +637,9 @@ class TestHyperband():
 
         bracket.rungs[0] = rung_0
 
-        trial_id = next(iter(rung_0['results'].keys()))
-        objective, point = rung_0['results'][trial_id]
-        rung_0['results'][trial_id] = (None, point)
+        trial_id = next(iter(rung_0["results"].keys()))
+        objective, point = rung_0["results"][trial_id]
+        rung_0["results"][trial_id] = (None, point)
 
         points = hyperband.suggest()
 
@@ -635,29 +671,29 @@ class TestHyperband():
 
     def test_full_process(self, monkeypatch, hyperband):
         """Test Hyperband full process."""
-        points = [('fidelity', i) for i in range(4000)]
+        points = [("fidelity", i) for i in range(4000)]
 
         def sample(num=1, seed=None):
             return points[:num]
 
-        monkeypatch.setattr(hyperband.space, 'sample', sample)
+        monkeypatch.setattr(hyperband.space, "sample", sample)
 
         # Fill all brackets' first rung
 
         for i in range(3):
             point = hyperband.suggest()[0]
             assert point == (9, i)
-            hyperband.observe([point], [{'objective': None}])
+            hyperband.observe([point], [{"objective": None}])
 
         for i in range(3):
             point = hyperband.suggest()[0]
             assert point == (3, i + 3)
-            hyperband.observe([point], [{'objective': None}])
+            hyperband.observe([point], [{"objective": None}])
 
         for i in range(9):
             point = hyperband.suggest()[0]
             assert point == (1, i + 3 + 3)
-            hyperband.observe([point], [{'objective': None}])
+            hyperband.observe([point], [{"objective": None}])
 
         assert hyperband.brackets[0].has_rung_filled(0)
         assert not hyperband.brackets[0].is_ready()
@@ -667,7 +703,7 @@ class TestHyperband():
         # Observe first bracket first rung
 
         for i in range(9):
-            hyperband.observe([(1, i + 3 + 3)], [{'objective': 16 - i}])
+            hyperband.observe([(1, i + 3 + 3)], [{"objective": 16 - i}])
 
         assert hyperband.brackets[0].is_ready()
         assert not hyperband.brackets[1].is_ready()
@@ -678,7 +714,7 @@ class TestHyperband():
         for i in range(3):
             point = hyperband.suggest()[0]
             assert point == (3, 3 + 3 + 9 - 1 - i)
-            hyperband.observe([point], [{'objective': None}])
+            hyperband.observe([point], [{"objective": None}])
 
         assert hyperband.brackets[0].has_rung_filled(1)
         assert not hyperband.brackets[0].is_ready()
@@ -688,7 +724,7 @@ class TestHyperband():
         # Observe first bracket second rung
 
         for i in range(3):
-            hyperband.observe([(3, 3 + 3 + 9 - 1 - i)], [{'objective': 8 - i}])
+            hyperband.observe([(3, 3 + 3 + 9 - 1 - i)], [{"objective": 8 - i}])
 
         assert hyperband.brackets[0].is_ready()
         assert not hyperband.brackets[1].is_ready()
@@ -697,7 +733,7 @@ class TestHyperband():
         # Observe second bracket first rung
 
         for i in range(3):
-            hyperband.observe([(3, i + 3)], [{'objective': 8 - i}])
+            hyperband.observe([(3, i + 3)], [{"objective": 8 - i}])
 
         assert hyperband.brackets[0].is_ready()
         assert hyperband.brackets[1].is_ready()
@@ -708,7 +744,7 @@ class TestHyperband():
         for i in range(1):
             point = hyperband.suggest()[0]
             assert point == (9, 3 + 3 - 1 - i)
-            hyperband.observe([point], [{'objective': None}])
+            hyperband.observe([point], [{"objective": None}])
 
         assert hyperband.brackets[0].is_ready()
         assert hyperband.brackets[1].has_rung_filled(1)
@@ -718,7 +754,7 @@ class TestHyperband():
         # Observe third bracket first rung
 
         for i in range(3):
-            hyperband.observe([(9, i)], [{'objective': 3 - i}])
+            hyperband.observe([(9, i)], [{"objective": 3 - i}])
 
         assert not hyperband.brackets[0].is_ready(2)
         assert not hyperband.brackets[1].is_ready(1)
@@ -728,7 +764,7 @@ class TestHyperband():
         # Observe second bracket second rung
 
         for i in range(1):
-            hyperband.observe([(9, 3 + 3 - 1 - i)], [{'objective': 5 - i}])
+            hyperband.observe([(9, 3 + 3 - 1 - i)], [{"objective": 5 - i}])
 
         assert not hyperband.brackets[0].is_ready(2)
         assert hyperband.brackets[1].is_ready(1)
@@ -739,7 +775,7 @@ class TestHyperband():
         for i in range(1):
             point = hyperband.suggest()[0]
             assert point == (9, 3 + 3 + 9 - 1 - 2 + i)
-            hyperband.observe([point], [{'objective': 3 - i}])
+            hyperband.observe([point], [{"objective": 3 - i}])
 
         assert hyperband.is_done
         assert hyperband.brackets[0].is_ready(2)
@@ -747,9 +783,9 @@ class TestHyperband():
         assert hyperband.suggest() is None
 
         # Refresh repeat and execution times property
-        monkeypatch.setattr(hyperband, 'repetitions', 2)
-        monkeypatch.setattr(hyperband, 'executed_times', 0)
-        hyperband.observe([(9, 12)], [{'objective': 3 - i}])
+        monkeypatch.setattr(hyperband, "repetitions", 2)
+        monkeypatch.setattr(hyperband, "executed_times", 0)
+        hyperband.observe([(9, 12)], [{"objective": 3 - i}])
         assert not hyperband.is_done
         assert not hyperband.brackets[0].is_ready(2)
         assert not hyperband.brackets[0].is_done

--- a/tests/unittests/algo/test_random.py
+++ b/tests/unittests/algo/test_random.py
@@ -12,9 +12,9 @@ from orion.algo.space import Integer, Real, Space
 def space():
     """Return an optimization space"""
     space = Space()
-    dim1 = Integer('yolo1', 'uniform', -3, 6)
+    dim1 = Integer("yolo1", "uniform", -3, 6)
     space.register(dim1)
-    dim2 = Real('yolo2', 'norm', 0.9)
+    dim2 = Real("yolo2", "norm", 0.9)
     space.register(dim2)
 
     return space
@@ -48,7 +48,7 @@ def test_set_state(space):
 def test_suggest_unique():
     """Verify that RandomSearch do not sample duplicates"""
     space = Space()
-    space.register(Integer('yolo1', 'uniform', -3, 6))
+    space.register(Integer("yolo1", "uniform", -3, 6))
 
     random_search = Random(space)
 
@@ -61,7 +61,7 @@ def test_suggest_unique():
 def test_suggest_unique_history():
     """Verify that RandomSearch do not sample duplicates based observed points"""
     space = Space()
-    space.register(Integer('yolo1', 'uniform', -3, 6))
+    space.register(Integer("yolo1", "uniform", -3, 6))
 
     random_search = Random(space)
 

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.algo.space`."""
 
-from collections import (defaultdict, OrderedDict)
+from collections import defaultdict, OrderedDict
 import sys
 
 import numpy as np
@@ -11,7 +11,14 @@ import pytest
 from scipy.stats import distributions as dists
 
 from orion.algo.space import (
-    Categorical, check_random_state, Dimension, Fidelity, Integer, Real, Space)
+    Categorical,
+    check_random_state,
+    Dimension,
+    Fidelity,
+    Integer,
+    Real,
+    Space,
+)
 
 
 class TestCheckRandomState:
@@ -41,9 +48,9 @@ class TestCheckRandomState:
     def test_rng_invalid_value(self):
         """Test that passing int returns RandomState"""
         with pytest.raises(ValueError) as exc:
-            check_random_state('oh_no_oh_no')
+            check_random_state("oh_no_oh_no")
 
-        assert '\'oh_no_oh_no\' cannot be used to seed' in str(exc.value)
+        assert "'oh_no_oh_no' cannot be used to seed" in str(exc.value)
 
 
 class TestDimension(object):
@@ -51,7 +58,7 @@ class TestDimension(object):
 
     def test_simple_instance(self, seed):
         """Test Dimension.__init__."""
-        dim = Dimension('yolo', 'norm', 0.9, 0.1)
+        dim = Dimension("yolo", "norm", 0.9, 0.1)
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert dists.norm.rvs(0.9, 0.1) == samples[0]
@@ -59,23 +66,25 @@ class TestDimension(object):
         assert dists.norm.interval(1.0, 0.9, 0.1) == dim.interval()
         assert dists.norm.interval(0.5, 0.9, 0.1) == dim.interval(0.5)
 
-        assert str(dim) == "Dimension(name=yolo, prior={norm: (0.9, 0.1), {}}, " \
-                           "shape=(), default value=None)"
+        assert (
+            str(dim) == "Dimension(name=yolo, prior={norm: (0.9, 0.1), {}}, "
+            "shape=(), default value=None)"
+        )
 
-        assert dim.name == 'yolo'
-        assert dim.type == 'dimension'
+        assert dim.name == "yolo"
+        assert dim.type == "dimension"
         assert dim.shape == ()
 
     def test_shaped_instance(self, seed):
         """Use shape keyword argument."""
-        dim = Dimension('yolo', 'norm', 0.9, shape=(3, 2))
+        dim = Dimension("yolo", "norm", 0.9, shape=(3, 2))
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert_eq(dists.norm.rvs(0.9, size=(3, 2)), samples[0])
 
         assert dim.shape == (3, 2)
 
-        dim = Dimension('yolo', 'norm', 0.9, shape=4)
+        dim = Dimension("yolo", "norm", 0.9, shape=4)
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert_eq(dists.norm.rvs(0.9, size=4), samples[0])
@@ -85,21 +94,21 @@ class TestDimension(object):
     def test_ban_size_kwarg(self):
         """Should not be able to use 'size' kwarg."""
         with pytest.raises(ValueError):
-            Dimension('yolo', 'norm', 0.9, size=(3, 2))
+            Dimension("yolo", "norm", 0.9, size=(3, 2))
 
     def test_ban_seed_kwarg(self):
         """Should not be able to use 'seed' kwarg."""
         with pytest.raises(ValueError):
-            Dimension('yolo', 'norm', 0.9, seed=8)
+            Dimension("yolo", "norm", 0.9, seed=8)
 
     def test_ban_rng_kwarg(self):
         """Should not be able to use 'random_state' kwarg."""
         with pytest.raises(ValueError):
-            Dimension('yolo', 'norm', 0.9, random_state=8)
+            Dimension("yolo", "norm", 0.9, random_state=8)
 
     def test_with_predefined_dist(self, seed):
         """Use an already defined distribution object as prior arg."""
-        dim = Dimension('yolo', dists.norm, 0.9)
+        dim = Dimension("yolo", dists.norm, 0.9)
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert dists.norm.rvs(0.9) == samples[0]
@@ -107,106 +116,115 @@ class TestDimension(object):
     def test_ban_discrete_kwarg(self):
         """Do not allow use for 'discrete' kwarg, because now there's `_Discrete`."""
         with pytest.raises(ValueError) as exc:
-            Dimension('yolo', 'uniform', -3, 4, shape=(4, 4), discrete=True)
+            Dimension("yolo", "uniform", -3, 4, shape=(4, 4), discrete=True)
         assert "pure `_Discrete`" in str(exc.value)
 
     def test_many_samples(self, seed):
         """More than 1."""
-        dim = Dimension('yolo', 'uniform', -3, 4, shape=(4, 4))
+        dim = Dimension("yolo", "uniform", -3, 4, shape=(4, 4))
         samples = dim.sample(n_samples=4, seed=seed)
         assert len(samples) == 4
         assert_eq(dists.uniform.rvs(-3, 4, size=(4, 4)), samples[0])
 
     def test_interval(self):
         """Test that bounds on variable."""
-        dim = Dimension('yolo', 'uniform', -3, 4)
-        assert dim.interval(1.0) == (-3.0, 1.0)  # reminder that `scale` is not upper bound
+        dim = Dimension("yolo", "uniform", -3, 4)
+        assert dim.interval(1.0) == (
+            -3.0,
+            1.0,
+        )  # reminder that `scale` is not upper bound
 
     def test_contains_bounds(self):
         """Test __contains__ for bounds."""
-        dim = Dimension('yolo', 'uniform', -3, 4)
+        dim = Dimension("yolo", "uniform", -3, 4)
         with pytest.raises(NotImplementedError):
             assert -3 in dim
 
     def test_contains_shape(self):
         """Test __contains__ for shape check."""
-        dim = Dimension(None, 'uniform', -3, 4, shape=(4, 4))
+        dim = Dimension(None, "uniform", -3, 4, shape=(4, 4))
 
         with pytest.raises(NotImplementedError):
             assert dists.uniform.rvs(-3, 4, size=(4, 4)) in dim
 
     def test_set_bad_name(self):
         """Try setting a name other than str or None."""
-        dim = Dimension('yolo', 'uniform', -3, 4, shape=(4, 4))
+        dim = Dimension("yolo", "uniform", -3, 4, shape=(4, 4))
         with pytest.raises(TypeError):
             dim.name = 4
 
     def test_init_with_default_value(self):
         """Make sure the __contains__ method does not work"""
         with pytest.raises(NotImplementedError):
-            Dimension('yolo', 'uniform', -3, 4, default_value=4)
+            Dimension("yolo", "uniform", -3, 4, default_value=4)
 
     def test_no_default_value(self):
         """Test that no giving a default value assigns None"""
-        dim = Dimension('yolo', 'uniform', -3, 4)
+        dim = Dimension("yolo", "uniform", -3, 4)
         assert dim.default_value is None
 
     def test_no_prior(self):
         """Test that giving a null prior defaults prior_name to `None`."""
-        dim = Dimension('yolo', None)
+        dim = Dimension("yolo", None)
         print(dim._prior_name)
         assert dim.prior is None
-        assert dim._prior_name == 'None'
+        assert dim._prior_name == "None"
 
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 6), reason="requires python3.6 or higher"
+    )
     def test_get_prior_string(self):
         """Test that prior string can be rebuilt."""
-        dim = Dimension('yolo', 'alpha', 1, 2, 3, some='args', plus='fluff', n=4)
-        assert dim.get_prior_string() == 'alpha(1, 2, 3, some=\'args\', plus=\'fluff\', n=4)'
+        dim = Dimension("yolo", "alpha", 1, 2, 3, some="args", plus="fluff", n=4)
+        assert (
+            dim.get_prior_string() == "alpha(1, 2, 3, some='args', plus='fluff', n=4)"
+        )
 
     def test_get_prior_string_uniform(self):
         """Test special uniform args are handled properly."""
-        dim = Dimension('yolo', 'uniform', 1, 2)
-        assert dim.get_prior_string() == 'uniform(1, 3)'
+        dim = Dimension("yolo", "uniform", 1, 2)
+        assert dim.get_prior_string() == "uniform(1, 3)"
 
     def test_get_prior_string_default_values(self, monkeypatch):
         """Test that default_value are included."""
+
         def contains(self, value):
             return True
-        monkeypatch.setattr(Dimension, '__contains__', contains)
-        dim = Dimension('yolo', 'alpha', 1, 2, default_value=1)
-        assert dim.get_prior_string() == 'alpha(1, 2, default_value=1)'
+
+        monkeypatch.setattr(Dimension, "__contains__", contains)
+        dim = Dimension("yolo", "alpha", 1, 2, default_value=1)
+        assert dim.get_prior_string() == "alpha(1, 2, default_value=1)"
 
     def test_get_prior_string_shape(self):
         """Test that shape is included."""
-        dim = Dimension('yolo', 'alpha', 1, 2, shape=(2, 3))
-        assert dim.get_prior_string() == 'alpha(1, 2, shape=(2, 3))'
+        dim = Dimension("yolo", "alpha", 1, 2, shape=(2, 3))
+        assert dim.get_prior_string() == "alpha(1, 2, shape=(2, 3))"
 
     def test_get_prior_string_loguniform(self):
         """Test that special loguniform prior name is replaced properly."""
-        dim = Dimension('yolo', 'reciprocal', 1e-10, 1)
-        assert dim.get_prior_string() == 'loguniform(1e-10, 1)'
+        dim = Dimension("yolo", "reciprocal", 1e-10, 1)
+        assert dim.get_prior_string() == "loguniform(1e-10, 1)"
 
     def test_prior_name(self):
         """Test prior name is correct in dimension"""
-        dim = Dimension('yolo', 'reciprocal', 1e-10, 1)
-        assert dim.prior_name == 'reciprocal'
+        dim = Dimension("yolo", "reciprocal", 1e-10, 1)
+        assert dim.prior_name == "reciprocal"
 
-        dim = Dimension('yolo', 'norm', 0.9)
-        assert dim.prior_name == 'norm'
+        dim = Dimension("yolo", "norm", 0.9)
+        assert dim.prior_name == "norm"
 
-        dim = Real('yolo', 'uniform', 1, 2)
-        assert dim.prior_name == 'uniform'
+        dim = Real("yolo", "uniform", 1, 2)
+        assert dim.prior_name == "uniform"
 
-        dim = Integer('yolo1', 'uniform', -3, 6)
-        assert dim.prior_name == 'int_uniform'
+        dim = Integer("yolo1", "uniform", -3, 6)
+        assert dim.prior_name == "int_uniform"
 
-        dim = Integer('yolo1', 'norm', -3, 6)
-        assert dim.prior_name == 'int_norm'
+        dim = Integer("yolo1", "norm", -3, 6)
+        assert dim.prior_name == "int_norm"
 
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 'lalala': 0.4}
-        dim = Categorical('yolo', categories)
-        assert dim.prior_name == 'choices'
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
+        dim = Categorical("yolo", categories)
+        assert dim.prior_name == "choices"
 
 
 class TestReal(object):
@@ -214,7 +232,7 @@ class TestReal(object):
 
     def test_simple_instance(self, seed):
         """Test Real.__init__."""
-        dim = Real('yolo', 'norm', 0.9)
+        dim = Real("yolo", "norm", 0.9)
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert dists.norm.rvs(0.9) == samples[0]
@@ -224,14 +242,17 @@ class TestReal(object):
 
         assert 1.0 in dim
 
-        assert str(dim) == "Real(name=yolo, prior={norm: (0.9,), {}}, shape=(), default value=None)"
-        assert dim.name == 'yolo'
-        assert dim.type == 'real'
+        assert (
+            str(dim)
+            == "Real(name=yolo, prior={norm: (0.9,), {}}, shape=(), default value=None)"
+        )
+        assert dim.name == "yolo"
+        assert dim.type == "real"
         assert dim.shape == ()
 
     def test_contains_extra_bounds(self):
         """Test __contains__ for the extra bounds."""
-        dim = Real('yolo', 'norm', 0, 3, low=-3, high=+3)
+        dim = Real("yolo", "norm", 0, 3, low=-3, high=+3)
         assert dists.uniform.rvs(-3, 3) in dim
         assert -4 not in dim
         assert +4 not in dim
@@ -239,7 +260,7 @@ class TestReal(object):
 
     def test_sample_from_extra_bounds_good(self):
         """Randomized test **successful** sampling with the extra bounds."""
-        dim = Real('yolo', 'norm', 0, 2, low=-5, high=+5, shape=(4, 4))
+        dim = Real("yolo", "norm", 0, 2, low=-5, high=+5, shape=(4, 4))
         for _ in range(8):
             samples = dim.sample(8)
             for sample in samples:
@@ -247,7 +268,7 @@ class TestReal(object):
 
     def test_sample_from_extra_bounds_bad(self):
         """Randomized test **unsuccessfully** sampling with the extra bounds."""
-        dim = Real('yolo', 'norm', 0, 2, low=-2, high=+2, shape=(4, 4))
+        dim = Real("yolo", "norm", 0, 2, low=-2, high=+2, shape=(4, 4))
         with pytest.raises(ValueError) as exc:
             dim.sample(8)
         assert "Improbable bounds" in str(exc.value)
@@ -255,46 +276,46 @@ class TestReal(object):
     def test_bad_bounds(self):
         """Try setting bound with high <= low."""
         with pytest.raises(ValueError):
-            Real('yolo', 'norm', 0, 2, low=+2, high=-2, shape=(4, 4))
+            Real("yolo", "norm", 0, 2, low=+2, high=-2, shape=(4, 4))
         with pytest.raises(ValueError):
-            Real('yolo', 'norm', 0, 2, low=+2, high=+2, shape=(4, 4))
+            Real("yolo", "norm", 0, 2, low=+2, high=+2, shape=(4, 4))
 
     def test_interval(self):
         """Interval takes into account explicitly bounds."""
-        dim = Real('yolo', 'norm', 0, 3, low=-3, high=+3)
+        dim = Real("yolo", "norm", 0, 3, low=-3, high=+3)
         assert dim.interval() == (-3, 3)
 
-        dim = Real('yolo', 'alpha', 0.9, low=-3, high=+3)
+        dim = Real("yolo", "alpha", 0.9, low=-3, high=+3)
         assert dim.interval() == (0, 3)
 
-        dim = Real('yolo', 'uniform', -2, 4, low=-3, high=+3)
+        dim = Real("yolo", "uniform", -2, 4, low=-3, high=+3)
         assert dim.interval() == (-2.0, 2.0)
 
     def test_init_with_default_value(self):
         """Make sure the default value is set"""
-        dim = Real('yolo', 'uniform', -3, 10, default_value=2.0)
+        dim = Real("yolo", "uniform", -3, 10, default_value=2.0)
 
         assert type(dim.default_value) is float
 
     def test_set_outside_bounds_default_value(self):
         """Make sure default value is inside the bounds"""
         with pytest.raises(ValueError):
-            Real('yolo', 'uniform', -3, 2, default_value=5)
+            Real("yolo", "uniform", -3, 2, default_value=5)
 
     def test_no_default_value(self):
         """Make sure the default value is None"""
-        dim = Real('yolo', 'uniform', -3, 4)
+        dim = Real("yolo", "uniform", -3, 4)
         assert dim.default_value is None
 
     def test_cast_list(self):
         """Make sure list are cast to float and returned as list of values"""
-        dim = Real('yolo', 'uniform', -3, 4)
-        assert dim.cast(['1', '2']) == [1.0, 2.0]
+        dim = Real("yolo", "uniform", -3, 4)
+        assert dim.cast(["1", "2"]) == [1.0, 2.0]
 
     def test_cast_array(self):
         """Make sure array are cast to float and returned as array of values"""
-        dim = Real('yolo', 'uniform', -3, 4)
-        assert np.all(dim.cast(np.array(['1', '2'])) == np.array([1.0, 2.0]))
+        dim = Real("yolo", "uniform", -3, 4)
+        assert np.all(dim.cast(np.array(["1", "2"])) == np.array([1.0, 2.0]))
 
 
 class TestInteger(object):
@@ -302,7 +323,7 @@ class TestInteger(object):
 
     def test_simple_instance(self, seed):
         """Test Integer.__init__."""
-        dim = Integer('yolo', 'uniform', -3, 6)
+        dim = Integer("yolo", "uniform", -3, 6)
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert samples[0] == -2
@@ -312,21 +333,23 @@ class TestInteger(object):
 
         assert 1.0 in dim
 
-        assert str(dim) == "Integer(name=yolo, prior={uniform: (-3, 6), {}}, "\
-                           "shape=(), default value=None)"
+        assert (
+            str(dim) == "Integer(name=yolo, prior={uniform: (-3, 6), {}}, "
+            "shape=(), default value=None)"
+        )
 
-        assert dim.name == 'yolo'
-        assert dim.type == 'integer'
+        assert dim.name == "yolo"
+        assert dim.type == "integer"
         assert dim.shape == ()
 
     def test_inclusive_intervals(self):
         """Test that discretized bounds are valid"""
-        dim = Integer('yolo', 'uniform', -3, 5.5)
+        dim = Integer("yolo", "uniform", -3, 5.5)
         assert dim.interval() == (-3, 3)
 
     def test_contains(self):
         """Check for integer test."""
-        dim = Integer('yolo', 'uniform', -3, 6)
+        dim = Integer("yolo", "uniform", -3, 6)
 
         assert 0.1 not in dim
         assert (0.1, -0.2) not in dim
@@ -338,57 +361,57 @@ class TestInteger(object):
 
     def test_interval_with_infs(self):
         """Regression test: Interval handles correctly extreme bounds."""
-        dim = Integer('yolo', 'poisson', 5)
+        dim = Integer("yolo", "poisson", 5)
         # XXX: Complete this on both end of interval when scipy bug is fixed
         assert dim.interval()[1] == np.inf
 
     @pytest.mark.xfail(reason="scipy bug")
     def test_scipy_integer_dist_interval_bug(self):
         """Scipy does not return the correct answer for integer distributions."""
-        dim = Integer('yolo', 'randint', -3, 6)
+        dim = Integer("yolo", "randint", -3, 6)
         assert dim.interval() == (-3, 6)
         assert dim.interval(1.0) == (-3, 6)
         assert dim.interval(0.9999) == (-3, 6)
 
-        dim = Integer('yolo2', 'randint', -2, 4, loc=8)
+        dim = Integer("yolo2", "randint", -2, 4, loc=8)
         assert dim.interval() == (6, 12)
 
     def test_init_with_default_value(self):
         """Make sure the type of the default value is int"""
-        dim = Integer('yolo', 'uniform', -3, 10, default_value=2)
+        dim = Integer("yolo", "uniform", -3, 10, default_value=2)
 
         assert type(dim.default_value) is int
 
     def test_set_outside_bounds_default_value(self):
         """Make sure the default value is inside the bounds of the dimensions"""
         with pytest.raises(ValueError):
-            Integer('yolo', 'uniform', -3, 2, default_value=4)
+            Integer("yolo", "uniform", -3, 2, default_value=4)
 
     def test_no_default_value(self):
         """Make sure the default value is None"""
-        dim = Integer('yolo', 'uniform', -3, 4)
+        dim = Integer("yolo", "uniform", -3, 4)
         assert dim.default_value is None
 
     def test_cast_borders(self):
         """Make sure cast to int returns correct borders"""
-        dim = Integer('yolo', 'uniform', -3, 5)
+        dim = Integer("yolo", "uniform", -3, 5)
         assert dim.cast(-3.0) == -3
         assert dim.cast(2.0) == 2
 
     def test_cast_list(self):
         """Make sure list are cast to int and returned as list of values"""
-        dim = Integer('yolo', 'uniform', -3, 5)
-        assert dim.cast(['1', '2']) == [1, 2]
+        dim = Integer("yolo", "uniform", -3, 5)
+        assert dim.cast(["1", "2"]) == [1, 2]
 
     def test_cast_array(self):
         """Make sure array are cast to int and returned as array of values"""
-        dim = Integer('yolo', 'uniform', -3, 5)
-        assert np.all(dim.cast(np.array(['1', '2'])) == np.array([1, 2]))
+        dim = Integer("yolo", "uniform", -3, 5)
+        assert np.all(dim.cast(np.array(["1", "2"])) == np.array([1, 2]))
 
     def test_get_prior_string_discrete(self):
         """Test that discrete is included."""
-        dim = Integer('yolo', 'uniform', 1, 2)
-        assert dim.get_prior_string() == 'uniform(1, 3, discrete=True)'
+        dim = Integer("yolo", "uniform", 1, 2)
+        assert dim.get_prior_string() == "uniform(1, 3, discrete=True)"
 
 
 class TestCategorical(object):
@@ -396,11 +419,11 @@ class TestCategorical(object):
 
     def test_with_tuple(self, seed):
         """Test Categorical.__init__ with a tuple."""
-        categories = ('asdfa', 2)
-        dim = Categorical('yolo', categories)
+        categories = ("asdfa", 2)
+        dim = Categorical("yolo", categories)
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
-        assert samples[0] == 'asdfa'
+        assert samples[0] == "asdfa"
         assert dim._probs == (0.5, 0.5)
 
         assert categories == dim.categories
@@ -408,18 +431,20 @@ class TestCategorical(object):
         assert 2 in dim
         assert 3 not in dim
 
-        assert str(dim) == "Categorical(name=yolo, prior={asdfa: 0.50, 2: 0.50}, "\
-                           "shape=(), default value=None)"
+        assert (
+            str(dim) == "Categorical(name=yolo, prior={asdfa: 0.50, 2: 0.50}, "
+            "shape=(), default value=None)"
+        )
 
-        assert dim.name == 'yolo'
-        assert dim.type == 'categorical'
+        assert dim.name == "yolo"
+        assert dim.type == "categorical"
         assert dim.shape == ()
 
     def test_with_dict(self, seed):
         """Test Categorical.__init__ with a dictionary."""
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', 2, 3, 4)
-        dim = Categorical('yolo', OrderedDict(zip(categories, probs)))
+        categories = ("asdfa", 2, 3, 4)
+        dim = Categorical("yolo", OrderedDict(zip(categories, probs)))
         samples = dim.sample(seed=seed)
         assert len(samples) == 1
         assert samples[0] == 2
@@ -430,17 +455,17 @@ class TestCategorical(object):
         assert 2 in dim
         assert 0 not in dim
 
-        assert dim.name == 'yolo'
-        assert dim.type == 'categorical'
+        assert dim.name == "yolo"
+        assert dim.type == "categorical"
         assert dim.shape == ()
 
     def test_probabilities_are_ok(self, seed):
         """Test that the probabilities given are legit using law of big numbers."""
         bins = defaultdict(int)
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', '2', '3', '4')
+        categories = ("asdfa", "2", "3", "4")
         categories = OrderedDict(zip(categories, probs))
-        dim = Categorical('yolo', categories)
+        dim = Categorical("yolo", categories)
         for _ in range(500):
             sample = dim.sample(seed=seed)[0]
             bins[sample] += 1
@@ -451,109 +476,111 @@ class TestCategorical(object):
 
     def test_contains_wrong_shape(self):
         """Check correct category but wrongly shaped array."""
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
-        dim = Categorical('yolo', categories, shape=2)
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
+        dim = Categorical("yolo", categories, shape=2)
 
         assert 3 not in dim
-        assert ('asdfa', 2) in dim
+        assert ("asdfa", 2) in dim
 
     def test_repr_too_many_cats(self):
         """Check ellipsis on str/repr of too many categories."""
         categories = tuple(range(10))
-        dim = Categorical('yolo', categories, shape=2)
+        dim = Categorical("yolo", categories, shape=2)
 
-        assert str(dim) == "Categorical(name=yolo, " \
-                           "prior={0: 0.10, 1: 0.10, ..., 8: 0.10, 9: 0.10}, " \
-                           "shape=(2,), default value=None)"
+        assert (
+            str(dim) == "Categorical(name=yolo, "
+            "prior={0: 0.10, 1: 0.10, ..., 8: 0.10, 9: 0.10}, "
+            "shape=(2,), default value=None)"
+        )
 
     def test_bad_probabilities(self):
         """User provided bad probabilities."""
-        categories = {'asdfa': 0.05, 2: 0.2, 3: 0.3, 4: 0.4}
+        categories = {"asdfa": 0.05, 2: 0.2, 3: 0.3, 4: 0.4}
         with pytest.raises(ValueError):
-            Categorical('yolo', categories, shape=2)
+            Categorical("yolo", categories, shape=2)
 
     def test_interval(self):
         """Check that calling `Categorical.interval` raises `RuntimeError`."""
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
-        dim = Categorical('yolo', categories, shape=2)
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
+        dim = Categorical("yolo", categories, shape=2)
 
-        assert dim.interval() == ('asdfa', 2, 3, 4)
+        assert dim.interval() == ("asdfa", 2, 3, 4)
 
     def test_that_objects_types_are_ok(self):
         """Check that output samples are of the correct type.
 
         Don't let numpy mess with their automatic type inference.
         """
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 'lalala': 0.4}
-        dim = Categorical('yolo', categories)
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
+        dim = Categorical("yolo", categories)
 
-        assert '2' not in dim
+        assert "2" not in dim
         assert 2 in dim
-        assert 'asdfa' in dim
+        assert "asdfa" in dim
 
-        dim = Categorical('yolo', categories, shape=(2,))
+        dim = Categorical("yolo", categories, shape=(2,))
 
-        assert ['2', 'asdfa'] not in dim
-        assert [2, 'asdfa'] in dim
+        assert ["2", "asdfa"] not in dim
+        assert [2, "asdfa"] in dim
 
     def test_init_with_default_value_string(self):
         """Make sure the default value is of the correct type"""
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 'lalala': 0.4}
-        dim = Categorical('yolo', categories, default_value="asdfa")
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
+        dim = Categorical("yolo", categories, default_value="asdfa")
 
         assert type(dim.default_value) is str
 
     def test_init_with_default_value_int(self):
         """Make sure the default value is of the correct type"""
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 'lalala': 0.4}
-        dim = Categorical('yolo', categories, default_value=2)
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
+        dim = Categorical("yolo", categories, default_value=2)
 
         assert type(dim.default_value) is int
 
     def test_init_with_wrong_default_value(self):
         """Make sure the default value exists"""
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 'lalala': 0.4}
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
 
         with pytest.raises(ValueError):
-            Categorical('yolo', categories, default_value=2.3)
+            Categorical("yolo", categories, default_value=2.3)
 
     def test_no_default_value(self):
         """Make sure the default value is None"""
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 'lalala': 0.4}
-        dim = Categorical('yolo', categories)
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
+        dim = Categorical("yolo", categories)
         assert dim.default_value is None
 
     def test_cast_list(self):
         """Make sure list are cast to categories and returned as list"""
-        categories = {'asdfa': 0.1, 2: 0.2, 3.0: 0.3, 'lalala': 0.4}
-        dim = Categorical('yolo', categories)
-        assert dim.cast(['asdfa']) == ['asdfa']
-        assert dim.cast(['2']) == [2]
-        assert dim.cast(['3.0']) == [3.0]
+        categories = {"asdfa": 0.1, 2: 0.2, 3.0: 0.3, "lalala": 0.4}
+        dim = Categorical("yolo", categories)
+        assert dim.cast(["asdfa"]) == ["asdfa"]
+        assert dim.cast(["2"]) == [2]
+        assert dim.cast(["3.0"]) == [3.0]
 
     def test_cast_list_multidim(self):
         """Make sure array are cast to int and returned as array of values"""
         categories = list(range(10))
-        categories[0] = 'asdfa'
-        categories[2] = 'lalala'
-        dim = Categorical('yolo', categories, shape=2)
-        sample = ['asdfa', '1']  # np.array(['asdfa', '1'], dtype=np.object)
-        assert dim.cast(sample) == ['asdfa', 1]
+        categories[0] = "asdfa"
+        categories[2] = "lalala"
+        dim = Categorical("yolo", categories, shape=2)
+        sample = ["asdfa", "1"]  # np.array(['asdfa', '1'], dtype=np.object)
+        assert dim.cast(sample) == ["asdfa", 1]
 
     def test_cast_array_multidim(self):
         """Make sure array are cast to int and returned as array of values"""
         categories = list(range(10))
-        categories[0] = 'asdfa'
-        categories[2] = 'lalala'
-        dim = Categorical('yolo', categories, shape=2)
-        sample = np.array(['asdfa', '1'], dtype=np.object)
-        assert np.all(dim.cast(sample) == np.array(['asdfa', 1], dtype=np.object))
+        categories[0] = "asdfa"
+        categories[2] = "lalala"
+        dim = Categorical("yolo", categories, shape=2)
+        sample = np.array(["asdfa", "1"], dtype=np.object)
+        assert np.all(dim.cast(sample) == np.array(["asdfa", 1], dtype=np.object))
 
     def test_cast_bad_category(self):
         """Make sure array are cast to int and returned as array of values"""
         categories = list(range(10))
-        dim = Categorical('yolo', categories, shape=2)
-        sample = np.array(['asdfa', '1'], dtype=np.object)
+        dim = Categorical("yolo", categories, shape=2)
+        sample = np.array(["asdfa", "1"], dtype=np.object)
         with pytest.raises(ValueError) as exc:
             dim.cast(sample)
         assert "Invalid category: asdfa" in str(exc.value)
@@ -564,53 +591,55 @@ class TestFidelity(object):
 
     def test_simple_instance(self):
         """Test Fidelity.__init__."""
-        dim = Fidelity('epoch', 1, 2)
+        dim = Fidelity("epoch", 1, 2)
 
         assert str(dim) == "Fidelity(name=epoch, low=1, high=2, base=2)"
         assert dim.low == 1
         assert dim.high == 2
         assert dim.base == 2
-        assert dim.name == 'epoch'
-        assert dim.type == 'fidelity'
+        assert dim.name == "epoch"
+        assert dim.type == "fidelity"
         assert dim.shape is None
 
     def test_min_resources(self):
         """Test that an error is raised if min is smaller than 1"""
         with pytest.raises(AttributeError) as exc:
-            Fidelity('epoch', 0, 2)
+            Fidelity("epoch", 0, 2)
         assert "Minimum resources must be a positive number." == str(exc.value)
 
     def test_min_max_resources(self):
         """Test that an error is raised if min is larger than max"""
         with pytest.raises(AttributeError) as exc:
-            Fidelity('epoch', 3, 2)
-        assert "Minimum resources must be smaller than maximum resources." == str(exc.value)
+            Fidelity("epoch", 3, 2)
+        assert "Minimum resources must be smaller than maximum resources." == str(
+            exc.value
+        )
 
     def test_base(self):
         """Test that an error is raised if base is smaller than 1"""
         with pytest.raises(AttributeError) as exc:
-            Fidelity('epoch', 1, 2, 0)
+            Fidelity("epoch", 1, 2, 0)
         assert "Base should be greater than or equal to 1" == str(exc.value)
 
     def test_sampling(self):
         """Make sure Fidelity simply returns `high`"""
-        dim = Fidelity('epoch', 1, 2)
+        dim = Fidelity("epoch", 1, 2)
         assert dim.sample() == [2]
-        dim = Fidelity('epoch', 1, 5)
+        dim = Fidelity("epoch", 1, 5)
         assert dim.sample() == [5]
-        dim = Fidelity('epoch', 1, 5)
+        dim = Fidelity("epoch", 1, 5)
         assert dim.sample(4) == [5] * 4
 
     def test_default_value(self):
         """Make sure Fidelity simply returns `high`"""
-        dim = Fidelity('epoch', 1, 2)
+        dim = Fidelity("epoch", 1, 2)
         assert dim.default_value == 2
-        dim = Fidelity('epoch', 1, 5)
+        dim = Fidelity("epoch", 1, 5)
         assert dim.default_value == 5
 
     def test_contains(self):
         """Make sure fidelity.__contains__ tests based on (min, max)"""
-        dim = Fidelity('epoch', 1, 10)
+        dim = Fidelity("epoch", 1, 10)
 
         assert 0 not in dim
         assert 1 in dim
@@ -620,12 +649,12 @@ class TestFidelity(object):
 
     def test_interval(self):
         """Check that interval() is (min, max)."""
-        dim = Fidelity('epoch', 1, 10)
+        dim = Fidelity("epoch", 1, 10)
         dim.interval() == (1, 10)
 
     def test_cast(self):
         """Check that error is being raised."""
-        dim = Fidelity('epoch', 1, 10)
+        dim = Fidelity("epoch", 1, 10)
         with pytest.raises(NotImplementedError):
             dim.cast()
 
@@ -642,23 +671,23 @@ class TestSpace(object):
         """Register bunch of dimensions, check if points/name are in space."""
         space = Space()
 
-        assert 'yolo' not in space
-        assert (('asdfa', 2), 0, 3.5) not in space
+        assert "yolo" not in space
+        assert (("asdfa", 2), 0, 3.5) not in space
 
-        categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
-        dim = Categorical('yolo', categories, shape=2)
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
+        dim = Categorical("yolo", categories, shape=2)
         space.register(dim)
-        dim = Integer('yolo2', 'uniform', -3, 6)
+        dim = Integer("yolo2", "uniform", -3, 6)
         space.register(dim)
-        dim = Real('yolo3', 'norm', 0.9)
+        dim = Real("yolo3", "norm", 0.9)
         space.register(dim)
 
-        assert 'yolo' in space
-        assert 'yolo2' in space
-        assert 'yolo3' in space
+        assert "yolo" in space
+        assert "yolo2" in space
+        assert "yolo3" in space
 
-        assert (('asdfa', 2), 0, 3.5) in space
-        assert (('asdfa', 2), 7, 3.5) not in space
+        assert (("asdfa", 2), 0, 3.5) in space
+        assert (("asdfa", 2), 7, 3.5) not in space
 
     def test_bad_contain(self):
         """Checking with no iterables does no good."""
@@ -670,18 +699,18 @@ class TestSpace(object):
         """Check whether sampling works correctly."""
         space = Space()
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', 2, 3, 4)
-        dim1 = Categorical('yolo', OrderedDict(zip(categories, probs)), shape=(2, 2))
+        categories = ("asdfa", 2, 3, 4)
+        dim1 = Categorical("yolo", OrderedDict(zip(categories, probs)), shape=(2, 2))
         space.register(dim1)
-        dim2 = Integer('yolo2', 'uniform', -3, 6)
+        dim2 = Integer("yolo2", "uniform", -3, 6)
         space.register(dim2)
-        dim3 = Real('yolo3', 'norm', 0.9)
+        dim3 = Real("yolo3", "norm", 0.9)
         space.register(dim3)
 
         point = space.sample(seed=seed)
-        test_point = [(dim1.sample()[0],
-                       dim2.sample()[0],
-                       dim3.sample()[0]), ]
+        test_point = [
+            (dim1.sample()[0], dim2.sample()[0], dim3.sample()[0]),
+        ]
         assert len(point) == len(test_point) == 1
         assert len(point[0]) == len(test_point[0]) == 3
         assert np.all(point[0][0] == test_point[0][0])
@@ -692,8 +721,10 @@ class TestSpace(object):
         points1 = dim1.sample(2)
         points2 = dim2.sample(2)
         points3 = dim3.sample(2)
-        test_points = [(points1[0], points2[0], points3[0]),
-                       (points1[1], points2[1], points3[1])]
+        test_points = [
+            (points1[0], points2[0], points3[0]),
+            (points1[1], points2[1], points3[1]),
+        ]
         assert len(points) == len(test_points) == 2
         for i in range(2):
             assert len(points[i]) == len(test_points[i]) == 3
@@ -705,12 +736,12 @@ class TestSpace(object):
         """Check whether interval is cool."""
         space = Space()
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', 2, 3, 4)
-        dim = Categorical('yolo', OrderedDict(zip(categories, probs)), shape=2)
+        categories = ("asdfa", 2, 3, 4)
+        dim = Categorical("yolo", OrderedDict(zip(categories, probs)), shape=2)
         space.register(dim)
-        dim = Integer('yolo2', 'uniform', -3, 6)
+        dim = Integer("yolo2", "uniform", -3, 6)
         space.register(dim)
-        dim = Real('yolo3', 'norm', 0.9)
+        dim = Real("yolo3", "norm", 0.9)
         space.register(dim)
 
         assert space.interval() == [categories, (-3, 3), (-np.inf, np.inf)]
@@ -719,21 +750,21 @@ class TestSpace(object):
         """Check whether space capacity is correct"""
         space = Space()
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', 2, 3, 4)
-        dim = Categorical('yolo', OrderedDict(zip(categories, probs)), shape=2)
+        categories = ("asdfa", 2, 3, 4)
+        dim = Categorical("yolo", OrderedDict(zip(categories, probs)), shape=2)
         space.register(dim)
-        dim = Integer('yolo2', 'uniform', -3, 6)
+        dim = Integer("yolo2", "uniform", -3, 6)
         space.register(dim)
-        dim = Fidelity('epoch', 1, 9, 3)
+        dim = Fidelity("epoch", 1, 9, 3)
         space.register(dim)
 
         assert space.cardinality == (4 ** 2) * (6 + 1) * 1
 
-        dim = Integer('yolo3', 'uniform', -3, 2, shape=(3, 2))
+        dim = Integer("yolo3", "uniform", -3, 2, shape=(3, 2))
         space.register(dim)
         assert space.cardinality == (4 ** 2) * (6 + 1) * 1 * ((2 + 1) ** (3 * 2))
 
-        dim = Real('yolo4', 'norm', 0.9)
+        dim = Real("yolo4", "norm", 0.9)
         space.register(dim)
         assert np.inf == space.cardinality
 
@@ -744,37 +775,37 @@ class TestSpace(object):
         # The name of an integer must be a of `str` type.
         # Integers are reversed for indexing the OrderedDict.
         with pytest.raises(TypeError) as exc:
-            space[5] = Integer('yolo', 'uniform', -3, 6)
+            space[5] = Integer("yolo", "uniform", -3, 6)
         assert "string" in str(exc.value)
 
         # Only object of type `Dimension` are allowed in `Space`.
         with pytest.raises(TypeError) as exc:
-            space['ispis'] = 'nope'
+            space["ispis"] = "nope"
         assert "Dimension" in str(exc.value)
 
         # Cannot register something with the same name.
-        space.register(Integer('yolo', 'uniform', -3, 6))
+        space.register(Integer("yolo", "uniform", -3, 6))
         with pytest.raises(ValueError) as exc:
-            space.register(Real('yolo', 'uniform', 0, 6))
+            space.register(Real("yolo", "uniform", 0, 6))
         assert "another name" in str(exc.value)
 
     def test_getitem(self):
         """Test getting dimensions from space."""
         space = Space()
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', 2, 3, 4)
-        dim = Categorical('yolo', OrderedDict(zip(categories, probs)), shape=2)
+        categories = ("asdfa", 2, 3, 4)
+        dim = Categorical("yolo", OrderedDict(zip(categories, probs)), shape=2)
         space.register(dim)
-        dim = Integer('yolo2', 'uniform', -3, 6)
+        dim = Integer("yolo2", "uniform", -3, 6)
         space.register(dim)
-        dim = Real('yolo3', 'norm', 0.9)
+        dim = Real("yolo3", "norm", 0.9)
         space.register(dim)
 
-        assert space['yolo'].type == 'categorical'
-        assert space[0].type == 'categorical'
+        assert space["yolo"].type == "categorical"
+        assert space[0].type == "categorical"
 
         with pytest.raises(KeyError):
-            space['asdf']
+            space["asdf"]
 
         with pytest.raises(IndexError):
             space[3]
@@ -782,16 +813,16 @@ class TestSpace(object):
     def test_order(self):
         """Test that the same space built twice will have the same ordering."""
         space1 = Space()
-        space1.register(Integer('yolo1', 'uniform', -3, 6, shape=(2,)))
-        space1.register(Integer('yolo2', 'uniform', -3, 6, shape=(2,)))
-        space1.register(Real('yolo3', 'norm', 0.9))
-        space1.register(Categorical('yolo4', ('asdfa', 2)))
+        space1.register(Integer("yolo1", "uniform", -3, 6, shape=(2,)))
+        space1.register(Integer("yolo2", "uniform", -3, 6, shape=(2,)))
+        space1.register(Real("yolo3", "norm", 0.9))
+        space1.register(Categorical("yolo4", ("asdfa", 2)))
 
         space2 = Space()
-        space2.register(Integer('yolo1', 'uniform', -3, 6, shape=(2,)))
-        space2.register(Real('yolo3', 'norm', 0.9))
-        space2.register(Categorical('yolo4', ('asdfa', 2)))
-        space2.register(Integer('yolo2', 'uniform', -3, 6, shape=(2,)))
+        space2.register(Integer("yolo1", "uniform", -3, 6, shape=(2,)))
+        space2.register(Real("yolo3", "norm", 0.9))
+        space2.register(Categorical("yolo4", ("asdfa", 2)))
+        space2.register(Integer("yolo2", "uniform", -3, 6, shape=(2,)))
 
         assert list(space1) == list(space1.keys())
         assert list(space2) == list(space2.keys())
@@ -804,44 +835,47 @@ class TestSpace(object):
     def test_repr(self):
         """Test str/repr."""
         space = Space()
-        dim = Integer('yolo2', 'uniform', -3, 6, shape=(2,))
+        dim = Integer("yolo2", "uniform", -3, 6, shape=(2,))
         space.register(dim)
-        dim = Real('yolo3', 'norm', 0.9)
+        dim = Real("yolo3", "norm", 0.9)
         space.register(dim)
 
-        assert str(space) == "Space(["\
-                             "Integer(name=yolo2, prior={uniform: (-3, 6), {}}, shape=(2,), "\
-                             "default value=None),\n"\
-                             "       Real(name=yolo3, prior={norm: (0.9,), {}}, shape=(), "\
-                             "default value=None)])"
+        assert (
+            str(space) == "Space(["
+            "Integer(name=yolo2, prior={uniform: (-3, 6), {}}, shape=(2,), "
+            "default value=None),\n"
+            "       Real(name=yolo3, prior={norm: (0.9,), {}}, shape=(), "
+            "default value=None)])"
+        )
 
     def test_configuration(self):
         """Test that configuration contains all dimensions."""
         space = Space()
-        space.register(Integer('yolo1', 'uniform', -3, 6, shape=(2,)))
-        space.register(Integer('yolo2', 'uniform', -3, 6, shape=(2,)))
-        space.register(Real('yolo3', 'norm', 0.9))
-        space.register(Categorical('yolo4', ('asdfa', 2)))
+        space.register(Integer("yolo1", "uniform", -3, 6, shape=(2,)))
+        space.register(Integer("yolo2", "uniform", -3, 6, shape=(2,)))
+        space.register(Real("yolo3", "norm", 0.9))
+        space.register(Categorical("yolo4", ("asdfa", 2)))
 
         assert space.configuration == {
-            'yolo1': 'uniform(-3, 3, shape=(2,), discrete=True)',
-            'yolo2': 'uniform(-3, 3, shape=(2,), discrete=True)',
-            'yolo3': 'norm(0.9)',
-            'yolo4': 'choices([\'asdfa\', 2])'}
+            "yolo1": "uniform(-3, 3, shape=(2,), discrete=True)",
+            "yolo2": "uniform(-3, 3, shape=(2,), discrete=True)",
+            "yolo3": "norm(0.9)",
+            "yolo4": "choices(['asdfa', 2])",
+        }
 
     def test_precision(self):
         """Test that precision is correctly handled."""
         space = Space()
-        space.register(Real('yolo1', 'norm', 0.9, precision=6))
-        space.register(Real('yolo2', 'norm', 0.9, precision=None))
-        space.register(Real('yolo5', 'norm', 0.9))
+        space.register(Real("yolo1", "norm", 0.9, precision=6))
+        space.register(Real("yolo2", "norm", 0.9, precision=None))
+        space.register(Real("yolo5", "norm", 0.9))
 
-        assert space['yolo1'].precision == 6
-        assert space['yolo2'].precision is None
-        assert space['yolo5'].precision == 4
-
-        with pytest.raises(TypeError):
-            space.register(Real('yolo3', 'norm', 0.9, precision=-12))
+        assert space["yolo1"].precision == 6
+        assert space["yolo2"].precision is None
+        assert space["yolo5"].precision == 4
 
         with pytest.raises(TypeError):
-            space.register(Real('yolo4', 'norm', 0.9, precision=0.6))
+            space.register(Real("yolo3", "norm", 0.9, precision=-12))
+
+        with pytest.raises(TypeError):
+            space.register(Real("yolo4", "norm", 0.9, precision=0.6))

--- a/tests/unittests/algo/test_tpe.py
+++ b/tests/unittests/algo/test_tpe.py
@@ -7,8 +7,14 @@ import pytest
 from scipy.stats import norm
 
 from orion.algo.space import Categorical, Fidelity, Integer, Real, Space
-from orion.algo.tpe import adaptive_parzen_estimator, CategoricalSampler, \
-    compute_max_ei_point, GMMSampler, ramp_up_weights, TPE
+from orion.algo.tpe import (
+    adaptive_parzen_estimator,
+    CategoricalSampler,
+    compute_max_ei_point,
+    GMMSampler,
+    ramp_up_weights,
+    TPE,
+)
 
 
 @pytest.fixture()
@@ -16,14 +22,14 @@ def space():
     """Return an optimization space"""
     space = Space()
 
-    dim1 = Real('yolo1', 'uniform', -10, 20)
+    dim1 = Real("yolo1", "uniform", -10, 20)
     space.register(dim1)
 
-    dim2 = Integer('yolo2', 'uniform', -5, 10)
+    dim2 = Integer("yolo2", "uniform", -5, 10)
     space.register(dim2)
 
-    categories = ['a', 0.1, 2, 'c']
-    dim3 = Categorical('yolo3', categories)
+    categories = ["a", 0.1, 2, "c"]
+    dim3 = Categorical("yolo3", categories)
     space.register(dim3)
 
     return space
@@ -75,30 +81,33 @@ def test_adaptive_parzen_normal_estimator():
     high = 5
 
     obs_mus = [1.2]
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+    )
     assert list(mus) == [1.2, 2]
     assert list(sigmas) == [3, 6]
     assert list(weights) == [1.0 / 2, 1.0 / 2]
 
     obs_mus = [3.4]
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=0.5,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=0.5, equal_weight=False, flat_num=25
+    )
     assert list(mus) == [2, 3.4]
     assert list(sigmas) == [6, 3]
     assert list(weights) == [0.5 / 1.5, 1.0 / 1.5]
 
     obs_mus = numpy.linspace(-1, 5, num=30, endpoint=False)
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+    )
 
     ramp = numpy.linspace(1.0 / 30, 1.0, num=30 - 25)
     full = numpy.ones(25 + 1)
-    all_weights = (numpy.concatenate([ramp, full]))
+    all_weights = numpy.concatenate([ramp, full])
 
     assert len(mus) == len(sigmas) == len(weights) == 30 + 1
-    assert numpy.all(weights[:30 - 25] == ramp / all_weights.sum())
-    assert numpy.all(weights[30 - 25:] == 1 / all_weights.sum())
+    assert numpy.all(weights[: 30 - 25] == ramp / all_weights.sum())
+    assert numpy.all(weights[30 - 25 :] == 1 / all_weights.sum())
     assert numpy.all(sigmas == 6 / 10)
 
 
@@ -109,41 +118,48 @@ def test_adaptive_parzen_normal_estimator_weight():
     high = 5
 
     # equal weight
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=True, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=True, flat_num=25
+    )
     assert numpy.all(weights == 1 / 31)
     assert numpy.all(sigmas == 6 / 10)
 
     # prior weight
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=0.5,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=0.5, equal_weight=False, flat_num=25
+    )
 
     ramp = numpy.linspace(1.0 / 30, 1.0, num=30 - 25)
     full = numpy.ones(25 + 1)
-    all_weights = (numpy.concatenate([ramp, full]))
+    all_weights = numpy.concatenate([ramp, full])
     prior_pos = numpy.searchsorted(mus, 2)
     all_weights[prior_pos] = 0.5
 
-    assert numpy.all(weights[:30 - 25] == (numpy.linspace(1.0 / 30, 1.0, num=30 - 25) /
-                                           all_weights.sum()))
-    assert numpy.all(weights[33 - 25:prior_pos] == 1 / all_weights.sum())
+    assert numpy.all(
+        weights[: 30 - 25]
+        == (numpy.linspace(1.0 / 30, 1.0, num=30 - 25) / all_weights.sum())
+    )
+    assert numpy.all(weights[33 - 25 : prior_pos] == 1 / all_weights.sum())
     assert weights[prior_pos] == 0.5 / all_weights.sum()
-    assert numpy.all(weights[prior_pos + 1:] == 1 / all_weights.sum())
+    assert numpy.all(weights[prior_pos + 1 :] == 1 / all_weights.sum())
     assert numpy.all(sigmas == 6 / 10)
 
     # full weights number
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=15)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=15
+    )
 
     ramp = numpy.linspace(1.0 / 30, 1.0, num=30 - 15)
     full = numpy.ones(15 + 1)
-    all_weights = (numpy.concatenate([ramp, full]))
+    all_weights = numpy.concatenate([ramp, full])
     prior_pos = numpy.searchsorted(mus, 2)
     all_weights[prior_pos] = 1.0
 
-    assert numpy.all(weights[:30 - 15] == (numpy.linspace(1.0 / 30, 1.0, num=30 - 15) /
-                                           all_weights.sum()))
-    assert numpy.all(weights[30 - 15:] == 1 / all_weights.sum())
+    assert numpy.all(
+        weights[: 30 - 15]
+        == (numpy.linspace(1.0 / 30, 1.0, num=30 - 15) / all_weights.sum())
+    )
+    assert numpy.all(weights[30 - 15 :] == 1 / all_weights.sum())
     assert numpy.all(sigmas == 6 / 10)
 
 
@@ -153,38 +169,42 @@ def test_adaptive_parzen_normal_estimator_sigma_clip():
     high = 5
 
     obs_mus = numpy.linspace(-1, 5, num=8, endpoint=False)
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+    )
     assert len(mus) == len(sigmas) == len(weights) == 8 + 1
     assert numpy.all(weights == 1 / 9)
     assert numpy.all(sigmas == 6 / 8)
 
     obs_mus = numpy.random.uniform(-1, 5, 30)
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+    )
 
     assert len(mus) == len(sigmas) == len(weights) == 30 + 1
     assert numpy.all(weights[-25:] == weights[-1])
     assert numpy.all(sigmas <= 6) and numpy.all(sigmas >= 6 / 10)
 
     obs_mus = numpy.random.uniform(-1, 5, 400)
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+    )
 
     assert len(mus) == len(sigmas) == len(weights) == 400 + 1
     assert numpy.all(weights[-25:] == weights[-1])
     assert numpy.all(sigmas <= 6) and numpy.all(sigmas >= 6 / 20)
 
     obs_mus = numpy.random.uniform(-1, 5, 10000)
-    mus, sigmas, weights = adaptive_parzen_estimator(obs_mus, low, high, prior_weight=1.0,
-                                                     equal_weight=False, flat_num=25)
+    mus, sigmas, weights = adaptive_parzen_estimator(
+        obs_mus, low, high, prior_weight=1.0, equal_weight=False, flat_num=25
+    )
 
     assert len(mus) == len(sigmas) == len(weights) == 10000 + 1
     assert numpy.all(weights[-25:] == weights[-1])
     assert numpy.all(sigmas <= 6) and numpy.all(sigmas >= 6 / 100)
 
 
-class TestCategoricalSampler():
+class TestCategoricalSampler:
     """Tests for TPE Categorical Sampler"""
 
     def test_cat_sampler_creation(self, tpe):
@@ -195,7 +215,7 @@ class TestCategoricalSampler():
         assert len(cat_sampler.weights) == len(choices)
 
         obs = [0, 3, 9]
-        choices = ['a', 'b', 11, 15, 17, 18, 19, 20, 25, 'c']
+        choices = ["a", "b", 11, 15, 17, 18, 19, 20, 25, "c"]
         cat_sampler = CategoricalSampler(tpe, obs, choices)
 
         assert len(cat_sampler.weights) == len(choices)
@@ -218,7 +238,7 @@ class TestCategoricalSampler():
 
         ramp = numpy.linspace(1.0 / 100, 1.0, num=100 - 30)
         full = numpy.ones(30)
-        ramp_weights = (numpy.concatenate([ramp, full]))
+        ramp_weights = numpy.concatenate([ramp, full])
 
         counts_obs = numpy.bincount(obs, weights=ramp_weights) + 0.5
         weights = counts_obs / counts_obs.sum()
@@ -228,7 +248,7 @@ class TestCategoricalSampler():
     def test_sample(self, tpe):
         """Test CategoricalSampler sample function"""
         obs = numpy.random.randint(0, 10, 100)
-        choices = ['a', 'b', 11, 15, 17, 18, 19, 20, 25, 'c']
+        choices = ["a", "b", 11, 15, 17, 18, 19, 20, 25, "c"]
         cat_sampler = CategoricalSampler(tpe, obs, choices)
 
         points = cat_sampler.sample(25)
@@ -255,17 +275,19 @@ class TestCategoricalSampler():
     def test_get_loglikelis(self, tpe):
         """Test to get log likelis of points"""
         obs = numpy.random.randint(0, 10, 100)
-        choices = ['a', 'b', 11, 15, 17, 18, 19, 20, 25, 'c']
+        choices = ["a", "b", 11, 15, 17, 18, 19, 20, 25, "c"]
         cat_sampler = CategoricalSampler(tpe, obs, choices)
 
         points = cat_sampler.sample(25)
 
         likelis = cat_sampler.get_loglikelis(points)
 
-        assert numpy.all(likelis == numpy.log(numpy.asarray(cat_sampler.weights)[points]))
+        assert numpy.all(
+            likelis == numpy.log(numpy.asarray(cat_sampler.weights)[points])
+        )
 
 
-class TestGMMSampler():
+class TestGMMSampler:
     """Tests for TPE GMM Sampler"""
 
     def test_gmm_sampler_creation(self, tpe):
@@ -345,7 +367,7 @@ class TestGMMSampler():
         assert len(likelis) == len(points)
 
 
-class TestTPE():
+class TestTPE:
     """Tests for the algo TPE."""
 
     def test_seed_rng(self, tpe):
@@ -370,40 +392,42 @@ class TestTPE():
     def test_unsupported_space(self):
         """Test tpe only work for supported search space"""
         space = Space()
-        dim1 = Real('yolo1', 'uniform', -10, 10)
+        dim1 = Real("yolo1", "uniform", -10, 10)
         space.register(dim1)
-        dim2 = Real('yolo2', 'reciprocal', 10, 20)
+        dim2 = Real("yolo2", "reciprocal", 10, 20)
         space.register(dim2)
-        categories = ['a', 0.1, 2, 'c']
-        dim3 = Categorical('yolo3', categories)
+        categories = ["a", 0.1, 2, "c"]
+        dim3 = Categorical("yolo3", categories)
         space.register(dim3)
-        dim4 = Fidelity('epoch', 1, 9, 3)
+        dim4 = Fidelity("epoch", 1, 9, 3)
         space.register(dim4)
         TPE(space)
 
         space = Space()
-        dim = Real('yolo1', 'norm', 0.9)
+        dim = Real("yolo1", "norm", 0.9)
         space.register(dim)
 
         with pytest.raises(ValueError) as ex:
             TPE(space)
 
-        assert 'TPE now only supports uniform, loguniform, uniform discrete and choices' \
-               in str(ex.value)
+        assert (
+            "TPE now only supports uniform, loguniform, uniform discrete and choices"
+            in str(ex.value)
+        )
 
         space = Space()
-        dim = Real('yolo1', 'uniform', 0.9, shape=(2, 1))
+        dim = Real("yolo1", "uniform", 0.9, shape=(2, 1))
         space.register(dim)
 
         with pytest.raises(ValueError) as ex:
             TPE(space)
 
-        assert 'TPE now only supports 1D shape' in str(ex.value)
+        assert "TPE now only supports 1D shape" in str(ex.value)
 
     def test_split_trials(self, tpe):
         """Test observed trials can be split based on TPE gamma"""
         space = Space()
-        dim1 = Real('yolo1', 'uniform', -3, 6)
+        dim1 = Real("yolo1", "uniform", -3, 6)
         space.register(dim1)
 
         tpe.space = space
@@ -414,7 +438,7 @@ class TestTPE():
         numpy.random.shuffle(points_results)
         points, results = zip(*points_results)
         for point, result in zip(points, results):
-            tpe.observe([[point]], [{'objective': result}])
+            tpe.observe([[point]], [{"objective": result}])
 
         tpe.gamma = 0.25
         below_points, above_points = tpe.split_trials()
@@ -431,10 +455,10 @@ class TestTPE():
     def test_sample_int_dimension(self):
         """Test sample values for a integer dimension"""
         space = Space()
-        dim1 = Integer('yolo1', 'uniform', -10, 20)
+        dim1 = Integer("yolo1", "uniform", -10, 20)
         space.register(dim1)
 
-        dim2 = Integer('yolo2', 'uniform', -5, 10, shape=(2))
+        dim2 = Integer("yolo2", "uniform", -5, 10, shape=(2))
         space.register(dim2)
 
         tpe = TPE(space)
@@ -442,8 +466,9 @@ class TestTPE():
         obs_points = numpy.random.randint(-10, 10, 100)
         below_points = [obs_points[:25]]
         above_points = [obs_points[25:]]
-        points = tpe.sample_one_dimension(dim1, 1,
-                                          below_points, above_points, tpe._sample_int_point)
+        points = tpe.sample_one_dimension(
+            dim1, 1, below_points, above_points, tpe._sample_int_point
+        )
         points = numpy.asarray(points)
         assert len(points) == 1
         assert all(points >= -10)
@@ -451,8 +476,9 @@ class TestTPE():
 
         obs_points_below = numpy.random.randint(-10, 0, 25).reshape(1, 25)
         obs_points_above = numpy.random.randint(0, 10, 75).reshape(1, 75)
-        points = tpe.sample_one_dimension(dim1, 1,
-                                          obs_points_below, obs_points_above, tpe._sample_int_point)
+        points = tpe.sample_one_dimension(
+            dim1, 1, obs_points_below, obs_points_above, tpe._sample_int_point
+        )
         points = numpy.asarray(points)
         assert len(points) == 1
         assert all(points >= -10)
@@ -461,25 +487,27 @@ class TestTPE():
         obs_points = numpy.random.randint(-5, 5, 100)
         below_points = [obs_points[:25], obs_points[25:50]]
         above_points = [obs_points[50:75], obs_points[75:]]
-        points = tpe.sample_one_dimension(dim2, 2,
-                                          below_points, above_points, tpe._sample_int_point)
+        points = tpe.sample_one_dimension(
+            dim2, 2, below_points, above_points, tpe._sample_int_point
+        )
         points = numpy.asarray(points)
         assert len(points) == 2
         assert all(points >= -10)
         assert all(points < 10)
 
         tpe.n_ei_candidates = 0
-        points = tpe.sample_one_dimension(dim2, 2,
-                                          below_points, above_points, tpe._sample_int_point)
+        points = tpe.sample_one_dimension(
+            dim2, 2, below_points, above_points, tpe._sample_int_point
+        )
         assert len(points) == 0
 
     def test_sample_categorical_dimension(self):
         """Test sample values for a categorical dimension"""
         space = Space()
-        categories = ['a', 'b', 11, 15, 17, 18, 19, 20, 25, 'c']
-        dim1 = Categorical('yolo1', categories)
+        categories = ["a", "b", 11, 15, 17, 18, 19, 20, 25, "c"]
+        dim1 = Categorical("yolo1", categories)
         space.register(dim1)
-        dim2 = Categorical('yolo2', categories, shape=(2))
+        dim2 = Categorical("yolo2", categories, shape=(2))
         space.register(dim2)
 
         tpe = TPE(space)
@@ -488,8 +516,9 @@ class TestTPE():
         obs_points = [categories[point] for point in obs_points]
         below_points = [obs_points[:25]]
         above_points = [obs_points[25:]]
-        points = tpe.sample_one_dimension(dim1, 1,
-                                          below_points, above_points, tpe._sample_categorical_point)
+        points = tpe.sample_one_dimension(
+            dim1, 1, below_points, above_points, tpe._sample_categorical_point
+        )
         assert len(points) == 1
         assert points[0] in categories
 
@@ -497,8 +526,9 @@ class TestTPE():
         obs_points_above = numpy.random.randint(3, 10, 75)
         below_points = [[categories[point] for point in obs_points_below]]
         above_points = [[categories[point] for point in obs_points_above]]
-        points = tpe.sample_one_dimension(dim1, 1,
-                                          below_points, above_points, tpe._sample_categorical_point)
+        points = tpe.sample_one_dimension(
+            dim1, 1, below_points, above_points, tpe._sample_categorical_point
+        )
         assert len(points) == 1
         assert points[0] in categories[:3]
 
@@ -507,33 +537,34 @@ class TestTPE():
         below_points = [obs_points[:25], obs_points[25:50]]
         above_points = [obs_points[50:75], obs_points[75:]]
 
-        points = tpe.sample_one_dimension(dim2, 2,
-                                          below_points, above_points, tpe._sample_categorical_point)
+        points = tpe.sample_one_dimension(
+            dim2, 2, below_points, above_points, tpe._sample_categorical_point
+        )
         assert len(points) == 2
         assert points[0] in categories
         assert points[1] in categories
 
         tpe.n_ei_candidates = 0
-        points = tpe.sample_one_dimension(dim2, 2,
-                                          below_points, above_points, tpe._sample_categorical_point)
+        points = tpe.sample_one_dimension(
+            dim2, 2, below_points, above_points, tpe._sample_categorical_point
+        )
         assert len(points) == 0
 
     def test_sample_real_dimension(self):
         """Test sample values for a real dimension"""
         space = Space()
-        dim1 = Real('yolo1', 'uniform', -10, 20)
+        dim1 = Real("yolo1", "uniform", -10, 20)
         space.register(dim1)
-        dim2 = Real('yolo2', 'uniform', -5, 10, shape=(2))
+        dim2 = Real("yolo2", "uniform", -5, 10, shape=(2))
         space.register(dim2)
-        dim3 = Real('yolo3', 'reciprocal', 1, 20)
+        dim3 = Real("yolo3", "reciprocal", 1, 20)
         space.register(dim3)
 
         tpe = TPE(space)
         points = numpy.random.uniform(-10, 10, 20)
         below_points = [points[:8]]
         above_points = [points[8:]]
-        points = tpe._sample_real_dimension(dim1, 1,
-                                            below_points, above_points)
+        points = tpe._sample_real_dimension(dim1, 1, below_points, above_points)
         points = numpy.asarray(points)
         assert len(points) == 1
         assert all(points >= -10)
@@ -542,8 +573,7 @@ class TestTPE():
         points = numpy.random.uniform(1, 20, 20)
         below_points = [points[:8]]
         above_points = [points[8:]]
-        points = tpe._sample_real_dimension(dim3, 1,
-                                            below_points, above_points)
+        points = tpe._sample_real_dimension(dim3, 1, below_points, above_points)
         points = numpy.asarray(points)
         assert len(points) == 1
         assert all(points >= 1)
@@ -551,8 +581,7 @@ class TestTPE():
 
         below_points = numpy.random.uniform(-10, 0, 25).reshape(1, 25)
         above_points = numpy.random.uniform(0, 10, 75).reshape(1, 75)
-        points = tpe._sample_real_dimension(dim1, 1,
-                                            below_points, above_points)
+        points = tpe._sample_real_dimension(dim1, 1, below_points, above_points)
         points = numpy.asarray(points)
         assert len(points) == 1
         assert all(points >= -10)
@@ -561,16 +590,14 @@ class TestTPE():
         points = numpy.random.uniform(-5, 5, 32)
         below_points = [points[:8], points[8:16]]
         above_points = [points[16:24], points[24:]]
-        points = tpe._sample_real_dimension(dim2, 2,
-                                            below_points, above_points)
+        points = tpe._sample_real_dimension(dim2, 2, below_points, above_points)
         points = numpy.asarray(points)
         assert len(points) == 2
         assert all(points >= -10)
         assert all(points < 10)
 
         tpe.n_ei_candidates = 0
-        points = tpe._sample_real_dimension(dim2, 2,
-                                            below_points, above_points)
+        points = tpe._sample_real_dimension(dim2, 2, below_points, above_points)
         assert len(points) == 0
 
     def test_suggest(self, tpe):
@@ -582,7 +609,7 @@ class TestTPE():
             assert len(point) == 1
             assert len(point[0]) == 3
             assert not isinstance(point[0][0], tuple)
-            tpe.observe(point, [{'objective': results[i]}])
+            tpe.observe(point, [{"objective": results[i]}])
 
         point = tpe.suggest(1)
         assert len(point) == 1
@@ -592,9 +619,9 @@ class TestTPE():
     def test_1d_shape(self, tpe):
         """Test suggest with 1D shape dimensions"""
         space = Space()
-        dim1 = Real('yolo1', 'uniform', -3, 6, shape=(2))
+        dim1 = Real("yolo1", "uniform", -3, 6, shape=(2))
         space.register(dim1)
-        dim2 = Real('yolo2', 'uniform', -2, 4)
+        dim2 = Real("yolo2", "uniform", -2, 4)
         space.register(dim2)
 
         tpe.space = space
@@ -606,7 +633,7 @@ class TestTPE():
             assert len(point) == 1
             assert len(point[0]) == 2
             assert len(point[0][0]) == 2
-            tpe.observe(point, [{'objective': results[i]}])
+            tpe.observe(point, [{"objective": results[i]}])
 
         point = tpe.suggest(1)
         assert len(point) == 1
@@ -615,28 +642,28 @@ class TestTPE():
 
     def test_suggest_initial_points(self, tpe, monkeypatch):
         """Test that initial points can be sampled correctly"""
-        points = [(i, i - 6, 'c') for i in range(1, 12)]
+        points = [(i, i - 6, "c") for i in range(1, 12)]
 
         global index
         index = 0
 
         def sample(num=1, seed=None):
             global index
-            pts = points[index:index + num]
+            pts = points[index : index + num]
             index += num
             return pts
 
-        monkeypatch.setattr(tpe.space, 'sample', sample)
+        monkeypatch.setattr(tpe.space, "sample", sample)
 
         tpe.n_initial_points = 10
         results = numpy.random.random(10)
         for i in range(1, 11):
             point = tpe.suggest(1)[0]
-            assert point == (i, i - 6, 'c')
-            tpe.observe([point], [{'objective': results[i - 1]}])
+            assert point == (i, i - 6, "c")
+            tpe.observe([point], [{"objective": results[i - 1]}])
 
         point = tpe.suggest(1)[0]
-        assert point != (11, 5, 'c')
+        assert point != (11, 5, "c")
 
     def test_suggest_ei_candidates(self, tpe):
         """Test suggest with no shape dimensions"""
@@ -649,7 +676,7 @@ class TestTPE():
             assert len(point) == 1
             assert len(point[0]) == 3
             assert not isinstance(point[0][0], tuple)
-            tpe.observe(point, [{'objective': results[i]}])
+            tpe.observe(point, [{"objective": results[i]}])
 
         point = tpe.suggest(1)
         assert not point

--- a/tests/unittests/analysis/test_lpi.py
+++ b/tests/unittests/analysis/test_lpi.py
@@ -5,22 +5,35 @@ import copy
 import numpy
 import pandas as pd
 import pytest
-from sklearn.ensemble import AdaBoostRegressor, BaggingRegressor,\
-    ExtraTreesRegressor, GradientBoostingRegressor, RandomForestRegressor
+from sklearn.ensemble import (
+    AdaBoostRegressor,
+    BaggingRegressor,
+    ExtraTreesRegressor,
+    GradientBoostingRegressor,
+    RandomForestRegressor,
+)
 
-from orion.analysis.lpi import compute_variances, lpi, make_grid, to_numpy, train_regressor
+from orion.analysis.lpi import (
+    compute_variances,
+    lpi,
+    make_grid,
+    to_numpy,
+    train_regressor,
+)
 from orion.core.io.space_builder import SpaceBuilder
 
 
-data = pd.DataFrame(data={
-    'id': ['a', 'b', 'c', 'd'],
-    'x': [0, 1, 2, 3],
-    'y': [1, 2, 0, 3],
-    'objective': [0.1, 0.2, 0.3, 0.5]
-})
+data = pd.DataFrame(
+    data={
+        "id": ["a", "b", "c", "d"],
+        "x": [0, 1, 2, 3],
+        "y": [1, 2, 0, 3],
+        "objective": [0.1, 0.2, 0.3, 0.5],
+    }
+)
 
 
-space = SpaceBuilder().build({'x': 'uniform(0, 6)', 'y': 'uniform(0, 3)'})
+space = SpaceBuilder().build({"x": "uniform(0, 6)", "y": "uniform(0, 3)"})
 
 
 def test_accept_empty():
@@ -28,16 +41,16 @@ def test_accept_empty():
     empty_frame = pd.DataFrame()
     results = lpi(empty_frame, space)
 
-    assert results.columns.tolist() == ['LPI']
+    assert results.columns.tolist() == ["LPI"]
     assert results.index.tolist() == list(space.keys())
-    assert results['LPI'].tolist() == [0, 0]
+    assert results["LPI"].tolist() == [0, 0]
 
-    empty_frame = pd.DataFrame(columns=['x', 'y', 'objective'])
+    empty_frame = pd.DataFrame(columns=["x", "y", "objective"])
     results = lpi(empty_frame, space)
 
-    assert results.columns.tolist() == ['LPI']
+    assert results.columns.tolist() == ["LPI"]
     assert results.index.tolist() == list(space.keys())
-    assert results['LPI'].tolist() == [0, 0]
+    assert results["LPI"].tolist() == [0, 0]
 
 
 def test_parameter_not_modified():
@@ -53,46 +66,48 @@ def test_to_numpy():
     array = to_numpy(data, space)
 
     assert array.shape == (4, 3)
-    numpy.testing.assert_equal(array[:, 0], data['x'])
-    numpy.testing.assert_equal(array[:, 1], data['y'])
-    numpy.testing.assert_equal(array[:, 2], data['objective'])
+    numpy.testing.assert_equal(array[:, 0], data["x"])
+    numpy.testing.assert_equal(array[:, 1], data["y"])
+    numpy.testing.assert_equal(array[:, 2], data["objective"])
 
 
 def test_train_regressor():
     """Test training different models"""
     array = to_numpy(data, space)
-    model = train_regressor('AdaBoostRegressor', array)
+    model = train_regressor("AdaBoostRegressor", array)
     assert isinstance(model, AdaBoostRegressor)
-    model = train_regressor('BaggingRegressor', array)
+    model = train_regressor("BaggingRegressor", array)
     assert isinstance(model, BaggingRegressor)
-    model = train_regressor('ExtraTreesRegressor', array)
+    model = train_regressor("ExtraTreesRegressor", array)
     assert isinstance(model, ExtraTreesRegressor)
-    model = train_regressor('GradientBoostingRegressor', array)
+    model = train_regressor("GradientBoostingRegressor", array)
     assert isinstance(model, GradientBoostingRegressor)
-    model = train_regressor('RandomForestRegressor', array)
+    model = train_regressor("RandomForestRegressor", array)
     assert isinstance(model, RandomForestRegressor)
 
 
 def test_train_regressor_kwargs():
     """Test training models with kwargs"""
     array = to_numpy(data, space)
-    model = train_regressor('RandomForestRegressor', array, max_depth=2, max_features='sqrt')
+    model = train_regressor(
+        "RandomForestRegressor", array, max_depth=2, max_features="sqrt"
+    )
     assert model.max_depth == 2
-    assert model.max_features == 'sqrt'
+    assert model.max_features == "sqrt"
 
 
 def test_train_regressor_invalid():
     """Test error message for invalid model names"""
     array = to_numpy(data, space)
     with pytest.raises(ValueError) as exc:
-        train_regressor('IDontExist', array)
-    assert exc.match('IDontExist is not a supported regressor')
+        train_regressor("IDontExist", array)
+    assert exc.match("IDontExist is not a supported regressor")
 
 
 def test_make_grid():
     """Test grid has correct format"""
     trials = to_numpy(data, space)
-    model = train_regressor('RandomForestRegressor', trials)
+    model = train_regressor("RandomForestRegressor", trials)
     best_point = trials[numpy.argmin(trials[:, -1])]
     grid = make_grid(best_point, space, model, 4)
 
@@ -108,12 +123,14 @@ def test_make_grid():
 def test_make_grid_predictor(monkeypatch):
     """Test grid contains corresponding predictions from the model"""
     trials = to_numpy(data, space)
-    model = train_regressor('RandomForestRegressor', trials)
+    model = train_regressor("RandomForestRegressor", trials)
     best_point = trials[numpy.argmin(trials[:, -1])]
 
     # Make sure model is not predicting exactly the original objective
     with numpy.testing.assert_raises(AssertionError):
-        numpy.testing.assert_equal(best_point[-1], model.predict(best_point[:-1].reshape(1, -1)))
+        numpy.testing.assert_equal(
+            best_point[-1], model.predict(best_point[:-1].reshape(1, -1))
+        )
 
     grid = make_grid(best_point, space, model, 4)
 
@@ -135,7 +152,7 @@ def test_compute_variance():
     grid[2, :, -1] = [0, 10, 20, 30, 40]
 
     variances = compute_variances(grid)
-    assert variances.shape == (3, )
+    assert variances.shape == (3,)
     assert variances[0] == 0
     assert variances[1] == numpy.var([0, 1, 2, 3, 4])
     assert variances[2] == numpy.var([0, 10, 20, 30, 40])
@@ -144,50 +161,54 @@ def test_compute_variance():
 def test_lpi_results():
     """Verify LPI results in DataFrame"""
     results = lpi(data, space, random_state=1)
-    assert results.columns.tolist() == ['LPI']
+    assert results.columns.tolist() == ["LPI"]
     assert results.index.tolist() == list(space.keys())
     # The data is made such that x correlates more strongly with objective than y
-    assert results['LPI'].loc['x'] > results['LPI'].loc['y']
+    assert results["LPI"].loc["x"] > results["LPI"].loc["y"]
 
 
 def test_lpi_with_categorical_data():
     """Verify LPI can be computed on categorical dimensions"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c', 'd'],
-        'x': [0, 1, 2, 3],
-        'y': ['b', 'c', 'a', 'd'],
-        'objective': [0.1, 0.2, 0.3, 0.5]
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c", "d"],
+            "x": [0, 1, 2, 3],
+            "y": ["b", "c", "a", "d"],
+            "objective": [0.1, 0.2, 0.3, 0.5],
+        }
+    )
 
     space = SpaceBuilder().build(
-        {'x': 'uniform(0, 6)',
-         'y': 'choices(["a", "b", "c", "d"])'})
+        {"x": "uniform(0, 6)", "y": 'choices(["a", "b", "c", "d"])'}
+    )
 
     results = lpi(data, space, random_state=1)
-    assert results.columns.tolist() == ['LPI']
-    assert results.index.tolist() == ['x', 'y']
+    assert results.columns.tolist() == ["LPI"]
+    assert results.index.tolist() == ["x", "y"]
     # The data is made such that x correlates more strongly with objective than y
-    assert results['LPI'].loc['x'] > results['LPI'].loc['y']
+    assert results["LPI"].loc["x"] > results["LPI"].loc["y"]
 
 
 def test_lpi_with_multidim_data():
     """Verify LPI can be computed on categorical dimensions"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c', 'd'],
-        'x': [[0, 2, 4], [1, 1, 3], [2, 2, 2], [3, 0, 3]],
-        'y': [['b', 'b'], ['c', 'b'], ['a', 'a'], ['d', 'c']],
-        'objective': [0.1, 0.2, 0.3, 0.5]
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c", "d"],
+            "x": [[0, 2, 4], [1, 1, 3], [2, 2, 2], [3, 0, 3]],
+            "y": [["b", "b"], ["c", "b"], ["a", "a"], ["d", "c"]],
+            "objective": [0.1, 0.2, 0.3, 0.5],
+        }
+    )
 
     space = SpaceBuilder().build(
-        {'x': 'uniform(0, 6, shape=3)',
-         'y': 'choices(["a", "b", "c", "d"], shape=2)'})
+        {"x": "uniform(0, 6, shape=3)", "y": 'choices(["a", "b", "c", "d"], shape=2)'}
+    )
 
     results = lpi(data, space, random_state=1)
-    assert results.columns.tolist() == ['LPI']
-    assert results.index.tolist() == ['x[0]', 'x[1]', 'x[2]', 'y[0]', 'y[1]']
+    assert results.columns.tolist() == ["LPI"]
+    assert results.index.tolist() == ["x[0]", "x[1]", "x[2]", "y[0]", "y[1]"]
     # The data is made such some x correlates more strongly with objective than other x and most y
-    assert results['LPI'].loc['x[0]'] > results['LPI'].loc['x[1]']
-    assert results['LPI'].loc['x[1]'] > results['LPI'].loc['x[2]']
-    assert results['LPI'].loc['x[0]'] > results['LPI'].loc['y[0]']
-    assert results['LPI'].loc['x[0]'] > results['LPI'].loc['y[1]']
+    assert results["LPI"].loc["x[0]"] > results["LPI"].loc["x[1]"]
+    assert results["LPI"].loc["x[1]"] > results["LPI"].loc["x[2]"]
+    assert results["LPI"].loc["x[0]"] > results["LPI"].loc["y[0]"]
+    assert results["LPI"].loc["x[0]"] > results["LPI"].loc["y[1]"]

--- a/tests/unittests/analysis/test_regret.py
+++ b/tests/unittests/analysis/test_regret.py
@@ -8,10 +8,7 @@ from orion.analysis.regret import regret
 
 def test_accept_dict():
     """Tests dictionary parameter is supported"""
-    data = {
-        'id': ['a', 'b', 'c', 'd'],
-        'objective': [0.1, 0.2, 0.3, 0.5]
-    }
+    data = {"id": ["a", "b", "c", "d"], "objective": [0.1, 0.2, 0.3, 0.5]}
 
     result = regret(data)
 
@@ -26,21 +23,20 @@ def test_accept_empty():
     assert result.empty
     assert result.equals(empty_frame)
 
-    empty_frame = pd.DataFrame(columns=['id', 'objective'])
+    empty_frame = pd.DataFrame(columns=["id", "objective"])
     result = regret(empty_frame)
 
     assert result.empty
-    assert 'best' not in result.columns
-    assert 'best_id' not in result.columns
+    assert "best" not in result.columns
+    assert "best_id" not in result.columns
     assert result.equals(empty_frame)
 
 
 def test_parameter_not_modified():
     """Tests the original dataframe is not modified"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c', 'd'],
-        'objective': [0.1, 0.2, 0.3, 0.5]
-    })
+    data = pd.DataFrame(
+        data={"id": ["a", "b", "c", "d"], "objective": [0.1, 0.2, 0.3, 0.5]}
+    )
 
     result = regret(data)
 
@@ -50,122 +46,133 @@ def test_parameter_not_modified():
 
 def test_length_names():
     """Tests the length of `names` parameter is two"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b'],
-        'objective': [0.1, 0.2]
-    })
+    data = pd.DataFrame(data={"id": ["a", "b"], "objective": [0.1, 0.2]})
 
     with pytest.raises(ValueError) as exception:
         regret(data, names=())
-    assert "`names` requires a tuple with 2 elements. 0 provided." in str(exception.value)
+    assert "`names` requires a tuple with 2 elements. 0 provided." in str(
+        exception.value
+    )
 
     with pytest.raises(ValueError) as exception:
-        regret(data, names=('a', 'b', 'c'))
-    assert "`names` requires a tuple with 2 elements. 3 provided." in str(exception.value)
+        regret(data, names=("a", "b", "c"))
+    assert "`names` requires a tuple with 2 elements. 3 provided." in str(
+        exception.value
+    )
 
 
 def test_default_column_names():
     """Tests default column names"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c', 'd'],
-        'objective': [0.1, 0.2, 0.3, 0.5]
-    })
+    data = pd.DataFrame(
+        data={"id": ["a", "b", "c", "d"], "objective": [0.1, 0.2, 0.3, 0.5]}
+    )
 
     result = regret(data)
 
-    assert 'best' in result.columns
-    assert 'best_id' in result.columns
+    assert "best" in result.columns
+    assert "best_id" in result.columns
 
 
 def test_input_column_names():
     """Tests custom column names"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c', 'd'],
-        'objective': [0.1, 0.2, 0.3, 0.5]
-    })
+    data = pd.DataFrame(
+        data={"id": ["a", "b", "c", "d"], "objective": [0.1, 0.2, 0.3, 0.5]}
+    )
 
-    result = regret(data, names=('something', 'else'))
+    result = regret(data, names=("something", "else"))
 
-    assert 'something' in result.columns
-    assert 'else' in result.columns
+    assert "something" in result.columns
+    assert "else" in result.columns
 
 
 def test_regret_sequential():
     """Tests that cumulative best objectives are linked to their respective ids"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c', 'd'],
-        'objective': [10, 12, 8, 9],
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c", "d"],
+            "objective": [10, 12, 8, 9],
+        }
+    )
 
     expected_best = [10, 10, 8, 8]
-    expected_ids = ['a', 'a', 'c', 'c']
+    expected_ids = ["a", "a", "c", "c"]
 
     result = regret(data)
 
-    assert all(result['best'].values == expected_best)
-    assert all(result['best_id'].values == expected_ids)
+    assert all(result["best"].values == expected_best)
+    assert all(result["best_id"].values == expected_ids)
 
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c'],
-        'objective': [10, 9, 8],
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c"],
+            "objective": [10, 9, 8],
+        }
+    )
 
     expected_best = [10, 9, 8]
-    expected_ids = ['a', 'b', 'c']
+    expected_ids = ["a", "b", "c"]
 
     result = regret(data)
 
-    assert all(result['best'].values == expected_best)
-    assert all(result['best_id'].values == expected_ids)
+    assert all(result["best"].values == expected_best)
+    assert all(result["best_id"].values == expected_ids)
 
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c'],
-        'objective': [8, 9, 10],
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c"],
+            "objective": [8, 9, 10],
+        }
+    )
 
     expected_best = [8, 8, 8]
-    expected_ids = ['a', 'a', 'a']
+    expected_ids = ["a", "a", "a"]
 
     result = regret(data)
 
-    assert all(result['best'].values == expected_best)
-    assert all(result['best_id'].values == expected_ids)
+    assert all(result["best"].values == expected_best)
+    assert all(result["best_id"].values == expected_ids)
 
-    data = pd.DataFrame(data={
-        'id': ['a'],
-        'objective': [10],
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a"],
+            "objective": [10],
+        }
+    )
 
     result = regret(data)
 
-    assert all(result['best'].values == [10])
-    assert all(result['best_id'].values == ['a'])
+    assert all(result["best"].values == [10])
+    assert all(result["best_id"].values == ["a"])
 
 
 def test_regret_equal():
     """Tests instances where trials share best objectives"""
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c'],
-        'objective': [8, 9, 8],
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c"],
+            "objective": [8, 9, 8],
+        }
+    )
 
     expected_best = [8, 8, 8]
-    expected_ids = ['a', 'a', 'a']
+    expected_ids = ["a", "a", "a"]
 
     result = regret(data)
 
-    assert all(result['best'].values == expected_best)
-    assert all(result['best_id'].values == expected_ids)
+    assert all(result["best"].values == expected_best)
+    assert all(result["best_id"].values == expected_ids)
 
-    data = pd.DataFrame(data={
-        'id': ['a', 'b', 'c'],
-        'objective': [8, 8, 8],
-    })
+    data = pd.DataFrame(
+        data={
+            "id": ["a", "b", "c"],
+            "objective": [8, 8, 8],
+        }
+    )
 
     expected_best = [8, 8, 8]
-    expected_ids = ['a', 'a', 'a']
+    expected_ids = ["a", "a", "a"]
 
     result = regret(data)
 
-    assert all(result['best'].values == expected_best)
-    assert all(result['best_id'].values == expected_ids)
+    assert all(result["best"].values == expected_best)
+    assert all(result["best_id"].values == expected_ids)

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -13,7 +13,11 @@ import orion.client.cli as cli
 import orion.core
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.pickleddb import PickledDB
-from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, RaceCondition
+from orion.core.utils.exceptions import (
+    BranchingEvent,
+    NoConfigurationError,
+    RaceCondition,
+)
 from orion.core.utils.singleton import SingletonNotInstantiatedError, update_singletons
 from orion.core.worker.experiment import ExperimentView
 from orion.storage.base import get_storage
@@ -25,38 +29,39 @@ workon = orion.client.workon
 
 
 config = dict(
-    name='supernaekei',
-    space={'x': 'uniform(0, 200)'},
-    metadata={'user': 'tsirif',
-              'orion_version': 'XYZ',
-              'VCS': {"type": "git",
-                      "is_dirty": False,
-                      "HEAD_sha": "test",
-                      "active_branch": None,
-                      "diff_sha": "diff"}},
+    name="supernaekei",
+    space={"x": "uniform(0, 200)"},
+    metadata={
+        "user": "tsirif",
+        "orion_version": "XYZ",
+        "VCS": {
+            "type": "git",
+            "is_dirty": False,
+            "HEAD_sha": "test",
+            "active_branch": None,
+            "diff_sha": "diff",
+        },
+    },
     version=1,
     pool_size=1,
     max_trials=10,
     max_broken=5,
-    working_dir='',
-    algorithms={'random': {'seed': 1}},
-    producer={'strategy': 'NoParallelStrategy'},
-    refers=dict(
-        root_id='supernaekei',
-        parent_id=None,
-        adapter=[])
-    )
+    working_dir="",
+    algorithms={"random": {"seed": 1}},
+    producer={"strategy": "NoParallelStrategy"},
+    refers=dict(root_id="supernaekei", parent_id=None, adapter=[]),
+)
 
 
 @pytest.fixture()
 def user_config():
     """Curate config as a user would provide it"""
     user_config = copy.deepcopy(config)
-    user_config.pop('metadata')
-    user_config.pop('version')
-    user_config['strategy'] = user_config.pop('producer')['strategy']
-    user_config.pop('refers')
-    user_config.pop('pool_size')
+    user_config.pop("metadata")
+    user_config.pop("version")
+    user_config["strategy"] = user_config.pop("producer")["strategy"]
+    user_config.pop("refers")
+    user_config.pop("pool_size")
     return user_config
 
 
@@ -74,7 +79,7 @@ class TestReportResults(object):
 
         Then: It should print `data` parameter instead to stdout.
         """
-        monkeypatch.delenv('ORION_RESULTS_PATH', raising=False)
+        monkeypatch.delenv("ORION_RESULTS_PATH", raising=False)
         reloaded_client = reload(cli)
 
         assert reloaded_client.IS_ORION_ON is False
@@ -84,17 +89,17 @@ class TestReportResults(object):
         reloaded_client.report_results(data)
         out, err = capsys.readouterr()
         assert reloaded_client._HAS_REPORTED_RESULTS is True
-        assert out == data + '\n'
-        assert err == ''
+        assert out == data + "\n"
+        assert err == ""
 
     def test_with_correct_env(self, monkeypatch, capsys, tmpdir, data):
         """Check that a file with correct data will be written to an existing
         file in a legit path.
         """
-        path = str(tmpdir.join('naedw.txt'))
-        with open(path, mode='w'):
+        path = str(tmpdir.join("naedw.txt"))
+        with open(path, mode="w"):
             pass
-        monkeypatch.setenv('ORION_RESULTS_PATH', path)
+        monkeypatch.setenv("ORION_RESULTS_PATH", path)
         reloaded_client = reload(cli)
 
         assert reloaded_client.IS_ORION_ON is True
@@ -104,10 +109,10 @@ class TestReportResults(object):
         reloaded_client.report_results(data)
         out, err = capsys.readouterr()
         assert reloaded_client._HAS_REPORTED_RESULTS is True
-        assert out == ''
-        assert err == ''
+        assert out == ""
+        assert err == ""
 
-        with open(path, mode='r') as results_file:
+        with open(path, mode="r") as results_file:
             res = json.load(results_file)
         assert res == data
 
@@ -115,8 +120,8 @@ class TestReportResults(object):
         """Check that a Warning will be raised at import time,
         if environmental is set but does not correspond to an existing file.
         """
-        path = str(tmpdir.join('naedw.txt'))
-        monkeypatch.setenv('ORION_RESULTS_PATH', path)
+        path = str(tmpdir.join("naedw.txt"))
+        monkeypatch.setenv("ORION_RESULTS_PATH", path)
 
         with pytest.raises(RuntimeWarning) as exc:
             reload(cli)
@@ -127,7 +132,7 @@ class TestReportResults(object):
         """Check that a Warning will be raised at call time,
         if function has already been called once.
         """
-        monkeypatch.delenv('ORION_RESULTS_PATH', raising=False)
+        monkeypatch.delenv("ORION_RESULTS_PATH", raising=False)
         reloaded_client = reload(cli)
 
         reloaded_client.report_results(data)
@@ -146,7 +151,7 @@ class TestCreateExperiment:
     @pytest.mark.usefixtures("setup_pickleddb_database")
     def test_create_experiment_no_storage(self, monkeypatch):
         """Test creation if storage is not configured"""
-        name = 'oopsie_forgot_a_storage'
+        name = "oopsie_forgot_a_storage"
         host = orion.core.config.storage.database.host
 
         with OrionState(storage=orion.core.config.storage.to_dict()) as cfg:
@@ -158,7 +163,7 @@ class TestCreateExperiment:
             with pytest.raises(SingletonNotInstantiatedError):
                 get_storage()
 
-            experiment = create_experiment(name=name, space={'x': 'uniform(0, 10)'})
+            experiment = create_experiment(name=name, space={"x": "uniform(0, 10)"})
 
             assert isinstance(experiment._experiment._storage, Legacy)
             assert isinstance(experiment._experiment._storage._db, PickledDB)
@@ -167,30 +172,35 @@ class TestCreateExperiment:
     def test_create_experiment_new_no_space(self):
         """Test that new experiment needs space"""
         with OrionState():
-            name = 'oopsie_forgot_a_space'
+            name = "oopsie_forgot_a_space"
             with pytest.raises(NoConfigurationError) as exc:
                 create_experiment(name=name)
 
-            assert 'Experiment {} does not exist in DB'.format(name) in str(exc.value)
+            assert "Experiment {} does not exist in DB".format(name) in str(exc.value)
 
     def test_create_experiment_bad_storage(self):
         """Test error message if storage is not configured properly"""
-        name = 'oopsie_bad_storage'
+        name = "oopsie_bad_storage"
         # Make sure there is no existing storage singleton
         update_singletons()
 
         with pytest.raises(NotImplementedError) as exc:
-            create_experiment(name=name, storage={'type': 'legacy',
-                                                  'database': {'type': 'idontexist'}})
+            create_experiment(
+                name=name,
+                storage={"type": "legacy", "database": {"type": "idontexist"}},
+            )
 
-        assert "Could not find implementation of AbstractDB, type = 'idontexist'" in str(exc.value)
+        assert (
+            "Could not find implementation of AbstractDB, type = 'idontexist'"
+            in str(exc.value)
+        )
 
     def test_create_experiment_new_default(self):
         """Test creating a new experiment with all defaults"""
-        name = 'all_default'
-        space = {'x': 'uniform(0, 10)'}
+        name = "all_default"
+        space = {"x": "uniform(0, 10)"}
         with OrionState():
-            experiment = create_experiment(name='all_default', space=space)
+            experiment = create_experiment(name="all_default", space=space)
 
             assert experiment.name == name
             assert experiment.space.configuration == space
@@ -198,9 +208,10 @@ class TestCreateExperiment:
             assert experiment.max_trials == orion.core.config.experiment.max_trials
             assert experiment.max_broken == orion.core.config.experiment.max_broken
             assert experiment.working_dir == orion.core.config.experiment.working_dir
-            assert experiment.algorithms.configuration == {'random': {'seed': None}}
-            assert (experiment.configuration['producer'] ==
-                    {'strategy': {'MaxParallelStrategy': {'default_result': float('inf')}}})
+            assert experiment.algorithms.configuration == {"random": {"seed": None}}
+            assert experiment.configuration["producer"] == {
+                "strategy": {"MaxParallelStrategy": {"default_result": float("inf")}}
+            }
 
     def test_create_experiment_new_full_config(self, user_config):
         """Test creating a new experiment by specifying all attributes."""
@@ -209,12 +220,12 @@ class TestCreateExperiment:
 
             exp_config = experiment.configuration
 
-            assert exp_config['space'] == config['space']
-            assert exp_config['max_trials'] == config['max_trials']
-            assert exp_config['max_broken'] == config['max_broken']
-            assert exp_config['working_dir'] == config['working_dir']
-            assert exp_config['algorithms'] == config['algorithms']
-            assert exp_config['producer'] == config['producer']
+            assert exp_config["space"] == config["space"]
+            assert exp_config["max_trials"] == config["max_trials"]
+            assert exp_config["max_broken"] == config["max_broken"]
+            assert exp_config["working_dir"] == config["working_dir"]
+            assert exp_config["algorithms"] == config["algorithms"]
+            assert exp_config["producer"] == config["producer"]
 
     def test_create_experiment_hit_no_branch(self, user_config):
         """Test creating an existing experiment by specifying all identical attributes."""
@@ -223,42 +234,50 @@ class TestCreateExperiment:
 
             exp_config = experiment.configuration
 
-            assert experiment.name == config['name']
+            assert experiment.name == config["name"]
             assert experiment.version == 1
-            assert exp_config['space'] == config['space']
-            assert exp_config['max_trials'] == config['max_trials']
-            assert exp_config['max_broken'] == config['max_broken']
-            assert exp_config['working_dir'] == config['working_dir']
-            assert exp_config['algorithms'] == config['algorithms']
-            assert exp_config['producer'] == config['producer']
+            assert exp_config["space"] == config["space"]
+            assert exp_config["max_trials"] == config["max_trials"]
+            assert exp_config["max_broken"] == config["max_broken"]
+            assert exp_config["working_dir"] == config["working_dir"]
+            assert exp_config["algorithms"] == config["algorithms"]
+            assert exp_config["producer"] == config["producer"]
 
     def test_create_experiment_hit_no_config(self):
         """Test creating an existing experiment by specifying the name only."""
         with OrionState(experiments=[config]):
-            experiment = create_experiment(config['name'])
+            experiment = create_experiment(config["name"])
 
-            assert experiment.name == config['name']
+            assert experiment.name == config["name"]
             assert experiment.version == 1
-            assert experiment.space.configuration == config['space']
-            assert experiment.algorithms.configuration == config['algorithms']
-            assert experiment.max_trials == config['max_trials']
-            assert experiment.max_broken == config['max_broken']
-            assert experiment.working_dir == config['working_dir']
-            assert experiment.producer['strategy'].configuration == config['producer']['strategy']
+            assert experiment.space.configuration == config["space"]
+            assert experiment.algorithms.configuration == config["algorithms"]
+            assert experiment.max_trials == config["max_trials"]
+            assert experiment.max_broken == config["max_broken"]
+            assert experiment.working_dir == config["working_dir"]
+            assert (
+                experiment.producer["strategy"].configuration
+                == config["producer"]["strategy"]
+            )
 
     def test_create_experiment_hit_branch(self):
         """Test creating a differing experiment that cause branching."""
         with OrionState(experiments=[config]):
-            experiment = create_experiment(config['name'], space={'y': 'uniform(0, 10)'})
+            experiment = create_experiment(
+                config["name"], space={"y": "uniform(0, 10)"}
+            )
 
-            assert experiment.name == config['name']
+            assert experiment.name == config["name"]
             assert experiment.version == 2
 
-            assert experiment.algorithms.configuration == config['algorithms']
-            assert experiment.max_trials == config['max_trials']
-            assert experiment.max_broken == config['max_broken']
-            assert experiment.working_dir == config['working_dir']
-            assert experiment.producer['strategy'].configuration == config['producer']['strategy']
+            assert experiment.algorithms.configuration == config["algorithms"]
+            assert experiment.max_trials == config["max_trials"]
+            assert experiment.max_broken == config["max_broken"]
+            assert experiment.working_dir == config["working_dir"]
+            assert (
+                experiment.producer["strategy"].configuration
+                == config["producer"]["strategy"]
+            )
 
     def test_create_experiment_race_condition(self, monkeypatch):
         """Test that a single race condition is handled seemlessly
@@ -267,12 +286,14 @@ class TestCreateExperiment:
         test for race conditions during version update.
         """
         with OrionState(experiments=[config]):
-            parent = create_experiment(config['name'])
-            child = create_experiment(config['name'], space={'y': 'uniform(0, 10)'})
+            parent = create_experiment(config["name"])
+            child = create_experiment(config["name"], space={"y": "uniform(0, 10)"})
 
             def insert_race_condition(self, query):
-                is_auto_version_query = (
-                    query == {'name': config['name'], 'refers.parent_id': parent.id})
+                is_auto_version_query = query == {
+                    "name": config["name"],
+                    "refers.parent_id": parent.id,
+                }
                 if is_auto_version_query:
                     data = [child.configuration]
                 # First time the query returns no other child
@@ -287,10 +308,13 @@ class TestCreateExperiment:
 
             insert_race_condition.count = 0
 
-            monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
-                                insert_race_condition)
+            monkeypatch.setattr(
+                get_storage().__class__, "fetch_experiments", insert_race_condition
+            )
 
-            experiment = create_experiment(config['name'], space={'y': 'uniform(0, 10)'})
+            experiment = create_experiment(
+                config["name"], space={"y": "uniform(0, 10)"}
+            )
 
             assert insert_race_condition.count == 1
             assert experiment.version == 2
@@ -299,12 +323,14 @@ class TestCreateExperiment:
     def test_create_experiment_race_condition_broken(self, monkeypatch):
         """Test that two or more race condition leads to raise"""
         with OrionState(experiments=[config]):
-            parent = create_experiment(config['name'])
-            child = create_experiment(config['name'], space={'y': 'uniform(0, 10)'})
+            parent = create_experiment(config["name"])
+            child = create_experiment(config["name"], space={"y": "uniform(0, 10)"})
 
             def insert_race_condition(self, query):
-                is_auto_version_query = (
-                    query == {'name': config['name'], 'refers.parent_id': parent.id})
+                is_auto_version_query = query == {
+                    "name": config["name"],
+                    "refers.parent_id": parent.id,
+                }
                 if is_auto_version_query:
                     data = [child.configuration]
                 # The query returns no other child, never!
@@ -317,23 +343,26 @@ class TestCreateExperiment:
 
             insert_race_condition.count = 0
 
-            monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
-                                insert_race_condition)
+            monkeypatch.setattr(
+                get_storage().__class__, "fetch_experiments", insert_race_condition
+            )
 
             with pytest.raises(RaceCondition) as exc:
-                create_experiment(config['name'], space={'y': 'uniform(0, 10)'})
+                create_experiment(config["name"], space={"y": "uniform(0, 10)"})
 
             assert insert_race_condition.count == 2
-            assert 'There was a race condition during branching and new version' in str(exc.value)
+            assert "There was a race condition during branching and new version" in str(
+                exc.value
+            )
 
     def test_create_experiment_hit_manual_branch(self):
         """Test creating a differing experiment that cause branching."""
-        new_space = {'y': 'uniform(0, 10)'}
+        new_space = {"y": "uniform(0, 10)"}
         with OrionState(experiments=[config]):
-            create_experiment(config['name'], space=new_space)
+            create_experiment(config["name"], space=new_space)
 
             with pytest.raises(BranchingEvent) as exc:
-                create_experiment(config['name'], version=1, space=new_space)
+                create_experiment(config["name"], version=1, space=new_space)
 
             assert "Configuration is different and generates" in str(exc.value)
 
@@ -341,11 +370,16 @@ class TestCreateExperiment:
         """Test that EphemeralDB is used in debug mode whatever the storage config given"""
         update_singletons()
 
-        conf_file = str(tmp_path / 'db.pkl')
+        conf_file = str(tmp_path / "db.pkl")
 
         create_experiment(
-            config['name'], space={'x': 'uniform(0, 10)'},
-            storage={'type': 'legacy', 'database': {'type': 'pickleddb', 'host': conf_file}})
+            config["name"],
+            space={"x": "uniform(0, 10)"},
+            storage={
+                "type": "legacy",
+                "database": {"type": "pickleddb", "host": conf_file},
+            },
+        )
 
         storage = get_storage()
 
@@ -355,8 +389,11 @@ class TestCreateExperiment:
         update_singletons()
 
         create_experiment(
-            config['name'], space={'x': 'uniform(0, 10)'},
-            storage={'type': 'legacy', 'database': {'type': 'pickleddb'}}, debug=True)
+            config["name"],
+            space={"x": "uniform(0, 10)"},
+            storage={"type": "legacy", "database": {"type": "pickleddb"}},
+            debug=True,
+        )
 
         storage = get_storage()
 
@@ -369,114 +406,137 @@ class TestWorkon:
 
     def test_workon(self):
         """Verify that workon processes properly"""
-        def foo(x):
-            return [dict(name='result', type='objective', value=x * 2)]
 
-        experiment = workon(foo, space={'x': 'uniform(0, 10)'}, max_trials=5)
+        def foo(x):
+            return [dict(name="result", type="objective", value=x * 2)]
+
+        experiment = workon(foo, space={"x": "uniform(0, 10)"}, max_trials=5)
         assert len(experiment.fetch_trials()) == 5
-        assert experiment.name == 'loop'
+        assert experiment.name == "loop"
         assert isinstance(experiment._experiment._storage, Legacy)
         assert isinstance(experiment._experiment._storage._db, EphemeralDB)
 
     def test_workon_algo(self):
         """Verify that algo config is processed properly"""
+
         def foo(x):
-            return [dict(name='result', type='objective', value=x * 2)]
+            return [dict(name="result", type="objective", value=x * 2)]
 
         experiment = workon(
-            foo, space={'x': 'uniform(0, 10)'}, max_trials=5,
-            algorithms={'random': {'seed': 5}})
+            foo,
+            space={"x": "uniform(0, 10)"},
+            max_trials=5,
+            algorithms={"random": {"seed": 5}},
+        )
 
         assert experiment.algorithms.algorithm.seed == 5
 
     def test_workon_name(self):
         """Verify setting the name with workon"""
+
         def foo(x):
-            return [dict(name='result', type='objective', value=x * 2)]
+            return [dict(name="result", type="objective", value=x * 2)]
 
-        experiment = workon(foo, space={'x': 'uniform(0, 10)'}, max_trials=5, name='voici')
+        experiment = workon(
+            foo, space={"x": "uniform(0, 10)"}, max_trials=5, name="voici"
+        )
 
-        assert experiment.name == 'voici'
+        assert experiment.name == "voici"
 
     def test_workon_fail(self, monkeypatch):
         """Verify that storage is reverted if workon fails"""
+
         def foo(x):
-            return [dict(name='result', type='objective', value=x * 2)]
+            return [dict(name="result", type="objective", value=x * 2)]
 
         def build_fail(*args, **kwargs):
-            raise RuntimeError('You shall not build!')
+            raise RuntimeError("You shall not build!")
 
-        monkeypatch.setattr('orion.core.io.experiment_builder.build', build_fail)
+        monkeypatch.setattr("orion.core.io.experiment_builder.build", build_fail)
 
         # Flush storage singleton
         update_singletons()
 
         with pytest.raises(RuntimeError) as exc:
-            experiment = workon(foo, space={'x': 'uniform(0, 10)'}, max_trials=5, name='voici')
+            experiment = workon(
+                foo, space={"x": "uniform(0, 10)"}, max_trials=5, name="voici"
+            )
 
-        assert exc.match('You shall not build!')
+        assert exc.match("You shall not build!")
 
         # Verify that tmp storage was cleared
         with pytest.raises(SingletonNotInstantiatedError):
             get_storage()
 
         # Now test with a prior storage
-        with OrionState(storage={'type': 'legacy', 'database': {'type': 'EphemeralDB'}}):
+        with OrionState(
+            storage={"type": "legacy", "database": {"type": "EphemeralDB"}}
+        ):
             storage = get_storage()
 
             with pytest.raises(RuntimeError) as exc:
-                workon(foo, space={'x': 'uniform(0, 10)'}, max_trials=5, name='voici')
+                workon(foo, space={"x": "uniform(0, 10)"}, max_trials=5, name="voici")
 
-            assert exc.match('You shall not build!')
+            assert exc.match("You shall not build!")
 
             assert get_storage() is storage
 
     def test_workon_twice(self):
         """Verify setting the each experiment has its own storage"""
+
         def foo(x):
-            return [dict(name='result', type='objective', value=x * 2)]
+            return [dict(name="result", type="objective", value=x * 2)]
 
-        experiment = workon(foo, space={'x': 'uniform(0, 10)'}, max_trials=5, name='voici')
+        experiment = workon(
+            foo, space={"x": "uniform(0, 10)"}, max_trials=5, name="voici"
+        )
 
-        assert experiment.name == 'voici'
+        assert experiment.name == "voici"
         assert len(experiment.fetch_trials()) == 5
 
-        experiment2 = workon(foo, space={'x': 'uniform(0, 10)'}, max_trials=1, name='voici')
+        experiment2 = workon(
+            foo, space={"x": "uniform(0, 10)"}, max_trials=1, name="voici"
+        )
 
-        assert experiment2.name == 'voici'
+        assert experiment2.name == "voici"
         assert len(experiment2.fetch_trials()) == 1
 
 
 class TestGetExperiment:
     """Test :meth:`orion.client.get_experiment`"""
 
-    @pytest.mark.usefixtures('mock_database')
+    @pytest.mark.usefixtures("mock_database")
     def test_experiment_do_not_exist(self):
         """Tests that an error is returned when the experiment doesn't exist"""
         with pytest.raises(NoConfigurationError) as exception:
-            get_experiment('a')
-        assert "No experiment with given name 'a' and version '*' inside database, " \
-               "no view can be created." == str(exception.value)
+            get_experiment("a")
+        assert (
+            "No experiment with given name 'a' and version '*' inside database, "
+            "no view can be created." == str(exception.value)
+        )
 
-    @pytest.mark.usefixtures('mock_database')
+    @pytest.mark.usefixtures("mock_database")
     def test_experiment_exist(self):
         """
         Tests that an instance of :class:`orion.core.worker.experiment.ExperimentView` is
         returned representing the latest version when none is given.
         """
-        experiment = create_experiment('a', space={'x': 'uniform(0, 10)'})
+        experiment = create_experiment("a", space={"x": "uniform(0, 10)"})
 
-        experiment = get_experiment('a')
+        experiment = get_experiment("a")
 
         assert experiment
         assert isinstance(experiment, ExperimentView)
 
-    @pytest.mark.usefixtures('mock_database')
+    @pytest.mark.usefixtures("mock_database")
     def test_version_do_not_exist(self, caplog):
         """Tests that a warning is printed when the experiment exist but the version doesn't"""
-        create_experiment('a', space={'x': 'uniform(0, 10)'})
+        create_experiment("a", space={"x": "uniform(0, 10)"})
 
-        experiment = get_experiment('a', 2)
+        experiment = get_experiment("a", 2)
 
         assert experiment.version == 1
-        assert "Version 2 was specified but most recent version is only 1. Using 1." in caplog.text
+        assert (
+            "Version 2 was specified but most recent version is only 1. Using 1."
+            in caplog.text
+        )

--- a/tests/unittests/core/cli/test_checks.py
+++ b/tests/unittests/core/cli/test_checks.py
@@ -16,7 +16,7 @@ from orion.core.utils.exceptions import CheckError
 @pytest.fixture
 def config():
     """Return a basic database configuration."""
-    return {'database': {'host': 'localhost', 'type': 'mongodb', 'name': 'user'}}
+    return {"database": {"host": "localhost", "type": "mongodb", "name": "user"}}
 
 
 @pytest.fixture
@@ -47,24 +47,26 @@ def clean_test(database):
 
 def test_check_default_config_pass(monkeypatch, presence, config):
     """Check if the default config test works."""
+
     def mock_default_config(self):
         return config
 
-    monkeypatch.setattr(orion.core.config.__class__, 'to_dict', mock_default_config)
+    monkeypatch.setattr(orion.core.config.__class__, "to_dict", mock_default_config)
 
     result, msg = presence.check_default_config()
 
     assert result == "Success"
     assert msg == ""
-    assert presence.db_config == config['storage']['database']
+    assert presence.db_config == config["storage"]["database"]
 
 
 def test_check_default_config_skip(monkeypatch, presence):
     """Check if test returns skip if no default config is found."""
+
     def mock_default_config(self):
         return {}
 
-    monkeypatch.setattr(orion.core.config.__class__, 'to_dict', mock_default_config)
+    monkeypatch.setattr(orion.core.config.__class__, "to_dict", mock_default_config)
 
     result, msg = presence.check_default_config()
     assert result == "Skipping"
@@ -74,6 +76,7 @@ def test_check_default_config_skip(monkeypatch, presence):
 
 def test_config_file_config_pass(monkeypatch, presence, config):
     """Check if test passes with valid configuration."""
+
     def mock_file_config(cmdargs):
         backward.update_db_config(config)
         return config
@@ -84,11 +87,12 @@ def test_config_file_config_pass(monkeypatch, presence, config):
 
     assert result == "Success"
     assert msg == ""
-    assert presence.db_config == config['storage']['database']
+    assert presence.db_config == config["storage"]["database"]
 
 
 def test_config_file_fails_missing_config(monkeypatch, presence, config):
     """Check if test fails with missing configuration."""
+
     def mock_file_config(cmdargs):
         return {}
 
@@ -103,8 +107,9 @@ def test_config_file_fails_missing_config(monkeypatch, presence, config):
 
 def test_config_file_fails_missing_database(monkeypatch, presence, config):
     """Check if test fails with missing database configuration."""
+
     def mock_file_config(cmdargs):
-        return {'algorithm': 'asha'}
+        return {"algorithm": "asha"}
 
     monkeypatch.setattr(experiment_builder, "get_cmd_config", mock_file_config)
 
@@ -117,8 +122,9 @@ def test_config_file_fails_missing_database(monkeypatch, presence, config):
 
 def test_config_file_fails_missing_value(monkeypatch, presence, config):
     """Check if test fails with missing value in database configuration."""
+
     def mock_file_config(cmdargs):
-        return {'storage': {'database': {}}}
+        return {"storage": {"database": {}}}
 
     monkeypatch.setattr(experiment_builder, "get_cmd_config", mock_file_config)
 
@@ -131,22 +137,23 @@ def test_config_file_fails_missing_value(monkeypatch, presence, config):
 
 def test_config_file_skips(monkeypatch, presence, config):
     """Check if test skips when another configuration is present."""
+
     def mock_file_config(self):
         return {}
 
-    presence.db_config = config['database']
+    presence.db_config = config["database"]
     monkeypatch.setattr(experiment_builder, "get_cmd_config", mock_file_config)
 
     result, msg = presence.check_configuration_file()
 
     assert result == "Skipping"
-    assert presence.db_config == config['database']
+    assert presence.db_config == config["database"]
 
 
-@pytest.mark.usefixtures('null_db_instances')
+@pytest.mark.usefixtures("null_db_instances")
 def test_creation_pass(presence, config):
     """Check if test passes with valid database configuration."""
-    presence.db_config = config['database']
+    presence.db_config = config["database"]
     creation = CreationStage(presence)
 
     result, msg = creation.check_database_creation()
@@ -156,10 +163,10 @@ def test_creation_pass(presence, config):
     assert creation.instance is not None
 
 
-@pytest.mark.usefixtures('null_db_instances')
+@pytest.mark.usefixtures("null_db_instances")
 def test_creation_fails(monkeypatch, presence, config):
     """Check if test fails when not connected."""
-    presence.db_config = config['database']
+    presence.db_config = config["database"]
     creation = CreationStage(presence)
 
     monkeypatch.setattr(MongoDB, "is_connected", False)
@@ -180,6 +187,7 @@ def test_operation_write_pass(operation):
 
 def test_operation_write_fails(monkeypatch, operation):
     """Check if test fails when write operation fails."""
+
     def mock_write(one, two):
         raise RuntimeError("Not working")
 
@@ -193,7 +201,7 @@ def test_operation_write_fails(monkeypatch, operation):
 
 def test_operation_read_pass(operation, clean_test):
     """Check if test passes when read operation works."""
-    operation.c_stage.instance.write('test', {'index': 'value'})
+    operation.c_stage.instance.write("test", {"index": "value"})
     result, msg = operation.check_read()
 
     assert result == "Success"
@@ -202,6 +210,7 @@ def test_operation_read_pass(operation, clean_test):
 
 def test_operation_read_fail_not_working(monkeypatch, operation):
     """Check if test fails when read operation fails."""
+
     def mock_read(one, two):
         raise RuntimeError("Not working")
 
@@ -215,7 +224,7 @@ def test_operation_read_fail_not_working(monkeypatch, operation):
 
 def test_operation_read_fail_unexpected_value(operation, clean_test):
     """Check if test fails on unexpected read value."""
-    operation.c_stage.instance.write('test', {'index': 'value2'})
+    operation.c_stage.instance.write("test", {"index": "value2"})
 
     with pytest.raises(CheckError) as ex:
         operation.check_read()
@@ -225,7 +234,7 @@ def test_operation_read_fail_unexpected_value(operation, clean_test):
 
 def test_operation_count_pass(operation, clean_test):
     """Check if test passes when count operation works."""
-    operation.c_stage.instance.write('test', {'index': 'value'})
+    operation.c_stage.instance.write("test", {"index": "value"})
     result, msg = operation.check_count()
 
     assert result == "Success"
@@ -234,8 +243,8 @@ def test_operation_count_pass(operation, clean_test):
 
 def test_operation_count_fails(monkeypatch, operation, clean_test):
     """Check if test fails when count operation fails."""
-    operation.c_stage.instance.write('test', {'index': 'value'})
-    operation.c_stage.instance.write('test', {'index': 'value'})
+    operation.c_stage.instance.write("test", {"index": "value"})
+    operation.c_stage.instance.write("test", {"index": "value"})
     with pytest.raises(CheckError) as ex:
         operation.check_count()
 
@@ -244,7 +253,7 @@ def test_operation_count_fails(monkeypatch, operation, clean_test):
 
 def test_operation_remove_pass(operation, clean_test):
     """Check if test passes when remove operation works."""
-    operation.c_stage.instance.write('test', {'index': 'value'})
+    operation.c_stage.instance.write("test", {"index": "value"})
     result, msg = operation.check_remove()
 
     assert result == "Success"
@@ -253,11 +262,11 @@ def test_operation_remove_pass(operation, clean_test):
 
 def test_operation_remove_fails(monkeypatch, operation, clean_test, database):
     """Check if test fails when remove operation fails."""
-    operation.c_stage.instance.write('test', {'index': 'value'})
-    operation.c_stage.instance.write('test', {'index': 'value'})
+    operation.c_stage.instance.write("test", {"index": "value"})
+    operation.c_stage.instance.write("test", {"index": "value"})
 
     def mock_remove(one, two):
-        database.test.delete_one({'index': 'value'})
+        database.test.delete_one({"index": "value"})
 
     monkeypatch.setattr(operation.c_stage.instance, "remove", mock_remove)
 

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -7,13 +7,24 @@ import pytest
 
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.utils.format_terminal import (
-    format_algorithm, format_commandline, format_config, format_dict, format_identification,
-    format_info, format_list, format_metadata, format_refers, format_space, format_stats,
-    format_title, get_trial_params)
+    format_algorithm,
+    format_commandline,
+    format_config,
+    format_dict,
+    format_identification,
+    format_info,
+    format_list,
+    format_metadata,
+    format_refers,
+    format_space,
+    format_stats,
+    format_title,
+    get_trial_params,
+)
 from orion.core.worker.trial import Trial
 
 
-class DummyExperiment():
+class DummyExperiment:
     """Dummy container to mock experiments"""
 
     pass
@@ -24,9 +35,10 @@ def dummy_trial():
     """Return a dummy trial object"""
     trial = Trial()
     trial._params = [
-        Trial.Param(name='a', type='real', value=0.0),
-        Trial.Param(name='b', type='integer', value=1),
-        Trial.Param(name='c', type='categorical', value='Some')]
+        Trial.Param(name="a", type="real", value=0.0),
+        Trial.Param(name="b", type="integer", value=1),
+        Trial.Param(name="c", type="categorical", value="Some"),
+    ]
     return trial
 
 
@@ -34,30 +46,16 @@ def dummy_trial():
 def dummy_dict():
     """Return a dict of dicts"""
     return {
-        1: {
-            1.1: "1.1.1",
-            1.2: {
-                "1.2.1": {},
-                "1.2.2": "1.2.2.1"
-            }
-        },
-        2: {
-            2.1: "2.1.1",
-            2.2: {}
-        },
-        3: {}
+        1: {1.1: "1.1.1", 1.2: {"1.2.1": {}, "1.2.2": "1.2.2.1"}},
+        2: {2.1: "2.1.1", 2.2: {}},
+        3: {},
     }
 
 
 @pytest.fixture
 def dummy_list_of_lists():
     """Return a list of lists"""
-    return [
-        1,
-        [2, 3],
-        4,
-        [5, 6, 7, 8]
-    ]
+    return [1, [2, 3], 4, [5, 6, 7, 8]]
 
 
 @pytest.fixture
@@ -65,24 +63,10 @@ def dummy_list_of_objects(dummy_dict):
     """Return a list of objects"""
     return [
         {
-            1: {
-                1.1: "1.1.1",
-                1.2: [
-                    "1.2.1",
-                    "1.2.2"
-                ]
-            },
+            1: {1.1: "1.1.1", 1.2: ["1.2.1", "1.2.2"]},
         },
-        [
-            4, 5
-        ],
-        {
-            2: {
-                2.1: "2.1.1",
-                2.2: {}
-            },
-            3: {}
-        }
+        [4, 5],
+        {2: {2.1: "2.1.1", 2.2: {}}, 3: {}},
     ]
 
 
@@ -91,18 +75,20 @@ def algorithm_dict():
     """Return an algorithm configuration"""
     return dict(
         bayesianoptimizer=dict(
-            acq_func='gp_hedge',
+            acq_func="gp_hedge",
             alpha=1e-10,
             n_initial_points=10,
             n_restarts_optimizer=0,
-            normalize_y=False))
+            normalize_y=False,
+        )
+    )
 
 
 def test_format_title():
     """Test title formatting template"""
     result = """Test\n===="""
 
-    assert format_title('Test') == result
+    assert format_title("Test") == result
 
 
 @pytest.mark.parametrize("depth", [0, 1, 2])
@@ -110,7 +96,11 @@ def test_format_dict_depth_synthetic(depth, dummy_dict):
     """Test dict formatting with different depths for one line"""
     WIDTH = 4
     tab = (" " * WIDTH) * depth
-    assert format_dict(dummy_dict, depth=depth, width=WIDTH).split("\n")[0].startswith(tab + "1")
+    assert (
+        format_dict(dummy_dict, depth=depth, width=WIDTH)
+        .split("\n")[0]
+        .startswith(tab + "1")
+    )
 
 
 def test_format_dict_depth_full(dummy_dict):
@@ -131,12 +121,15 @@ def test_format_dict_depth_full(dummy_dict):
     assert lines[8].startswith("3")
 
 
-@pytest.mark.parametrize("width,depth",
-                         itertools.product([0, 2], [1, 2]))
+@pytest.mark.parametrize("width,depth", itertools.product([0, 2], [1, 2]))
 def test_format_dict_width_synthetic(width, depth, dummy_dict):
     """Test dict formatting with different combination of widths and depth for one line"""
     tab = (" " * width) * depth
-    assert format_dict(dummy_dict, depth=depth, width=width).split("\n")[0].startswith(tab + "1")
+    assert (
+        format_dict(dummy_dict, depth=depth, width=width)
+        .split("\n")[0]
+        .startswith(tab + "1")
+    )
 
 
 @pytest.mark.parametrize("width", [0, 5, 12])
@@ -173,7 +166,9 @@ def test_format_dict_empty_leaf_template_custom():
     """Test dict empty leaf node formatting with custom template"""
     template = "{key} is a leaf\n"
     dummy_dict_with_leafs = {1: {2: {}}, 2: {}, 3: {1: 3, 2: {}}}
-    lines = format_dict(dummy_dict_with_leafs, templates={'empty_leaf': template}).split("\n")
+    lines = format_dict(
+        dummy_dict_with_leafs, templates={"empty_leaf": template}
+    ).split("\n")
     assert len(lines) == 6
     # 1:
     assert lines[1] == "2 is a leaf"
@@ -199,7 +194,7 @@ def test_format_dict_leaf_template_custom():
     """Test dict leaf node formatting with custom template"""
     template = "value of {key} is {value}\n"
     dummy_dict_with_leafs = {1: {2: {}}, 2: {}, 3: {1: 3, 2: {}}}
-    lines = format_dict(dummy_dict_with_leafs, templates={'leaf': template}).split("\n")
+    lines = format_dict(dummy_dict_with_leafs, templates={"leaf": template}).split("\n")
     assert len(lines) == 6
     # 1:
     #   2
@@ -226,7 +221,9 @@ def test_format_dict_node_template_custom():
     """Test dict formatting with custom node template"""
     template = "{key} is a dict:\n{value}\n"
     dummy_dict_with_leafs = {1: {2: {}}, 2: {}, 3: {1: {4: 3}, 2: {}}}
-    lines = format_dict(dummy_dict_with_leafs, templates={'dict_node': template}).split("\n")
+    lines = format_dict(dummy_dict_with_leafs, templates={"dict_node": template}).split(
+        "\n"
+    )
     assert len(lines) == 7
     assert lines[0] == "1 is a dict:"
     #   2
@@ -269,12 +266,14 @@ def test_format_list_depth_full(dummy_list_of_lists):
     assert lines[13] == "]"
 
 
-@pytest.mark.parametrize("width,depth",
-                         itertools.product([0, 2], [1, 2]))
+@pytest.mark.parametrize("width,depth", itertools.product([0, 2], [1, 2]))
 def test_format_list_width_synthetic(width, depth, dummy_list_of_lists):
     """Test list of lists formatting with different combination of widths and depth for one line"""
     tab = (" " * width) * depth
-    assert format_list(dummy_list_of_lists, depth=depth, width=width).split("\n")[0] == tab + "["
+    assert (
+        format_list(dummy_list_of_lists, depth=depth, width=width).split("\n")[0]
+        == tab + "["
+    )
 
 
 @pytest.mark.parametrize("width", [0, 5, 12])
@@ -310,7 +309,7 @@ def test_format_list_item_template(dummy_list_of_lists):
 def test_format_list_item_template_custom(dummy_list_of_lists):
     """Test list of lists with custom item template"""
     template = "{item} is an item\n"
-    lines = format_list(dummy_list_of_lists, templates={'item': template}).split("\n")
+    lines = format_list(dummy_list_of_lists, templates={"item": template}).split("\n")
     assert len(lines) == 14
     # 1:
     assert lines[1] == "1 is an item"
@@ -331,10 +330,7 @@ def test_format_list_node_template(dummy_list_of_lists):
 
 def test_format_list_node_template_custom(dummy_list_of_lists):
     """Test list of lists custom formatting"""
-    templates = dict(
-        list="[{items}]",
-        item="{item}",
-        list_node="{item}")
+    templates = dict(list="[{items}]", item="{item}", list_node="{item}")
     lines = format_list(dummy_list_of_lists, templates=templates).split("\n")
     assert len(lines) == 1
     assert lines[0] == "[1[23]4[5678]]"
@@ -342,7 +338,9 @@ def test_format_list_node_template_custom(dummy_list_of_lists):
 
 def test_format_dict_with_list(dummy_list_of_objects):
     """Test dict formatting with embedded lists"""
-    assert format_dict(dummy_list_of_objects) == """\
+    assert (
+        format_dict(dummy_list_of_objects)
+        == """\
 [
     1:
         1.1: 1.1.1
@@ -361,6 +359,7 @@ def test_format_dict_with_list(dummy_list_of_objects):
     3
 ]\
 """
+    )
 
 
 def test_format_identification():
@@ -368,26 +367,32 @@ def test_format_identification():
     experiment = DummyExperiment()
     experiment.name = "test"
     experiment.version = 1
-    experiment.metadata = {'user': 'corneauf'}
-    assert format_identification(experiment) == """\
+    experiment.metadata = {"user": "corneauf"}
+    assert (
+        format_identification(experiment)
+        == """\
 Identification
 ==============
 name: test
 version: 1
 user: corneauf
 """
+    )
 
 
 def test_format_commandline():
     """Test commandline section formatting"""
     experiment = DummyExperiment()
-    commandline = ['executing.sh', '--some', 'random', '--command', 'line', 'arguments']
-    experiment.metadata = {'user_args': commandline}
-    assert format_commandline(experiment) == """\
+    commandline = ["executing.sh", "--some", "random", "--command", "line", "arguments"]
+    experiment.metadata = {"user_args": commandline}
+    assert (
+        format_commandline(experiment)
+        == """\
 Commandline
 ===========
 executing.sh --some random --command line arguments
 """
+    )
 
 
 def test_format_config(monkeypatch):
@@ -397,7 +402,9 @@ def test_format_config(monkeypatch):
     experiment.max_trials = 100
     experiment.max_broken = 5
     experiment.working_dir = "working_dir"
-    assert format_config(experiment) == """\
+    assert (
+        format_config(experiment)
+        == """\
 Config
 ======
 pool size: 10
@@ -405,13 +412,16 @@ max trials: 100
 max broken: 5
 working dir: working_dir
 """
+    )
 
 
 def test_format_algorithm(algorithm_dict):
     """Test algorithm section formatting"""
     experiment = DummyExperiment()
-    experiment.configuration = {'algorithms': algorithm_dict}
-    assert format_algorithm(experiment) == """\
+    experiment.configuration = {"algorithms": algorithm_dict}
+    assert (
+        format_algorithm(experiment)
+        == """\
 Algorithm
 =========
 bayesianoptimizer:
@@ -421,37 +431,45 @@ bayesianoptimizer:
     n_restarts_optimizer: 0
     normalize_y: False
 """
+    )
 
 
 def test_format_space():
     """Test space section formatting"""
     experiment = DummyExperiment()
     space = SpaceBuilder().build(
-        {"some": 'choices(["random", "or", "not"])',
-         "command": 'uniform(0, 1)'})
+        {"some": 'choices(["random", "or", "not"])', "command": "uniform(0, 1)"}
+    )
     experiment.space = space
-    assert format_space(experiment) == """\
+    assert (
+        format_space(experiment)
+        == """\
 Space
 =====
 command: uniform(0, 1)
 some: choices(['random', 'or', 'not'])
 """
+    )
 
 
 def test_format_metadata():
     """Test metadata section formatting"""
     experiment = DummyExperiment()
     experiment.metadata = dict(
-        user='user',
-        datetime='now',
-        orion_version='1.0.1',
+        user="user",
+        datetime="now",
+        orion_version="1.0.1",
         VCS=dict(
-            HEAD_sha='sha',
-            active_branch='branch',
-            diff_sha='smt',
+            HEAD_sha="sha",
+            active_branch="branch",
+            diff_sha="smt",
             is_dirty=True,
-            type='git'))
-    assert format_metadata(experiment) == """\
+            type="git",
+        ),
+    )
+    assert (
+        format_metadata(experiment)
+        == """\
 Meta-data
 =========
 user: user
@@ -464,6 +482,7 @@ VCS:
   is_dirty: True
   type: git
 """
+    )
 
 
 def test_format_refers_root():
@@ -476,19 +495,22 @@ def test_format_refers_root():
     #     parent='user',
     #     datetime='now',
     #     orion_version='1.0.1')
-    assert format_refers(experiment) == """\
+    assert (
+        format_refers(experiment)
+        == """\
 Parent experiment
 =================
 root: 
 parent: 
 adapter: 
-"""  # noqa: W291
+"""
+    )  # noqa: W291
 
 
 def test_format_refers_child():
     """Test refers section formatting for a child experiment"""
-    ROOT_NAME = 'root-name'
-    PARENT_NAME = 'parent-name'
+    ROOT_NAME = "root-name"
+    PARENT_NAME = "parent-name"
 
     root = DummyExperiment()
     root.name = ROOT_NAME
@@ -502,9 +524,7 @@ def test_format_refers_child():
     child.node.root = root
 
     adapter = DummyExperiment()
-    adapter.configuration = dict(
-        adummy='dict',
-        foran='adapter')
+    adapter.configuration = dict(adummy="dict", foran="adapter")
 
     child.refers = dict(adapter=adapter)
 
@@ -512,7 +532,9 @@ def test_format_refers_child():
     #     parent='user',
     #     datetime='now',
     #     orion_version='1.0.1')
-    assert format_refers(child) == """\
+    assert (
+        format_refers(child)
+        == """\
 Parent experiment
 =================
 root: root-name
@@ -520,7 +542,8 @@ parent: parent-name
 adapter: 
   adummy: dict
   foran: adapter
-"""  # noqa: W291
+"""
+    )  # noqa: W291
 
 
 def test_get_trial_params_empty():
@@ -535,24 +558,27 @@ def test_get_trial_params(dummy_trial):
     experiment = DummyExperiment()
     experiment.get_trial = lambda trial=None, uid=None: dummy_trial
     params = get_trial_params(None, experiment)
-    assert params['a'] == 0.0
-    assert params['b'] == 1
-    assert params['c'] == 'Some'
+    assert params["a"] == 0.0
+    assert params["b"] == 1
+    assert params["c"] == "Some"
 
 
 def test_format_stats(dummy_trial):
     """Test stats section formatting"""
     experiment = DummyExperiment()
     experiment.stats = dict(
-        best_trials_id='dummy',
+        best_trials_id="dummy",
         trials_completed=10,
         best_evaluation=0.1,
-        start_time='yesterday',
-        finish_time='now',
-        duration='way too long')
+        start_time="yesterday",
+        finish_time="now",
+        duration="way too long",
+    )
     experiment.get_trial = lambda trial=None, uid=None: dummy_trial
     experiment.is_done = False
-    assert format_stats(experiment) == """\
+    assert (
+        format_stats(experiment)
+        == """\
 Stats
 =====
 completed: False
@@ -568,39 +594,47 @@ start time: yesterday
 finish time: now
 duration: way too long
 """
+    )
 
 
 def test_format_info(algorithm_dict, dummy_trial):
     """Test full formatting string"""
     experiment = DummyExperiment()
-    commandline = ['executing.sh', '--some~choices(["random", "or", "not"])',
-                   '--command~uniform(0, 1)']
-    experiment.name = 'test'
+    commandline = [
+        "executing.sh",
+        '--some~choices(["random", "or", "not"])',
+        "--command~uniform(0, 1)",
+    ]
+    experiment.name = "test"
     experiment.version = 1
-    experiment.metadata = {'user_args': commandline}
+    experiment.metadata = {"user_args": commandline}
     experiment.pool_size = 10
     experiment.max_trials = 100
     experiment.max_broken = 5
     experiment.working_dir = "working_dir"
-    experiment.configuration = {'algorithms': algorithm_dict}
+    experiment.configuration = {"algorithms": algorithm_dict}
 
     space = SpaceBuilder().build(
-        {"some": 'choices(["random", "or", "not"])',
-         "command": 'uniform(0, 1)'})
+        {"some": 'choices(["random", "or", "not"])', "command": "uniform(0, 1)"}
+    )
     experiment.space = space
-    experiment.metadata.update(dict(
-        user='user',
-        datetime='now',
-        orion_version='1.0.1',
-        VCS=dict(
-            HEAD_sha='sha',
-            active_branch='branch',
-            diff_sha='smt',
-            is_dirty=True,
-            type='git')))
+    experiment.metadata.update(
+        dict(
+            user="user",
+            datetime="now",
+            orion_version="1.0.1",
+            VCS=dict(
+                HEAD_sha="sha",
+                active_branch="branch",
+                diff_sha="smt",
+                is_dirty=True,
+                type="git",
+            ),
+        )
+    )
 
-    ROOT_NAME = 'root-name'
-    PARENT_NAME = 'parent-name'
+    ROOT_NAME = "root-name"
+    PARENT_NAME = "parent-name"
 
     root = DummyExperiment()
     root.name = ROOT_NAME
@@ -613,22 +647,23 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment.node.root = root
 
     adapter = DummyExperiment()
-    adapter.configuration = dict(
-        adummy='dict',
-        foran='adapter')
+    adapter.configuration = dict(adummy="dict", foran="adapter")
 
     experiment.refers = dict(adapter=adapter)
     experiment.stats = dict(
-        best_trials_id='dummy',
+        best_trials_id="dummy",
         trials_completed=10,
         best_evaluation=0.1,
-        start_time='yesterday',
-        finish_time='now',
-        duration='way too long')
+        start_time="yesterday",
+        finish_time="now",
+        duration="way too long",
+    )
     experiment.get_trial = lambda trial=None, uid=None: dummy_trial
     experiment.is_done = False
 
-    assert format_info(experiment) == """\
+    assert (
+        format_info(experiment)
+        == """\
 Identification
 ==============
 name: test
@@ -702,4 +737,5 @@ start time: yesterday
 finish time: now
 duration: way too long
 
-"""  # noqa: W291
+"""
+    )  # noqa: W291

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -8,29 +8,29 @@ import os
 
 import pytest
 
-from orion.algo.space import (Categorical, Integer, Real, Space)
+from orion.algo.space import Categorical, Integer, Real, Space
 from orion.core.evc import conflicts
-from orion.core.io.convert import (JSONConverter, YAMLConverter)
+from orion.core.io.convert import JSONConverter, YAMLConverter
 import orion.core.io.experiment_builder as experiment_builder
 from orion.core.io.space_builder import DimensionBuilder
 import orion.core.utils.backward as backward
 from orion.testing import default_datetime, MockDatetime
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
-YAML_SAMPLE = os.path.join(TEST_DIR, 'sample_config.yml')
-YAML_DIFF_SAMPLE = os.path.join(TEST_DIR, 'sample_config_diff.yml')
-JSON_SAMPLE = os.path.join(TEST_DIR, 'sample_config.json')
-UNKNOWN_SAMPLE = os.path.join(TEST_DIR, 'sample_config.txt')
-UNKNOWN_TEMPLATE = os.path.join(TEST_DIR, 'sample_config_template.txt')
+YAML_SAMPLE = os.path.join(TEST_DIR, "sample_config.yml")
+YAML_DIFF_SAMPLE = os.path.join(TEST_DIR, "sample_config_diff.yml")
+JSON_SAMPLE = os.path.join(TEST_DIR, "sample_config.json")
+UNKNOWN_SAMPLE = os.path.join(TEST_DIR, "sample_config.txt")
+UNKNOWN_TEMPLATE = os.path.join(TEST_DIR, "sample_config_template.txt")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def yaml_sample_path():
     """Return path with a yaml sample file."""
     return os.path.abspath(YAML_SAMPLE)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def yaml_diff_sample_path():
     """Return path with a different yaml sample file."""
     return os.path.abspath(YAML_DIFF_SAMPLE)
@@ -39,16 +39,16 @@ def yaml_diff_sample_path():
 @pytest.fixture
 def yaml_config(yaml_sample_path):
     """Return a list containing the key and the sample path for a yaml config."""
-    return ['--config', yaml_sample_path]
+    return ["--config", yaml_sample_path]
 
 
 @pytest.fixture
 def yaml_diff_config(yaml_diff_sample_path):
     """Return a list containing the key and the sample path for a different yaml config."""
-    return ['--config', yaml_diff_sample_path]
+    return ["--config", yaml_diff_sample_path]
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def json_sample_path():
     """Return path with a json sample file."""
     return JSON_SAMPLE
@@ -57,101 +57,101 @@ def json_sample_path():
 @pytest.fixture
 def json_config(json_sample_path):
     """Return a list containing the key and the sample path for a json config."""
-    return ['--config', json_sample_path]
+    return ["--config", json_sample_path]
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def unknown_type_sample_path():
     """Return path with a sample file of unknown configuration filetype."""
     return UNKNOWN_SAMPLE
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def unknown_type_template_path():
     """Return path with a template file of unknown configuration filetype."""
     return UNKNOWN_TEMPLATE
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def some_sample_path():
     """Return path with a sample file of unknown configuration filetype."""
-    return os.path.join(TEST_DIR, 'some_sample_config.txt')
+    return os.path.join(TEST_DIR, "some_sample_config.txt")
 
 
 @pytest.fixture
 def some_sample_config(some_sample_path):
     """Return a list containing the key and the sample path for some config."""
-    return ['--config', some_sample_path]
+    return ["--config", some_sample_path]
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def yaml_converter():
     """Return a yaml converter."""
     return YAMLConverter()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def json_converter():
     """Return a json converter."""
     return JSONConverter()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def space():
     """Construct a simple space with every possible kind of Dimension."""
     space = Space()
-    categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
-    dim = Categorical('yolo', categories, shape=2)
+    categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
+    dim = Categorical("yolo", categories, shape=2)
     space.register(dim)
-    dim = Integer('yolo2', 'uniform', -3, 6)
+    dim = Integer("yolo2", "uniform", -3, 6)
     space.register(dim)
-    dim = Real('yolo3', 'alpha', 0.9)
+    dim = Real("yolo3", "alpha", 0.9)
     space.register(dim)
     return space
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def hierarchical_space():
     """Construct a space with hierarchical Dimensions."""
     space = Space()
-    categories = {'asdfa': 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
-    dim = Categorical('yolo.first', categories, shape=2)
+    categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, 4: 0.4}
+    dim = Categorical("yolo.first", categories, shape=2)
     space.register(dim)
-    dim = Integer('yolo.second', 'uniform', -3, 6)
+    dim = Integer("yolo.second", "uniform", -3, 6)
     space.register(dim)
-    dim = Real('yoloflat', 'alpha', 0.9)
+    dim = Real("yoloflat", "alpha", 0.9)
     space.register(dim)
     return space
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def fixed_suggestion():
     """Return the same tuple/sample from a possible space."""
-    return (('asdfa', 2), 0, 3.5)
+    return (("asdfa", 2), 0, 3.5)
 
 
 @pytest.fixture()
 def with_user_tsirif(monkeypatch):
     """Make ``getpass.getuser()`` return ``'tsirif'``."""
-    monkeypatch.setattr(getpass, 'getuser', lambda: 'tsirif')
+    monkeypatch.setattr(getpass, "getuser", lambda: "tsirif")
 
 
 @pytest.fixture()
 def with_user_bouthilx(monkeypatch):
     """Make ``getpass.getuser()`` return ``'bouthilx'``."""
-    monkeypatch.setattr(getpass, 'getuser', lambda: 'bouthilx')
+    monkeypatch.setattr(getpass, "getuser", lambda: "bouthilx")
 
 
 @pytest.fixture()
 def with_user_dendi(monkeypatch):
     """Make ``getpass.getuser()`` return ``'dendi'``."""
-    monkeypatch.setattr(getpass, 'getuser', lambda: 'dendi')
+    monkeypatch.setattr(getpass, "getuser", lambda: "dendi")
 
 
 @pytest.fixture()
 def random_dt(monkeypatch):
     """Make ``datetime.datetime.utcnow()`` return an arbitrary date."""
-    monkeypatch.setattr(datetime, 'datetime', MockDatetime)
+    monkeypatch.setattr(datetime, "datetime", MockDatetime)
     return default_datetime()
 
 
@@ -160,8 +160,8 @@ def hacked_exp(with_user_dendi, random_dt, clean_db, create_db_instance):
     """Return an `Experiment` instance with hacked _id to find trials in
     fake database.
     """
-    exp = experiment_builder.build(name='supernaedo2-dendi')
-    exp._id = 'supernaedo2-dendi'  # white box hack
+    exp = experiment_builder.build(name="supernaedo2-dendi")
+    exp._id = "supernaedo2-dendi"  # white box hack
     return exp
 
 
@@ -169,35 +169,39 @@ def hacked_exp(with_user_dendi, random_dt, clean_db, create_db_instance):
 def trial_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_instance):
     """Replace trial ids by the actual ids of the experiments."""
     db = create_db_instance
-    experiments = db.read('experiments', {})
-    experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
-    trials = db.read('trials')
+    experiments = db.read("experiments", {})
+    experiment_dict = dict(
+        (experiment["name"], experiment) for experiment in experiments
+    )
+    trials = db.read("trials")
 
     for trial in trials:
-        query = {'experiment': trial['experiment']}
-        update = {'experiment': experiment_dict[trial['experiment']]['_id']}
-        db.write('trials', update, query)
+        query = {"experiment": trial["experiment"]}
+        update = {"experiment": experiment_dict[trial["experiment"]]["_id"]}
+        db.write("trials", update, query)
 
 
 @pytest.fixture()
 def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_instance):
     """Replace trial ids by the actual ids of the experiments."""
     db = create_db_instance
-    query = {'metadata.user': 'tsirif'}
-    selection = {'name': 1, 'refers': 1}
-    experiments = db.read('experiments', query, selection)
-    experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
+    query = {"metadata.user": "tsirif"}
+    selection = {"name": 1, "refers": 1}
+    experiments = db.read("experiments", query, selection)
+    experiment_dict = dict(
+        (experiment["name"], experiment) for experiment in experiments
+    )
 
     for experiment in experiments:
-        query = {'_id': experiment['_id']}
+        query = {"_id": experiment["_id"]}
 
-        root_id = experiment_dict[experiment['refers']['root_id']]['_id']
-        if experiment['refers']['parent_id'] is not None:
-            parent_id = experiment_dict[experiment['refers']['parent_id']]['_id']
+        root_id = experiment_dict[experiment["refers"]["root_id"]]["_id"]
+        if experiment["refers"]["parent_id"] is not None:
+            parent_id = experiment_dict[experiment["refers"]["parent_id"]]["_id"]
         else:
             parent_id = None
-        update = {'refers.root_id': root_id, 'refers.parent_id': parent_id}
-        db.write('experiments', update, query)
+        update = {"refers.root_id": root_id, "refers.parent_id": parent_id}
+        db.write("experiments", update, query)
 
 
 ###
@@ -210,16 +214,18 @@ def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_inst
 @pytest.fixture
 def new_config():
     """Generate a new experiment configuration"""
-    user_script = 'abs_path/black_box.py'
+    user_script = "abs_path/black_box.py"
     config = dict(
-        name='test',
-        algorithms='fancy',
+        name="test",
+        algorithms="fancy",
         version=1,
-        metadata={'VCS': 'to be changed',
-                  'user_script': user_script,
-                  'user_args': [
-                      user_script, '--new~normal(0,2)', '--changed~normal(0,2)'],
-                  'user': 'some_user_name'})
+        metadata={
+            "VCS": "to be changed",
+            "user_script": user_script,
+            "user_args": [user_script, "--new~normal(0,2)", "--changed~normal(0,2)"],
+            "user": "some_user_name",
+        },
+    )
 
     backward.populate_space(config)
 
@@ -229,33 +235,40 @@ def new_config():
 @pytest.fixture
 def old_config(create_db_instance):
     """Generate an old experiment configuration"""
-    user_script = 'abs_path/black_box.py'
+    user_script = "abs_path/black_box.py"
     config = dict(
-        name='test',
-        algorithms='random',
+        name="test",
+        algorithms="random",
         version=1,
-        metadata={'VCS': {"type": "git",
-                          "is_dirty": False,
-                          "HEAD_sha": "test",
-                          "active_branch": None,
-                          "diff_sha": "diff",
-                          },
-                  'user_script': user_script,
-                  'user_args': [
-                      user_script, '--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
-                  'user': 'some_user_name'})
+        metadata={
+            "VCS": {
+                "type": "git",
+                "is_dirty": False,
+                "HEAD_sha": "test",
+                "active_branch": None,
+                "diff_sha": "diff",
+            },
+            "user_script": user_script,
+            "user_args": [
+                user_script,
+                "--missing~uniform(-10,10)",
+                "--changed~uniform(-10,10)",
+            ],
+            "user": "some_user_name",
+        },
+    )
 
     backward.populate_space(config)
 
-    create_db_instance.write('experiments', config)
+    create_db_instance.write("experiments", config)
     return config
 
 
 @pytest.fixture
 def new_dimension_conflict(old_config, new_config):
     """Generate a new dimension conflict for new experiment configuration"""
-    name = 'new'
-    prior = 'normal(0, 2)'
+    name = "new"
+    prior = "normal(0, 2)"
     dimension = DimensionBuilder().build(name, prior)
     return conflicts.NewDimensionConflict(old_config, new_config, dimension, prior)
 
@@ -263,8 +276,8 @@ def new_dimension_conflict(old_config, new_config):
 @pytest.fixture
 def new_dimension_with_default_conflict(old_config, new_config):
     """Generate a new dimension conflict with default value for new experiment configuration"""
-    name = 'new'
-    prior = 'normal(0, 2, default_value=0.001)'
+    name = "new"
+    prior = "normal(0, 2, default_value=0.001)"
     dimension = DimensionBuilder().build(name, prior)
     return conflicts.NewDimensionConflict(old_config, new_config, dimension, prior)
 
@@ -272,8 +285,8 @@ def new_dimension_with_default_conflict(old_config, new_config):
 @pytest.fixture
 def new_dimension_same_prior_conflict(old_config, new_config):
     """Generate a new dimension conflict with different prior for renaming tests"""
-    name = 'new'
-    prior = 'uniform(-10, 10)'
+    name = "new"
+    prior = "uniform(-10, 10)"
     dimension = DimensionBuilder().build(name, prior)
     return conflicts.NewDimensionConflict(old_config, new_config, dimension, prior)
 
@@ -281,19 +294,20 @@ def new_dimension_same_prior_conflict(old_config, new_config):
 @pytest.fixture
 def changed_dimension_conflict(old_config, new_config):
     """Generate a changed dimension conflict"""
-    name = 'changed'
-    old_prior = 'uniform(-10, 10)'
-    new_prior = 'normal(0, 2)'
+    name = "changed"
+    old_prior = "uniform(-10, 10)"
+    new_prior = "normal(0, 2)"
     dimension = DimensionBuilder().build(name, old_prior)
-    return conflicts.ChangedDimensionConflict(old_config, new_config,
-                                              dimension, old_prior, new_prior)
+    return conflicts.ChangedDimensionConflict(
+        old_config, new_config, dimension, old_prior, new_prior
+    )
 
 
 @pytest.fixture
 def missing_dimension_conflict(old_config, new_config):
     """Generate a missing dimension conflict"""
-    name = 'missing'
-    prior = 'uniform(-10, 10)'
+    name = "missing"
+    prior = "uniform(-10, 10)"
     dimension = DimensionBuilder().build(name, prior)
     return conflicts.MissingDimensionConflict(old_config, new_config, dimension, prior)
 
@@ -301,8 +315,8 @@ def missing_dimension_conflict(old_config, new_config):
 @pytest.fixture
 def missing_dimension_with_default_conflict(old_config, new_config):
     """Generate a missing dimension conflict with a default value"""
-    name = 'missing'
-    prior = 'uniform(-10, 10, default_value=0.0)'
+    name = "missing"
+    prior = "uniform(-10, 10, default_value=0.0)"
     dimension = DimensionBuilder().build(name, prior)
     return conflicts.MissingDimensionConflict(old_config, new_config, dimension, prior)
 
@@ -323,8 +337,8 @@ def code_conflict(old_config, new_config):
 def cli_conflict(old_config, new_config):
     """Generate a commandline conflict"""
     new_config = copy.deepcopy(new_config)
-    new_config['metadata']['user_args'].append("--some-new=args")
-    new_config['metadata']['user_args'].append("--bool-arg")
+    new_config["metadata"]["user_args"].append("--some-new=args")
+    new_config["metadata"]["user_args"].append("--bool-arg")
     backward.populate_space(new_config)
     return conflicts.CommandLineConflict(old_config, new_config)
 
@@ -345,11 +359,12 @@ def experiment_name_conflict(old_config, new_config):
 def bad_exp_parent_config():
     """Generate a new experiment configuration"""
     config = dict(
-        _id='test',
-        name='test',
-        metadata={'user': 'corneauf', 'user_args': ['--x~normal(0,1)']},
+        _id="test",
+        name="test",
+        metadata={"user": "corneauf", "user_args": ["--x~normal(0,1)"]},
         version=1,
-        algorithms='random')
+        algorithms="random",
+    )
 
     backward.populate_space(config)
 
@@ -360,8 +375,8 @@ def bad_exp_parent_config():
 def bad_exp_child_config(bad_exp_parent_config):
     """Generate a new experiment configuration"""
     config = copy.deepcopy(bad_exp_parent_config)
-    config['_id'] = "test2"
-    config['refers'] = {'parent_id': 'test'}
-    config['version'] = 2
+    config["_id"] = "test2"
+    config["refers"] = {"parent_id": "test"}
+    config["version"] = 2
 
     return config

--- a/tests/unittests/core/evc/conftest.py
+++ b/tests/unittests/core/evc/conftest.py
@@ -10,20 +10,16 @@ from orion.core.evc import conflicts
 @pytest.fixture
 def parent_config():
     """Generate a new experiment configuration"""
-    return dict(
-        _id='test',
-        name='test',
-        metadata={'user': 'corneauf'},
-        version=1)
+    return dict(_id="test", name="test", metadata={"user": "corneauf"}, version=1)
 
 
 @pytest.fixture
 def child_config(parent_config):
     """Generate a new experiment configuration"""
     config = copy.deepcopy(parent_config)
-    config['_id'] = "test2"
-    config['refers'] = {'parent_id': 'test'}
-    config['version'] = 2
+    config["_id"] = "test2"
+    config["refers"] = {"parent_id": "test"}
+    config["version"] = 2
 
     return config
 
@@ -31,29 +27,29 @@ def child_config(parent_config):
 @pytest.fixture
 def exp_no_child_conflict(create_db_instance, parent_config):
     """Generate an experiment name conflict"""
-    create_db_instance.write('experiments', parent_config)
+    create_db_instance.write("experiments", parent_config)
     return conflicts.ExperimentNameConflict(parent_config, parent_config)
 
 
 @pytest.fixture
 def exp_w_child_conflict(create_db_instance, parent_config, child_config):
     """Generate an experiment name conflict"""
-    create_db_instance.write('experiments', parent_config)
-    create_db_instance.write('experiments', child_config)
+    create_db_instance.write("experiments", parent_config)
+    create_db_instance.write("experiments", child_config)
     return conflicts.ExperimentNameConflict(child_config, child_config)
 
 
 @pytest.fixture
 def exp_w_child_as_parent_conflict(create_db_instance, parent_config, child_config):
     """Generate an experiment name conflict"""
-    create_db_instance.write('experiments', parent_config)
-    create_db_instance.write('experiments', child_config)
+    create_db_instance.write("experiments", parent_config)
+    create_db_instance.write("experiments", child_config)
     return conflicts.ExperimentNameConflict(parent_config, parent_config)
 
 
 @pytest.fixture
 def existing_exp_conflict(create_db_instance, parent_config):
     """Generate an experiment name conflict"""
-    create_db_instance.write('experiments', parent_config)
-    create_db_instance.write('experiments', {'name': 'dummy', 'version': 1})
+    create_db_instance.write("experiments", parent_config)
+    create_db_instance.write("experiments", {"name": "dummy", "version": 1})
     return conflicts.ExperimentNameConflict(parent_config, parent_config)

--- a/tests/unittests/core/evc/test_adapters.py
+++ b/tests/unittests/core/evc/test_adapters.py
@@ -6,8 +6,15 @@ import pytest
 
 from orion.algo.space import Real
 from orion.core.evc.adapters import (
-    Adapter, AlgorithmChange, CodeChange, CompositeAdapter, DimensionAddition, DimensionDeletion,
-    DimensionPriorChange, DimensionRenaming)
+    Adapter,
+    AlgorithmChange,
+    CodeChange,
+    CompositeAdapter,
+    DimensionAddition,
+    DimensionDeletion,
+    DimensionPriorChange,
+    DimensionRenaming,
+)
 from orion.core.io.space_builder import DimensionBuilder
 from orion.core.worker.trial import Trial
 
@@ -15,7 +22,7 @@ from orion.core.worker.trial import Trial
 @pytest.fixture
 def dummy_param():
     """Give dummy param integer param with value 1"""
-    return Trial.Param(name='dummy', type='integer', value=1)
+    return Trial.Param(name="dummy", type="integer", value=1)
 
 
 @pytest.fixture
@@ -61,13 +68,23 @@ def multidim_prior():
 
 
 @pytest.fixture
-def trials(small_prior, large_prior, normal_prior, disjoint_prior,
-           integer_prior, categorical_prior, multidim_prior):
+def trials(
+    small_prior,
+    large_prior,
+    normal_prior,
+    disjoint_prior,
+    integer_prior,
+    categorical_prior,
+    multidim_prior,
+):
     """Trials with dimensions for all priors defined as fixtures"""
     N_TRIALS = 10
 
-    priors = dict((name, prior) for (name, prior) in locals().items()
-                  if isinstance(name, str) and name.endswith("_prior"))
+    priors = dict(
+        (name, prior)
+        for (name, prior) in locals().items()
+        if isinstance(name, str) and name.endswith("_prior")
+    )
 
     trials = []
     for _ in range(N_TRIALS):
@@ -75,7 +92,9 @@ def trials(small_prior, large_prior, normal_prior, disjoint_prior,
         for name, prior in priors.items():
             dimension = DimensionBuilder().build(name, prior)
             value = dimension.sample()[0]
-            params.append(Trial.Param(name=name, type=dimension.type, value=value).to_dict())
+            params.append(
+                Trial.Param(name=name, type=dimension.type, value=value).to_dict()
+            )
         trials.append(Trial(params=params))
 
     return trials
@@ -97,7 +116,7 @@ class TestDimensionAdditionInit(object):
         with object which is not a param or a dictionary definition of it
         """
         with pytest.raises(TypeError) as exc_info:
-            DimensionAddition('bad')
+            DimensionAddition("bad")
 
         assert "Invalid param argument type ('<class 'str'>')." in str(exc_info.value)
 
@@ -112,7 +131,7 @@ class TestDimensionAdditionInit(object):
         with a dictionary which is a bad definition of a param
         """
         with pytest.raises(AttributeError) as exc_info:
-            DimensionAddition({'bad': 'dict'})
+            DimensionAddition({"bad": "dict"})
 
         assert "'Param' object has no attribute 'bad'" in str(exc_info.value)
 
@@ -133,7 +152,7 @@ class TestDimensionDeletionInit(object):
         with object which is not a param or a dictionary definition of it
         """
         with pytest.raises(TypeError) as exc_info:
-            DimensionDeletion('bad')
+            DimensionDeletion("bad")
 
         assert "Invalid param argument type ('<class 'str'>')." in str(exc_info.value)
 
@@ -148,7 +167,7 @@ class TestDimensionDeletionInit(object):
         with a dictionary which is a bad definition of a param
         """
         with pytest.raises(AttributeError) as exc_info:
-            print(DimensionDeletion({'bad': 'dict'}).param)
+            print(DimensionDeletion({"bad": "dict"}).param)
 
         assert "'Param' object has no attribute 'bad'" in str(exc_info.value)
 
@@ -156,11 +175,13 @@ class TestDimensionDeletionInit(object):
 class TestDimensionPriorChangeInit(object):
     """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`"""
 
-    def test_dimension_prior_change_init_with_dimensions(self, large_prior, small_prior):
+    def test_dimension_prior_change_init_with_dimensions(
+        self, large_prior, small_prior
+    ):
         """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`
         with valid string definitions of dimension prior
         """
-        dimension_prior_change = DimensionPriorChange('dummy', large_prior, small_prior)
+        dimension_prior_change = DimensionPriorChange("dummy", large_prior, small_prior)
 
         assert dimension_prior_change.old_prior == large_prior
         assert dimension_prior_change.new_prior == small_prior
@@ -175,9 +196,11 @@ class TestDimensionPriorChangeInit(object):
         with non valid string definitions of dimension prior
         """
         with pytest.raises(TypeError) as exc_info:
-            DimensionPriorChange('dummy', 'bad', 'priors')
+            DimensionPriorChange("dummy", "bad", "priors")
 
-        assert "Parameter 'old': Please provide a valid form for prior" in str(exc_info.value)
+        assert "Parameter 'old': Please provide a valid form for prior" in str(
+            exc_info.value
+        )
 
 
 class TestDimensionRenamingInit(object):
@@ -187,16 +210,16 @@ class TestDimensionRenamingInit(object):
         """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`
         with valid names
         """
-        dimension_renaming = DimensionRenaming('old_name', 'new_name')
-        assert dimension_renaming.old_name == 'old_name'
-        assert dimension_renaming.new_name == 'new_name'
+        dimension_renaming = DimensionRenaming("old_name", "new_name")
+        assert dimension_renaming.old_name == "old_name"
+        assert dimension_renaming.new_name == "new_name"
 
     def test_dimension_renaming_init_bad_name(self):
         """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`
         with invalid names which are not strings
         """
         with pytest.raises(TypeError) as exc_info:
-            DimensionRenaming({'bad': 'name'}, None)
+            DimensionRenaming({"bad": "name"}, None)
 
         assert "" in str(exc_info.value)
 
@@ -227,7 +250,7 @@ class TestCodeChangeInit(object):
         with invalid change types
         """
         with pytest.raises(ValueError) as exc_info:
-            CodeChange('bad type')
+            CodeChange("bad type")
 
         assert "Invalid code change type 'bad type'" in str(exc_info.value)
 
@@ -258,17 +281,18 @@ class TestCompositeAdapterInit(object):
         with invalid adapters
         """
         with pytest.raises(TypeError) as exc_info:
-            CompositeAdapter('bad', 'adapters')
+            CompositeAdapter("bad", "adapters")
 
-        assert ("Provided adapters must be adapter objects, not '<class 'str'>" in
-                str(exc_info.value))
+        assert "Provided adapters must be adapter objects, not '<class 'str'>" in str(
+            exc_info.value
+        )
 
 
 def test_adapter_creation(dummy_param):
     """Test initialization using :meth:`orion.core.evc.adapters.Adapter.build`"""
-    adapter = Adapter.build([{
-        'of_type': 'DimensionAddition',
-        'param': dummy_param.to_dict()}])
+    adapter = Adapter.build(
+        [{"of_type": "DimensionAddition", "param": dummy_param.to_dict()}]
+    )
 
     assert isinstance(adapter, CompositeAdapter)
     assert len(adapter.adapters) == 1
@@ -285,7 +309,7 @@ class TestDimensionAdditionForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
         with valid param and trials
         """
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
         dimension_addition_adapter = DimensionAddition(new_param)
 
         adapted_trials = dimension_addition_adapter.forward(trials)
@@ -298,24 +322,26 @@ class TestDimensionAdditionForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
         with valid param and incompatible trials because param already exists
         """
-        new_param = Trial.Param(name='normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="normal_prior", type="integer", value=1)
         dimension_addition_adapter = DimensionAddition(new_param)
 
         with pytest.raises(RuntimeError) as exc_info:
             dimension_addition_adapter.forward(trials)
-        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+        assert "Provided trial does not have a compatible configuration" in str(
+            exc_info.value
+        )
 
     def test_dimension_addition_backward(self, dummy_param, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
         with valid param and valid trials
         """
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
         dimension_addition_adapter = DimensionAddition(new_param)
 
-        sampler = DimensionBuilder().build('random', 'uniform(10, 100, discrete=True)')
+        sampler = DimensionBuilder().build("random", "uniform(10, 100, discrete=True)")
         for trial in trials:
             random_param = new_param.to_dict()
-            random_param['value'] = sampler.sample()
+            random_param["value"] = sampler.sample()
             trial._params.append(Trial.Param(**random_param))
 
         adapted_trials = dimension_addition_adapter.backward(trials)
@@ -347,12 +373,14 @@ class TestDimensionAdditionForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
         with valid param and invalid trials because param does not exist
         """
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
         dimension_addition_adapter = DimensionAddition(new_param)
 
         with pytest.raises(RuntimeError) as exc_info:
             dimension_addition_adapter.backward(trials)
-        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+        assert "Provided trial does not have a compatible configuration" in str(
+            exc_info.value
+        )
 
 
 class TestDimensionDeletionForwardBackward(object):
@@ -364,13 +392,13 @@ class TestDimensionDeletionForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
         with valid param and valid trials
         """
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
         dimension_deletion_adapter = DimensionDeletion(new_param)
 
-        sampler = DimensionBuilder().build('random', 'uniform(10, 100, discrete=True)')
+        sampler = DimensionBuilder().build("random", "uniform(10, 100, discrete=True)")
         for trial in trials:
             random_param = new_param.to_dict()
-            random_param['value'] = sampler.sample()
+            random_param["value"] = sampler.sample()
             trial._params.append(Trial.Param(**random_param))
 
         adapted_trials = dimension_deletion_adapter.forward(trials)
@@ -402,18 +430,20 @@ class TestDimensionDeletionForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
         with valid param and invalid trials because param does not exist
         """
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
         dimension_deletion_adapter = DimensionDeletion(new_param)
 
         with pytest.raises(RuntimeError) as exc_info:
             dimension_deletion_adapter.forward(trials)
-        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+        assert "Provided trial does not have a compatible configuration" in str(
+            exc_info.value
+        )
 
     def test_dimension_deletion_backward(self, dummy_param, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
         with valid param and valid trials
         """
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
         dimension_deletion_adapter = DimensionDeletion(new_param)
 
         adapted_trials = dimension_deletion_adapter.backward(trials)
@@ -426,12 +456,14 @@ class TestDimensionDeletionForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
         with valid param and invalid trials because param already exist
         """
-        new_param = Trial.Param(name='normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="normal_prior", type="integer", value=1)
         dimension_deletion_adapter = DimensionDeletion(new_param)
 
         with pytest.raises(RuntimeError) as exc_info:
             dimension_deletion_adapter.backward(trials)
-        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+        assert "Provided trial does not have a compatible configuration" in str(
+            exc_info.value
+        )
 
 
 class TestDimensionPriorChangeForwardBackward(object):
@@ -444,19 +476,22 @@ class TestDimensionPriorChangeForwardBackward(object):
         with compatible priors
         """
         dimension_prior_change_adapter = DimensionPriorChange(
-            'small_prior', small_prior, large_prior)
+            "small_prior", small_prior, large_prior
+        )
 
         adapted_trials = dimension_prior_change_adapter.forward(trials)
 
         assert len(adapted_trials) == len(trials)
 
     def test_dimension_prior_change_forward_incompatible_dimensions(
-            self, small_prior, disjoint_prior, trials):
+        self, small_prior, disjoint_prior, trials
+    ):
         """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward`
         with incompatible priors, such that all trials are filtered out
         """
         dimension_prior_change_adapter = DimensionPriorChange(
-            'small_prior', small_prior, disjoint_prior)
+            "small_prior", small_prior, disjoint_prior
+        )
 
         adapted_trials = dimension_prior_change_adapter.forward(trials)
 
@@ -467,19 +502,22 @@ class TestDimensionPriorChangeForwardBackward(object):
         with compatible priors
         """
         dimension_prior_change_adapter = DimensionPriorChange(
-            'large_prior', large_prior, small_prior)
+            "large_prior", large_prior, small_prior
+        )
 
         adapted_trials = dimension_prior_change_adapter.backward(trials)
 
         assert len(adapted_trials) == len(trials)
 
     def test_dimension_prior_change_backward_incompatible_dimensions(
-            self, disjoint_prior, small_prior, trials):
+        self, disjoint_prior, small_prior, trials
+    ):
         """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
         with incompatible priors, such that all trials are filtered out
         """
         dimension_prior_change_adapter = DimensionPriorChange(
-            'small_prior', disjoint_prior, small_prior)
+            "small_prior", disjoint_prior, small_prior
+        )
 
         adapted_trials = dimension_prior_change_adapter.backward(trials)
 
@@ -495,8 +533,8 @@ class TestDimensionRenamingForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
         with valid names
         """
-        old_name = 'small_prior'
-        new_name = 'new_name'
+        old_name = "small_prior"
+        new_name = "new_name"
 
         dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
 
@@ -514,21 +552,23 @@ class TestDimensionRenamingForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
         with non existing old name in trials
         """
-        old_name = 'bad name'
-        new_name = 'small_prior'
+        old_name = "bad name"
+        new_name = "small_prior"
 
         dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
 
         with pytest.raises(RuntimeError) as exc_info:
             dimension_renaming_adapter.forward(trials)
-        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+        assert "Provided trial does not have a compatible configuration" in str(
+            exc_info.value
+        )
 
     def test_dimension_renaming_backward(self, trials):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
         with valid names
         """
-        old_name = 'old_name'
-        new_name = 'small_prior'
+        old_name = "old_name"
+        new_name = "small_prior"
 
         dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
 
@@ -546,14 +586,16 @@ class TestDimensionRenamingForwardBackward(object):
         """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
         with non existing new name in trials
         """
-        old_name = 'small_prior'
-        new_name = 'bad name'
+        old_name = "small_prior"
+        new_name = "bad name"
 
         dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
 
         with pytest.raises(RuntimeError) as exc_info:
             dimension_renaming_adapter.backward(trials)
-        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+        assert "Provided trial does not have a compatible configuration" in str(
+            exc_info.value
+        )
 
 
 class TestAlgorithmChangeForwardBackward(object):
@@ -663,7 +705,7 @@ class TestCompositeAdapterForwardBackward(object):
 
     def test_composite_adapter_forward(self, dummy_param, trials):
         """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` with two adapters"""
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
 
         dimension_addition_adapter = DimensionAddition(new_param)
         dimension_deletion_adapter = DimensionDeletion(new_param)
@@ -676,7 +718,9 @@ class TestCompositeAdapterForwardBackward(object):
         assert adapted_trials[4]._params[-1] == new_param
         assert adapted_trials[-1]._params[-1] == new_param
 
-        composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+        composite_adapter = CompositeAdapter(
+            dimension_addition_adapter, dimension_deletion_adapter
+        )
 
         adapted_trials = composite_adapter.forward(trials)
 
@@ -688,7 +732,7 @@ class TestCompositeAdapterForwardBackward(object):
 
     def test_composite_adapter_backward(self, dummy_param, trials):
         """Test :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with two adapters"""
-        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
 
         dimension_addition_adapter = DimensionAddition(new_param)
         dimension_deletion_adapter = DimensionDeletion(new_param)
@@ -701,7 +745,9 @@ class TestCompositeAdapterForwardBackward(object):
         assert adapted_trials[4]._params[-1] == new_param
         assert adapted_trials[-1]._params[-1] == new_param
 
-        composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+        composite_adapter = CompositeAdapter(
+            dimension_addition_adapter, dimension_deletion_adapter
+        )
 
         adapted_trials = composite_adapter.backward(trials)
 
@@ -718,8 +764,8 @@ def test_dimension_addition_configuration(dummy_param):
 
     configuration = dimension_addition_adapter.configuration[0]
 
-    assert configuration['of_type'] == "dimensionaddition"
-    assert configuration['param'] == dummy_param.to_dict()
+    assert configuration["of_type"] == "dimensionaddition"
+    assert configuration["param"] == dummy_param.to_dict()
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 
@@ -730,38 +776,40 @@ def test_dimension_deletion_configuration(dummy_param):
 
     configuration = dimension_deletion_adapter.configuration[0]
 
-    assert configuration['of_type'] == "dimensiondeletion"
-    assert configuration['param'] == dummy_param.to_dict()
+    assert configuration["of_type"] == "dimensiondeletion"
+    assert configuration["param"] == dummy_param.to_dict()
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 
 
 def test_dimension_prior_change_configuration(small_prior, large_prior):
     """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.configuration`"""
-    dimension_name = 'small_prior'
-    dimension_prior_change_adapter = DimensionPriorChange(dimension_name, small_prior, large_prior)
+    dimension_name = "small_prior"
+    dimension_prior_change_adapter = DimensionPriorChange(
+        dimension_name, small_prior, large_prior
+    )
 
     configuration = dimension_prior_change_adapter.configuration[0]
 
-    assert configuration['of_type'] == "dimensionpriorchange"
-    assert configuration['name'] == dimension_name
-    assert configuration['old_prior'] == small_prior
-    assert configuration['new_prior'] == large_prior
+    assert configuration["of_type"] == "dimensionpriorchange"
+    assert configuration["name"] == dimension_name
+    assert configuration["old_prior"] == small_prior
+    assert configuration["new_prior"] == large_prior
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 
 
 def test_dimension_renaming_configuration():
     """Test :meth:`orion.core.evc.adapters.DimensionRenaming.configuration`"""
-    old_name = 'old_name'
-    new_name = 'new_name'
+    old_name = "old_name"
+    new_name = "new_name"
     dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
 
     configuration = dimension_renaming_adapter.configuration[0]
 
-    assert configuration['of_type'] == "dimensionrenaming"
-    assert configuration['old_name'] == old_name
-    assert configuration['new_name'] == new_name
+    assert configuration["of_type"] == "dimensionrenaming"
+    assert configuration["old_name"] == old_name
+    assert configuration["new_name"] == new_name
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 
@@ -772,7 +820,7 @@ def test_algorithm_change_configuration():
 
     configuration = algorithm_change_adaptor.configuration[0]
 
-    assert configuration['of_type'] == "algorithmchange"
+    assert configuration["of_type"] == "algorithmchange"
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 
@@ -783,19 +831,21 @@ def test_code_change_configuration():
 
     configuration = code_change_adaptor.configuration[0]
 
-    assert configuration['of_type'] == "codechange"
-    assert configuration['change_type'] == CodeChange.UNSURE
+    assert configuration["of_type"] == "codechange"
+    assert configuration["change_type"] == CodeChange.UNSURE
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 
 
 def test_composite_configuration(dummy_param):
     """Test :meth:`orion.core.evc.adapters.CompositeAdapter.configuration`"""
-    new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+    new_param = Trial.Param(name="second_normal_prior", type="integer", value=1)
     dimension_addition_adapter = DimensionAddition(dummy_param)
     dimension_deletion_adapter = DimensionDeletion(new_param)
 
-    composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+    composite_adapter = CompositeAdapter(
+        dimension_addition_adapter, dimension_deletion_adapter
+    )
 
     configuration = composite_adapter.configuration
 

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -13,8 +13,14 @@ import orion.core.utils.backward as backward
 
 
 @pytest.fixture
-def conflicts(new_dimension_conflict, changed_dimension_conflict, missing_dimension_conflict,
-              algorithm_conflict, code_conflict, experiment_name_conflict):
+def conflicts(
+    new_dimension_conflict,
+    changed_dimension_conflict,
+    missing_dimension_conflict,
+    algorithm_conflict,
+    code_conflict,
+    experiment_name_conflict,
+):
     """Create a container for conflicts with one of each types for testing purposes"""
     conflicts = evc.conflicts.Conflicts()
     conflicts.register(new_dimension_conflict)
@@ -42,9 +48,13 @@ class TestNewDimensionConflict(object):
         assert not new_dimension_with_default_conflict.is_resolved
         resolution = new_dimension_with_default_conflict.try_resolve()
         assert new_dimension_with_default_conflict.is_resolved
-        assert isinstance(resolution, new_dimension_with_default_conflict.AddDimensionResolution)
-        assert (resolution.default_value ==
-                new_dimension_with_default_conflict.dimension.default_value)
+        assert isinstance(
+            resolution, new_dimension_with_default_conflict.AddDimensionResolution
+        )
+        assert (
+            resolution.default_value
+            == new_dimension_with_default_conflict.dimension.default_value
+        )
 
     def test_try_resolve_default(self, new_dimension_conflict):
         """Verify that resolution includes default value if provided"""
@@ -53,7 +63,7 @@ class TestNewDimensionConflict(object):
         resolution = new_dimension_conflict.try_resolve(default_value)
         assert new_dimension_conflict.is_resolved
         assert isinstance(resolution, new_dimension_conflict.AddDimensionResolution)
-        assert (resolution.default_value == default_value)
+        assert resolution.default_value == default_value
 
     def test_try_resolve_default_over_dim(self, new_dimension_with_default_conflict):
         """Verify that resolution overwrites dimension's default value if one is provided"""
@@ -61,21 +71,25 @@ class TestNewDimensionConflict(object):
         assert not new_dimension_with_default_conflict.is_resolved
         resolution = new_dimension_with_default_conflict.try_resolve(default_value)
         assert new_dimension_with_default_conflict.is_resolved
-        assert isinstance(resolution, new_dimension_with_default_conflict.AddDimensionResolution)
-        assert (resolution.default_value == default_value)
+        assert isinstance(
+            resolution, new_dimension_with_default_conflict.AddDimensionResolution
+        )
+        assert resolution.default_value == default_value
 
     def test_try_resolve_bad_default(self, new_dimension_conflict):
         """Verify that resolution fails if default value is invalid"""
         assert not new_dimension_conflict.is_resolved
         with pytest.raises(ValueError) as exc:
-            new_dimension_conflict.try_resolve('bad-default')
+            new_dimension_conflict.try_resolve("bad-default")
         assert "could not convert string to float: 'bad-default'" in str(exc.value)
 
     def test_try_resolve_twice(self, new_dimension_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not new_dimension_conflict.is_resolved
-        assert isinstance(new_dimension_conflict.try_resolve(),
-                          new_dimension_conflict.AddDimensionResolution)
+        assert isinstance(
+            new_dimension_conflict.try_resolve(),
+            new_dimension_conflict.AddDimensionResolution,
+        )
         assert new_dimension_conflict.is_resolved
         assert new_dimension_conflict.try_resolve() is None
 
@@ -90,8 +104,10 @@ class TestChangedDimensionConflict(object):
     def test_try_resolve_twice(self, changed_dimension_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not changed_dimension_conflict.is_resolved
-        assert isinstance(changed_dimension_conflict.try_resolve(),
-                          changed_dimension_conflict.ChangeDimensionResolution)
+        assert isinstance(
+            changed_dimension_conflict.try_resolve(),
+            changed_dimension_conflict.ChangeDimensionResolution,
+        )
         assert changed_dimension_conflict.is_resolved
         assert changed_dimension_conflict.try_resolve() is None
 
@@ -99,14 +115,18 @@ class TestChangedDimensionConflict(object):
         """Verify that resolution is achievable without any input"""
         assert not changed_dimension_conflict.is_resolved
         resolution = changed_dimension_conflict.try_resolve()
-        assert isinstance(resolution, changed_dimension_conflict.ChangeDimensionResolution)
+        assert isinstance(
+            resolution, changed_dimension_conflict.ChangeDimensionResolution
+        )
         assert changed_dimension_conflict.is_resolved
         assert resolution.conflict is changed_dimension_conflict
 
     def test_repr(self, changed_dimension_conflict):
         """Verify the representation of conflict for user interface"""
-        assert (repr(changed_dimension_conflict) ==
-                "changed~uniform(-10, 10) != changed~normal(0, 2)")
+        assert (
+            repr(changed_dimension_conflict)
+            == "changed~uniform(-10, 10) != changed~normal(0, 2)"
+        )
 
 
 class TestMissingDimensionConflict(object):
@@ -117,18 +137,26 @@ class TestMissingDimensionConflict(object):
         assert not missing_dimension_conflict.is_resolved
         resolution = missing_dimension_conflict.try_resolve()
         assert missing_dimension_conflict.is_resolved
-        assert isinstance(resolution, missing_dimension_conflict.RemoveDimensionResolution)
+        assert isinstance(
+            resolution, missing_dimension_conflict.RemoveDimensionResolution
+        )
         assert resolution.default_value is Dimension.NO_DEFAULT_VALUE
 
-    def test_try_resolve_default_from_dim(self, missing_dimension_with_default_conflict):
+    def test_try_resolve_default_from_dim(
+        self, missing_dimension_with_default_conflict
+    ):
         """Verify that resolution uses default value from dim when no provided by user"""
         assert not missing_dimension_with_default_conflict.is_resolved
         resolution = missing_dimension_with_default_conflict.try_resolve()
         assert missing_dimension_with_default_conflict.is_resolved
-        assert isinstance(resolution,
-                          missing_dimension_with_default_conflict.RemoveDimensionResolution)
-        assert (resolution.default_value ==
-                missing_dimension_with_default_conflict.dimension.default_value)
+        assert isinstance(
+            resolution,
+            missing_dimension_with_default_conflict.RemoveDimensionResolution,
+        )
+        assert (
+            resolution.default_value
+            == missing_dimension_with_default_conflict.dimension.default_value
+        )
 
     def test_try_resolve_default(self, missing_dimension_conflict):
         """Verify that resolution uses default value provided by user"""
@@ -136,40 +164,53 @@ class TestMissingDimensionConflict(object):
         assert not missing_dimension_conflict.is_resolved
         resolution = missing_dimension_conflict.try_resolve(default_value=default_value)
         assert missing_dimension_conflict.is_resolved
-        assert isinstance(resolution, missing_dimension_conflict.RemoveDimensionResolution)
-        assert (resolution.default_value == default_value)
+        assert isinstance(
+            resolution, missing_dimension_conflict.RemoveDimensionResolution
+        )
+        assert resolution.default_value == default_value
 
-    def test_try_resolve_default_over_dim(self, missing_dimension_with_default_conflict):
+    def test_try_resolve_default_over_dim(
+        self, missing_dimension_with_default_conflict
+    ):
         """Verify that resolution overwrite dimension's default value when user provide one"""
         default_value = 1.2
         assert not missing_dimension_with_default_conflict.is_resolved
         resolution = missing_dimension_with_default_conflict.try_resolve(
-            default_value=default_value)
+            default_value=default_value
+        )
         assert missing_dimension_with_default_conflict.is_resolved
-        assert isinstance(resolution,
-                          missing_dimension_with_default_conflict.RemoveDimensionResolution)
-        assert (resolution.default_value == default_value)
+        assert isinstance(
+            resolution,
+            missing_dimension_with_default_conflict.RemoveDimensionResolution,
+        )
+        assert resolution.default_value == default_value
 
     def test_try_resolve_bad_default(self, missing_dimension_conflict):
         """Verify that resolution fails if default value is invalid"""
         assert not missing_dimension_conflict.is_resolved
         with pytest.raises(ValueError) as exc:
-            missing_dimension_conflict.try_resolve(default_value='-100')
+            missing_dimension_conflict.try_resolve(default_value="-100")
         assert "Default value `-100.0` is outside" in str(exc.value)
 
-    def test_try_resolve_renaming(self, missing_dimension_conflict, new_dimension_conflict):
+    def test_try_resolve_renaming(
+        self, missing_dimension_conflict, new_dimension_conflict
+    ):
         """Verify that resolution is a renaming when new_dimension_conflict is provided"""
         assert not missing_dimension_conflict.is_resolved
         resolution = missing_dimension_conflict.try_resolve(new_dimension_conflict)
-        assert isinstance(resolution, missing_dimension_conflict.RenameDimensionResolution)
+        assert isinstance(
+            resolution, missing_dimension_conflict.RenameDimensionResolution
+        )
         assert resolution.conflict is missing_dimension_conflict
         assert resolution.new_dimension_conflict is new_dimension_conflict
 
     def test_try_resolve_twice(self, missing_dimension_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not missing_dimension_conflict.is_resolved
-        assert isinstance(missing_dimension_conflict.try_resolve(),
-                          missing_dimension_conflict.RemoveDimensionResolution)
+        assert isinstance(
+            missing_dimension_conflict.try_resolve(),
+            missing_dimension_conflict.RemoveDimensionResolution,
+        )
         assert missing_dimension_conflict.is_resolved
         assert missing_dimension_conflict.try_resolve() is None
 
@@ -184,8 +225,9 @@ class TestAlgorithmConflict(object):
     def test_try_resolve_twice(self, algorithm_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not algorithm_conflict.is_resolved
-        assert isinstance(algorithm_conflict.try_resolve(),
-                          algorithm_conflict.AlgorithmResolution)
+        assert isinstance(
+            algorithm_conflict.try_resolve(), algorithm_conflict.AlgorithmResolution
+        )
         assert algorithm_conflict.is_resolved
         assert algorithm_conflict.try_resolve() is None
 
@@ -199,8 +241,10 @@ class TestAlgorithmConflict(object):
 
     def test_repr(self, old_config, new_config, algorithm_conflict):
         """Verify the representation of conflict for user interface"""
-        repr_baseline = "{0}\n   !=\n{1}".format(pprint.pformat(old_config['algorithms']),
-                                                 pprint.pformat(new_config['algorithms']))
+        repr_baseline = "{0}\n   !=\n{1}".format(
+            pprint.pformat(old_config["algorithms"]),
+            pprint.pformat(new_config["algorithms"]),
+        )
         assert repr(algorithm_conflict) == repr_baseline
 
 
@@ -210,8 +254,10 @@ class TestCodeConflict(object):
     def test_try_resolve_twice(self, code_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not code_conflict.is_resolved
-        assert isinstance(code_conflict.try_resolve(evc.adapters.CodeChange.BREAK),
-                          code_conflict.CodeResolution)
+        assert isinstance(
+            code_conflict.try_resolve(evc.adapters.CodeChange.BREAK),
+            code_conflict.CodeResolution,
+        )
         assert code_conflict.is_resolved
         assert code_conflict.try_resolve() is None
 
@@ -238,15 +284,17 @@ class TestCodeConflict(object):
     @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_repr(self, code_conflict):
         """Verify the representation of conflict for user interface"""
-        assert repr(code_conflict) == "Old hash commit '{'HEAD_sha': 'test', "\
-                                      "'active_branch': None, 'diff_sha': 'diff', "\
-                                      "'is_dirty': False, 'type': 'git'}'  "\
-                                      "!= new hash commit ''to be changed''"
+        assert (
+            repr(code_conflict) == "Old hash commit '{'HEAD_sha': 'test', "
+            "'active_branch': None, 'diff_sha': 'diff', "
+            "'is_dirty': False, 'type': 'git'}'  "
+            "!= new hash commit ''to be changed''"
+        )
 
     def test_hash_commit_compar(self):
         """Test that old config hash commit evals to empty."""
-        old_config = {'metadata': {'VCS': {}}}
-        new_config = {'metadata': {'VCS': {}}}
+        old_config = {"metadata": {"VCS": {}}}
+        new_config = {"metadata": {"VCS": {}}}
 
         assert list(conflict.CodeConflict.detect(old_config, new_config)) == []
 
@@ -257,8 +305,10 @@ class TestCommandLineConflict(object):
     def test_try_resolve_twice(self, cli_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not cli_conflict.is_resolved
-        assert isinstance(cli_conflict.try_resolve(evc.adapters.CommandLineChange.BREAK),
-                          cli_conflict.CommandLineResolution)
+        assert isinstance(
+            cli_conflict.try_resolve(evc.adapters.CommandLineChange.BREAK),
+            cli_conflict.CommandLineResolution,
+        )
         assert cli_conflict.is_resolved
         assert cli_conflict.try_resolve() is None
 
@@ -284,10 +334,10 @@ class TestCommandLineConflict(object):
 
     def test_repr(self, cli_conflict):
         """Verify the representation of conflict for user interface"""
-        assert (
-            repr(cli_conflict) == (
-                "Old arguments '_pos_0 abs_path/black_box.py' != "
-                "new arguments '_pos_0 abs_path/black_box.py bool-arg True some-new args'"))
+        assert repr(cli_conflict) == (
+            "Old arguments '_pos_0 abs_path/black_box.py' != "
+            "new arguments '_pos_0 abs_path/black_box.py bool-arg True some-new args'"
+        )
 
 
 class TestScriptConfigConflict(object):
@@ -296,8 +346,10 @@ class TestScriptConfigConflict(object):
     def test_try_resolve_twice(self, config_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not config_conflict.is_resolved
-        assert isinstance(config_conflict.try_resolve(evc.adapters.ScriptConfigChange.BREAK),
-                          config_conflict.ScriptConfigResolution)
+        assert isinstance(
+            config_conflict.try_resolve(evc.adapters.ScriptConfigChange.BREAK),
+            config_conflict.ScriptConfigResolution,
+        )
         assert config_conflict.is_resolved
         assert config_conflict.try_resolve() is None
 
@@ -327,8 +379,8 @@ class TestScriptConfigConflict(object):
 
     def test_comparison(self, yaml_config, yaml_diff_config):
         """Test that different configs are detected as conflict."""
-        old_config = {'metadata': {'user_args': yaml_config}}
-        new_config = {'metadata': {'user_args': yaml_diff_config}}
+        old_config = {"metadata": {"user_args": yaml_config}}
+        new_config = {"metadata": {"user_args": yaml_diff_config}}
 
         backward.populate_space(old_config)
         backward.populate_space(new_config)
@@ -338,8 +390,8 @@ class TestScriptConfigConflict(object):
 
     def test_comparison_idem(self, yaml_config):
         """Test that identical configs are not detected as conflict."""
-        old_config = {'metadata': {'user_args': yaml_config}}
-        new_config = {'metadata': {'user_args': yaml_config + ['--other', 'args']}}
+        old_config = {"metadata": {"user_args": yaml_config}}
+        new_config = {"metadata": {"user_args": yaml_config + ["--other", "args"]}}
 
         backward.populate_space(old_config)
         backward.populate_space(new_config)
@@ -354,8 +406,10 @@ class TestExperimentNameConflict(object):
     def test_try_resolve_twice(self, experiment_name_conflict):
         """Verify that conflict cannot be resolved twice"""
         assert not experiment_name_conflict.is_resolved
-        assert isinstance(experiment_name_conflict.try_resolve("dummy"),
-                          experiment_name_conflict.ExperimentNameResolution)
+        assert isinstance(
+            experiment_name_conflict.try_resolve("dummy"),
+            experiment_name_conflict.ExperimentNameResolution,
+        )
         assert experiment_name_conflict.is_resolved
         assert experiment_name_conflict.try_resolve() is None
 
@@ -419,8 +473,10 @@ class TestExperimentNameConflict(object):
 
     def test_repr(self, experiment_name_conflict):
         """Verify the representation of conflict for user interface"""
-        assert (repr(experiment_name_conflict) ==
-                "Experiment name 'test' already exist with version '1'")
+        assert (
+            repr(experiment_name_conflict)
+            == "Experiment name 'test' already exist with version '1'"
+        )
 
 
 class TestConflicts(object):
@@ -446,8 +502,11 @@ class TestConflicts(object):
 
     def test_get_many_types(self, conflicts):
         """Verify that get() fetches many types properly"""
-        types = (evc.conflicts.NewDimensionConflict, evc.conflicts.AlgorithmConflict,
-                 evc.conflicts.ExperimentNameConflict)
+        types = (
+            evc.conflicts.NewDimensionConflict,
+            evc.conflicts.AlgorithmConflict,
+            evc.conflicts.ExperimentNameConflict,
+        )
         found_conflicts = conflicts.get(types)
         assert len(found_conflicts) == 3
         assert isinstance(found_conflicts[0], types)
@@ -456,19 +515,20 @@ class TestConflicts(object):
 
     def test_get_dimension_name(self, conflicts):
         """Verify that get() fetch the conflict associated to given dimension_name"""
-        found_conflicts = conflicts.get(dimension_name='missing')
+        found_conflicts = conflicts.get(dimension_name="missing")
         assert len(found_conflicts) == 1
         assert isinstance(found_conflicts[0], evc.conflicts.MissingDimensionConflict)
-        assert found_conflicts[0].dimension.name == 'missing'
+        assert found_conflicts[0].dimension.name == "missing"
 
     def test_get_invalid_dimension_name(self, conflicts):
         """Verify that get() raises when dimension_name is invalid"""
         with pytest.raises(ValueError) as exc:
-            conflicts.get(dimension_name='invalid')
+            conflicts.get(dimension_name="invalid")
         assert "Dimension name 'invalid' not found in conflicts" in str(exc.value)
 
     def test_get_callback(self, conflicts):
         """Verify that get() callback are effectively used"""
+
         def always_true(conflict):
             return True
 
@@ -498,19 +558,23 @@ class TestConflicts(object):
         conflicts.get_remaining()[0].try_resolve()
         assert len(conflicts.get_resolved()) == 2
 
-    def test_get_resolutions(self, conflicts, new_dimension_conflict, missing_dimension_conflict):
+    def test_get_resolutions(
+        self, conflicts, new_dimension_conflict, missing_dimension_conflict
+    ):
         """Verify that get_resolution() only fetch unique resolutions"""
         assert len(list(conflicts.get_resolutions())) == 0
-        conflicts.try_resolve(missing_dimension_conflict,
-                              new_dimension_conflict=new_dimension_conflict)
+        conflicts.try_resolve(
+            missing_dimension_conflict, new_dimension_conflict=new_dimension_conflict
+        )
         assert len(list(conflicts.get_resolutions())) == 1
         assert len(list(conflicts.get_resolved())) == 2
         conflicts.get_remaining()[0].try_resolve()
         assert len(list(conflicts.get_resolutions())) == 2
         assert len(conflicts.get_resolved()) == 3
 
-    def test_are_resolved(self, new_dimension_conflict, missing_dimension_conflict,
-                          algorithm_conflict):
+    def test_are_resolved(
+        self, new_dimension_conflict, missing_dimension_conflict, algorithm_conflict
+    ):
         """Verify if resolution status is correct"""
         conflicts = evc.conflicts.Conflicts()
         conflicts.register(new_dimension_conflict)
@@ -549,36 +613,44 @@ class TestConflicts(object):
         """Verify try_resolve errors are silenced"""
         conflicts.try_resolve(code_conflict)
         out, err = capsys.readouterr()
-        assert (out.split("\n")[-3] ==
-                "ValueError: Invalid code change type 'None'. Should be one of "
-                "['noeffect', 'break', 'unsure']")
+        assert (
+            out.split("\n")[-3]
+            == "ValueError: Invalid code change type 'None'. Should be one of "
+            "['noeffect', 'break', 'unsure']"
+        )
 
         conflicts.try_resolve(code_conflict, silence_errors=True)
         out, err = capsys.readouterr()
-        assert out == ''
+        assert out == ""
 
     def test_try_resolve_keyboard_interrupt(self, capsys, code_conflict, conflicts):
         """Verify try_resolve catch all errors but not keyboard interrupt"""
+
         def raise_base_exception(*args, **kwargs):
             raise Exception("Raised properly")
+
         code_conflict.try_resolve = raise_base_exception
         conflicts.try_resolve(code_conflict)
         out, err = capsys.readouterr()
-        assert (out.split("\n")[-3] == "Exception: Raised properly")
+        assert out.split("\n")[-3] == "Exception: Raised properly"
 
         def raise_keyboard_interrupt(*args, **kwargs):
             raise KeyboardInterrupt()
+
         code_conflict.try_resolve = raise_keyboard_interrupt
         with pytest.raises(KeyboardInterrupt):
             conflicts.try_resolve(code_conflict)
 
     def test_try_resolve_side_effect_conflicts(
-            self, new_dimension_conflict,
-            missing_dimension_conflict, conflicts):
+        self, new_dimension_conflict, missing_dimension_conflict, conflicts
+    ):
         """Verify try_resolve register new conflicts created by resolutions"""
         assert len(conflicts.conflicts) == 6
-        conflicts.try_resolve(missing_dimension_conflict,
-                              new_dimension_conflict=new_dimension_conflict)
+        conflicts.try_resolve(
+            missing_dimension_conflict, new_dimension_conflict=new_dimension_conflict
+        )
         assert len(conflicts.conflicts) == 7
-        assert isinstance(conflicts.conflicts[-1], evc.conflicts.ChangedDimensionConflict)
+        assert isinstance(
+            conflicts.conflicts[-1], evc.conflicts.ChangedDimensionConflict
+        )
         assert not conflicts.conflicts[-1].is_resolved

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -18,12 +18,14 @@ build_trimmed_tree = "dummy"
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_parent_fetch_trials(create_db_instance):
     """Test that experiment fetch trials from parent properly (adapters are muted)"""
-    experiment_name = 'supernaedo2.3'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.3']
+    experiment_name = "supernaedo2.3"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.3"]
 
     experiment = ExperimentView(experiment_name)
-    exp_node = ExperimentNode(experiment.name, experiment.version, experiment=experiment)
+    exp_node = ExperimentNode(
+        experiment.name, experiment.version, experiment=experiment
+    )
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
 
     assert exp_node.item.name == experiment_name
@@ -37,9 +39,9 @@ def test_parent_fetch_trials(create_db_instance):
     experiment.connect_to_version_control_tree(exp_node)
 
     for node in exp_node.root:
-        node.item._experiment.refers['adapter'] = Adapter.build([])
+        node.item._experiment.refers["adapter"] = Adapter.build([])
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(experiment.fetch_trials(query)) == 4
     assert len(experiment._experiment._node.parent.item.fetch_trials(query)) == 6
     assert len(experiment.fetch_trials_tree(query)) == 10
@@ -50,9 +52,9 @@ def test_parent_fetch_trials(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_children_fetch_trials(create_db_instance):
     """Test that experiment fetch trials from children properly (adapters are muted)"""
-    experiment_name = 'supernaedo2'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.3']
+    experiment_name = "supernaedo2"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.3"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -68,9 +70,9 @@ def test_children_fetch_trials(create_db_instance):
     experiment.connect_to_version_control_tree(exp_node)
 
     for node in exp_node.root:
-        node.item._experiment.refers['adapter'] = Adapter.build([])
+        node.item._experiment.refers["adapter"] = Adapter.build([])
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(experiment.fetch_trials(query)) == 6
     assert len(experiment._experiment._node.children[0].item.fetch_trials(query)) == 4
     assert len(experiment.fetch_trials_tree(query)) == 10
@@ -81,9 +83,9 @@ def test_children_fetch_trials(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_parent_parent_fetch_trials(create_db_instance):
     """Test that experiment fetch trials from grand parent properly (adapters are muted)"""
-    experiment_name = 'supernaedo2.3.1'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.3.1']
+    experiment_name = "supernaedo2.3.1"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.3.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -101,9 +103,9 @@ def test_parent_parent_fetch_trials(create_db_instance):
     experiment.connect_to_version_control_tree(exp_node)
 
     for node in exp_node.root:
-        node.item._experiment.refers['adapter'] = Adapter.build([])
+        node.item._experiment.refers["adapter"] = Adapter.build([])
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.parent.parent.item.fetch_trials(query)) == 6
     assert len(exp_node.parent.item.fetch_trials(query)) == 4
     assert len(exp_node.item.fetch_trials(query)) == 2
@@ -116,9 +118,9 @@ def test_parent_parent_fetch_trials(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_children_children_fetch_trials(create_db_instance):
     """Test that experiment fetch trials from grand children properly (adapters are muted)"""
-    experiment_name = 'supernaedo2'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.3.1']
+    experiment_name = "supernaedo2"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.3.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -135,9 +137,9 @@ def test_children_children_fetch_trials(create_db_instance):
     experiment.connect_to_version_control_tree(exp_node)
 
     for node in exp_node.root:
-        node.item._experiment.refers['adapter'] = Adapter.build([])
+        node.item._experiment.refers["adapter"] = Adapter.build([])
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.item.fetch_trials(query)) == 6
     assert len(exp_node.children[0].item.fetch_trials(query)) == 4
     assert len(exp_node.children[0].children[0].item.fetch_trials(query)) == 2
@@ -150,9 +152,9 @@ def test_children_children_fetch_trials(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_deletion_adapter_forward(create_db_instance):
     """Test that all decoding_layer=gru pass to children"""
-    experiment_name = 'supernaedo2.1'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.1']
+    experiment_name = "supernaedo2.1"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -167,11 +169,11 @@ def test_deletion_adapter_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.item.fetch_trials(query)) == 1
     assert len(exp_node.parent.item.fetch_trials(query)) == 6
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     assert len(adapter.forward(exp_node.parent.item.fetch_trials(query))) == 1
     assert len(experiment.fetch_trials_tree(query)) == 1 + 1
 
@@ -181,9 +183,9 @@ def test_deletion_adapter_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_deletion_adapter_backward(create_db_instance):
     """Test that all decoding_layer are passed with gru to parent"""
-    experiment_name = 'supernaedo2'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.1']
+    experiment_name = "supernaedo2"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -197,11 +199,11 @@ def test_deletion_adapter_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.item.fetch_trials(query)) == 6
     assert len(exp_node.children[0].item.fetch_trials(query)) == 1
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     assert len(adapter.backward(exp_node.children[0].item.fetch_trials(query))) == 1
     assert len(experiment.fetch_trials_tree(query)) == 6 + 1
 
@@ -211,9 +213,9 @@ def test_deletion_adapter_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_renaming_forward(create_db_instance):
     """Test that all encoding_layer are renamed to encoding in children"""
-    experiment_name = 'supernaedo2.3'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.3']
+    experiment_name = "supernaedo2.3"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.3"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -227,17 +229,19 @@ def test_renaming_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     parent_trials = exp_node.parent.item.fetch_trials(query)
     assert len(parent_trials) == 6
     assert len(exp_node.item.fetch_trials(query)) == 4
 
     assert all((trial._params[0].name == "/encoding_layer") for trial in parent_trials)
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 6
-    assert all((trial._params[0].name == "/encoding") for trial in adapted_parent_trials)
+    assert all(
+        (trial._params[0].name == "/encoding") for trial in adapted_parent_trials
+    )
 
     assert len(experiment.fetch_trials_tree(query)) == 6 + 4
 
@@ -247,9 +251,9 @@ def test_renaming_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_renaming_backward(create_db_instance):
     """Test that all encoding are renamed to encoding_layer in parent"""
-    experiment_name = 'supernaedo2'
-    root_name = 'supernaedo2'
-    leaf_names = ['supernaedo2.3']
+    experiment_name = "supernaedo2"
+    root_name = "supernaedo2"
+    leaf_names = ["supernaedo2.3"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -263,17 +267,20 @@ def test_renaming_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     children_trials = exp_node.children[0].item.fetch_trials(query)
     assert len(children_trials) == 4
     assert len(exp_node.item.fetch_trials(query)) == 6
 
     assert all((trial._params[0].name == "/encoding") for trial in children_trials)
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 4
-    assert all((trial._params[0].name == "/encoding_layer") for trial in adapted_children_trials)
+    assert all(
+        (trial._params[0].name == "/encoding_layer")
+        for trial in adapted_children_trials
+    )
 
     assert len(experiment.fetch_trials_tree(query)) == 6 + 4
 
@@ -283,9 +290,9 @@ def test_renaming_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_prior_change_forward(create_db_instance):
     """Test that trials from parent only pass to children if valid in the new prior"""
-    experiment_name = 'supernaedo2.3.1'
-    root_name = 'supernaedo2.3'
-    leaf_names = ['supernaedo2.3.1']
+    experiment_name = "supernaedo2.3.1"
+    root_name = "supernaedo2.3"
+    leaf_names = ["supernaedo2.3.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -299,12 +306,12 @@ def test_prior_change_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     parent_trials = exp_node.parent.item.fetch_trials(query)
     assert len(parent_trials) == 4
     assert len(exp_node.item.fetch_trials(query)) == 2
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 1
     assert len(experiment.fetch_trials_tree(query)) == 2 + 1
@@ -315,9 +322,9 @@ def test_prior_change_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_prior_change_backward(create_db_instance):
     """Test that all encoding are renamed to encoding_layer in parent"""
-    experiment_name = 'supernaedo2.3'
-    root_name = 'supernaedo2.3'
-    leaf_names = ['supernaedo2.3.1']
+    experiment_name = "supernaedo2.3"
+    root_name = "supernaedo2.3"
+    leaf_names = ["supernaedo2.3.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -331,12 +338,12 @@ def test_prior_change_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     children_trials = exp_node.children[0].item.fetch_trials(query)
     assert len(children_trials) == 2
     assert len(exp_node.item.fetch_trials(query)) == 4
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 1
 
@@ -348,9 +355,9 @@ def test_prior_change_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_code_change_noeffect_forward(create_db_instance):
     """Test that all trials pass to children when code change type is 'noeffect'"""
-    experiment_name = 'supernaedo2.3.1.1'
-    root_name = 'supernaedo2.3.1'
-    leaf_names = ['supernaedo2.3.1.1']
+    experiment_name = "supernaedo2.3.1.1"
+    root_name = "supernaedo2.3.1"
+    leaf_names = ["supernaedo2.3.1.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -364,12 +371,12 @@ def test_code_change_noeffect_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     parent_trials = exp_node.parent.item.fetch_trials(query)
     assert len(parent_trials) == 2
     assert len(exp_node.item.fetch_trials(query)) == 1
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     assert adapter.adapters[0].change_type == CodeChange.NOEFFECT
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 2
@@ -381,9 +388,9 @@ def test_code_change_noeffect_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_code_change_noeffect_backward(create_db_instance):
     """Test that all trials pass to parent when code change type is 'noeffect'"""
-    experiment_name = 'supernaedo2.3.1'
-    root_name = 'supernaedo2.3.1'
-    leaf_names = ['supernaedo2.3.1.1']
+    experiment_name = "supernaedo2.3.1"
+    root_name = "supernaedo2.3.1"
+    leaf_names = ["supernaedo2.3.1.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -397,12 +404,12 @@ def test_code_change_noeffect_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     children_trials = exp_node.children[0].item.fetch_trials(query)
     assert len(children_trials) == 1
     assert len(exp_node.item.fetch_trials(query)) == 2
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     assert adapter.adapters[0].change_type == CodeChange.NOEFFECT
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 1
@@ -415,9 +422,9 @@ def test_code_change_noeffect_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_code_change_unsure_forward(create_db_instance):
     """Test that all trials pass to children when code change type is 'unsure'"""
-    experiment_name = 'supernaedo2.3.1.2'
-    root_name = 'supernaedo2.3.1'
-    leaf_names = ['supernaedo2.3.1.2']
+    experiment_name = "supernaedo2.3.1.2"
+    root_name = "supernaedo2.3.1"
+    leaf_names = ["supernaedo2.3.1.2"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -431,12 +438,12 @@ def test_code_change_unsure_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     parent_trials = exp_node.parent.item.fetch_trials(query)
     assert len(parent_trials) == 2
     assert len(exp_node.item.fetch_trials(query)) == 1
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     assert adapter.adapters[0].change_type == CodeChange.UNSURE
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 2
@@ -448,9 +455,9 @@ def test_code_change_unsure_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_code_change_unsure_backward(create_db_instance):
     """Test that no trials pass to parent when code change type is 'unsure'"""
-    experiment_name = 'supernaedo2.3.1'
-    root_name = 'supernaedo2.3.1'
-    leaf_names = ['supernaedo2.3.1.2']
+    experiment_name = "supernaedo2.3.1"
+    root_name = "supernaedo2.3.1"
+    leaf_names = ["supernaedo2.3.1.2"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -464,12 +471,12 @@ def test_code_change_unsure_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     children_trials = exp_node.children[0].item.fetch_trials(query)
     assert len(children_trials) == 1
     assert len(exp_node.item.fetch_trials(query)) == 2
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     assert adapter.adapters[0].change_type == CodeChange.UNSURE
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 0
@@ -482,9 +489,9 @@ def test_code_change_unsure_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_code_change_break_forward(create_db_instance):
     """Test that no trials pass to children when code change type is 'break'"""
-    experiment_name = 'supernaedo2.3.1.3'
-    root_name = 'supernaedo2.3.1'
-    leaf_names = ['supernaedo2.3.1.3']
+    experiment_name = "supernaedo2.3.1.3"
+    root_name = "supernaedo2.3.1"
+    leaf_names = ["supernaedo2.3.1.3"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -498,12 +505,12 @@ def test_code_change_break_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     parent_trials = exp_node.parent.item.fetch_trials(query)
     assert len(parent_trials) == 2
     assert len(exp_node.item.fetch_trials(query)) == 1
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     assert adapter.adapters[0].change_type == CodeChange.BREAK
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 0
@@ -515,9 +522,9 @@ def test_code_change_break_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_code_change_break_backward(create_db_instance):
     """Test that no trials pass to parent when code change type is 'break'"""
-    experiment_name = 'supernaedo2.3.1'
-    root_name = 'supernaedo2.3.1'
-    leaf_names = ['supernaedo2.3.1.3']
+    experiment_name = "supernaedo2.3.1"
+    root_name = "supernaedo2.3.1"
+    leaf_names = ["supernaedo2.3.1.3"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -531,12 +538,12 @@ def test_code_change_break_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     children_trials = exp_node.children[0].item.fetch_trials(query)
     assert len(children_trials) == 1
     assert len(exp_node.item.fetch_trials(query)) == 2
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     assert adapter.adapters[0].change_type == CodeChange.BREAK
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 0
@@ -549,9 +556,9 @@ def test_code_change_break_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_algo_change_forward(create_db_instance):
     """Test that all trials pass to children when algorithm is changed"""
-    experiment_name = 'supernaedo2.2.1'
-    root_name = 'supernaedo2.2'
-    leaf_names = ['supernaedo2.2.1']
+    experiment_name = "supernaedo2.2.1"
+    root_name = "supernaedo2.2"
+    leaf_names = ["supernaedo2.2.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -565,12 +572,12 @@ def test_algo_change_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     parent_trials = exp_node.parent.item.fetch_trials(query)
     assert len(parent_trials) == 1
     assert len(exp_node.item.fetch_trials(query)) == 1
 
-    adapter = experiment.refers['adapter']
+    adapter = experiment.refers["adapter"]
     adapted_parent_trials = adapter.forward(parent_trials)
     assert len(adapted_parent_trials) == 1
     assert len(experiment.fetch_trials_tree(query)) == 1 + 1
@@ -581,9 +588,9 @@ def test_algo_change_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_algo_change_backward(create_db_instance):
     """Test that all trials pass to parent when algorithm is changed"""
-    experiment_name = 'supernaedo2.2'
-    root_name = 'supernaedo2.2'
-    leaf_names = ['supernaedo2.2.1']
+    experiment_name = "supernaedo2.2"
+    root_name = "supernaedo2.2"
+    leaf_names = ["supernaedo2.2.1"]
 
     experiment = ExperimentView(experiment_name)
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
@@ -597,12 +604,12 @@ def test_algo_change_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     children_trials = exp_node.children[0].item.fetch_trials(query)
     assert len(children_trials) == 1
     assert len(exp_node.item.fetch_trials(query)) == 1
 
-    adapter = exp_node.children[0].item.refers['adapter']
+    adapter = exp_node.children[0].item.refers["adapter"]
     adapted_children_trials = adapter.backward(children_trials)
     assert len(adapted_children_trials) == 1
 
@@ -614,7 +621,7 @@ def test_algo_change_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_full_backward(create_db_instance):
     """Test that trials are adapted properly up to root"""
-    experiment_name = 'supernaedo2'
+    experiment_name = "supernaedo2"
     root_name = None
     leaf_names = []
 
@@ -622,14 +629,14 @@ def test_full_backward(create_db_instance):
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
 
     assert exp_node.item.name == experiment_name
-    assert exp_node.children[0].item.name == 'supernaedo2.1'
-    assert exp_node.children[1].item.name == 'supernaedo2.2'
-    assert exp_node.children[2].item.name == 'supernaedo2.3'
-    assert exp_node.children[1].children[0].item.name == 'supernaedo2.2.1'
-    assert exp_node.children[2].children[0].item.name == 'supernaedo2.3.1'
-    assert exp_node.children[2].children[0].children[0].item.name == 'supernaedo2.3.1.1'
-    assert exp_node.children[2].children[0].children[1].item.name == 'supernaedo2.3.1.2'
-    assert exp_node.children[2].children[0].children[2].item.name == 'supernaedo2.3.1.3'
+    assert exp_node.children[0].item.name == "supernaedo2.1"
+    assert exp_node.children[1].item.name == "supernaedo2.2"
+    assert exp_node.children[2].item.name == "supernaedo2.3"
+    assert exp_node.children[1].children[0].item.name == "supernaedo2.2.1"
+    assert exp_node.children[2].children[0].item.name == "supernaedo2.3.1"
+    assert exp_node.children[2].children[0].children[0].item.name == "supernaedo2.3.1.1"
+    assert exp_node.children[2].children[0].children[1].item.name == "supernaedo2.3.1.2"
+    assert exp_node.children[2].children[0].children[2].item.name == "supernaedo2.3.1.3"
     # 2
     # |    \      \
     # 2.1  2.2    2.3
@@ -641,16 +648,22 @@ def test_full_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.item.fetch_trials(query)) == 6
     assert len(exp_node.children[0].item.fetch_trials(query)) == 1
     assert len(exp_node.children[1].item.fetch_trials(query)) == 1
     assert len(exp_node.children[2].item.fetch_trials(query)) == 4
     assert len(exp_node.children[1].children[0].item.fetch_trials(query)) == 1
     assert len(exp_node.children[2].children[0].item.fetch_trials(query)) == 2
-    assert len(exp_node.children[2].children[0].children[0].item.fetch_trials(query)) == 1
-    assert len(exp_node.children[2].children[0].children[1].item.fetch_trials(query)) == 1
-    assert len(exp_node.children[2].children[0].children[2].item.fetch_trials(query)) == 1
+    assert (
+        len(exp_node.children[2].children[0].children[0].item.fetch_trials(query)) == 1
+    )
+    assert (
+        len(exp_node.children[2].children[0].children[1].item.fetch_trials(query)) == 1
+    )
+    assert (
+        len(exp_node.children[2].children[0].children[2].item.fetch_trials(query)) == 1
+    )
 
     assert len(experiment.fetch_trials_tree(query)) == 15
 
@@ -660,7 +673,7 @@ def test_full_backward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_full_forward(create_db_instance):
     """Test that trials are adapted properly down to leaf"""
-    experiment_name = 'supernaedo2.3.1.1'
+    experiment_name = "supernaedo2.3.1.1"
     root_name = None
     leaf_names = []
 
@@ -668,9 +681,9 @@ def test_full_forward(create_db_instance):
     exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
 
     assert exp_node.item.name == experiment_name
-    assert exp_node.parent.item.name == 'supernaedo2.3.1'
-    assert exp_node.parent.parent.item.name == 'supernaedo2.3'
-    assert exp_node.parent.parent.parent.item.name == 'supernaedo2'
+    assert exp_node.parent.item.name == "supernaedo2.3.1"
+    assert exp_node.parent.parent.item.name == "supernaedo2.3"
+    assert exp_node.parent.parent.parent.item.name == "supernaedo2"
     # 2
     # |
     # 2.3
@@ -682,7 +695,7 @@ def test_full_forward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.item.fetch_trials(query)) == 1
     assert len(exp_node.parent.item.fetch_trials(query)) == 2
     assert len(exp_node.parent.parent.item.fetch_trials(query)) == 4
@@ -696,8 +709,8 @@ def test_full_forward(create_db_instance):
 @pytest.mark.usefixtures("refers_id_substitution")
 def test_full_forward_full_backward(create_db_instance):
     """Test that trials are adapted properly forward from parent and backward from leafs"""
-    experiment_name = 'supernaedo2.3'
-    root_name = 'supernaedo2'
+    experiment_name = "supernaedo2.3"
+    root_name = "supernaedo2"
     leaf_names = []
 
     experiment = ExperimentView(experiment_name)
@@ -705,10 +718,10 @@ def test_full_forward_full_backward(create_db_instance):
 
     assert exp_node.item.name == experiment_name
     assert exp_node.parent.name == root_name
-    assert exp_node.children[0].item.name == 'supernaedo2.3.1'
-    assert exp_node.children[0].children[0].item.name == 'supernaedo2.3.1.1'
-    assert exp_node.children[0].children[1].item.name == 'supernaedo2.3.1.2'
-    assert exp_node.children[0].children[2].item.name == 'supernaedo2.3.1.3'
+    assert exp_node.children[0].item.name == "supernaedo2.3.1"
+    assert exp_node.children[0].children[0].item.name == "supernaedo2.3.1.1"
+    assert exp_node.children[0].children[1].item.name == "supernaedo2.3.1.2"
+    assert exp_node.children[0].children[2].item.name == "supernaedo2.3.1.3"
     # 2
     # |
     # 2.3
@@ -720,7 +733,7 @@ def test_full_forward_full_backward(create_db_instance):
 
     experiment.connect_to_version_control_tree(exp_node)
 
-    query = {'status': 'completed'}
+    query = {"status": "completed"}
     assert len(exp_node.parent.item.fetch_trials(query)) == 6
     assert len(exp_node.item.fetch_trials(query)) == 4
     assert len(exp_node.children[0].item.fetch_trials(query)) == 2

--- a/tests/unittests/core/evc/test_resolutions.py
+++ b/tests/unittests/core/evc/test_resolutions.py
@@ -18,21 +18,25 @@ def add_dimension_resolution(new_dimension_conflict):
 @pytest.fixture
 def change_dimension_resolution(changed_dimension_conflict):
     """Create a resolution for a changed prior"""
-    return changed_dimension_conflict.ChangeDimensionResolution(changed_dimension_conflict)
+    return changed_dimension_conflict.ChangeDimensionResolution(
+        changed_dimension_conflict
+    )
 
 
 @pytest.fixture
 def remove_dimension_resolution(missing_dimension_conflict):
     """Create a resolution to remove a missing dimension"""
-    return missing_dimension_conflict.RemoveDimensionResolution(missing_dimension_conflict,
-                                                                default_value=0)
+    return missing_dimension_conflict.RemoveDimensionResolution(
+        missing_dimension_conflict, default_value=0
+    )
 
 
 @pytest.fixture
 def rename_dimension_resolution(missing_dimension_conflict, new_dimension_conflict):
     """Create a resolution to rename a missing dimension to a new dimension"""
-    return missing_dimension_conflict.RenameDimensionResolution(missing_dimension_conflict,
-                                                                new_dimension_conflict)
+    return missing_dimension_conflict.RenameDimensionResolution(
+        missing_dimension_conflict, new_dimension_conflict
+    )
 
 
 @pytest.fixture
@@ -50,8 +54,9 @@ def code_resolution(code_conflict):
 @pytest.fixture
 def experiment_name_resolution(create_db_instance, experiment_name_conflict):
     """Create a resolution for a code conflict"""
-    return experiment_name_conflict.ExperimentNameResolution(experiment_name_conflict,
-                                                             new_name="new-exp-name")
+    return experiment_name_conflict.ExperimentNameResolution(
+        experiment_name_conflict, new_name="new-exp-name"
+    )
 
 
 class TestAddDimensionResolution(object):
@@ -59,59 +64,80 @@ class TestAddDimensionResolution(object):
 
     def test_init_no_default(self, new_dimension_conflict):
         """Verify instantiation of resolution without default value"""
-        resolution = new_dimension_conflict.AddDimensionResolution(new_dimension_conflict)
+        resolution = new_dimension_conflict.AddDimensionResolution(
+            new_dimension_conflict
+        )
         assert resolution.default_value is Dimension.NO_DEFAULT_VALUE
 
     def test_init_no_default_but_in_dim(self, new_dimension_with_default_conflict):
         """Verify instantiation of resolution with default value in dimension"""
         resolution = new_dimension_with_default_conflict.AddDimensionResolution(
-            new_dimension_with_default_conflict)
-        assert (resolution.default_value ==
-                new_dimension_with_default_conflict.dimension.default_value)
+            new_dimension_with_default_conflict
+        )
+        assert (
+            resolution.default_value
+            == new_dimension_with_default_conflict.dimension.default_value
+        )
 
-    def test_init_with_default(self, new_dimension_conflict,
-                               new_dimension_with_default_conflict):
+    def test_init_with_default(
+        self, new_dimension_conflict, new_dimension_with_default_conflict
+    ):
         """Verify instantiation of resolution with default value given by user"""
         default_value = 1.1
         resolution = new_dimension_conflict.AddDimensionResolution(
-            new_dimension_conflict, default_value=default_value)
+            new_dimension_conflict, default_value=default_value
+        )
         assert resolution.default_value == default_value
 
-        assert new_dimension_with_default_conflict.dimension.default_value != default_value
+        assert (
+            new_dimension_with_default_conflict.dimension.default_value != default_value
+        )
         resolution = new_dimension_conflict.AddDimensionResolution(
-            new_dimension_with_default_conflict, default_value=default_value)
+            new_dimension_with_default_conflict, default_value=default_value
+        )
         assert resolution.default_value == default_value
 
     def test_init_bad_default(self, new_dimension_conflict):
         """Verify instantiation of resolution with invalid default value"""
-        default_value = 'bad'
+        default_value = "bad"
         with pytest.raises(ValueError) as exc:
-            new_dimension_conflict.AddDimensionResolution(new_dimension_conflict,
-                                                          default_value=default_value)
+            new_dimension_conflict.AddDimensionResolution(
+                new_dimension_conflict, default_value=default_value
+            )
         assert "could not convert string to float: 'bad'" in str(exc.value)
 
     def test_new_prior_no_default(self, new_dimension_conflict):
         """Verify prior string without default value"""
-        resolution = new_dimension_conflict.AddDimensionResolution(new_dimension_conflict)
-        assert resolution.new_prior == 'norm(0, 2)'
+        resolution = new_dimension_conflict.AddDimensionResolution(
+            new_dimension_conflict
+        )
+        assert resolution.new_prior == "norm(0, 2)"
 
     def test_new_prior_default_from_dim(self, new_dimension_with_default_conflict):
         """Verify prior string with default value in dimension"""
         resolution = new_dimension_with_default_conflict.AddDimensionResolution(
-            new_dimension_with_default_conflict)
-        assert resolution.new_prior == 'norm(0, 2, default_value=0.001)'
+            new_dimension_with_default_conflict
+        )
+        assert resolution.new_prior == "norm(0, 2, default_value=0.001)"
 
-    def test_new_prior_default(self, new_dimension_conflict,
-                               new_dimension_with_default_conflict):
+    def test_new_prior_default(
+        self, new_dimension_conflict, new_dimension_with_default_conflict
+    ):
         """Verify prior string with new default value given by user"""
         default_value = 1.2
         resolution = new_dimension_with_default_conflict.AddDimensionResolution(
-            new_dimension_with_default_conflict, default_value=default_value)
-        assert resolution.new_prior == 'norm(0, 2, default_value={})'.format(default_value)
+            new_dimension_with_default_conflict, default_value=default_value
+        )
+        assert resolution.new_prior == "norm(0, 2, default_value={})".format(
+            default_value
+        )
 
-        resolution = new_dimension_conflict.AddDimensionResolution(new_dimension_conflict,
-                                                                   default_value=default_value)
-        assert resolution.new_prior == 'norm(0, 2, default_value={})'.format(default_value)
+        resolution = new_dimension_conflict.AddDimensionResolution(
+            new_dimension_conflict, default_value=default_value
+        )
+        assert resolution.new_prior == "norm(0, 2, default_value={})".format(
+            default_value
+        )
 
     def test_prefix(self, add_dimension_resolution):
         """Verify prefix of resolution with corresponding marker"""
@@ -124,27 +150,35 @@ class TestAddDimensionResolution(object):
     def test_repr_default_from_dim(self, new_dimension_with_default_conflict):
         """Verify resolution representation for user interface, without default value"""
         resolution = new_dimension_with_default_conflict.AddDimensionResolution(
-            new_dimension_with_default_conflict)
+            new_dimension_with_default_conflict
+        )
         assert repr(resolution) == "new~+norm(0, 2, default_value=0.001)"
 
     def test_adapters_without_default(self, new_dimension_conflict):
         """Verify adapters without default values (filter everything out)"""
-        param = {'name': 'new', 'type': 'real', 'value': Dimension.NO_DEFAULT_VALUE}
-        resolution = new_dimension_conflict.AddDimensionResolution(new_dimension_conflict)
+        param = {"name": "new", "type": "real", "value": Dimension.NO_DEFAULT_VALUE}
+        resolution = new_dimension_conflict.AddDimensionResolution(
+            new_dimension_conflict
+        )
         resolution_adapters = resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert (resolution_adapters[0].configuration ==
-                adapters.DimensionAddition(param).configuration)
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionAddition(param).configuration
+        )
 
     def test_adapters_with_default(self, new_dimension_conflict):
         """Verify adapters with default values"""
-        param = {'name': 'new', 'type': 'real', 'value': 1.1}
-        resolution = new_dimension_conflict.AddDimensionResolution(new_dimension_conflict,
-                                                                   default_value=1.1)
+        param = {"name": "new", "type": "real", "value": 1.1}
+        resolution = new_dimension_conflict.AddDimensionResolution(
+            new_dimension_conflict, default_value=1.1
+        )
         resolution_adapters = resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert (resolution_adapters[0].configuration ==
-                adapters.DimensionAddition(param).configuration)
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionAddition(param).configuration
+        )
 
     def test_revert(self, new_dimension_conflict, add_dimension_resolution):
         """Verify reverting resolution set conflict to unresolved"""
@@ -159,11 +193,11 @@ class TestChangeDimensionResolution(object):
 
     def test_prefix(self, change_dimension_resolution):
         """Verify prefix of resolution with corresponding marker"""
-        assert change_dimension_resolution.prefix == 'changed~+'
+        assert change_dimension_resolution.prefix == "changed~+"
 
     def test_repr(self, change_dimension_resolution):
         """Verify resolution representation for user interface"""
-        assert repr(change_dimension_resolution) == 'changed~+normal(0, 2)'
+        assert repr(change_dimension_resolution) == "changed~+normal(0, 2)"
 
     def test_adapters(self, change_dimension_resolution):
         """Verify adapters with old and new priors"""
@@ -172,8 +206,10 @@ class TestChangeDimensionResolution(object):
         new_prior = "normal(0, 2)"
         resolution_adapters = change_dimension_resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert (resolution_adapters[0].configuration ==
-                adapters.DimensionPriorChange(name, old_prior, new_prior).configuration)
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionPriorChange(name, old_prior, new_prior).configuration
+        )
 
     def test_revert(self, changed_dimension_conflict, change_dimension_resolution):
         """Verify reverting resolution set conflict to unresolved"""
@@ -189,52 +225,64 @@ class TestRemoveDimensionResolution(object):
     def test_prefix(self, missing_dimension_conflict):
         """Verify prefix of resolution with corresponding marker"""
         resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict)
-        assert resolution.prefix == 'missing~-'
+            missing_dimension_conflict
+        )
+        assert resolution.prefix == "missing~-"
 
     def test_repr_no_default(self, missing_dimension_conflict):
         """Verify resolution representation for user interface, without default value"""
         resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict)
-        assert repr(resolution) == 'missing~-'
+            missing_dimension_conflict
+        )
+        assert repr(resolution) == "missing~-"
 
     def test_repr_default_from_dim(self, missing_dimension_with_default_conflict):
         """Verify resolution representation for user interface, with default value from dimension"""
         resolution = missing_dimension_with_default_conflict.RemoveDimensionResolution(
-            missing_dimension_with_default_conflict)
-        assert repr(resolution) == 'missing~-0.0'
+            missing_dimension_with_default_conflict
+        )
+        assert repr(resolution) == "missing~-0.0"
 
-    def test_repr_default(self, missing_dimension_conflict,
-                          missing_dimension_with_default_conflict):
+    def test_repr_default(
+        self, missing_dimension_conflict, missing_dimension_with_default_conflict
+    ):
         """Verify resolution representation for user interface, with default provided by user"""
         default_value = 1.2
         resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_with_default_conflict, default_value=default_value)
-        assert repr(resolution) == 'missing~-{}'.format(default_value)
+            missing_dimension_with_default_conflict, default_value=default_value
+        )
+        assert repr(resolution) == "missing~-{}".format(default_value)
 
         resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict, default_value=default_value)
-        assert repr(resolution) == 'missing~-{}'.format(default_value)
+            missing_dimension_conflict, default_value=default_value
+        )
+        assert repr(resolution) == "missing~-{}".format(default_value)
 
     def test_adapters_without_default(self, missing_dimension_conflict):
         """Verify adapters without default value"""
-        param = {'name': 'missing', 'type': 'real', 'value': Dimension.NO_DEFAULT_VALUE}
+        param = {"name": "missing", "type": "real", "value": Dimension.NO_DEFAULT_VALUE}
         resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict)
+            missing_dimension_conflict
+        )
         resolution_adapters = resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert (resolution_adapters[0].configuration ==
-                adapters.DimensionDeletion(param).configuration)
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionDeletion(param).configuration
+        )
 
     def test_adapters_with_default(self, missing_dimension_conflict):
         """Verify adapters with default value"""
-        param = {'name': 'missing', 'type': 'real', 'value': 1.2}
+        param = {"name": "missing", "type": "real", "value": 1.2}
         resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict, default_value=1.2)
+            missing_dimension_conflict, default_value=1.2
+        )
         resolution_adapters = resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert (resolution_adapters[0].configuration ==
-                adapters.DimensionDeletion(param).configuration)
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionDeletion(param).configuration
+        )
 
     def test_revert(self, missing_dimension_conflict, remove_dimension_resolution):
         """Verify reverting resolution set conflict to unresolved"""
@@ -247,36 +295,44 @@ class TestRemoveDimensionResolution(object):
 class TestRenameDimensionResolution(object):
     """Test methods for renaming of missing dimensions"""
 
-    def test_init_same_prior(self, missing_dimension_conflict, new_dimension_same_prior_conflict):
+    def test_init_same_prior(
+        self, missing_dimension_conflict, new_dimension_same_prior_conflict
+    ):
         """Verify initialisation with identical priors generates no side-effect conflicts"""
         assert not missing_dimension_conflict.is_resolved
         assert not new_dimension_same_prior_conflict.is_resolved
         resolution = missing_dimension_conflict.RenameDimensionResolution(
-            missing_dimension_conflict, new_dimension_same_prior_conflict)
+            missing_dimension_conflict, new_dimension_same_prior_conflict
+        )
         assert missing_dimension_conflict.is_resolved
         assert new_dimension_same_prior_conflict.is_resolved
         assert resolution.new_conflicts == []
 
-    def test_init_different_prior(self, missing_dimension_conflict, new_dimension_conflict):
+    def test_init_different_prior(
+        self, missing_dimension_conflict, new_dimension_conflict
+    ):
         """Verify initialisation with different priors generates a side-effect conflict"""
         assert not missing_dimension_conflict.is_resolved
         assert not new_dimension_conflict.is_resolved
         resolution = missing_dimension_conflict.RenameDimensionResolution(
-            missing_dimension_conflict, new_dimension_conflict)
+            missing_dimension_conflict, new_dimension_conflict
+        )
         assert missing_dimension_conflict.is_resolved
         assert new_dimension_conflict.is_resolved
         assert len(resolution.new_conflicts) == 1
-        assert isinstance(resolution.new_conflicts[0], conflicts.ChangedDimensionConflict)
+        assert isinstance(
+            resolution.new_conflicts[0], conflicts.ChangedDimensionConflict
+        )
         assert resolution.new_conflicts[0].old_prior == missing_dimension_conflict.prior
         assert resolution.new_conflicts[0].new_prior == new_dimension_conflict.prior
 
     def test_prefix(self, rename_dimension_resolution):
         """Verify prefix of resolution with corresponding marker"""
-        assert rename_dimension_resolution.prefix == 'missing~>'
+        assert rename_dimension_resolution.prefix == "missing~>"
 
     def test_repr(self, rename_dimension_resolution):
         """Verify resolution representation for user interface"""
-        assert repr(rename_dimension_resolution) == 'missing~>new'
+        assert repr(rename_dimension_resolution) == "missing~>new"
 
     def test_adapters(self, rename_dimension_resolution):
         """Verify adapters with old and new names"""
@@ -284,13 +340,18 @@ class TestRenameDimensionResolution(object):
         new_name = "new"
         resolution_adapters = rename_dimension_resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert (resolution_adapters[0].configuration ==
-                adapters.DimensionRenaming(old_name, new_name).configuration)
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionRenaming(old_name, new_name).configuration
+        )
 
-    def test_revert_same_prior(self, missing_dimension_conflict, new_dimension_same_prior_conflict):
+    def test_revert_same_prior(
+        self, missing_dimension_conflict, new_dimension_same_prior_conflict
+    ):
         """Verify reverting resolution set conflict to unresolved"""
         resolution = missing_dimension_conflict.RenameDimensionResolution(
-            missing_dimension_conflict, new_dimension_same_prior_conflict)
+            missing_dimension_conflict, new_dimension_same_prior_conflict
+        )
         assert missing_dimension_conflict.is_resolved
         assert new_dimension_same_prior_conflict.is_resolved
         assert len(resolution.new_conflicts) == 0
@@ -301,8 +362,12 @@ class TestRenameDimensionResolution(object):
         assert missing_dimension_conflict.resolution is None
         assert new_dimension_same_prior_conflict.resolution is None
 
-    def test_revert_different_prior(self, missing_dimension_conflict, new_dimension_conflict,
-                                    rename_dimension_resolution):
+    def test_revert_different_prior(
+        self,
+        missing_dimension_conflict,
+        new_dimension_conflict,
+        rename_dimension_resolution,
+    ):
         """Verify reverting resolution set conflict to unresolved and deprecate the side-effect
         conflict
         """
@@ -326,11 +391,14 @@ class TestAlgorithmResolution(object):
         """Verify shallow adapters for algorithm change"""
         resolution_adapters = algorithm_resolution.get_adapters()
         assert len(resolution_adapters) == 1
-        assert resolution_adapters[0].configuration == adapters.AlgorithmChange().configuration
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.AlgorithmChange().configuration
+        )
 
     def test_repr(self, algorithm_resolution):
         """Verify resolution representation for user interface"""
-        assert repr(algorithm_resolution) == '--algorithm-change'
+        assert repr(algorithm_resolution) == "--algorithm-change"
 
     def test_revert(self, algorithm_conflict, algorithm_resolution):
         """Verify reverting resolution set conflict to unresolved"""
@@ -355,12 +423,14 @@ class TestCodeResolution(object):
             code_resolution = code_conflict.CodeResolution(code_conflict, change_type)
             resolution_adapters = code_resolution.get_adapters()
             assert len(resolution_adapters) == 1
-            assert (resolution_adapters[0].configuration ==
-                    adapters.CodeChange(change_type).configuration)
+            assert (
+                resolution_adapters[0].configuration
+                == adapters.CodeChange(change_type).configuration
+            )
 
     def test_repr(self, code_resolution):
         """Verify resolution representation for user interface"""
-        assert repr(code_resolution) == '--code-change-type break'
+        assert repr(code_resolution) == "--code-change-type break"
 
     def test_revert(self, code_conflict, code_resolution):
         """Verify reverting resolution set conflict to unresolved"""
@@ -379,18 +449,23 @@ class TestExperimentNameResolution(object):
 
     def test_repr(self, experiment_name_resolution):
         """Verify resolution representation for user interface"""
-        assert repr(experiment_name_resolution) == '--branch-to new-exp-name'
+        assert repr(experiment_name_resolution) == "--branch-to new-exp-name"
 
-    def test_revert(self, old_config, new_config,
-                    experiment_name_conflict, experiment_name_resolution):
+    def test_revert(
+        self,
+        old_config,
+        new_config,
+        experiment_name_conflict,
+        experiment_name_resolution,
+    ):
         """Verify reverting resolution set conflict to unresolved and reset name in config"""
         assert experiment_name_conflict.is_resolved
-        assert new_config['name'] == experiment_name_resolution.new_name
-        assert new_config['version'] == experiment_name_resolution.new_version
+        assert new_config["name"] == experiment_name_resolution.new_name
+        assert new_config["version"] == experiment_name_resolution.new_version
 
         assert experiment_name_resolution.revert() == []
 
-        assert new_config['name'] == old_config['name']
-        assert new_config['version'] == old_config['version']
+        assert new_config["name"] == old_config["name"]
+        assert new_config["version"] == old_config["version"]
         assert not experiment_name_conflict.is_resolved
         assert experiment_name_conflict.resolution is None

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -1,6 +1,11 @@
 """Test for generic :class:`orion.core.evc.tree`"""
 
-from orion.core.evc.tree import DepthFirstTraversal, flattened, PreOrderTraversal, TreeNode
+from orion.core.evc.tree import (
+    DepthFirstTraversal,
+    flattened,
+    PreOrderTraversal,
+    TreeNode,
+)
 
 
 def test_node_creation():
@@ -319,7 +324,7 @@ def test_preorder_traversal():
     TreeNode("h", e)
 
     rval = [node.item for node in PreOrderTraversal(root)]
-    assert rval == ['a', 'b', 'f', 'g', 'c', 'd', 'e', 'h']
+    assert rval == ["a", "b", "f", "g", "c", "d", "e", "h"]
 
 
 def test_depth_first_traversal():
@@ -341,7 +346,7 @@ def test_depth_first_traversal():
     TreeNode("h", e)
 
     rval = [node.item for node in DepthFirstTraversal(root)]
-    assert rval == ['f', 'g', 'b', 'c', 'd', 'h', 'e', 'a']
+    assert rval == ["f", "g", "b", "c", "d", "h", "e", "a"]
 
 
 def test_map_children():
@@ -440,4 +445,4 @@ def test_flattened():
 
     TreeNode("h", e)
 
-    assert flattened(root) == ['a', 'b', 'f', 'g', 'c', 'd', 'e', 'h']
+    assert flattened(root) == ["a", "b", "f", "g", "c", "d", "e", "h"]

--- a/tests/unittests/core/io/conftest.py
+++ b/tests/unittests/core/io/conftest.py
@@ -14,8 +14,9 @@ from orion.core.evc import conflicts
 @pytest.fixture()
 def config_file():
     """Open config file with new config"""
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             "orion_config.yaml")
+    file_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "orion_config.yaml"
+    )
 
     return open(file_path)
 
@@ -23,8 +24,9 @@ def config_file():
 @pytest.fixture()
 def old_config_file():
     """Open config file with original config from an experiment in db"""
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             "orion_old_config.yaml")
+    file_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "orion_old_config.yaml"
+    )
 
     return open(file_path)
 
@@ -32,8 +34,9 @@ def old_config_file():
 @pytest.fixture()
 def incomplete_config_file():
     """Open config file with partial database configuration"""
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             "orion_incomplete_config.yaml")
+    file_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "orion_incomplete_config.yaml"
+    )
 
     return open(file_path)
 
@@ -41,20 +44,16 @@ def incomplete_config_file():
 @pytest.fixture
 def parent_config():
     """Generate a new experiment configuration"""
-    return dict(
-        _id='test',
-        name='test',
-        metadata={'user': 'corneauf'},
-        version=1)
+    return dict(_id="test", name="test", metadata={"user": "corneauf"}, version=1)
 
 
 @pytest.fixture
 def child_config(parent_config):
     """Generate a new experiment configuration"""
     config = copy.deepcopy(parent_config)
-    config['_id'] = "test2"
-    config['refers'] = {'parent_id': 'test'}
-    config['version'] = 2
+    config["_id"] = "test2"
+    config["refers"] = {"parent_id": "test"}
+    config["version"] = 2
 
     return config
 
@@ -62,8 +61,8 @@ def child_config(parent_config):
 @pytest.fixture
 def experiment_name_conflict(create_db_instance, parent_config, child_config):
     """Generate an experiment name conflict"""
-    create_db_instance.remove('experiments', {'name': 'test'})
-    create_db_instance.remove('experiments', {'name': 'test2'})
-    create_db_instance.write('experiments', parent_config)
-    create_db_instance.write('experiments', child_config)
+    create_db_instance.remove("experiments", {"name": "test"})
+    create_db_instance.remove("experiments", {"name": "test2"})
+    create_db_instance.write("experiments", parent_config)
+    create_db_instance.write("experiments", child_config)
     return conflicts.ExperimentNameConflict(parent_config, parent_config)

--- a/tests/unittests/core/io/database_test.py
+++ b/tests/unittests/core/io/database_test.py
@@ -6,8 +6,10 @@ import pytest
 
 from orion.core.io.database import Database, ReadOnlyDB
 from orion.core.io.database.mongodb import MongoDB
-from orion.core.utils.singleton import SingletonAlreadyInstantiatedError, \
-    SingletonNotInstantiatedError
+from orion.core.utils.singleton import (
+    SingletonAlreadyInstantiatedError,
+    SingletonNotInstantiatedError,
+)
 
 
 @pytest.mark.usefixtures("null_db_instances")
@@ -33,21 +35,22 @@ class TestDatabaseFactory(object):
     def test_notfound_type_first_call(self):
         """Raise when supplying not implemented wrapper name."""
         with pytest.raises(NotImplementedError) as exc_info:
-            Database('notfound')
+            Database("notfound")
 
-        assert 'AbstractDB' in str(exc_info.value)
+        assert "AbstractDB" in str(exc_info.value)
 
     def test_instantiation_and_singleton(self):
         """Test create just one object, that object persists between calls."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
+        database = Database(
+            of_type="MongoDB", name="orion_test", username="user", password="pass"
+        )
 
         assert isinstance(database, MongoDB)
         assert database is MongoDB()
         assert database is Database()
 
         with pytest.raises(SingletonAlreadyInstantiatedError):
-            Database('fire', [], {'it_matters': 'it\'s singleton'})
+            Database("fire", [], {"it_matters": "it's singleton"})
 
 
 @pytest.mark.usefixtures("null_db_instances", "clean_db")
@@ -70,7 +73,10 @@ class TestReadOnlyDatabase(object):
         database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
-        args = {"collection_name": "trials", "query": {"experiment": "supernaedo2-dendi"}}
+        args = {
+            "collection_name": "trials",
+            "query": {"experiment": "supernaedo2-dendi"},
+        }
         readonly_result = readonly_database.read(**args)
         result = database.read(**args)
 

--- a/tests/unittests/core/io/interactive_commands/test_branching_prompt.py
+++ b/tests/unittests/core/io/interactive_commands/test_branching_prompt.py
@@ -14,19 +14,23 @@ from orion.core.io.space_builder import DimensionBuilder
 @pytest.fixture
 def new_cat_dimension_conflict(old_config, new_config):
     """Generate a new dimension conflict with categorical prior for new experiment configuration"""
-    name = 'new-cat'
+    name = "new-cat"
     prior = 'choices(["hello", 2])'
     dimension = DimensionBuilder().build(name, prior)
     return evc.conflicts.NewDimensionConflict(old_config, new_config, dimension, prior)
 
 
 @pytest.fixture
-def missing_conflict_with_identical_prior(old_config, new_config, new_dimension_conflict):
+def missing_conflict_with_identical_prior(
+    old_config, new_config, new_dimension_conflict
+):
     """Generate a missing dimension conflict which have the same prior as the new dim conflict"""
-    name = 'missing-idem'
+    name = "missing-idem"
     prior = new_dimension_conflict.prior
     dimension = DimensionBuilder().build(name, prior)
-    return evc.conflicts.MissingDimensionConflict(old_config, new_config, dimension, prior)
+    return evc.conflicts.MissingDimensionConflict(
+        old_config, new_config, dimension, prior
+    )
 
 
 @pytest.fixture
@@ -34,19 +38,28 @@ def missing_cat_dimension_conflict(old_config, new_config):
     """Generate a missing dimension conflict with categorical prior for new experiment
     configuration
     """
-    name = 'missing-cat'
+    name = "missing-cat"
     prior = 'choices(["goodbye", 5])'
     dimension = DimensionBuilder().build(name, prior)
-    return evc.conflicts.MissingDimensionConflict(old_config, new_config, dimension, prior)
+    return evc.conflicts.MissingDimensionConflict(
+        old_config, new_config, dimension, prior
+    )
 
 
 @pytest.fixture
-def conflicts(new_dimension_conflict, new_cat_dimension_conflict,
-              changed_dimension_conflict,
-              missing_dimension_conflict, missing_cat_dimension_conflict,
-              missing_conflict_with_identical_prior,
-              algorithm_conflict, code_conflict, cli_conflict, config_conflict,
-              experiment_name_conflict):
+def conflicts(
+    new_dimension_conflict,
+    new_cat_dimension_conflict,
+    changed_dimension_conflict,
+    missing_dimension_conflict,
+    missing_cat_dimension_conflict,
+    missing_conflict_with_identical_prior,
+    algorithm_conflict,
+    code_conflict,
+    cli_conflict,
+    config_conflict,
+    experiment_name_conflict,
+):
     """Create a container for conflicts with one of each types for testing purposes"""
     conflicts = evc.conflicts.Conflicts()
     conflicts.register(new_dimension_conflict)
@@ -66,7 +79,7 @@ def conflicts(new_dimension_conflict, new_cat_dimension_conflict,
 @pytest.fixture
 def branch_builder(conflicts):
     """Generate the experiment branch builder"""
-    return ExperimentBranchBuilder(conflicts, {'manual_resolution': True})
+    return ExperimentBranchBuilder(conflicts, {"manual_resolution": True})
 
 
 @pytest.fixture
@@ -99,7 +112,7 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 1
         branch_solver_prompt.do_add("new")
         out, err = capsys.readouterr()
-        assert "Dimension name \'new\' not found in conflicts" in out
+        assert "Dimension name 'new' not found in conflicts" in out
         assert len(conflicts.get_resolved()) == 1
 
     def test_add_dim_with_default(self, conflicts, branch_solver_prompt):
@@ -128,7 +141,7 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_add("new_cat --default-value='hello'")
         assert len(conflicts.get_resolved()) == 1
-        assert conflicts.get_resolved()[0].resolution.default_value == 'hello'
+        assert conflicts.get_resolved()[0].resolution.default_value == "hello"
 
         conflicts.revert(conflicts.get_resolved()[0].resolution)
         assert len(conflicts.get_resolved()) == 0
@@ -136,7 +149,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 1
         assert conflicts.get_resolved()[0].resolution.default_value == 2
 
-    def test_add_dim_with_cat_bad_default(self, capsys, conflicts, branch_solver_prompt):
+    def test_add_dim_with_cat_bad_default(
+        self, capsys, conflicts, branch_solver_prompt
+    ):
         """Verify that error message is given for default value of invalid category"""
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_add("new_cat --default-value='bad'")
@@ -149,7 +164,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_add("new")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_change_dim(self, conflicts, branch_solver_prompt):
@@ -165,7 +182,7 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 1
         branch_solver_prompt.do_add("changed")
         out, err = capsys.readouterr()
-        assert "Dimension name \'changed\' not found in conflicts" in out
+        assert "Dimension name 'changed' not found in conflicts" in out
         assert len(conflicts.get_resolved()) == 1
 
     def test_reset_change(self, conflicts, branch_solver_prompt):
@@ -173,7 +190,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_add("changed")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_remove_dim(self, conflicts, branch_solver_prompt):
@@ -197,7 +216,7 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 1
         branch_solver_prompt.do_remove("missing")
         out, err = capsys.readouterr()
-        assert "Dimension name \'missing\' not found in conflicts" in out
+        assert "Dimension name 'missing' not found in conflicts" in out
         assert len(conflicts.get_resolved()) == 1
 
     def test_remove_dim_with_default(self, conflicts, branch_solver_prompt):
@@ -226,7 +245,7 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_remove("missing_cat --default-value='goodbye'")
         assert len(conflicts.get_resolved()) == 1
-        assert conflicts.get_resolved()[0].resolution.default_value == 'goodbye'
+        assert conflicts.get_resolved()[0].resolution.default_value == "goodbye"
 
         conflicts.revert(conflicts.get_resolved()[0].resolution)
         assert len(conflicts.get_resolved()) == 0
@@ -234,7 +253,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 1
         assert conflicts.get_resolved()[0].resolution.default_value == 5
 
-    def test_remove_dim_with_cat_bad_default(self, capsys, conflicts, branch_solver_prompt):
+    def test_remove_dim_with_cat_bad_default(
+        self, capsys, conflicts, branch_solver_prompt
+    ):
         """Verify that error message is given for default value of invalid category"""
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_remove("missing_cat --default-value='bad'")
@@ -247,7 +268,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_remove("missing")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_rename_dim(self, conflicts, branch_solver_prompt):
@@ -272,7 +295,7 @@ class TestCommands(object):
         assert len(conflicts.get()) == 11
         branch_solver_prompt.do_rename("new_cat new")
         out, err = capsys.readouterr()
-        assert "Dimension name \'new_cat\' not found in conflicts" in out
+        assert "Dimension name 'new_cat' not found in conflicts" in out
         assert len(conflicts.get_resolved()) == 0
         assert len(conflicts.get()) == 11
 
@@ -280,7 +303,7 @@ class TestCommands(object):
         assert len(conflicts.get()) == 11
         branch_solver_prompt.do_rename("missing missing_cat")
         out, err = capsys.readouterr()
-        assert "Dimension name \'missing_cat\' not found in conflicts" in out
+        assert "Dimension name 'missing_cat' not found in conflicts" in out
         assert len(conflicts.get_resolved()) == 0
         assert len(conflicts.get()) == 11
 
@@ -291,7 +314,9 @@ class TestCommands(object):
         branch_solver_prompt.do_rename("missing_idem new")
         assert len(conflicts.get_resolved()) == 2
         assert len(conflicts.get()) == 11
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
         assert len(conflicts.get()) == 11
 
@@ -302,7 +327,9 @@ class TestCommands(object):
         branch_solver_prompt.do_rename("missing new")
         assert len(conflicts.get_resolved()) == 2
         assert len(conflicts.get()) == 12
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
         assert len(conflicts.get()) == 11
 
@@ -335,7 +362,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_code("break")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_set_algo(self, conflicts, branch_solver_prompt):
@@ -359,7 +388,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_algo("")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("' {}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "' {}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_set_config_change_type(self, conflicts, branch_solver_prompt):
@@ -376,7 +407,9 @@ class TestCommands(object):
         assert "invalid choice: 'bad'" in err
         assert len(conflicts.get_resolved()) == 0
 
-    def test_set_config_change_type_twice(self, capsys, conflicts, branch_solver_prompt):
+    def test_set_config_change_type_twice(
+        self, capsys, conflicts, branch_solver_prompt
+    ):
         """Verify that error message is given trying to solve twice the same conflict"""
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_config("break")
@@ -391,7 +424,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_config("break")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_set_commandline_change_type(self, conflicts, branch_solver_prompt):
@@ -400,7 +435,9 @@ class TestCommands(object):
         branch_solver_prompt.do_commandline("break")
         assert len(conflicts.get_resolved()) == 1
 
-    def test_set_commandline_change_bad_type(self, capsys, conflicts, branch_solver_prompt):
+    def test_set_commandline_change_bad_type(
+        self, capsys, conflicts, branch_solver_prompt
+    ):
         """Verify error message when attempting cli resolution with bad type"""
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_commandline("bad")
@@ -408,7 +445,9 @@ class TestCommands(object):
         assert "invalid choice: 'bad'" in err
         assert len(conflicts.get_resolved()) == 0
 
-    def test_set_commandline_change_type_twice(self, capsys, conflicts, branch_solver_prompt):
+    def test_set_commandline_change_type_twice(
+        self, capsys, conflicts, branch_solver_prompt
+    ):
         """Verify that error message is given trying to solve twice the same conflict"""
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_commandline("break")
@@ -423,7 +462,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_commandline("break")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_set_experiment_name(self, conflicts, branch_solver_prompt):
@@ -455,7 +496,9 @@ class TestCommands(object):
         assert len(conflicts.get_resolved()) == 0
         branch_solver_prompt.do_name("new-name")
         assert len(conflicts.get_resolved()) == 1
-        branch_solver_prompt.do_reset("'{}'".format(str(conflicts.get_resolved()[0].resolution)))
+        branch_solver_prompt.do_reset(
+            "'{}'".format(str(conflicts.get_resolved()[0].resolution))
+        )
         assert len(conflicts.get_resolved()) == 0
 
     def test_commit_wont_quit_if_not_solved(self, conflicts, branch_solver_prompt):

--- a/tests/unittests/core/io/test_cmdline_parser.py
+++ b/tests/unittests/core/io/test_cmdline_parser.py
@@ -14,16 +14,16 @@ def basic_config():
     """Return a simple configuration"""
     config = OrderedDict()
 
-    config['_pos_0'] = 'python'
-    config['_pos_1'] = 'script.py'
-    config['_pos_2'] = 'some'
-    config['_pos_3'] = 'pos'
-    config['_pos_4'] = 'args'
-    config['with'] = 'args'
-    config['and'] = ['multiple', 'args']
-    config['plus'] = True
-    config['booleans'] = True
-    config['equal'] = 'value'
+    config["_pos_0"] = "python"
+    config["_pos_1"] = "script.py"
+    config["_pos_2"] = "some"
+    config["_pos_3"] = "pos"
+    config["_pos_4"] = "args"
+    config["with"] = "args"
+    config["and"] = ["multiple", "args"]
+    config["plus"] = True
+    config["booleans"] = True
+    config["equal"] = "value"
 
     return config
 
@@ -33,16 +33,16 @@ def basic_keys():
     """Return keys of a simple configuration"""
     keys = OrderedDict()
 
-    keys['_pos_0'] = '_pos_0'
-    keys['_pos_1'] = '_pos_1'
-    keys['_pos_2'] = '_pos_2'
-    keys['_pos_3'] = '_pos_3'
-    keys['_pos_4'] = '_pos_4'
-    keys['with'] = '--with'
-    keys['and'] = '--and'
-    keys['plus'] = '--plus'
-    keys['booleans'] = '--booleans'
-    keys['equal'] = '--equal'
+    keys["_pos_0"] = "_pos_0"
+    keys["_pos_1"] = "_pos_1"
+    keys["_pos_2"] = "_pos_2"
+    keys["_pos_3"] = "_pos_3"
+    keys["_pos_4"] = "_pos_4"
+    keys["with"] = "--with"
+    keys["and"] = "--and"
+    keys["plus"] = "--plus"
+    keys["booleans"] = "--booleans"
+    keys["equal"] = "--equal"
 
     return keys
 
@@ -67,11 +67,11 @@ def test_parse_paths(monkeypatch):
     cmdline_parser = CmdlineParser()
     assert cmdline_parser._parse_paths(__file__) == os.path.abspath(__file__)
 
-    values = ['test_resolve_config.py', 'test', 'nada', __file__]
+    values = ["test_resolve_config.py", "test", "nada", __file__]
     parsed_values = cmdline_parser._parse_paths(values)
-    assert parsed_values[0] == os.path.abspath('test_resolve_config.py')
-    assert parsed_values[1] == 'test'
-    assert parsed_values[2] == 'nada'
+    assert parsed_values[0] == os.path.abspath("test_resolve_config.py")
+    assert parsed_values[1] == "test"
+    assert parsed_values[2] == "nada"
     assert parsed_values[3] == os.path.abspath(__file__)
 
 
@@ -80,7 +80,8 @@ def test_parse_arguments(basic_config, basic_keys):
     cmdline_parser = CmdlineParser()
     keys, arguments = cmdline_parser._parse_arguments(
         "python script.py some pos args --with args --and multiple args "
-        "--plus --booleans --equal=value".split(" "))
+        "--plus --booleans --equal=value".split(" ")
+    )
 
     assert arguments == basic_config
     assert keys == basic_keys
@@ -92,25 +93,38 @@ def test_parse_arguments_template():
 
     cmdline_parser.parse(
         "python script.py some pos args "
-        "--with args --and multiple args --plus --booleans --equal=value".split(" "))
+        "--with args --and multiple args --plus --booleans --equal=value".split(" ")
+    )
 
-    assert (
-        cmdline_parser.template ==
-        ['{_pos_0}', '{_pos_1}', '{_pos_2}', '{_pos_3}', '{_pos_4}', '--with', '{with}', '--and',
-         '{and[0]}', '{and[1]}', '--plus', '--booleans', '--equal', '{equal}'])
+    assert cmdline_parser.template == [
+        "{_pos_0}",
+        "{_pos_1}",
+        "{_pos_2}",
+        "{_pos_3}",
+        "{_pos_4}",
+        "--with",
+        "{with}",
+        "--and",
+        "{and[0]}",
+        "{and[1]}",
+        "--plus",
+        "--booleans",
+        "--equal",
+        "{equal}",
+    ]
 
 
 def test_format(to_format):
     """Test that the format method assigns the correc values"""
     cmdline_parser = CmdlineParser()
 
-    cmdline_parser.parse(to_format.split(' '))
+    cmdline_parser.parse(to_format.split(" "))
 
-    keys, arguments = cmdline_parser._parse_arguments(to_format.split(' '))
+    keys, arguments = cmdline_parser._parse_arguments(to_format.split(" "))
 
     formatted = cmdline_parser.format(arguments)
 
-    assert formatted == to_format.split(' ')
+    assert formatted == to_format.split(" ")
 
 
 def test_parse_arguments_bad_command():
@@ -121,7 +135,8 @@ def test_parse_arguments_bad_command():
         cmdline_parser.parse(
             "python script.py some pos args "
             "--with args --and multiple args --plus --booleans "
-            "--and dummy.yaml".split(" "))
+            "--and dummy.yaml".split(" ")
+        )
 
     assert "Conflict: two arguments have the same name: and" in str(exc_info.value)
 
@@ -130,12 +145,14 @@ def test_has_already_been_parsed():
     """Test the template from the branching"""
     cmdline_parser = CmdlineParser()
 
-    command = "python script.py some pos args " \
-              "--with args --and multiple args --plus --booleans "
+    command = (
+        "python script.py some pos args "
+        "--with args --and multiple args --plus --booleans "
+    )
 
-    cmdline_parser.parse(command.split(' '))
+    cmdline_parser.parse(command.split(" "))
     with pytest.raises(RuntimeError) as exc_info:
-        cmdline_parser.parse(command.split(' '))
+        cmdline_parser.parse(command.split(" "))
 
     assert "already" in str(exc_info.value)
 
@@ -146,60 +163,81 @@ def test_get_state_dict():
 
     cmdline_parser.parse(
         "python script.py some pos args "
-        "--with args --and multiple args --plus --booleans --equal=value".split(" "))
+        "--with args --and multiple args --plus --booleans --equal=value".split(" ")
+    )
 
     assert cmdline_parser.get_state_dict() == {
-        'keys': list(map(list, cmdline_parser.keys.items())),
-        'arguments': list(map(list, cmdline_parser.arguments.items())),
-        'template': cmdline_parser.template}
+        "keys": list(map(list, cmdline_parser.keys.items())),
+        "arguments": list(map(list, cmdline_parser.arguments.items())),
+        "template": cmdline_parser.template,
+    }
 
 
 def test_set_state_dict():
     """Test that set_state_dict sets state properly to generate new cmdline."""
     cmdline_parser = CmdlineParser()
 
-    cmdline_parser.set_state_dict({
-        'arguments': {},
-        'template': ['{_pos_0}', '{_pos_1}', '--with', '{with}', '--plus', '--booleans']})
+    cmdline_parser.set_state_dict(
+        {
+            "arguments": {},
+            "template": [
+                "{_pos_0}",
+                "{_pos_1}",
+                "--with",
+                "{with}",
+                "--plus",
+                "--booleans",
+            ],
+        }
+    )
 
-    assert cmdline_parser.format({'_pos_0': 'voici', '_pos_1': 'voila', 'with': 'classe'}) == [
-        'voici', 'voila', '--with', 'classe', '--plus', '--booleans']
+    assert cmdline_parser.format(
+        {"_pos_0": "voici", "_pos_1": "voila", "with": "classe"}
+    ) == ["voici", "voila", "--with", "classe", "--plus", "--booleans"]
 
 
 def test_parse_not_enough_dashes():
     """Test that arguments with many chars but one dash are supported even if it is not standard"""
     cmdline_parser = CmdlineParser()
     keys, arguments = cmdline_parser._parse_arguments(
-        "pos -not-enough dashes "
-        "--enough dashes -o my".split(" "))
+        "pos -not-enough dashes " "--enough dashes -o my".split(" ")
+    )
 
-    assert arguments == OrderedDict((
-        ('_pos_0', 'pos'),
-        ('not-enough', 'dashes'),
-        ('enough', 'dashes'),
-        ('o', 'my')))
+    assert arguments == OrderedDict(
+        (("_pos_0", "pos"), ("not-enough", "dashes"), ("enough", "dashes"), ("o", "my"))
+    )
 
-    assert keys == OrderedDict((
-        ('_pos_0', '_pos_0'),
-        ('not-enough', '-not-enough'),
-        ('enough', '--enough'),
-        ('o', '-o')))
+    assert keys == OrderedDict(
+        (
+            ("_pos_0", "_pos_0"),
+            ("not-enough", "-not-enough"),
+            ("enough", "--enough"),
+            ("o", "-o"),
+        )
+    )
 
 
 def test_parse_fugly_underscores():
     """Test that underscores are kept as such no matter how fugly this is"""
     cmdline_parser = CmdlineParser()
     keys, arguments = cmdline_parser._parse_arguments(
-        "pos -my_poor eyes --are_bleeding because --of-these underscores".split(" "))
+        "pos -my_poor eyes --are_bleeding because --of-these underscores".split(" ")
+    )
 
-    assert arguments == OrderedDict((
-        ('_pos_0', 'pos'),
-        ('my_poor', 'eyes'),
-        ('are_bleeding', 'because'),
-        ('of-these', 'underscores')))
+    assert arguments == OrderedDict(
+        (
+            ("_pos_0", "pos"),
+            ("my_poor", "eyes"),
+            ("are_bleeding", "because"),
+            ("of-these", "underscores"),
+        )
+    )
 
-    assert keys == OrderedDict((
-        ('_pos_0', '_pos_0'),
-        ('my_poor', '-my_poor'),
-        ('are_bleeding', '--are_bleeding'),
-        ('of-these', '--of-these')))
+    assert keys == OrderedDict(
+        (
+            ("_pos_0", "_pos_0"),
+            ("my_poor", "-my_poor"),
+            ("are_bleeding", "--are_bleeding"),
+            ("of-these", "--of-these"),
+        )
+    )

--- a/tests/unittests/core/io/test_config.py
+++ b/tests/unittests/core/io/test_config.py
@@ -15,9 +15,9 @@ from orion.core.io.config import Configuration, ConfigurationError
 @pytest.fixture
 def yaml_path():
     """Create a temporary yaml file and return the path"""
-    file_path = './my.yaml'
-    with open(file_path, 'w') as f:
-        f.write(yaml.dump({'test': 'from my yaml!'}))
+    file_path = "./my.yaml"
+    with open(file_path, "w") as f:
+        f.write(yaml.dump({"test": "from my yaml!"}))
 
     yield file_path
 
@@ -27,9 +27,9 @@ def yaml_path():
 @pytest.fixture
 def broken_yaml_path():
     """Create a temporary yaml file and return the path"""
-    file_path = './my.yaml'
-    with open(file_path, 'w') as f:
-        f.write(yaml.dump({'coucou': 'from my yaml!'}))
+    file_path = "./my.yaml"
+    with open(file_path, "w") as f:
+        f.write(yaml.dump({"coucou": "from my yaml!"}))
 
     yield file_path
 
@@ -39,10 +39,16 @@ def broken_yaml_path():
 @pytest.fixture
 def subdict_yaml_path():
     """Create a temporary yaml file with subdicts and return the path"""
-    file_path = './my.yaml'
-    with open(file_path, 'w') as f:
-        f.write(yaml.dump({'test': {'i am': 'a sub-dict'},
-                           'test2': {'test': {'me is': 'sub-conf sub-dict'}}}))
+    file_path = "./my.yaml"
+    with open(file_path, "w") as f:
+        f.write(
+            yaml.dump(
+                {
+                    "test": {"i am": "a sub-dict"},
+                    "test2": {"test": {"me is": "sub-conf sub-dict"}},
+                }
+            )
+        )
 
     yield file_path
 
@@ -55,7 +61,7 @@ def test_fetch_non_existing_option():
     with pytest.raises(ConfigurationError) as exc:
         config.voici_voila
 
-    assert 'Configuration does not have an attribute \'voici_voila\'.' in str(exc.value)
+    assert "Configuration does not have an attribute 'voici_voila'." in str(exc.value)
 
 
 def test_access_to_config():
@@ -81,11 +87,11 @@ def test_set_subconfig():
 def test_access_config_without_values():
     """Test that access to config without values raises ConfigurationError"""
     config = Configuration()
-    config.add_option('test', option_type=int)
+    config.add_option("test", option_type=int)
     with pytest.raises(ConfigurationError) as exc:
         config.test
 
-    assert 'Configuration not set and no default provided: test.' in str(exc.value)
+    assert "Configuration not set and no default provided: test." in str(exc.value)
 
 
 def test_set_non_existing_option():
@@ -99,7 +105,7 @@ def test_set_non_existing_option():
 def test_set_subconfig_over_option():
     """Test that overwritting an option with a subconfig is not possible"""
     config = Configuration()
-    config.add_option('test', option_type=int)
+    config.add_option("test", option_type=int)
     config.test = 1
     assert config.test == 1
     with pytest.raises(TypeError) as exc:
@@ -110,7 +116,7 @@ def test_set_subconfig_over_option():
 def test_set_int_value():
     """Test that an integer option can have its value set"""
     config = Configuration()
-    config.add_option('test', option_type=int)
+    config.add_option("test", option_type=int)
 
     with pytest.raises(ConfigurationError) as exc:
         config.test
@@ -121,13 +127,15 @@ def test_set_int_value():
     assert config.test == 1
     with pytest.raises(TypeError) as exc:
         config.test = "voici_voila"
-    assert "<class 'int'> cannot be set to voici_voila with type <class 'str'>" in str(exc.value)
+    assert "<class 'int'> cannot be set to voici_voila with type <class 'str'>" in str(
+        exc.value
+    )
 
 
 def test_set_real_value():
     """Test that a float option can have its value set"""
     config = Configuration()
-    config.add_option('test', option_type=float)
+    config.add_option("test", option_type=float)
 
     with pytest.raises(ConfigurationError) as exc:
         config.test
@@ -138,13 +146,16 @@ def test_set_real_value():
     assert config.test == 1.0
     with pytest.raises(TypeError) as exc:
         config.test = "voici_voila"
-    assert "<class 'float'> cannot be set to voici_voila with type <class 'str'>" in str(exc.value)
+    assert (
+        "<class 'float'> cannot be set to voici_voila with type <class 'str'>"
+        in str(exc.value)
+    )
 
 
 def test_set_str_value():
     """Test that a string option can have its value set"""
     config = Configuration()
-    config.add_option('test', option_type=str)
+    config.add_option("test", option_type=str)
 
     with pytest.raises(ConfigurationError):
         config.test
@@ -159,7 +170,7 @@ def test_set_value_of_subconfig_directly():
     """Test that we can access subconfig and set value directly"""
     config = Configuration()
     config.sub = Configuration()
-    config.sub.add_option('test', option_type=str)
+    config.sub.add_option("test", option_type=str)
 
     with pytest.raises(ConfigurationError):
         config.test
@@ -173,14 +184,14 @@ def test_set_value_of_subconfig_directly():
 def test_set_value_like_dict():
     """Test that we can set values like a dictionary"""
     config = Configuration()
-    config.add_option('test', option_type=str)
+    config.add_option("test", option_type=str)
 
     with pytest.raises(ConfigurationError):
         config.test
 
-    config['test'] = "1"
+    config["test"] = "1"
     assert config.test == "1"
-    config['test'] = 1
+    config["test"] = 1
     assert config.test == "1"
 
 
@@ -188,14 +199,14 @@ def test_set_subconfig_value_like_dict():
     """Test that we can set values like a dictionary"""
     config = Configuration()
     config.sub = Configuration()
-    config.sub.add_option('test', option_type=str)
+    config.sub.add_option("test", option_type=str)
 
     with pytest.raises(ConfigurationError):
         config.test
 
-    config['sub.test'] = "1"
+    config["sub.test"] = "1"
     assert config.sub.test == "1"
-    config['sub.test'] = 1
+    config["sub.test"] = 1
     assert config.sub.test == "1"
 
 
@@ -203,8 +214,8 @@ def test_set_invalid_subconfig_value_like_dict():
     """Test that deep keys cannot be set if subconfig does not exist"""
     config = Configuration()
     with pytest.raises(BaseException) as exc:
-        config['sub.test'] = "1"
-    assert 'Configuration does not have an attribute \'sub\'.' in str(exc.value)
+        config["sub.test"] = "1"
+    assert "Configuration does not have an attribute 'sub'." in str(exc.value)
 
 
 def test_yaml_loading_empty_config(yaml_path):
@@ -214,20 +225,22 @@ def test_yaml_loading_empty_config(yaml_path):
     with pytest.raises(ConfigurationError) as exc:
         config.load_yaml(yaml_path)
 
-    assert 'Configuration does not have an attribute \'test\'.' in str(exc.value)
+    assert "Configuration does not have an attribute 'test'." in str(exc.value)
 
 
 def test_default_value():
     """Test that default value is given only when nothing else is available"""
     config = Configuration()
-    config.add_option('test', option_type=str, default="voici_voila")
+    config.add_option("test", option_type=str, default="voici_voila")
     assert config.test == "voici_voila"
 
 
 def test_yaml_precedence(yaml_path):
     """Test that yaml definition has precedence over default values"""
     config = Configuration()
-    config.add_option('test', option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE")
+    config.add_option(
+        "test", option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE"
+    )
     assert config.test == "voici_voila"
 
     config.load_yaml(yaml_path)
@@ -237,15 +250,17 @@ def test_yaml_precedence(yaml_path):
 def test_env_var_precedence(yaml_path):
     """Test that env_var has precedence over yaml values"""
     config = Configuration()
-    config.add_option('test', option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE")
+    config.add_option(
+        "test", option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE"
+    )
     assert config.test == "voici_voila"
 
     config.load_yaml(yaml_path)
     assert config.test == "from my yaml!"
 
-    os.environ['TOP_SECRET_MESSAGE'] = 'coussi_coussa'
+    os.environ["TOP_SECRET_MESSAGE"] = "coussi_coussa"
     assert config.test == "coussi_coussa"
-    del os.environ['TOP_SECRET_MESSAGE']
+    del os.environ["TOP_SECRET_MESSAGE"]
 
     assert config.test == "from my yaml!"
 
@@ -253,29 +268,33 @@ def test_env_var_precedence(yaml_path):
 def test_env_var_list(yaml_path):
     """Test that env_var lists are correctly handled"""
     config = Configuration()
-    config.add_option('test', option_type=list, default=["voici"], env_var="TOP_SECRET_LIST")
+    config.add_option(
+        "test", option_type=list, default=["voici"], env_var="TOP_SECRET_LIST"
+    )
     assert config.test == ["voici"]
 
-    os.environ['TOP_SECRET_LIST'] = 'voila:voici:voila'
-    assert config.test == ['voila', 'voici', 'voila']
+    os.environ["TOP_SECRET_LIST"] = "voila:voici:voila"
+    assert config.test == ["voila", "voici", "voila"]
 
 
 def test_local_precedence(yaml_path):
     """Test local setting has precedence over env var values"""
     config = Configuration()
-    config.add_option('test', option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE")
+    config.add_option(
+        "test", option_type=str, default="voici_voila", env_var="TOP_SECRET_MESSAGE"
+    )
     assert config.test == "voici_voila"
 
     config.load_yaml(yaml_path)
     assert config.test == "from my yaml!"
 
-    os.environ['TOP_SECRET_MESSAGE'] = 'coussi_coussa'
+    os.environ["TOP_SECRET_MESSAGE"] = "coussi_coussa"
     assert config.test == "coussi_coussa"
 
     config.test = "comme_ci_comme_ca"
     assert config.test == "comme_ci_comme_ca"
 
-    del os.environ['TOP_SECRET_MESSAGE']
+    del os.environ["TOP_SECRET_MESSAGE"]
 
 
 def test_overwrite_subconfig():
@@ -283,7 +302,7 @@ def test_overwrite_subconfig():
     config = Configuration()
     config.nested = Configuration()
     with pytest.raises(ValueError) as exc:
-        config.add_option('nested', option_type=str)
+        config.add_option("nested", option_type=str)
     assert "Configuration already contains nested" == str(exc.value)
 
     with pytest.raises(ValueError) as exc:
@@ -294,139 +313,133 @@ def test_overwrite_subconfig():
 def test_load_yaml_with_dict_items(subdict_yaml_path):
     """Test that yaml config with items assigned with dicts is supported"""
     config = Configuration()
-    default = {'default': 'sub-dict'}
-    config.add_option('test', option_type=dict, default=default)
+    default = {"default": "sub-dict"}
+    config.add_option("test", option_type=dict, default=default)
     assert config.test == default
     config.test2 = Configuration()
-    config.test2.add_option('test', option_type=dict, default=default)
+    config.test2.add_option("test", option_type=dict, default=default)
     assert config.test2.test == default
 
     config.load_yaml(subdict_yaml_path)
-    assert config.test == {'i am': 'a sub-dict'}
-    assert config.test2.test == {'me is': 'sub-conf sub-dict'}
+    assert config.test == {"i am": "a sub-dict"}
+    assert config.test2.test == {"me is": "sub-conf sub-dict"}
 
 
 def test_load_yaml_unknown_option(broken_yaml_path):
     """Test error message when yaml config contains unknown options"""
     config = Configuration()
-    config.add_option('test', option_type=str, default='hello')
-    assert config.test == 'hello'
+    config.add_option("test", option_type=str, default="hello")
+    assert config.test == "hello"
 
     with pytest.raises(ConfigurationError) as exc:
         config.load_yaml(broken_yaml_path)
-    assert exc.match('Configuration does not have an attribute \'coucou\'')
+    assert exc.match("Configuration does not have an attribute 'coucou'")
 
 
 def test_to_dict():
     """Test dictionary representation of the configuration"""
     config = Configuration()
-    config.add_option('test', option_type=str, default="voici_voila")
+    config.add_option("test", option_type=str, default="voici_voila")
     config.nested = Configuration()
-    config.nested.add_option('test2', option_type=str, default="zici")
+    config.nested.add_option("test2", option_type=str, default="zici")
 
-    assert config.to_dict() == {
-        'test': 'voici_voila',
-        'nested': {
-            'test2': 'zici'}}
+    assert config.to_dict() == {"test": "voici_voila", "nested": {"test2": "zici"}}
 
-    config.test = 'hello'
-    config.nested.test2 = 'labas'
+    config.test = "hello"
+    config.nested.test2 = "labas"
 
-    assert config.to_dict() == {
-        'test': 'hello',
-        'nested': {
-            'test2': 'labas'}}
+    assert config.to_dict() == {"test": "hello", "nested": {"test2": "labas"}}
 
 
 def test_key_curation():
     """Test that both - and _ maps to same options"""
     config = Configuration()
-    config.add_option('test-with-dashes', option_type=int, default=1)
-    config.add_option('test_with_underscores', option_type=int, default=2)
-    config.add_option('test-all_mixedup', option_type=int, default=3)
+    config.add_option("test-with-dashes", option_type=int, default=1)
+    config.add_option("test_with_underscores", option_type=int, default=2)
+    config.add_option("test-all_mixedup", option_type=int, default=3)
 
-    assert config['test-with-dashes'] == 1
-    assert config['test_with_underscores'] == 2
-    assert config['test-all_mixedup'] == 3
+    assert config["test-with-dashes"] == 1
+    assert config["test_with_underscores"] == 2
+    assert config["test-all_mixedup"] == 3
 
-    assert config['test_with_dashes'] == 1
-    assert config['test-with-underscores'] == 2
-    assert config['test_all-mixedup'] == 3
+    assert config["test_with_dashes"] == 1
+    assert config["test-with-underscores"] == 2
+    assert config["test_all-mixedup"] == 3
 
     assert config.test_with_dashes == 1
     assert config.test_with_underscores == 2
     assert config.test_all_mixedup == 3
 
-    config['test_with_dashes'] = 4
-    assert config['test-with-dashes'] == 4
+    config["test_with_dashes"] = 4
+    assert config["test-with-dashes"] == 4
 
 
 def test_nested_key_curation():
     """Test that both - and _ maps to same options in nested configs as well"""
     config = Configuration()
-    config.add_option('test-with-dashes', option_type=str, default="voici_voila")
+    config.add_option("test-with-dashes", option_type=str, default="voici_voila")
     config.nested = Configuration()
-    config.nested.add_option('test_with_underscores', option_type=str, default="zici")
+    config.nested.add_option("test_with_underscores", option_type=str, default="zici")
 
-    assert config['nested']['test_with_underscores'] == 'zici'
-    assert config['nested']['test-with-underscores'] == 'zici'
+    assert config["nested"]["test_with_underscores"] == "zici"
+    assert config["nested"]["test-with-underscores"] == "zici"
 
-    config['nested']['test-with-underscores'] = 'labas'
-    assert config.nested.test_with_underscores == 'labas'
+    config["nested"]["test-with-underscores"] = "labas"
+    assert config.nested.test_with_underscores == "labas"
 
 
 def test_help_option():
     """Verify adding documentation to options."""
     config = Configuration()
-    config.add_option('option', option_type=str, help='A useless option!')
+    config.add_option("option", option_type=str, help="A useless option!")
 
-    assert config.help('option') == 'A useless option!'
+    assert config.help("option") == "A useless option!"
 
 
 def test_help_nested_option():
     """Verify adding documentation to a nested option."""
     config = Configuration()
-    config.add_option('option', option_type=str, help='A useless option!')
+    config.add_option("option", option_type=str, help="A useless option!")
     config.nested = Configuration()
-    config.nested.add_option('option', option_type=str, help='A useless nested option!')
+    config.nested.add_option("option", option_type=str, help="A useless nested option!")
 
-    assert config.help('nested.option') == 'A useless nested option!'
-    assert config.nested.help('option') == 'A useless nested option!'
+    assert config.help("nested.option") == "A useless nested option!"
+    assert config.nested.help("option") == "A useless nested option!"
 
 
 def test_help_option_with_default():
     """Verify adding documentation to options with default value."""
     config = Configuration()
-    config.add_option('option', option_type=str, default='a', help='A useless option!')
+    config.add_option("option", option_type=str, default="a", help="A useless option!")
 
-    assert config.help('option') == 'A useless option! (default: a)'
+    assert config.help("option") == "A useless option! (default: a)"
 
 
 def test_no_help_option():
     """Verify not adding documentation to options."""
     config = Configuration()
-    config.add_option('option', option_type=str)
+    config.add_option("option", option_type=str)
 
-    assert config.help('option') == 'Undocumented'
+    assert config.help("option") == "Undocumented"
 
 
 def test_argument_parser():
     """Verify the argument parser built based on config."""
     config = Configuration()
-    config.add_option('option', option_type=str)
+    config.add_option("option", option_type=str)
 
     parser = argparse.ArgumentParser()
     config.add_arguments(parser)
 
-    options = parser.parse_args(['--option', 'a'])
+    options = parser.parse_args(["--option", "a"])
 
-    assert options.option == 'a'
+    assert options.option == "a"
 
 
 def test_argument_parser_ignore_default():
     """Verify the argument parser does not get default values."""
     config = Configuration()
-    config.add_option('option', option_type=str, default='b')
+    config.add_option("option", option_type=str, default="b")
 
     parser = argparse.ArgumentParser()
     config.add_arguments(parser)
@@ -439,64 +452,70 @@ def test_argument_parser_ignore_default():
 def test_argument_parser_rename():
     """Verify the argument parser built based on config with some options renamed."""
     config = Configuration()
-    config.add_option('option', option_type=str)
+    config.add_option("option", option_type=str)
 
     parser = argparse.ArgumentParser()
-    config.add_arguments(parser, rename=dict(option='--new-option'))
+    config.add_arguments(parser, rename=dict(option="--new-option"))
 
     with pytest.raises(SystemExit) as exc:
-        options = parser.parse_args(['--option', 'a'])
+        options = parser.parse_args(["--option", "a"])
 
-    assert exc.match('2')
+    assert exc.match("2")
 
-    options = parser.parse_args(['--new-option', 'a'])
+    options = parser.parse_args(["--new-option", "a"])
 
-    assert options.new_option == 'a'
+    assert options.new_option == "a"
 
 
 def test_argument_parser_dict_list_tuple():
     """Verify the argument parser does not contain options of type dict/list/tuple in config."""
     config = Configuration()
-    config.add_option('st', option_type=str)
-    config.add_option('di', option_type=dict)
-    config.add_option('li', option_type=list)
-    config.add_option('tu', option_type=tuple)
+    config.add_option("st", option_type=str)
+    config.add_option("di", option_type=dict)
+    config.add_option("li", option_type=list)
+    config.add_option("tu", option_type=tuple)
 
     parser = argparse.ArgumentParser()
     config.add_arguments(parser)
 
     options = parser.parse_args([])
-    assert vars(options) == {'st': None}
+    assert vars(options) == {"st": None}
 
     with pytest.raises(SystemExit) as exc:
-        options = parser.parse_args(['--di', 'ct'])
+        options = parser.parse_args(["--di", "ct"])
 
-    assert exc.match('2')
+    assert exc.match("2")
 
 
 def test_deprecate_option(caplog):
     """Test deprecating an option."""
     config = Configuration()
     config.add_option(
-        'option', option_type=str, default='hello',
-        deprecate=dict(version='v1.0', alternative='None! T_T'))
+        "option",
+        option_type=str,
+        default="hello",
+        deprecate=dict(version="v1.0", alternative="None! T_T"),
+    )
 
-    config.add_option(
-        'ok', option_type=str, default='hillo')
+    config.add_option("ok", option_type=str, default="hillo")
 
     # Access the deprecated option and trigger a warning.
     with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
-        assert config.option == 'hello'
+        assert config.option == "hello"
 
-    assert caplog.record_tuples == [(
-        'orion.core.io.config', logging.WARNING,
-        '(DEPRECATED) Option `option` will be removed in v1.0. Use `None! T_T` instead.')]
+    assert caplog.record_tuples == [
+        (
+            "orion.core.io.config",
+            logging.WARNING,
+            "(DEPRECATED) Option `option` will be removed in v1.0. Use `None! T_T` instead.",
+        )
+    ]
 
     caplog.clear()
 
     # Access the non-deprecated option and trigger no warnings.
     with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
-        assert config.ok == 'hillo'
+        assert config.ok == "hillo"
 
     assert caplog.record_tuples == []
 
@@ -506,80 +525,103 @@ def test_deprecate_option_missing_version():
     config = Configuration()
     with pytest.raises(ValueError) as exc:
         config.add_option(
-            'option', option_type=str,
-            deprecate=dict(alternative='None! T_T'))
+            "option", option_type=str, deprecate=dict(alternative="None! T_T")
+        )
 
-    assert exc.match('`version` is missing in deprecate option')
+    assert exc.match("`version` is missing in deprecate option")
 
 
 def test_deprecate_option_no_alternative(caplog):
     """Verify option deprecation when there is no alternative."""
     config = Configuration()
     config.add_option(
-        'option', option_type=str, default='hello',
-        deprecate=dict(version='v1.0'))
+        "option", option_type=str, default="hello", deprecate=dict(version="v1.0")
+    )
 
     # Access the deprecated option and trigger a warning.
     with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
-        assert config.option == 'hello'
+        assert config.option == "hello"
 
-    assert caplog.record_tuples == [(
-        'orion.core.io.config', logging.WARNING,
-        '(DEPRECATED) Option `option` will be removed in v1.0.')]
+    assert caplog.record_tuples == [
+        (
+            "orion.core.io.config",
+            logging.WARNING,
+            "(DEPRECATED) Option `option` will be removed in v1.0.",
+        )
+    ]
 
 
 def test_deprecate_option_help():
     """Verify help message of a deprecated option."""
     config = Configuration()
     config.add_option(
-        'option', option_type=str,
-        deprecate=dict(version='v1.0', alternative='None! T_T'),
-        help='A useless option!')
+        "option",
+        option_type=str,
+        deprecate=dict(version="v1.0", alternative="None! T_T"),
+        help="A useless option!",
+    )
 
-    assert config.help('option') == '(DEPRECATED) A useless option!'
+    assert config.help("option") == "(DEPRECATED) A useless option!"
 
 
 def test_deprecate_option_print_with_different_name(caplog):
     """Verify deprecation warning with different name (for nested options)."""
     config = Configuration()
     config.add_option(
-        'option', option_type=str, default='hello',
-        deprecate=dict(version='v1.0', alternative='None! T_T', name='nested.option'))
+        "option",
+        option_type=str,
+        default="hello",
+        deprecate=dict(version="v1.0", alternative="None! T_T", name="nested.option"),
+    )
 
     # Access the deprecated option and trigger a warning.
     with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
-        assert config.option == 'hello'
+        assert config.option == "hello"
 
-    assert caplog.record_tuples == [(
-        'orion.core.io.config', logging.WARNING,
-        '(DEPRECATED) Option `nested.option` will be removed in v1.0. Use `None! T_T` instead.')]
+    assert caplog.record_tuples == [
+        (
+            "orion.core.io.config",
+            logging.WARNING,
+            "(DEPRECATED) Option `nested.option` will be removed in v1.0. Use `None! T_T` instead.",
+        )
+    ]
 
 
 def test_get_deprecated_key(caplog):
     """Verify deprecation warning using get()."""
     config = Configuration()
     config.add_option(
-        'option', option_type=str, default='hello',
-        deprecate=dict(version='v1.0', alternative='None! T_T'))
+        "option",
+        option_type=str,
+        default="hello",
+        deprecate=dict(version="v1.0", alternative="None! T_T"),
+    )
 
     # Access the deprecated option and trigger a warning.
     with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
-        assert config.get('option') == 'hello'
+        assert config.get("option") == "hello"
 
-    assert caplog.record_tuples == [(
-        'orion.core.io.config', logging.WARNING,
-        '(DEPRECATED) Option `option` will be removed in v1.0. Use `None! T_T` instead.')]
+    assert caplog.record_tuples == [
+        (
+            "orion.core.io.config",
+            logging.WARNING,
+            "(DEPRECATED) Option `option` will be removed in v1.0. Use `None! T_T` instead.",
+        )
+    ]
 
 
 def test_get_deprecated_key_ignore_warning(caplog):
     """Verify deprecation warning using get(deprecated='ignore')."""
     config = Configuration()
     config.add_option(
-        'option', option_type=str, default='hello',
-        deprecate=dict(version='v1.0', alternative='None! T_T'))
+        "option",
+        option_type=str,
+        default="hello",
+        deprecate=dict(version="v1.0", alternative="None! T_T"),
+    )
 
     # Access the deprecated option and trigger a warning.
     with caplog.at_level(logging.WARNING, logger="orion.core.io.config"):
-        assert config.get('option', deprecated='ignore') == 'hello'
+        assert config.get("option", deprecated="ignore") == "hello"
 
     assert caplog.record_tuples == []

--- a/tests/unittests/core/io/test_converters.py
+++ b/tests/unittests/core/io/test_converters.py
@@ -5,8 +5,12 @@ import os
 
 import pytest
 
-from orion.core.io.convert import (GenericConverter, infer_converter_from_file_type,
-                                   JSONConverter, YAMLConverter)
+from orion.core.io.convert import (
+    GenericConverter,
+    infer_converter_from_file_type,
+    JSONConverter,
+    YAMLConverter,
+)
 
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -33,7 +37,7 @@ def test_unknown_file_ext(unknown_type_sample_path):
 @pytest.fixture()
 def generic_converter():
     """Return a generic converter."""
-    return GenericConverter(expression_prefix='o~')
+    return GenericConverter(expression_prefix="o~")
 
 
 class TestGenericConverter(object):
@@ -43,28 +47,29 @@ class TestGenericConverter(object):
         """Test parsing method."""
         ret = generic_converter.parse(unknown_type_sample_path)
         assert ret == {
-            'lalala': 'o~uniform(1, 3, shape=(100, 3))',
-            'lala': {
-                'la': 'o~uniform(1, 3, shape=(100, 3))',
-                'l2a': 'o~+gaussian(0, 0.1, shape=(100, 3))'
-                },
-            '': {
-                'lala': {
-                    'iela': 'o~uniform(1, 3, shape=(100, 3))',
-                    '': {
-                        'iela': 'o~uniform(1, 3, shape=(100, 3))',
-                        },
+            "lalala": "o~uniform(1, 3, shape=(100, 3))",
+            "lala": {
+                "la": "o~uniform(1, 3, shape=(100, 3))",
+                "l2a": "o~+gaussian(0, 0.1, shape=(100, 3))",
+            },
+            "": {
+                "lala": {
+                    "iela": "o~uniform(1, 3, shape=(100, 3))",
+                    "": {
+                        "iela": "o~uniform(1, 3, shape=(100, 3))",
                     },
                 },
-            'aaalispera': 'o~normal(3, 1)',
-            'a': 'o~normal(5, 3)',
-            'b': 'o~>a_serious_name',
-            'a_serious_name': 'o~-',
-            'another_serious_name': 'o~loguniform(0.001, 0.5)',
-            }
+            },
+            "aaalispera": "o~normal(3, 1)",
+            "a": "o~normal(5, 3)",
+            "b": "o~>a_serious_name",
+            "a_serious_name": "o~-",
+            "another_serious_name": "o~loguniform(0.001, 0.5)",
+        }
 
-        assert generic_converter.template == \
-            """{lalala!s}
+        assert (
+            generic_converter.template
+            == """{lalala!s}
 
 {/lala/la!s}
 {//lala/iela!s}
@@ -96,34 +101,35 @@ a_var = {b!s}
 
 {lala/l2a!s}
 """
+        )
 
     def test_bad_parse_1(self, generic_converter):
         """Check that conflict is reported when duplicates are present."""
-        BAD_UNKNOWN_SAMPLE_1 = os.path.join(TEST_DIR, '..', 'bad_config1.txt')
+        BAD_UNKNOWN_SAMPLE_1 = os.path.join(TEST_DIR, "..", "bad_config1.txt")
         with pytest.raises(ValueError) as exc:
             generic_converter.parse(BAD_UNKNOWN_SAMPLE_1)
-        assert '/lala/la' in str(exc.value)
+        assert "/lala/la" in str(exc.value)
 
     def test_bad_parse_2(self, generic_converter):
         """Check that conflict is reported even when more sneaky duplicate happens."""
-        BAD_UNKNOWN_SAMPLE_2 = os.path.join(TEST_DIR, '..', 'bad_config2.txt')
+        BAD_UNKNOWN_SAMPLE_2 = os.path.join(TEST_DIR, "..", "bad_config2.txt")
         with pytest.raises(ValueError) as exc:
             generic_converter.parse(BAD_UNKNOWN_SAMPLE_2)
-        assert 'lala/la' in str(exc.value)
+        assert "lala/la" in str(exc.value)
 
     def test_bad_parse_3(self, generic_converter):
         """Check that conflict is reported if a namespace points is both and not final."""
-        BAD_UNKNOWN_SAMPLE_3 = os.path.join(TEST_DIR, '..', 'bad_config3.txt')
+        BAD_UNKNOWN_SAMPLE_3 = os.path.join(TEST_DIR, "..", "bad_config3.txt")
         with pytest.raises(ValueError) as exc:
             generic_converter.parse(BAD_UNKNOWN_SAMPLE_3)
-        assert 'lala' in str(exc.value)
+        assert "lala" in str(exc.value)
 
     def test_bad_parse_4(self, generic_converter):
         """Check that conflict is reported if a namespace points is both and not final."""
-        BAD_UNKNOWN_SAMPLE_4 = os.path.join(TEST_DIR, '..', 'bad_config4.txt')
+        BAD_UNKNOWN_SAMPLE_4 = os.path.join(TEST_DIR, "..", "bad_config4.txt")
         with pytest.raises(ValueError) as exc:
             generic_converter.parse(BAD_UNKNOWN_SAMPLE_4)
-        assert 'lala' in str(exc.value)
+        assert "lala" in str(exc.value)
 
     def test_generate(self, tmpdir, generic_converter, unknown_type_sample_path):
         """Check generation of a particular instance of configuration."""
@@ -131,31 +137,32 @@ a_var = {b!s}
 
         output_file = str(tmpdir.join("output.lalal"))
         data = {
-            'lalala': 'ispi',
-            'lala': {
-                'la': 5,
-                'l2a': '+gaussian(0, 0.1, shape=(100, 3))',
-                },
-            '': {
-                'lala': {
-                    'iela': 1,
-                    '': {
-                        'iela': 2,
-                        },
+            "lalala": "ispi",
+            "lala": {
+                "la": 5,
+                "l2a": "+gaussian(0, 0.1, shape=(100, 3))",
+            },
+            "": {
+                "lala": {
+                    "iela": 1,
+                    "": {
+                        "iela": 2,
                     },
                 },
-            'aaalispera': 3,
-            'a': 4,
-            'b': 'o~>a_serious_name',
-            'a_serious_name': 'o~-',
-            'another_serious_name': [1, 3],
-            }
+            },
+            "aaalispera": 3,
+            "a": 4,
+            "b": "o~>a_serious_name",
+            "a_serious_name": "o~-",
+            "another_serious_name": [1, 3],
+        }
         generic_converter.generate(output_file, data)
 
         with open(output_file) as f:
             out = f.read()
-        assert out == \
-            """ispi
+        assert (
+            out
+            == """ispi
 
 5
 1
@@ -187,38 +194,45 @@ a_var = o~>a_serious_name
 
 +gaussian(0, 0.1, shape=(100, 3))
 """
+        )
 
-    def test_get_state_dict(self, unknown_type_sample_path, unknown_type_template_path,
-                            generic_converter):
+    def test_get_state_dict(
+        self, unknown_type_sample_path, unknown_type_template_path, generic_converter
+    ):
         """Test getting state dict."""
         generic_converter.parse(unknown_type_sample_path)
         assert generic_converter.get_state_dict() == {
-            'expression_prefix': 'o~',
-            'has_leading': {
-                '/lala//iela': '/',
-                '/lala/iela': '/',
-                'lala/la': '/'},
-            'regex': '([\\/]?[\\w|\\/|-]+)~([\\+]?.*\\)|\\-|\\>[A-Za-z_]\\w*)',
-            'template': open(unknown_type_template_path, 'r').read()}
+            "expression_prefix": "o~",
+            "has_leading": {"/lala//iela": "/", "/lala/iela": "/", "lala/la": "/"},
+            "regex": "([\\/]?[\\w|\\/|-]+)~([\\+]?.*\\)|\\-|\\>[A-Za-z_]\\w*)",
+            "template": open(unknown_type_template_path, "r").read(),
+        }
 
     def test_set_state_dict(self, tmpdir, generic_converter):
         """Test that set_state_dict sets state properly to generate new config."""
-        generic_converter.set_state_dict({
-            'expression_prefix': '',
-            'has_leading': {
-                'voici': '/'},
-            'regex': generic_converter.regex.pattern,
-            'template': """\
+        generic_converter.set_state_dict(
+            {
+                "expression_prefix": "",
+                "has_leading": {"voici": "/"},
+                "regex": generic_converter.regex.pattern,
+                "template": """\
 voici = {/voici}
-voila = voici + {voila}"""})
+voila = voici + {voila}""",
+            }
+        )
 
         output_file = str(tmpdir.join("output.lalal"))
 
-        generic_converter.generate(output_file, {'/voici': 'me voici', 'voila': 'me voila'})
+        generic_converter.generate(
+            output_file, {"/voici": "me voici", "voila": "me voila"}
+        )
 
         with open(output_file) as f:
             out = f.read()
 
-        assert out == """\
+        assert (
+            out
+            == """\
 voici = me voici
 voila = voici + me voila"""
+        )

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -13,7 +13,11 @@ from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.pickleddb import PickledDB
 import orion.core.io.experiment_builder as experiment_builder
 import orion.core.utils.backward as backward
-from orion.core.utils.exceptions import BranchingEvent, NoConfigurationError, RaceCondition
+from orion.core.utils.exceptions import (
+    BranchingEvent,
+    NoConfigurationError,
+    RaceCondition,
+)
 from orion.core.utils.singleton import update_singletons
 from orion.storage.base import get_storage
 from orion.storage.legacy import Legacy
@@ -28,42 +32,45 @@ def count_experiments():
 @pytest.fixture
 def space():
     """Build a space definition"""
-    return {'x': 'uniform(-50,50)'}
+    return {"x": "uniform(-50,50)"}
 
 
 @pytest.fixture()
 def python_api_config():
     """Create a configuration without the cli fluff."""
     new_config = dict(
-        name='supernaekei',
+        name="supernaekei",
         version=1,
-        space={'x': 'uniform(0,10)'},
-        metadata={'user': 'tsirif',
-                  'orion_version': 'XYZ',
-                  'VCS': {"type": "git",
-                          "is_dirty": False,
-                          "HEAD_sha": "test",
-                          "active_branch": None,
-                          "diff_sha": "diff"}},
+        space={"x": "uniform(0,10)"},
+        metadata={
+            "user": "tsirif",
+            "orion_version": "XYZ",
+            "VCS": {
+                "type": "git",
+                "is_dirty": False,
+                "HEAD_sha": "test",
+                "active_branch": None,
+                "diff_sha": "diff",
+            },
+        },
         max_trials=1000,
         max_broken=5,
-        working_dir='',
+        working_dir="",
         algorithms={
-            'dumbalgo': {
-                'done': False,
-                'judgement': None,
-                'scoring': 0,
-                'seed': None,
-                'suspend': False,
-                'value': 5}},
-        producer={'strategy': 'NoParallelStrategy'},
-        _id='fasdfasfa',
-        something_to_be_ignored='asdfa',
-        refers=dict(
-            root_id='supernaekei',
-            parent_id=None,
-            adapter=[])
-        )
+            "dumbalgo": {
+                "done": False,
+                "judgement": None,
+                "scoring": 0,
+                "seed": None,
+                "suspend": False,
+                "value": 5,
+            }
+        },
+        producer={"strategy": "NoParallelStrategy"},
+        _id="fasdfasfa",
+        something_to_be_ignored="asdfa",
+        refers=dict(root_id="supernaekei", parent_id=None, adapter=[]),
+    )
 
     return new_config
 
@@ -72,42 +79,43 @@ def python_api_config():
 def new_config(random_dt, script_path):
     """Create a configuration that will not hit the database."""
     new_config = dict(
-        name='supernaekei',
-        metadata={'user': 'tsirif',
-                  'orion_version': 'XYZ',
-                  'user_script': script_path,
-                  'user_config': 'abs_path/hereitis.yaml',
-                  'user_args': [
-                      script_path,
-                      '--mini-batch~uniform(32, 256, discrete=True)'],
-                  'VCS': {"type": "git",
-                          "is_dirty": False,
-                          "HEAD_sha": "test",
-                          "active_branch": None,
-                          "diff_sha": "diff"}},
+        name="supernaekei",
+        metadata={
+            "user": "tsirif",
+            "orion_version": "XYZ",
+            "user_script": script_path,
+            "user_config": "abs_path/hereitis.yaml",
+            "user_args": [script_path, "--mini-batch~uniform(32, 256, discrete=True)"],
+            "VCS": {
+                "type": "git",
+                "is_dirty": False,
+                "HEAD_sha": "test",
+                "active_branch": None,
+                "diff_sha": "diff",
+            },
+        },
         version=1,
         pool_size=10,
         max_trials=1000,
         max_broken=5,
-        working_dir='',
+        working_dir="",
         algorithms={
-            'dumbalgo': {
-                'done': False,
-                'judgement': None,
-                'scoring': 0,
-                'seed': None,
-                'suspend': False,
-                'value': 5}},
-        producer={'strategy': 'NoParallelStrategy'},
+            "dumbalgo": {
+                "done": False,
+                "judgement": None,
+                "scoring": 0,
+                "seed": None,
+                "suspend": False,
+                "value": 5,
+            }
+        },
+        producer={"strategy": "NoParallelStrategy"},
         # attrs starting with '_' also
-        _id='fasdfasfa',
+        _id="fasdfasfa",
         # and in general anything which is not in Experiment's slots
-        something_to_be_ignored='asdfa',
-        refers=dict(
-            root_id='supernaekei',
-            parent_id=None,
-            adapter=[])
-        )
+        something_to_be_ignored="asdfa",
+        refers=dict(root_id="supernaekei", parent_id=None, adapter=[]),
+    )
 
     backward.populate_space(new_config)
 
@@ -118,12 +126,16 @@ def new_config(random_dt, script_path):
 def parent_version_config():
     """Return a configuration for an experiment."""
     config = dict(
-        _id='parent_config',
+        _id="parent_config",
         name="old_experiment",
         version=1,
-        algorithms='random',
-        metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
-                  'user_args': ['--x~normal(0,1)']})
+        algorithms="random",
+        metadata={
+            "user": "corneauf",
+            "datetime": datetime.datetime.utcnow(),
+            "user_args": ["--x~normal(0,1)"],
+        },
+    )
 
     backward.populate_space(config)
 
@@ -134,38 +146,38 @@ def parent_version_config():
 def child_version_config(parent_version_config):
     """Return a configuration for an experiment."""
     config = copy.deepcopy(parent_version_config)
-    config['_id'] = 'child_config'
-    config['version'] = 2
-    config['refers'] = {'parent_id': 'parent_config'}
-    config['metadata']['datetime'] = datetime.datetime.utcnow()
-    config['metadata']['user_args'].append('--y~+normal(0,1)')
+    config["_id"] = "child_config"
+    config["version"] = 2
+    config["refers"] = {"parent_id": "parent_config"}
+    config["metadata"]["datetime"] = datetime.datetime.utcnow()
+    config["metadata"]["user_args"].append("--y~+normal(0,1)")
     backward.populate_space(config)
     return config
 
 
-@pytest.mark.usefixtures('with_user_tsirif', 'version_XYZ')
+@pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
 def test_get_cmd_config(config_file):
     """Test local config (cmdconfig, cmdargs)"""
     cmdargs = {"config": config_file}
     local_config = experiment_builder.get_cmd_config(cmdargs)
 
-    assert local_config['algorithms'] == 'random'
-    assert local_config['strategy'] == 'NoParallelStrategy'
-    assert local_config['max_trials'] == 100
-    assert local_config['max_broken'] == 5
-    assert local_config['name'] == 'voila_voici'
-    assert local_config['pool_size'] == 1
-    assert local_config['storage'] == {
-        'database': {
-            'host': 'mongodb://user:pass@localhost',
-            'name': 'orion_test',
-            'type': 'mongodb'}}
-    assert local_config['metadata'] == {
-        'orion_version': 'XYZ',
-        'user': 'tsirif'}
+    assert local_config["algorithms"] == "random"
+    assert local_config["strategy"] == "NoParallelStrategy"
+    assert local_config["max_trials"] == 100
+    assert local_config["max_broken"] == 5
+    assert local_config["name"] == "voila_voici"
+    assert local_config["pool_size"] == 1
+    assert local_config["storage"] == {
+        "database": {
+            "host": "mongodb://user:pass@localhost",
+            "name": "orion_test",
+            "type": "mongodb",
+        }
+    }
+    assert local_config["metadata"] == {"orion_version": "XYZ", "user": "tsirif"}
 
 
-@pytest.mark.usefixtures('with_user_tsirif', 'version_XYZ')
+@pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
 def test_get_cmd_config_from_incomplete_config(incomplete_config_file):
     """Test local config with incomplete user configuration file
     (default, env_vars, cmdconfig, cmdargs)
@@ -175,70 +187,72 @@ def test_get_cmd_config_from_incomplete_config(incomplete_config_file):
     cmdargs = {"config": incomplete_config_file}
     local_config = experiment_builder.get_cmd_config(cmdargs)
 
-    assert 'algorithms' not in local_config
-    assert 'max_trials' not in local_config
-    assert 'max_broken' not in local_config
-    assert 'pool_size' not in local_config
-    assert 'name' not in local_config['storage']['database']
-    assert local_config['storage']['database']['host'] == 'mongodb://user:pass@localhost'
-    assert local_config['storage']['database']['type'] == 'incomplete'
-    assert local_config['name'] == 'incomplete'
-    assert local_config['metadata'] == {
-        'orion_version': 'XYZ',
-        'user': 'tsirif'}
+    assert "algorithms" not in local_config
+    assert "max_trials" not in local_config
+    assert "max_broken" not in local_config
+    assert "pool_size" not in local_config
+    assert "name" not in local_config["storage"]["database"]
+    assert (
+        local_config["storage"]["database"]["host"] == "mongodb://user:pass@localhost"
+    )
+    assert local_config["storage"]["database"]["type"] == "incomplete"
+    assert local_config["name"] == "incomplete"
+    assert local_config["metadata"] == {"orion_version": "XYZ", "user": "tsirif"}
 
 
 def test_fetch_config_from_db_no_hit():
     """Verify that fetch_config_from_db returns an empty dict when the experiment is not in db"""
     with OrionState(experiments=[], trials=[]):
-        db_config = experiment_builder.fetch_config_from_db(name='supernaekei')
+        db_config = experiment_builder.fetch_config_from_db(name="supernaekei")
 
     assert db_config == {}
 
 
-@pytest.mark.usefixtures('with_user_tsirif')
+@pytest.mark.usefixtures("with_user_tsirif")
 def test_fetch_config_from_db_hit(new_config):
     """Verify db config when experiment is in db"""
     with OrionState(experiments=[new_config], trials=[]):
-        db_config = experiment_builder.fetch_config_from_db(name='supernaekei')
+        db_config = experiment_builder.fetch_config_from_db(name="supernaekei")
 
-    assert db_config['name'] == new_config['name']
-    assert db_config['refers'] == new_config['refers']
-    assert db_config['metadata'] == new_config['metadata']
-    assert db_config['pool_size'] == new_config['pool_size']
-    assert db_config['max_trials'] == new_config['max_trials']
-    assert db_config['max_broken'] == new_config['max_broken']
-    assert db_config['algorithms'] == new_config['algorithms']
-    assert db_config['metadata'] == new_config['metadata']
+    assert db_config["name"] == new_config["name"]
+    assert db_config["refers"] == new_config["refers"]
+    assert db_config["metadata"] == new_config["metadata"]
+    assert db_config["pool_size"] == new_config["pool_size"]
+    assert db_config["max_trials"] == new_config["max_trials"]
+    assert db_config["max_broken"] == new_config["max_broken"]
+    assert db_config["algorithms"] == new_config["algorithms"]
+    assert db_config["metadata"] == new_config["metadata"]
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
 def test_build_view_from_args_no_hit(config_file):
     """Try building experiment view when not in db"""
-    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    cmdargs = {"name": "supernaekei", "config": config_file}
 
     with OrionState(experiments=[], trials=[]):
         with pytest.raises(NoConfigurationError) as exc_info:
             experiment_builder.build_view_from_args(cmdargs)
-        assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
+        assert "No experiment with given name 'supernaekei' and version '*'" in str(
+            exc_info.value
+        )
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
 def test_build_view_from_args_hit(config_file, random_dt, new_config):
     """Try building experiment view when in db"""
-    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    cmdargs = {"name": "supernaekei", "config": config_file}
 
     with OrionState(experiments=[new_config], trials=[]):
         exp_view = experiment_builder.build_view_from_args(cmdargs)
 
-    assert exp_view._id == new_config['_id']
-    assert exp_view.name == new_config['name']
-    assert exp_view.configuration['refers'] == new_config['refers']
-    assert exp_view.metadata == new_config['metadata']
-    assert exp_view.pool_size == new_config['pool_size']
-    assert exp_view.max_trials == new_config['max_trials']
-    assert exp_view.max_broken == new_config['max_broken']
-    assert exp_view.algorithms.configuration == new_config['algorithms']
+    assert exp_view._id == new_config["_id"]
+    assert exp_view.name == new_config["name"]
+    assert exp_view.configuration["refers"] == new_config["refers"]
+    assert exp_view.metadata == new_config["metadata"]
+    assert exp_view.pool_size == new_config["pool_size"]
+    assert exp_view.max_trials == new_config["max_trials"]
+    assert exp_view.max_broken == new_config["max_broken"]
+    assert exp_view.algorithms.configuration == new_config["algorithms"]
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
@@ -246,55 +260,69 @@ def test_build_view_from_args_hit_no_conf_file(config_file, random_dt, new_confi
     """Try building experiment view when in db, and local config file of user script does
     not exist
     """
-    cmdargs = {'name': 'supernaekei', 'config': config_file}
-    new_config['metadata']['user_args'] += ['--config', new_config['metadata']['user_config']]
+    cmdargs = {"name": "supernaekei", "config": config_file}
+    new_config["metadata"]["user_args"] += [
+        "--config",
+        new_config["metadata"]["user_config"],
+    ]
 
     with OrionState(experiments=[new_config], trials=[]) as cfg:
         exp_view = experiment_builder.build_view_from_args(cmdargs)
 
-    assert exp_view._id == new_config['_id']
-    assert exp_view.name == new_config['name']
-    assert exp_view.configuration['refers'] == new_config['refers']
-    assert exp_view.metadata == new_config['metadata']
-    assert exp_view.pool_size == new_config['pool_size']
-    assert exp_view.max_trials == new_config['max_trials']
-    assert exp_view.max_broken == new_config['max_broken']
-    assert exp_view.algorithms.configuration == new_config['algorithms']
+    assert exp_view._id == new_config["_id"]
+    assert exp_view.name == new_config["name"]
+    assert exp_view.configuration["refers"] == new_config["refers"]
+    assert exp_view.metadata == new_config["metadata"]
+    assert exp_view.pool_size == new_config["pool_size"]
+    assert exp_view.max_trials == new_config["max_trials"]
+    assert exp_view.max_broken == new_config["max_broken"]
+    assert exp_view.algorithms.configuration == new_config["algorithms"]
 
 
 @pytest.mark.usefixtures("with_user_dendi")
 def test_build_from_args_no_hit(config_file, random_dt, script_path, new_config):
     """Try building experiment when not in db"""
-    cmdargs = {'name': 'supernaekei', 'config': config_file,
-               'user_args': [script_path,
-                             'x~uniform(0,10)']}
+    cmdargs = {
+        "name": "supernaekei",
+        "config": config_file,
+        "user_args": [script_path, "x~uniform(0,10)"],
+    }
 
     with OrionState(experiments=[], trials=[]):
         with pytest.raises(NoConfigurationError) as exc_info:
             experiment_builder.build_view_from_args(cmdargs)
-        assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
+        assert "No experiment with given name 'supernaekei' and version '*'" in str(
+            exc_info.value
+        )
 
         exp = experiment_builder.build_from_args(cmdargs)
 
-    assert exp.name == cmdargs['name']
-    assert exp.configuration['refers'] == {'adapter': [], 'parent_id': None, 'root_id': exp._id}
-    assert exp.metadata['datetime'] == random_dt
-    assert exp.metadata['user'] == 'dendi'
-    assert exp.metadata['user_script'] == cmdargs['user_args'][0]
-    assert exp.metadata['user_args'] == cmdargs['user_args']
+    assert exp.name == cmdargs["name"]
+    assert exp.configuration["refers"] == {
+        "adapter": [],
+        "parent_id": None,
+        "root_id": exp._id,
+    }
+    assert exp.metadata["datetime"] == random_dt
+    assert exp.metadata["user"] == "dendi"
+    assert exp.metadata["user_script"] == cmdargs["user_args"][0]
+    assert exp.metadata["user_args"] == cmdargs["user_args"]
     assert exp.pool_size == 1
     assert exp.max_trials == 100
     assert exp.max_broken == 5
-    assert exp.algorithms.configuration == {'random': {'seed': None}}
+    assert exp.algorithms.configuration == {"random": {"seed": None}}
 
 
-@pytest.mark.usefixtures("version_XYZ", "with_user_tsirif", "mock_infer_versioning_metadata")
+@pytest.mark.usefixtures(
+    "version_XYZ", "with_user_tsirif", "mock_infer_versioning_metadata"
+)
 def test_build_from_args_hit(old_config_file, script_path, new_config):
     """Try building experiment when in db (no branch)"""
-    cmdargs = {'name': 'supernaekei',
-               'config': old_config_file,
-               'user_args': [script_path,
-                             '--mini-batch~uniform(32, 256, discrete=True)']}
+    cmdargs = {
+        "name": "supernaekei",
+        "config": old_config_file,
+        "user_args": [script_path, "--mini-batch~uniform(32, 256, discrete=True)"],
+    }
 
     with OrionState(experiments=[new_config], trials=[]):
         # Test that experiment already exists
@@ -302,25 +330,25 @@ def test_build_from_args_hit(old_config_file, script_path, new_config):
 
         exp = experiment_builder.build_from_args(cmdargs)
 
-    assert exp._id == new_config['_id']
-    assert exp.name == new_config['name']
+    assert exp._id == new_config["_id"]
+    assert exp.name == new_config["name"]
     assert exp.version == 1
-    assert exp.configuration['refers'] == new_config['refers']
-    assert exp.metadata == new_config['metadata']
-    assert exp.max_trials == new_config['max_trials']
-    assert exp.max_broken == new_config['max_broken']
-    assert exp.algorithms.configuration == new_config['algorithms']
+    assert exp.configuration["refers"] == new_config["refers"]
+    assert exp.metadata == new_config["metadata"]
+    assert exp.max_trials == new_config["max_trials"]
+    assert exp.max_broken == new_config["max_broken"]
+    assert exp.algorithms.configuration == new_config["algorithms"]
 
 
 @pytest.mark.usefixtures("with_user_bouthilx")
 def test_build_from_args_force_user(new_config):
     """Try building experiment view when in db"""
-    cmdargs = {'name': new_config['name']}
-    cmdargs['user'] = 'tsirif'
+    cmdargs = {"name": new_config["name"]}
+    cmdargs["user"] = "tsirif"
     with OrionState(experiments=[new_config], trials=[]):
         # Test that experiment already exists
         exp_view = experiment_builder.build_from_args(cmdargs)
-    assert exp_view.metadata['user'] == 'tsirif'
+    assert exp_view.metadata["user"] == "tsirif"
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
@@ -328,8 +356,11 @@ def test_build_from_args_debug_mode(script_path):
     """Try building experiment in debug mode"""
     update_singletons()
     experiment_builder.build_from_args(
-        {'name': 'whatever',
-         'user_args': [script_path, '--mini-batch~uniform(32, 256)']})
+        {
+            "name": "whatever",
+            "user_args": [script_path, "--mini-batch~uniform(32, 256)"],
+        }
+    )
 
     storage = get_storage()
 
@@ -339,9 +370,12 @@ def test_build_from_args_debug_mode(script_path):
     update_singletons()
 
     experiment_builder.build_from_args(
-        {'name': 'whatever',
-         'user_args': [script_path, '--mini-batch~uniform(32, 256)'],
-         'debug': True})
+        {
+            "name": "whatever",
+            "user_args": [script_path, "--mini-batch~uniform(32, 256)"],
+            "debug": True,
+        }
+    )
     storage = get_storage()
 
     assert isinstance(storage, Legacy)
@@ -355,7 +389,7 @@ def test_build_view_from_args_debug_mode(script_path):
 
     # Can't build view if none exist. It's fine we only want to test the storage creation.
     with pytest.raises(NoConfigurationError):
-        experiment_builder.build_view_from_args({'name': 'whatever'})
+        experiment_builder.build_view_from_args({"name": "whatever"})
 
     storage = get_storage()
 
@@ -366,7 +400,7 @@ def test_build_view_from_args_debug_mode(script_path):
 
     # Can't build view if none exist. It's fine we only want to test the storage creation.
     with pytest.raises(NoConfigurationError):
-        experiment_builder.build_view_from_args({'name': 'whatever', 'debug': True})
+        experiment_builder.build_view_from_args({"name": "whatever", "debug": True})
 
     storage = get_storage()
 
@@ -377,8 +411,8 @@ def test_build_view_from_args_debug_mode(script_path):
 @pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
 def test_build_no_hit(config_file, random_dt, script_path):
     """Try building experiment from config when not in db"""
-    name = 'supernaekei'
-    space = {'x': 'uniform(0, 10)'}
+    name = "supernaekei"
+    space = {"x": "uniform(0, 10)"}
     max_trials = 100
     max_broken = 5
 
@@ -386,35 +420,45 @@ def test_build_no_hit(config_file, random_dt, script_path):
 
         with pytest.raises(NoConfigurationError) as exc_info:
             experiment_builder.build_view(name)
-        assert "No experiment with given name 'supernaekei' and version '*'" in str(exc_info.value)
+        assert "No experiment with given name 'supernaekei' and version '*'" in str(
+            exc_info.value
+        )
 
         exp = experiment_builder.build(
-            name, space=space, max_trials=max_trials, max_broken=max_broken)
+            name, space=space, max_trials=max_trials, max_broken=max_broken
+        )
 
     assert exp.name == name
-    assert exp.configuration['refers'] == {'adapter': [], 'parent_id': None, 'root_id': exp._id}
+    assert exp.configuration["refers"] == {
+        "adapter": [],
+        "parent_id": None,
+        "root_id": exp._id,
+    }
     assert exp.metadata == {
-        'datetime': random_dt,
-        'user': 'tsirif',
-        'orion_version': 'XYZ'}
-    assert exp.configuration['space'] == space
+        "datetime": random_dt,
+        "user": "tsirif",
+        "orion_version": "XYZ",
+    }
+    assert exp.configuration["space"] == space
     assert exp.max_trials == max_trials
     assert exp.max_broken == max_broken
     assert not exp.is_done
-    assert exp.algorithms.configuration == {'random': {'seed': None}}
+    assert exp.algorithms.configuration == {"random": {"seed": None}}
 
 
 def test_build_no_commandline_config():
     """Try building experiment with no commandline configuration."""
     with OrionState(experiments=[], trials=[]):
         with pytest.raises(NoConfigurationError):
-            experiment_builder.build('supernaekei')
+            experiment_builder.build("supernaekei")
 
 
-@pytest.mark.usefixtures("with_user_dendi", "mock_infer_versioning_metadata", "version_XYZ")
+@pytest.mark.usefixtures(
+    "with_user_dendi", "mock_infer_versioning_metadata", "version_XYZ"
+)
 def test_build_hit(python_api_config):
     """Try building experiment from config when in db (no branch)"""
-    name = 'supernaekei'
+    name = "supernaekei"
 
     with OrionState(experiments=[python_api_config], trials=[]):
 
@@ -423,20 +467,20 @@ def test_build_hit(python_api_config):
 
         exp = experiment_builder.build(**python_api_config)
 
-    assert exp._id == python_api_config['_id']
-    assert exp.name == python_api_config['name']
-    assert exp.configuration['refers'] == python_api_config['refers']
-    python_api_config['metadata']['user'] = 'dendi'
-    assert exp.metadata == python_api_config['metadata']
-    assert exp.max_trials == python_api_config['max_trials']
-    assert exp.max_broken == python_api_config['max_broken']
-    assert exp.algorithms.configuration == python_api_config['algorithms']
+    assert exp._id == python_api_config["_id"]
+    assert exp.name == python_api_config["name"]
+    assert exp.configuration["refers"] == python_api_config["refers"]
+    python_api_config["metadata"]["user"] = "dendi"
+    assert exp.metadata == python_api_config["metadata"]
+    assert exp.max_trials == python_api_config["max_trials"]
+    assert exp.max_broken == python_api_config["max_broken"]
+    assert exp.algorithms.configuration == python_api_config["algorithms"]
 
 
 @pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
 def test_build_without_config_hit(python_api_config):
     """Try building experiment without commandline config when in db (no branch)"""
-    name = 'supernaekei'
+    name = "supernaekei"
 
     with OrionState(experiments=[python_api_config], trials=[]):
 
@@ -445,22 +489,21 @@ def test_build_without_config_hit(python_api_config):
 
         exp = experiment_builder.build(name=name)
 
-    assert exp._id == python_api_config['_id']
-    assert exp.name == python_api_config['name']
-    assert exp.configuration['refers'] == python_api_config['refers']
-    assert exp.metadata == python_api_config['metadata']
-    assert exp.max_trials == python_api_config['max_trials']
-    assert exp.max_broken == python_api_config['max_broken']
-    assert exp.algorithms.configuration == python_api_config['algorithms']
+    assert exp._id == python_api_config["_id"]
+    assert exp.name == python_api_config["name"]
+    assert exp.configuration["refers"] == python_api_config["refers"]
+    assert exp.metadata == python_api_config["metadata"]
+    assert exp.max_trials == python_api_config["max_trials"]
+    assert exp.max_broken == python_api_config["max_broken"]
+    assert exp.algorithms.configuration == python_api_config["algorithms"]
 
 
 @pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
 def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
     """Try building experiment without commandline when in db (no branch)"""
-    name = 'supernaekei'
+    name = "supernaekei"
 
-    cmdargs = {'name': name,
-               'config': old_config_file}
+    cmdargs = {"name": name, "config": old_config_file}
 
     with OrionState(experiments=[new_config], trials=[]):
         # Test that experiment already exists (this should fail otherwise)
@@ -468,13 +511,13 @@ def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
 
         exp = experiment_builder.build_from_args(cmdargs)
 
-    assert exp._id == new_config['_id']
-    assert exp.name == new_config['name']
-    assert exp.configuration['refers'] == new_config['refers']
-    assert exp.metadata == new_config['metadata']
-    assert exp.max_trials == new_config['max_trials']
-    assert exp.max_broken == new_config['max_broken']
-    assert exp.algorithms.configuration == new_config['algorithms']
+    assert exp._id == new_config["_id"]
+    assert exp.name == new_config["name"]
+    assert exp.configuration["refers"] == new_config["refers"]
+    assert exp.metadata == new_config["metadata"]
+    assert exp.max_trials == new_config["max_trials"]
+    assert exp.max_broken == new_config["max_broken"]
+    assert exp.algorithms.configuration == new_config["algorithms"]
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
@@ -491,16 +534,19 @@ class TestExperimentVersioning(object):
     def test_new_experiment_w_version(self, space):
         """Create a new and never-seen-before experiment with a version."""
         with OrionState():
-            exp = experiment_builder.build(name="exp_wout_version", version=1, space=space)
+            exp = experiment_builder.build(
+                name="exp_wout_version", version=1, space=space
+            )
 
         assert exp.version == 1
 
     def test_backward_compatibility_no_version(self, parent_version_config):
         """Branch from parent that has no version field."""
-        parent_version_config.pop('version')
+        parent_version_config.pop("version")
         with OrionState(experiments=[parent_version_config]):
-            exp = experiment_builder.build(name=parent_version_config["name"],
-                                           space={'y': 'uniform(0, 10)'})
+            exp = experiment_builder.build(
+                name=parent_version_config["name"], space={"y": "uniform(0, 10)"}
+            )
 
         assert exp.version == 2
 
@@ -511,26 +557,35 @@ class TestExperimentVersioning(object):
 
         assert exp.version == 1
 
-    def test_old_experiment_2_wout_version(self, parent_version_config, child_version_config):
+    def test_old_experiment_2_wout_version(
+        self, parent_version_config, child_version_config
+    ):
         """Create an already existing experiment without a version and getting last one."""
         with OrionState(experiments=[parent_version_config, child_version_config]):
             exp = experiment_builder.build(name=parent_version_config["name"])
 
         assert exp.version == 2
 
-    def test_old_experiment_w_version(self, parent_version_config, child_version_config):
+    def test_old_experiment_w_version(
+        self, parent_version_config, child_version_config
+    ):
         """Create an already existing experiment with a version."""
         with OrionState(experiments=[parent_version_config, child_version_config]):
-            exp = experiment_builder.build(name=parent_version_config["name"], version=1)
+            exp = experiment_builder.build(
+                name=parent_version_config["name"], version=1
+            )
 
         assert exp.version == 1
 
-    def test_old_experiment_w_version_bigger_than_max(self, parent_version_config,
-                                                      child_version_config):
+    def test_old_experiment_w_version_bigger_than_max(
+        self, parent_version_config, child_version_config
+    ):
         """Create an already existing experiment with a too large version."""
-        print(child_version_config['name'])
+        print(child_version_config["name"])
         with OrionState(experiments=[parent_version_config, child_version_config]):
-            exp = experiment_builder.build(name=parent_version_config["name"], version=8)
+            exp = experiment_builder.build(
+                name=parent_version_config["name"], version=8
+            )
 
         assert exp.version == 2
 
@@ -547,79 +602,88 @@ class TestBuild(object):
         """
         with OrionState(experiments=[new_config], trials=[]):
 
-            new_config['max_trials'] = 5000
+            new_config["max_trials"] = 5000
 
             exp = experiment_builder.build(**new_config)
 
         # Deliver an external configuration to finalize init
-        new_config['algorithms']['dumbalgo']['done'] = False
-        new_config['algorithms']['dumbalgo']['judgement'] = None
-        new_config['algorithms']['dumbalgo']['scoring'] = 0
-        new_config['algorithms']['dumbalgo']['suspend'] = False
-        new_config['algorithms']['dumbalgo']['value'] = 5
-        new_config['algorithms']['dumbalgo']['seed'] = None
-        new_config['producer']['strategy'] = "NoParallelStrategy"
-        new_config.pop('something_to_be_ignored')
+        new_config["algorithms"]["dumbalgo"]["done"] = False
+        new_config["algorithms"]["dumbalgo"]["judgement"] = None
+        new_config["algorithms"]["dumbalgo"]["scoring"] = 0
+        new_config["algorithms"]["dumbalgo"]["suspend"] = False
+        new_config["algorithms"]["dumbalgo"]["value"] = 5
+        new_config["algorithms"]["dumbalgo"]["seed"] = None
+        new_config["producer"]["strategy"] = "NoParallelStrategy"
+        new_config.pop("something_to_be_ignored")
         assert exp.configuration == new_config
 
     def test_good_set_before_init_no_hit(self, random_dt, new_config):
         """Trying to set, overwrite everything from input."""
         with OrionState(experiments=[], trials=[]):
             exp = experiment_builder.build(**new_config)
-            found_config = list(get_storage().fetch_experiments({'name': 'supernaekei',
-                                                                 'metadata.user': 'tsirif'}))
+            found_config = list(
+                get_storage().fetch_experiments(
+                    {"name": "supernaekei", "metadata.user": "tsirif"}
+                )
+            )
 
-        new_config['metadata']['datetime'] = exp.metadata['datetime']
+        new_config["metadata"]["datetime"] = exp.metadata["datetime"]
 
         assert len(found_config) == 1
-        _id = found_config[0].pop('_id')
-        assert _id != 'fasdfasfa'
+        _id = found_config[0].pop("_id")
+        assert _id != "fasdfasfa"
         assert exp._id == _id
-        new_config['refers'] = {}
-        new_config.pop('_id')
-        new_config.pop('something_to_be_ignored')
-        new_config['algorithms']['dumbalgo']['done'] = False
-        new_config['algorithms']['dumbalgo']['judgement'] = None
-        new_config['algorithms']['dumbalgo']['scoring'] = 0
-        new_config['algorithms']['dumbalgo']['suspend'] = False
-        new_config['algorithms']['dumbalgo']['value'] = 5
-        new_config['algorithms']['dumbalgo']['seed'] = None
-        new_config['refers'] = {'adapter': [], 'parent_id': None, 'root_id': _id}
+        new_config["refers"] = {}
+        new_config.pop("_id")
+        new_config.pop("something_to_be_ignored")
+        new_config["algorithms"]["dumbalgo"]["done"] = False
+        new_config["algorithms"]["dumbalgo"]["judgement"] = None
+        new_config["algorithms"]["dumbalgo"]["scoring"] = 0
+        new_config["algorithms"]["dumbalgo"]["suspend"] = False
+        new_config["algorithms"]["dumbalgo"]["value"] = 5
+        new_config["algorithms"]["dumbalgo"]["seed"] = None
+        new_config["refers"] = {"adapter": [], "parent_id": None, "root_id": _id}
         assert found_config[0] == new_config
-        assert exp.name == new_config['name']
-        assert exp.configuration['refers'] == new_config['refers']
-        assert exp.metadata == new_config['metadata']
-        assert exp.pool_size == new_config['pool_size']
-        assert exp.max_trials == new_config['max_trials']
-        assert exp.max_broken == new_config['max_broken']
-        assert exp.working_dir == new_config['working_dir']
-        assert exp.version == new_config['version']
-        assert exp.algorithms.configuration == new_config['algorithms']
+        assert exp.name == new_config["name"]
+        assert exp.configuration["refers"] == new_config["refers"]
+        assert exp.metadata == new_config["metadata"]
+        assert exp.pool_size == new_config["pool_size"]
+        assert exp.max_trials == new_config["max_trials"]
+        assert exp.max_broken == new_config["max_broken"]
+        assert exp.working_dir == new_config["working_dir"]
+        assert exp.version == new_config["version"]
+        assert exp.algorithms.configuration == new_config["algorithms"]
 
     def test_working_dir_is_correctly_set(self, new_config):
         """Check if working_dir is correctly changed."""
         with OrionState():
-            new_config['working_dir'] = './'
+            new_config["working_dir"] = "./"
             exp = experiment_builder.build(**new_config)
             storage = get_storage()
-            found_config = list(storage.fetch_experiments({'name': 'supernaekei',
-                                                           'metadata.user': 'tsirif'}))
+            found_config = list(
+                storage.fetch_experiments(
+                    {"name": "supernaekei", "metadata.user": "tsirif"}
+                )
+            )
 
             found_config = found_config[0]
             exp = experiment_builder.build(**found_config)
-            assert exp.working_dir == './'
+            assert exp.working_dir == "./"
 
     def test_working_dir_works_when_db_absent(self, database, new_config):
         """Check if working_dir is correctly when absent from the database."""
         with OrionState(experiments=[], trials=[]):
             exp = experiment_builder.build(**new_config)
             storage = get_storage()
-            found_config = list(storage.fetch_experiments({'name': 'supernaekei',
-                                                           'metadata.user': 'tsirif'}))
+            found_config = list(
+                storage.fetch_experiments(
+                    {"name": "supernaekei", "metadata.user": "tsirif"}
+                )
+            )
 
             found_config = found_config[0]
             exp = experiment_builder.build(**found_config)
-            assert exp.working_dir == ''
+            assert exp.working_dir == ""
 
     def test_configuration_hit_no_diffs(self, new_config):
         """Return a configuration dict according to an experiment object.
@@ -633,14 +697,14 @@ class TestBuild(object):
             exp = experiment_builder.build(**new_config)
             assert experiment_count_before == count_experiments()
 
-        new_config['algorithms']['dumbalgo']['done'] = False
-        new_config['algorithms']['dumbalgo']['judgement'] = None
-        new_config['algorithms']['dumbalgo']['scoring'] = 0
-        new_config['algorithms']['dumbalgo']['suspend'] = False
-        new_config['algorithms']['dumbalgo']['value'] = 5
-        new_config['algorithms']['dumbalgo']['seed'] = None
-        new_config['producer']['strategy'] = "NoParallelStrategy"
-        new_config.pop('something_to_be_ignored')
+        new_config["algorithms"]["dumbalgo"]["done"] = False
+        new_config["algorithms"]["dumbalgo"]["judgement"] = None
+        new_config["algorithms"]["dumbalgo"]["scoring"] = 0
+        new_config["algorithms"]["dumbalgo"]["suspend"] = False
+        new_config["algorithms"]["dumbalgo"]["value"] = 5
+        new_config["algorithms"]["dumbalgo"]["seed"] = None
+        new_config["producer"]["strategy"] = "NoParallelStrategy"
+        new_config.pop("something_to_be_ignored")
         assert exp.configuration == new_config
 
     def test_instantiation_after_init(self, new_config):
@@ -650,35 +714,38 @@ class TestBuild(object):
 
         assert isinstance(exp.algorithms, BaseAlgorithm)
         assert isinstance(exp.space, Space)
-        assert isinstance(exp.refers['adapter'], BaseAdapter)
+        assert isinstance(exp.refers["adapter"], BaseAdapter)
 
     def test_algo_case_insensitive(self, new_config):
         """Verify that algo with uppercase or lowercase leads to same experiment"""
         with OrionState(experiments=[new_config], trials=[]):
-            new_config['algorithms']['DUMBALGO'] = new_config['algorithms'].pop('dumbalgo')
+            new_config["algorithms"]["DUMBALGO"] = new_config["algorithms"].pop(
+                "dumbalgo"
+            )
             exp = experiment_builder.build(**new_config)
 
             assert exp.version == 1
 
     def test_hierarchical_space(self, new_config):
         """Verify space can have hierarchical structure"""
-        space = {'a': {'x': 'uniform(0, 10, discrete=True)'},
-                 'b': {'y': 'loguniform(1e-08, 1)',
-                       'z': 'choices([\'voici\', \'voila\', 2])'}}
+        space = {
+            "a": {"x": "uniform(0, 10, discrete=True)"},
+            "b": {"y": "loguniform(1e-08, 1)", "z": "choices(['voici', 'voila', 2])"},
+        }
 
         with OrionState(experiments=[], trials=[]):
-            exp = experiment_builder.build('hierarchy', space=space)
+            exp = experiment_builder.build("hierarchy", space=space)
 
-            exp2 = experiment_builder.build('hierarchy')
+            exp2 = experiment_builder.build("hierarchy")
 
-        assert 'a.x' in exp.space
-        assert 'b.y' in exp.space
-        assert 'b.z' in exp.space
+        assert "a.x" in exp.space
+        assert "b.y" in exp.space
+        assert "b.z" in exp.space
 
         # Make sure it can be fetched properly from db as well
-        assert 'a.x' in exp2.space
-        assert 'b.y' in exp2.space
-        assert 'b.z' in exp2.space
+        assert "a.x" in exp2.space
+        assert "b.y" in exp2.space
+        assert "b.z" in exp2.space
 
     def test_try_set_after_race_condition(self, new_config, monkeypatch):
         """Cannot set a configuration after init if it looses a race
@@ -703,7 +770,9 @@ class TestBuild(object):
 
             insert_race_condition.count = 0
 
-            monkeypatch.setattr(experiment_builder, 'fetch_config_from_db', insert_race_condition)
+            monkeypatch.setattr(
+                experiment_builder, "fetch_config_from_db", insert_race_condition
+            )
 
             experiment_builder.build(**new_config)
 
@@ -718,26 +787,30 @@ class TestBuild(object):
 
     def test_algorithm_config_with_just_a_string(self):
         """Test that configuring an algorithm with just a string is OK."""
-        name = 'supernaedo3'
-        space = {'x': 'uniform(0,10)'}
-        algorithms = 'dumbalgo'
+        name = "supernaedo3"
+        space = {"x": "uniform(0,10)"}
+        algorithms = "dumbalgo"
 
         with OrionState(experiments=[], trials=[]):
-            exp = experiment_builder.build(name=name, space=space, algorithms=algorithms)
+            exp = experiment_builder.build(
+                name=name, space=space, algorithms=algorithms
+            )
 
-        assert exp.configuration['algorithms'] == {
-            'dumbalgo': {
-                'done': False,
-                'judgement': None,
-                'scoring': 0,
-                'suspend': False,
-                'value': 5,
-                'seed': None}}
+        assert exp.configuration["algorithms"] == {
+            "dumbalgo": {
+                "done": False,
+                "judgement": None,
+                "scoring": 0,
+                "suspend": False,
+                "value": 5,
+                "seed": None,
+            }
+        }
 
     def test_new_child_with_branch(self):
         """Check that experiment is not incremented when branching with a new name."""
-        name = 'parent'
-        space = {'x': 'uniform(0, 10)'}
+        name = "parent"
+        space = {"x": "uniform(0, 10)"}
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name=name, space=space)
@@ -745,48 +818,56 @@ class TestBuild(object):
             assert parent.name == name
             assert parent.version == 1
 
-            child_name = 'child'
+            child_name = "child"
 
-            child = experiment_builder.build(name=name, branching={'branch_to': child_name})
-
-            assert child.name == child_name
-            assert child.version == 1
-            assert child.refers['parent_id'] == parent.id
-
-            child_name = 'child2'
-
-            child = experiment_builder.build(name=child_name, branching={'branch_from': name})
+            child = experiment_builder.build(
+                name=name, branching={"branch_to": child_name}
+            )
 
             assert child.name == child_name
             assert child.version == 1
-            assert child.refers['parent_id'] == parent.id
+            assert child.refers["parent_id"] == parent.id
+
+            child_name = "child2"
+
+            child = experiment_builder.build(
+                name=child_name, branching={"branch_from": name}
+            )
+
+            assert child.name == child_name
+            assert child.version == 1
+            assert child.refers["parent_id"] == parent.id
 
     def test_no_increment_when_child_exist(self):
         """Check that experiment cannot be incremented when asked for v1 while v2 exists."""
-        name = 'parent'
-        space = {'x': 'uniform(0,10)'}
+        name = "parent"
+        space = {"x": "uniform(0,10)"}
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name=name, space=space)
-            child = experiment_builder.build(name=name, space={'x': 'loguniform(1,10)'})
+            child = experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
             assert child.name == parent.name
             assert parent.version == 1
             assert child.version == 2
 
             with pytest.raises(BranchingEvent) as exc_info:
-                experiment_builder.build(name=name, version=1, space={'x': 'loguniform(1,10)'})
-            assert 'Configuration is different and generates a branching' in str(exc_info.value)
+                experiment_builder.build(
+                    name=name, version=1, space={"x": "loguniform(1,10)"}
+                )
+            assert "Configuration is different and generates a branching" in str(
+                exc_info.value
+            )
 
     def test_race_condition_wout_version(self, monkeypatch):
         """Test that an experiment loosing the race condition during version increment raises
         RaceCondition if version number was not specified.
         """
-        name = 'parent'
-        space = {'x': 'uniform(0,10)'}
+        name = "parent"
+        space = {"x": "uniform(0,10)"}
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name, space=space)
-            child = experiment_builder.build(name=name, space={'x': 'loguniform(1,10)'})
+            child = experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
             assert child.name == parent.name
             assert parent.version == 1
             assert child.version == 2
@@ -802,7 +883,10 @@ class TestBuild(object):
             #     -> DuplicateKeyError
 
             def insert_race_condition_1(self, query):
-                is_auto_version_query = (query == {'name': name, 'refers.parent_id': parent.id})
+                is_auto_version_query = query == {
+                    "name": name,
+                    "refers.parent_id": parent.id,
+                }
                 if is_auto_version_query:
                     data = [child.configuration]
                 # First time the query returns no other child
@@ -817,15 +901,21 @@ class TestBuild(object):
 
             insert_race_condition_1.count = 0
 
-            monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
-                                insert_race_condition_1)
+            monkeypatch.setattr(
+                get_storage().__class__, "fetch_experiments", insert_race_condition_1
+            )
 
             with pytest.raises(RaceCondition) as exc_info:
-                experiment_builder.build(name=name, space={'x': 'loguniform(1,10)'})
-            assert 'There was likely a race condition during version' in str(exc_info.value)
+                experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+            assert "There was likely a race condition during version" in str(
+                exc_info.value
+            )
 
             def insert_race_condition_2(self, query):
-                is_auto_version_query = (query == {'name': name, 'refers.parent_id': parent.id})
+                is_auto_version_query = query == {
+                    "name": name,
+                    "refers.parent_id": parent.id,
+                }
                 # First time the query returns no other child
                 if is_auto_version_query:
                     data = []
@@ -840,12 +930,13 @@ class TestBuild(object):
 
             insert_race_condition_2.count = 0
 
-            monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
-                                insert_race_condition_2)
+            monkeypatch.setattr(
+                get_storage().__class__, "fetch_experiments", insert_race_condition_2
+            )
 
             with pytest.raises(RaceCondition) as exc_info:
-                experiment_builder.build(name=name, space={'x': 'loguniform(1,10)'})
-            assert 'There was a race condition during branching.' in str(exc_info.value)
+                experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+            assert "There was a race condition during branching." in str(exc_info.value)
 
     def test_race_condition_w_version(self, monkeypatch):
         """Test that an experiment loosing the race condition during version increment cannot
@@ -856,12 +947,12 @@ class TestBuild(object):
         one. Therefore raising and handling RaceCondition would lead to infinite recursion in
         the experiment builder.
         """
-        name = 'parent'
-        space = {'x': 'uniform(0,10)'}
+        name = "parent"
+        space = {"x": "uniform(0,10)"}
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name, space=space)
-            child = experiment_builder.build(name=name, space={'x': 'loguniform(1,10)'})
+            child = experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
             assert child.name == parent.name
             assert parent.version == 1
             assert child.version == 2
@@ -877,7 +968,10 @@ class TestBuild(object):
             #     -> DuplicateKeyError
 
             def insert_race_condition_1(self, query):
-                is_auto_version_query = (query == {'name': name, 'refers.parent_id': parent.id})
+                is_auto_version_query = query == {
+                    "name": name,
+                    "refers.parent_id": parent.id,
+                }
                 if is_auto_version_query:
                     data = [child.configuration]
                 # First time the query returns no other child
@@ -892,15 +986,21 @@ class TestBuild(object):
 
             insert_race_condition_1.count = 0
 
-            monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
-                                insert_race_condition_1)
+            monkeypatch.setattr(
+                get_storage().__class__, "fetch_experiments", insert_race_condition_1
+            )
 
             with pytest.raises(BranchingEvent) as exc_info:
-                experiment_builder.build(name=name, version=1, space={'x': 'loguniform(1,10)'})
-            assert 'Configuration is different and generates' in str(exc_info.value)
+                experiment_builder.build(
+                    name=name, version=1, space={"x": "loguniform(1,10)"}
+                )
+            assert "Configuration is different and generates" in str(exc_info.value)
 
             def insert_race_condition_2(self, query):
-                is_auto_version_query = (query == {'name': name, 'refers.parent_id': parent.id})
+                is_auto_version_query = query == {
+                    "name": name,
+                    "refers.parent_id": parent.id,
+                }
                 # First time the query returns no other child
                 if is_auto_version_query:
                     data = []
@@ -915,12 +1015,15 @@ class TestBuild(object):
 
             insert_race_condition_2.count = 0
 
-            monkeypatch.setattr(get_storage().__class__, 'fetch_experiments',
-                                insert_race_condition_2)
+            monkeypatch.setattr(
+                get_storage().__class__, "fetch_experiments", insert_race_condition_2
+            )
 
             with pytest.raises(RaceCondition) as exc_info:
-                experiment_builder.build(name=name, version=1, space={'x': 'loguniform(1,10)'})
-            assert 'There was a race condition during branching.' in str(exc_info.value)
+                experiment_builder.build(
+                    name=name, version=1, space={"x": "loguniform(1,10)"}
+                )
+            assert "There was a race condition during branching." in str(exc_info.value)
 
 
 class TestInitExperimentView(object):
@@ -930,25 +1033,26 @@ class TestInitExperimentView(object):
         """Hit user name, but exp_name does not hit the db."""
         with OrionState(experiments=[], trials=[]):
             with pytest.raises(NoConfigurationError) as exc_info:
-                experiment_builder.build_view('supernaekei')
-            assert ("No experiment with given name 'supernaekei' and version '*'"
-                    in str(exc_info.value))
+                experiment_builder.build_view("supernaekei")
+            assert "No experiment with given name 'supernaekei' and version '*'" in str(
+                exc_info.value
+            )
 
     def test_existing_experiment_view(self, new_config):
         """Hit exp_name + user's name in the db, fetch most recent entry."""
         with OrionState(experiments=[new_config], trials=[]):
-            exp = experiment_builder.build_view(name='supernaekei')
+            exp = experiment_builder.build_view(name="supernaekei")
 
-        assert exp._id == new_config['_id']
-        assert exp.name == new_config['name']
-        assert exp.configuration['refers'] == new_config['refers']
-        assert exp.metadata == new_config['metadata']
-        assert exp.pool_size == new_config['pool_size']
-        assert exp.max_trials == new_config['max_trials']
-        assert exp.max_broken == new_config['max_broken']
-        assert exp.version == new_config['version']
-        assert isinstance(exp.refers['adapter'], BaseAdapter)
-        assert exp.algorithms.configuration == new_config['algorithms']
+        assert exp._id == new_config["_id"]
+        assert exp.name == new_config["name"]
+        assert exp.configuration["refers"] == new_config["refers"]
+        assert exp.metadata == new_config["metadata"]
+        assert exp.pool_size == new_config["pool_size"]
+        assert exp.max_trials == new_config["max_trials"]
+        assert exp.max_broken == new_config["max_broken"]
+        assert exp.version == new_config["version"]
+        assert isinstance(exp.refers["adapter"], BaseAdapter)
+        assert exp.algorithms.configuration == new_config["algorithms"]
 
         with pytest.raises(AttributeError):
             exp.this_is_not_in_config = 5

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -24,25 +24,27 @@ def parser():
 @pytest.fixture
 def parser_diff_prefix():
     """Return an instance of `OrionCmdlineParser` with a different config prefix."""
-    return OrionCmdlineParser(config_prefix='config2', allow_non_existing_files=True)
+    return OrionCmdlineParser(config_prefix="config2", allow_non_existing_files=True)
 
 
 @pytest.fixture
 def commandline():
     """Return a simple commandline list."""
-    return ["--seed=555",
-            "--lr~uniform(-3, 1)",
-            "--non-prior=choices({{'sgd': 0.2, 'adam': 0.8}})",
-            "--prior~choices({'sgd': 0.2, 'adam': 0.8})"]
+    return [
+        "--seed=555",
+        "--lr~uniform(-3, 1)",
+        "--non-prior=choices({{'sgd': 0.2, 'adam': 0.8}})",
+        "--prior~choices({'sgd': 0.2, 'adam': 0.8})",
+    ]
 
 
 @pytest.fixture
 def commandline_fluff(commandline):
     """Add extra useless info to commandline."""
     cmd_args = commandline
-    cmd_args.extend(["--some-path=~/some_path",
-                     "--home-path=~",
-                     "~/../folder/.hidden/folder"])
+    cmd_args.extend(
+        ["--some-path=~/some_path", "--home-path=~", "~/../folder/.hidden/folder"]
+    )
     return cmd_args
 
 
@@ -61,12 +63,12 @@ def test_parse_from_yaml_config(parser, yaml_config):
     config = parser.priors
 
     assert len(config.keys()) == 6
-    assert '/layers/1/width' in config
-    assert '/layers/1/type' in config
-    assert '/layers/2/type' in config
-    assert '/training/lr0' in config
-    assert '/training/mbs' in config
-    assert '/something-same' in config
+    assert "/layers/1/width" in config
+    assert "/layers/1/type" in config
+    assert "/layers/2/type" in config
+    assert "/training/lr0" in config
+    assert "/training/mbs" in config
+    assert "/something-same" in config
 
 
 def test_parse_from_json_config(parser, json_config):
@@ -75,12 +77,12 @@ def test_parse_from_json_config(parser, json_config):
     config = parser.priors
 
     assert len(config.keys()) == 6
-    assert '/layers/1/width' in config
-    assert '/layers/1/type' in config
-    assert '/layers/2/type' in config
-    assert '/training/lr0' in config
-    assert '/training/mbs' in config
-    assert '/something-same' in config
+    assert "/layers/1/width" in config
+    assert "/layers/1/type" in config
+    assert "/layers/2/type" in config
+    assert "/training/lr0" in config
+    assert "/training/mbs" in config
+    assert "/something-same" in config
 
 
 def test_parse_from_unknown_config(parser, some_sample_config):
@@ -89,12 +91,12 @@ def test_parse_from_unknown_config(parser, some_sample_config):
     config = parser.priors
 
     assert len(config.keys()) == 6
-    assert '/layers/1/width' in config
-    assert '/layers/1/type' in config
-    assert '/layers/2/type' in config
-    assert '/training/lr0' in config
-    assert '/training/mbs' in config
-    assert '/something-same' in config
+    assert "/layers/1/width" in config
+    assert "/layers/1/type" in config
+    assert "/layers/2/type" in config
+    assert "/training/lr0" in config
+    assert "/training/mbs" in config
+    assert "/something-same" in config
 
 
 def test_parse_equivalency(yaml_config, json_config):
@@ -117,11 +119,23 @@ def test_parse_from_args_only(parser, commandline_fluff):
 
     assert not parser.config_file_data
     assert len(parser.cmd_priors) == 2
-    assert '/lr' in parser.cmd_priors
-    assert '/prior' in parser.cmd_priors
-    assert parser.parser.template == \
-        ['--seed', '{seed}', '--lr', '{lr}', '--non-prior', '{non-prior}', '--prior', '{prior}',
-         '--some-path', '{some-path}', '--home-path', '{home-path[0]}', '{home-path[1]}']
+    assert "/lr" in parser.cmd_priors
+    assert "/prior" in parser.cmd_priors
+    assert parser.parser.template == [
+        "--seed",
+        "{seed}",
+        "--lr",
+        "{lr}",
+        "--non-prior",
+        "{non-prior}",
+        "--prior",
+        "{prior}",
+        "--some-path",
+        "{some-path}",
+        "--home-path",
+        "{home-path[0]}",
+        "{home-path[1]}",
+    ]
 
 
 def test_parse_from_args_and_config_yaml(parser, commandline, yaml_config):
@@ -133,18 +147,28 @@ def test_parse_from_args_and_config_yaml(parser, commandline, yaml_config):
     config = parser.priors
 
     assert len(config) == 8
-    assert '/lr' in config
-    assert '/prior' in config
-    assert '/layers/1/width' in config
-    assert '/layers/1/type' in config
-    assert '/layers/2/type' in config
-    assert '/training/lr0' in config
-    assert '/training/mbs' in config
-    assert '/something-same' in config
+    assert "/lr" in config
+    assert "/prior" in config
+    assert "/layers/1/width" in config
+    assert "/layers/1/type" in config
+    assert "/layers/2/type" in config
+    assert "/training/lr0" in config
+    assert "/training/mbs" in config
+    assert "/something-same" in config
 
     template = parser.parser.template
-    assert template == ['--config', '{config}', '--seed', '{seed}', '--lr', '{lr}',
-                        '--non-prior', '{non-prior}', '--prior', '{prior}']
+    assert template == [
+        "--config",
+        "{config}",
+        "--seed",
+        "{seed}",
+        "--lr",
+        "{lr}",
+        "--non-prior",
+        "{non-prior}",
+        "--prior",
+        "{prior}",
+    ]
 
 
 def test_parse_finds_conflict(parser, commandline, yaml_config):
@@ -156,72 +180,106 @@ def test_parse_finds_conflict(parser, commandline, yaml_config):
     with pytest.raises(ValueError) as exc:
         parser.parse(cmd_args)
 
-    assert 'Conflict' in str(exc.value)
+    assert "Conflict" in str(exc.value)
 
 
 def test_format_commandline_only(parser, commandline):
     """Format the commandline using only args."""
     parser.parse(commandline)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'}])
+    trial = Trial(
+        params=[
+            {"name": "/lr", "type": "real", "value": -2.4},
+            {"name": "/prior", "type": "categorical", "value": "sgd"},
+        ]
+    )
 
     cmd_inst = parser.format(trial=trial)
-    assert cmd_inst == ["--seed", "555",
-                        "--lr", "-2.4",
-                        "--non-prior", "choices({'sgd': 0.2, 'adam': 0.8})",
-                        "--prior", "sgd"]
+    assert cmd_inst == [
+        "--seed",
+        "555",
+        "--lr",
+        "-2.4",
+        "--non-prior",
+        "choices({'sgd': 0.2, 'adam': 0.8})",
+        "--prior",
+        "sgd",
+    ]
 
 
-def test_format_commandline_and_config(parser, commandline, json_config, tmpdir, json_converter):
+def test_format_commandline_and_config(
+    parser, commandline, json_config, tmpdir, json_converter
+):
     """Format the commandline and a configuration file."""
     cmd_args = json_config
     cmd_args.extend(commandline)
 
     parser.parse(cmd_args)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
-        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
-        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
-        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
-        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
-        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
-        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+    trial = Trial(
+        params=[
+            {"name": "/lr", "type": "real", "value": -2.4},
+            {"name": "/prior", "type": "categorical", "value": "sgd"},
+            {"name": "/layers/1/width", "type": "integer", "value": 100},
+            {"name": "/layers/1/type", "type": "categorical", "value": "relu"},
+            {"name": "/layers/2/type", "type": "categorical", "value": "sigmoid"},
+            {"name": "/training/lr0", "type": "real", "value": 0.032},
+            {"name": "/training/mbs", "type": "integer", "value": 64},
+            {"name": "/something-same", "type": "categorical", "value": "3"},
+        ]
+    )
 
     output_file = str(tmpdir.join("output.json"))
 
     cmd_inst = parser.format(output_file, trial)
 
-    assert cmd_inst == ['--config', output_file, "--seed", "555", "--lr", "-2.4",
-                        "--non-prior", "choices({'sgd': 0.2, 'adam': 0.8})", "--prior", "sgd"]
+    assert cmd_inst == [
+        "--config",
+        output_file,
+        "--seed",
+        "555",
+        "--lr",
+        "-2.4",
+        "--non-prior",
+        "choices({'sgd': 0.2, 'adam': 0.8})",
+        "--prior",
+        "sgd",
+    ]
 
     output_data = json_converter.parse(output_file)
-    assert output_data == {'yo': 5, 'training': {'lr0': 0.032, 'mbs': 64},
-                           'layers': [{'width': 64, 'type': 'relu'},
-                                      {'width': 100, 'type': 'relu'},
-                                      {'width': 16, 'type': 'sigmoid'}],
-                           'something-same': '3'}
+    assert output_data == {
+        "yo": 5,
+        "training": {"lr0": 0.032, "mbs": 64},
+        "layers": [
+            {"width": 64, "type": "relu"},
+            {"width": 100, "type": "relu"},
+            {"width": 16, "type": "sigmoid"},
+        ],
+        "something-same": "3",
+    }
 
 
-def test_format_without_config_path(parser, commandline, json_config, tmpdir, json_converter):
+def test_format_without_config_path(
+    parser, commandline, json_config, tmpdir, json_converter
+):
     """Verify that parser.format() raises ValueError when config path not passed."""
     cmd_args = json_config
     cmd_args.extend(commandline)
 
     parser.parse(cmd_args)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
-        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
-        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
-        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
-        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
-        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
-        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+    trial = Trial(
+        params=[
+            {"name": "/lr", "type": "real", "value": -2.4},
+            {"name": "/prior", "type": "categorical", "value": "sgd"},
+            {"name": "/layers/1/width", "type": "integer", "value": 100},
+            {"name": "/layers/1/type", "type": "categorical", "value": "relu"},
+            {"name": "/layers/2/type", "type": "categorical", "value": "sigmoid"},
+            {"name": "/training/lr0", "type": "real", "value": 0.032},
+            {"name": "/training/mbs", "type": "integer", "value": 64},
+            {"name": "/something-same", "type": "categorical", "value": "3"},
+        ]
+    )
 
     with pytest.raises(ValueError) as exc_info:
         parser.format(trial=trial)
@@ -233,14 +291,18 @@ def test_format_with_properties(parser, cmd_with_properties, hacked_exp):
     """Test if format correctly puts the value of `trial` and `exp` when used as properties"""
     parser.parse(cmd_with_properties)
 
-    trial = Trial(experiment='trial_test', params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'}])
+    trial = Trial(
+        experiment="trial_test",
+        params=[
+            {"name": "/lr", "type": "real", "value": -2.4},
+            {"name": "/prior", "type": "categorical", "value": "sgd"},
+        ],
+    )
 
     cmd_line = parser.format(None, trial=trial, experiment=hacked_exp)
 
     assert trial.hash_name in cmd_line
-    assert 'supernaedo2-dendi' in cmd_line
+    assert "supernaedo2-dendi" in cmd_line
 
 
 def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
@@ -249,25 +311,25 @@ def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
     config = parser_diff_prefix.priors
 
     assert len(config.keys()) == 6
-    assert '/layers/1/width' in config
-    assert '/layers/1/type' in config
-    assert '/layers/2/type' in config
-    assert '/training/lr0' in config
-    assert '/training/mbs' in config
-    assert '/something-same' in config
+    assert "/layers/1/width" in config
+    assert "/layers/1/type" in config
+    assert "/layers/2/type" in config
+    assert "/training/lr0" in config
+    assert "/training/mbs" in config
+    assert "/something-same" in config
 
 
 def test_infer_user_script(script_path):
     """Test that user script is infered correctly"""
     parser = OrionCmdlineParser()
-    parser.parse(f'{script_path} and some args'.split(' '))
+    parser.parse(f"{script_path} and some args".split(" "))
     assert parser.user_script == script_path
 
 
 def test_infer_user_script_python(script_path):
     """Test that user script is infered correctly when using python"""
     parser = OrionCmdlineParser()
-    parser.parse(f'python {script_path} and some args'.split(' '))
+    parser.parse(f"python {script_path} and some args".split(" "))
     assert parser.user_script == script_path
 
 
@@ -276,18 +338,18 @@ def test_infer_user_script_when_missing():
     parser = OrionCmdlineParser()
 
     with pytest.raises(FileNotFoundError) as exc:
-        parser.parse('python script.py and some args'.split(' '))
-    assert exc.match('The path specified for the script does not exist')
+        parser.parse("python script.py and some args".split(" "))
+    assert exc.match("The path specified for the script does not exist")
 
     parser = OrionCmdlineParser(allow_non_existing_files=True)
-    parser.parse('python script.py and some args'.split(' '))
-    assert parser.user_script == 'script.py'
+    parser.parse("python script.py and some args".split(" "))
+    assert parser.user_script == "script.py"
 
 
 def test_configurable_config_arg_do_not_exist(script_path):
     """Test that parser can handle command if config file does not exist"""
     parser = OrionCmdlineParser()
-    command = f'python {script_path} --config idontexist.yaml'.split(' ')
+    command = f"python {script_path} --config idontexist.yaml".split(" ")
     with pytest.raises(OSError) as exc:
         parser.parse(command)
     assert exc.match("The path specified for the script config does not exist")
@@ -299,16 +361,14 @@ def test_configurable_config_arg_do_not_exist(script_path):
 def test_get_state_dict_before_parse(parser, commandline):
     """Test getting state dict."""
     assert parser.get_state_dict() == {
-        'parser': {
-            'keys': [],
-            'arguments': [],
-            'template': []},
-        'cmd_priors': list(map(list, parser.cmd_priors.items())),
-        'file_priors': list(map(list, parser.file_priors.items())),
-        'config_file_data': parser.config_file_data,
-        'config_prefix': parser.config_prefix,
-        'file_config_path': parser.file_config_path,
-        'converter': None}
+        "parser": {"keys": [], "arguments": [], "template": []},
+        "cmd_priors": list(map(list, parser.cmd_priors.items())),
+        "file_priors": list(map(list, parser.file_priors.items())),
+        "config_file_data": parser.config_file_data,
+        "config_prefix": parser.config_prefix,
+        "file_config_path": parser.file_config_path,
+        "converter": None,
+    }
 
 
 def test_get_state_dict_after_parse_no_config_file(parser, commandline):
@@ -316,13 +376,14 @@ def test_get_state_dict_after_parse_no_config_file(parser, commandline):
     parser.parse(commandline)
 
     assert parser.get_state_dict() == {
-        'parser': parser.parser.get_state_dict(),
-        'cmd_priors': list(map(list, parser.cmd_priors.items())),
-        'file_priors': list(map(list, parser.file_priors.items())),
-        'config_file_data': parser.config_file_data,
-        'config_prefix': parser.config_prefix,
-        'file_config_path': parser.file_config_path,
-        'converter': None}
+        "parser": parser.parser.get_state_dict(),
+        "cmd_priors": list(map(list, parser.cmd_priors.items())),
+        "file_priors": list(map(list, parser.file_priors.items())),
+        "config_file_data": parser.config_file_data,
+        "config_prefix": parser.config_prefix,
+        "file_config_path": parser.file_config_path,
+        "converter": None,
+    }
 
 
 def test_get_state_dict_after_parse_with_config_file(parser, yaml_config, commandline):
@@ -333,13 +394,14 @@ def test_get_state_dict_after_parse_with_config_file(parser, yaml_config, comman
     parser.parse(cmd_args)
 
     assert parser.get_state_dict() == {
-        'parser': parser.parser.get_state_dict(),
-        'cmd_priors': list(map(list, parser.cmd_priors.items())),
-        'file_priors': list(map(list, parser.file_priors.items())),
-        'config_file_data': parser.config_file_data,
-        'config_prefix': parser.config_prefix,
-        'file_config_path': parser.file_config_path,
-        'converter': parser.converter.get_state_dict()}
+        "parser": parser.parser.get_state_dict(),
+        "cmd_priors": list(map(list, parser.cmd_priors.items())),
+        "file_priors": list(map(list, parser.file_priors.items())),
+        "config_file_data": parser.config_file_data,
+        "config_prefix": parser.config_prefix,
+        "file_config_path": parser.file_config_path,
+        "converter": parser.converter.get_state_dict(),
+    }
 
 
 def test_set_state_dict(parser, commandline, json_config, tmpdir, json_converter):
@@ -356,26 +418,44 @@ def test_set_state_dict(parser, commandline, json_config, tmpdir, json_converter
 
     blank_parser.set_state_dict(state)
 
-    trial = Trial(params=[
-        {'name': '/lr', 'type': 'real', 'value': -2.4},
-        {'name': '/prior', 'type': 'categorical', 'value': 'sgd'},
-        {'name': '/layers/1/width', 'type': 'integer', 'value': 100},
-        {'name': '/layers/1/type', 'type': 'categorical', 'value': 'relu'},
-        {'name': '/layers/2/type', 'type': 'categorical', 'value': 'sigmoid'},
-        {'name': '/training/lr0', 'type': 'real', 'value': 0.032},
-        {'name': '/training/mbs', 'type': 'integer', 'value': 64},
-        {'name': '/something-same', 'type': 'categorical', 'value': '3'}])
+    trial = Trial(
+        params=[
+            {"name": "/lr", "type": "real", "value": -2.4},
+            {"name": "/prior", "type": "categorical", "value": "sgd"},
+            {"name": "/layers/1/width", "type": "integer", "value": 100},
+            {"name": "/layers/1/type", "type": "categorical", "value": "relu"},
+            {"name": "/layers/2/type", "type": "categorical", "value": "sigmoid"},
+            {"name": "/training/lr0", "type": "real", "value": 0.032},
+            {"name": "/training/mbs", "type": "integer", "value": 64},
+            {"name": "/something-same", "type": "categorical", "value": "3"},
+        ]
+    )
 
     output_file = str(tmpdir.join("output.json"))
 
     cmd_inst = blank_parser.format(output_file, trial)
 
-    assert cmd_inst == ['--config', output_file, "--seed", "555", "--lr", "-2.4",
-                        "--non-prior", "choices({'sgd': 0.2, 'adam': 0.8})", "--prior", "sgd"]
+    assert cmd_inst == [
+        "--config",
+        output_file,
+        "--seed",
+        "555",
+        "--lr",
+        "-2.4",
+        "--non-prior",
+        "choices({'sgd': 0.2, 'adam': 0.8})",
+        "--prior",
+        "sgd",
+    ]
 
     output_data = json_converter.parse(output_file)
-    assert output_data == {'yo': 5, 'training': {'lr0': 0.032, 'mbs': 64},
-                           'layers': [{'width': 64, 'type': 'relu'},
-                                      {'width': 100, 'type': 'relu'},
-                                      {'width': 16, 'type': 'sigmoid'}],
-                           'something-same': '3'}
+    assert output_data == {
+        "yo": 5,
+        "training": {"lr0": 0.032, "mbs": 64},
+        "layers": [
+            {"width": 64, "type": "relu"},
+            {"width": 100, "type": "relu"},
+            {"width": 16, "type": "sigmoid"},
+        ],
+        "something-same": "3",
+    }

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -18,6 +18,7 @@ import orion.core.io.resolve_config as resolve_config
 @pytest.fixture
 def force_is_exe(monkeypatch):
     """Mock resolve_config to recognize any string as an executable script."""
+
     def is_exe(path):
         return True
 
@@ -29,61 +30,63 @@ def test_socket_on_osx(monkeypatch):
     """Verify that default hostname is set properly on OSX"""
     config = orion.core.build_config()
     assert config.storage.database.host == socket.gethostbyname(socket.gethostname())
-    assert socket.gethostbyname(socket.gethostname()) != 'localhost'
+    assert socket.gethostbyname(socket.gethostname()) != "localhost"
 
-    monkeypatch.setattr(socket, 'gethostname', lambda: 'wrong_name_on_osx')
+    monkeypatch.setattr(socket, "gethostname", lambda: "wrong_name_on_osx")
     config = orion.core.build_config()
-    assert config.storage.database.host == 'localhost'
+    assert config.storage.database.host == "localhost"
 
 
 def test_fetch_env_vars():
     """Verify env vars are fetched properly"""
     env_vars_config = resolve_config.fetch_env_vars()
-    assert env_vars_config == {'database': {}}
+    assert env_vars_config == {"database": {}}
 
     db_name = "orion_test"
 
-    os.environ['ORION_DB_NAME'] = db_name
+    os.environ["ORION_DB_NAME"] = db_name
 
     env_vars_config = resolve_config.fetch_env_vars()
-    assert env_vars_config == {'database': {'name': 'orion_test'}}
+    assert env_vars_config == {"database": {"name": "orion_test"}}
 
     db_type = "MongoDB"
-    os.environ['ORION_DB_TYPE'] = db_type
+    os.environ["ORION_DB_TYPE"] = db_type
 
     env_vars_config = resolve_config.fetch_env_vars()
-    assert env_vars_config == {'database': {'name': db_name, 'type': db_type}}
+    assert env_vars_config == {"database": {"name": db_name, "type": db_type}}
 
 
 @pytest.mark.usefixtures("version_XYZ")
 def test_fetch_metadata_orion_version():
     """Verify orion version"""
     metadata = resolve_config.fetch_metadata()
-    assert metadata['orion_version'] == 'XYZ'
+    assert metadata["orion_version"] == "XYZ"
 
 
 def test_fetch_metadata_executable_users_script(script_path):
     """Verify executable user script with absolute path"""
     metadata = resolve_config.fetch_metadata(user_args=[script_path])
-    assert metadata['user_script'] == os.path.abspath(script_path)
+    assert metadata["user_script"] == os.path.abspath(script_path)
 
 
 def test_fetch_metadata_non_executable_users_script():
     """Verify executable user script keeps given path"""
-    script_path = 'tests/functional/demo/orion_config.yaml'
+    script_path = "tests/functional/demo/orion_config.yaml"
     metadata = resolve_config.fetch_metadata(user_args=[script_path])
-    assert metadata['user_script'] == script_path
+    assert metadata["user_script"] == script_path
 
 
 def test_fetch_metadata_python_users_script(script_path):
     """Verify user script is correctly infered if called with python"""
-    metadata = resolve_config.fetch_metadata(user_args=['python', script_path, 'some', 'args'])
-    assert metadata['user_script'] == script_path
+    metadata = resolve_config.fetch_metadata(
+        user_args=["python", script_path, "some", "args"]
+    )
+    assert metadata["user_script"] == script_path
 
 
 def test_fetch_metadata_not_existed_path():
     """Verfiy the raise of error when user_script path does not exist"""
-    path = 'dummy/path'
+    path = "dummy/path"
     with pytest.raises(OSError) as exc_info:
         resolve_config.fetch_metadata(user_args=[path])
     assert "The path specified for the script does not exist" in str(exc_info.value)
@@ -94,15 +97,15 @@ def test_fetch_metadata_user_args(script_path):
     """Verify user args"""
     user_args = [os.path.abspath(script_path)] + list(map(str, range(10)))
     metadata = resolve_config.fetch_metadata(user_args=user_args)
-    assert metadata['user_script'] == user_args[0]
-    assert metadata['user_args'] == user_args
+    assert metadata["user_script"] == user_args[0]
+    assert metadata["user_args"] == user_args
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
 def test_fetch_metadata_user_tsirif():
     """Verify user name"""
     metadata = resolve_config.fetch_metadata()
-    assert metadata['user'] == "tsirif"
+    assert metadata["user"] == "tsirif"
 
 
 def test_fetch_metadata():
@@ -114,69 +117,70 @@ def test_fetch_metadata():
 def test_fetch_config_from_cmdargs():
     """Verify fetch_config returns empty dict on no config file path"""
     cmdargs = {
-        'name': 'test',
-        'user': 'me',
-        'version': 1,
-        'config': None,
-        'exp_max_trials': 'exp_max_trials',
-        'worker_trials': 'worker_trials',
-        'exp_max_broken': 'exp_max_broken',
-        'working_dir': 'working_dir',
-        'pool_size': 'pool_size',
-        'max_trials': 'max_trials',
-        'heartbeat': 'heartbeat',
-        'worker_max_trials': 'worker_max_trials',
-        'worker_max_broken': 'worker_max_broken',
-        'max_idle_time': 'max_idle_time',
-        'interrupt_signal_code': 'interrupt_signal_code',
-        'user_script_config': 'user_script_config',
-        'manual_resolution': 'manual_resolution',
-        'non_monitored_arguments': 'non_monitored_arguments',
-        'ignore_code_changes': 'ignore_code_changes',
-        'auto_resolution': 'auto_resolution',
-        'branch_from': 'branch_from',
-        'algorithm_change': 'algorithm_change',
-        'code_change_type': 'code_change_type',
-        'cli_change_type': 'cli_change_type',
-        'branch_to': 'branch_to',
-        'config_change_type': 'config_change_type'}
+        "name": "test",
+        "user": "me",
+        "version": 1,
+        "config": None,
+        "exp_max_trials": "exp_max_trials",
+        "worker_trials": "worker_trials",
+        "exp_max_broken": "exp_max_broken",
+        "working_dir": "working_dir",
+        "pool_size": "pool_size",
+        "max_trials": "max_trials",
+        "heartbeat": "heartbeat",
+        "worker_max_trials": "worker_max_trials",
+        "worker_max_broken": "worker_max_broken",
+        "max_idle_time": "max_idle_time",
+        "interrupt_signal_code": "interrupt_signal_code",
+        "user_script_config": "user_script_config",
+        "manual_resolution": "manual_resolution",
+        "non_monitored_arguments": "non_monitored_arguments",
+        "ignore_code_changes": "ignore_code_changes",
+        "auto_resolution": "auto_resolution",
+        "branch_from": "branch_from",
+        "algorithm_change": "algorithm_change",
+        "code_change_type": "code_change_type",
+        "cli_change_type": "cli_change_type",
+        "branch_to": "branch_to",
+        "config_change_type": "config_change_type",
+    }
 
     config = resolve_config.fetch_config_from_cmdargs(cmdargs)
 
-    assert config.pop('config', None) is None
+    assert config.pop("config", None) is None
 
-    exp_config = config.pop('experiment')
-    assert exp_config.pop('name') == 'test'
-    assert exp_config.pop('version') == 1
-    assert exp_config.pop('user') == 'me'
-    assert exp_config.pop('max_trials') == 'exp_max_trials'
-    assert exp_config.pop('max_broken') == 'exp_max_broken'
-    assert exp_config.pop('working_dir') == 'working_dir'
-    assert exp_config.pop('pool_size') == 'pool_size'
+    exp_config = config.pop("experiment")
+    assert exp_config.pop("name") == "test"
+    assert exp_config.pop("version") == 1
+    assert exp_config.pop("user") == "me"
+    assert exp_config.pop("max_trials") == "exp_max_trials"
+    assert exp_config.pop("max_broken") == "exp_max_broken"
+    assert exp_config.pop("working_dir") == "working_dir"
+    assert exp_config.pop("pool_size") == "pool_size"
 
     assert exp_config == {}
 
-    worker_config = config.pop('worker')
-    assert worker_config.pop('heartbeat') == 'heartbeat'
-    assert worker_config.pop('max_trials') == 'worker_max_trials'
-    assert worker_config.pop('max_broken') == 'worker_max_broken'
-    assert worker_config.pop('max_idle_time') == 'max_idle_time'
-    assert worker_config.pop('interrupt_signal_code') == 'interrupt_signal_code'
-    assert worker_config.pop('user_script_config') == 'user_script_config'
+    worker_config = config.pop("worker")
+    assert worker_config.pop("heartbeat") == "heartbeat"
+    assert worker_config.pop("max_trials") == "worker_max_trials"
+    assert worker_config.pop("max_broken") == "worker_max_broken"
+    assert worker_config.pop("max_idle_time") == "max_idle_time"
+    assert worker_config.pop("interrupt_signal_code") == "interrupt_signal_code"
+    assert worker_config.pop("user_script_config") == "user_script_config"
 
     assert worker_config == {}
 
-    evc_config = config.pop('evc')
-    assert evc_config.pop('manual_resolution') == 'manual_resolution'
-    assert evc_config.pop('non_monitored_arguments') == 'non_monitored_arguments'
-    assert evc_config.pop('ignore_code_changes') == 'ignore_code_changes'
-    assert evc_config.pop('auto_resolution') == 'auto_resolution'
-    assert evc_config.pop('branch_from') == 'branch_from'
-    assert evc_config.pop('algorithm_change') == 'algorithm_change'
-    assert evc_config.pop('code_change_type') == 'code_change_type'
-    assert evc_config.pop('cli_change_type') == 'cli_change_type'
-    assert evc_config.pop('branch_to') == 'branch_to'
-    assert evc_config.pop('config_change_type') == 'config_change_type'
+    evc_config = config.pop("evc")
+    assert evc_config.pop("manual_resolution") == "manual_resolution"
+    assert evc_config.pop("non_monitored_arguments") == "non_monitored_arguments"
+    assert evc_config.pop("ignore_code_changes") == "ignore_code_changes"
+    assert evc_config.pop("auto_resolution") == "auto_resolution"
+    assert evc_config.pop("branch_from") == "branch_from"
+    assert evc_config.pop("algorithm_change") == "algorithm_change"
+    assert evc_config.pop("code_change_type") == "code_change_type"
+    assert evc_config.pop("cli_change_type") == "cli_change_type"
+    assert evc_config.pop("branch_to") == "branch_to"
+    assert evc_config.pop("config_change_type") == "config_change_type"
 
     assert evc_config == {}
 
@@ -185,7 +189,8 @@ def test_fetch_config_from_cmdargs():
 
 @pytest.mark.parametrize(
     "argument",
-    ['config', 'user', 'user_args', 'name', 'version', 'branch_from', 'branch_to'])
+    ["config", "user", "user_args", "name", "version", "branch_from", "branch_to"],
+)
 def test_fetch_config_from_cmdargs_no_empty(argument):
     """Verify fetch_config returns only defined arguments."""
     config = resolve_config.fetch_config_from_cmdargs({})
@@ -199,10 +204,10 @@ def test_fetch_config_from_cmdargs_no_empty(argument):
 
     config = resolve_config.fetch_config_from_cmdargs({argument: 1})
 
-    if argument in ['name', 'user', 'version']:
-        assert config == {'experiment': {argument: 1}}
-    elif argument in ['branch_from', 'branch_to']:
-        assert config == {'evc': {argument: 1}}
+    if argument in ["name", "user", "version"]:
+        assert config == {"experiment": {argument: 1}}
+    elif argument in ["branch_from", "branch_to"]:
+        assert config == {"evc": {argument: 1}}
     else:
         assert config == {argument: 1}
 
@@ -217,79 +222,97 @@ def test_fetch_config(config_file):
     """Verify fetch_config returns valid dictionnary"""
     config = resolve_config.fetch_config({"config": config_file})
 
-    assert config.pop('storage') == {
-        'database': {
-            'host': 'mongodb://user:pass@localhost',
-            'name': 'orion_test',
-            'type': 'mongodb'}}
+    assert config.pop("storage") == {
+        "database": {
+            "host": "mongodb://user:pass@localhost",
+            "name": "orion_test",
+            "type": "mongodb",
+        }
+    }
 
-    assert config.pop('experiment') == {
-        'max_trials': 100,
-        'max_broken': 5,
-        'name': 'voila_voici',
-        'pool_size': 1,
-        'algorithms': 'random',
-        'strategy': 'NoParallelStrategy'}
+    assert config.pop("experiment") == {
+        "max_trials": 100,
+        "max_broken": 5,
+        "name": "voila_voici",
+        "pool_size": 1,
+        "algorithms": "random",
+        "strategy": "NoParallelStrategy",
+    }
 
     assert config == {}
 
 
 def test_fetch_config_global_local_coherence(monkeypatch, config_file):
     """Verify fetch_config parses local config according to global config structure."""
+
     def mocked_config(file_object):
         return orion.core.config.to_dict()
-    monkeypatch.setattr('yaml.safe_load', mocked_config)
+
+    monkeypatch.setattr("yaml.safe_load", mocked_config)
 
     config = resolve_config.fetch_config({"config": config_file})
 
     # Test storage subconfig
-    storage_config = config.pop('storage')
-    database_config = storage_config.pop('database')
-    assert storage_config.pop('type') == orion.core.config.storage.type
+    storage_config = config.pop("storage")
+    database_config = storage_config.pop("database")
+    assert storage_config.pop("type") == orion.core.config.storage.type
     assert storage_config == {}
 
-    assert database_config.pop('host') == orion.core.config.storage.database.host
-    assert database_config.pop('name') == orion.core.config.storage.database.name
-    assert database_config.pop('port') == orion.core.config.storage.database.port
-    assert database_config.pop('type') == orion.core.config.storage.database.type
+    assert database_config.pop("host") == orion.core.config.storage.database.host
+    assert database_config.pop("name") == orion.core.config.storage.database.name
+    assert database_config.pop("port") == orion.core.config.storage.database.port
+    assert database_config.pop("type") == orion.core.config.storage.database.type
 
     assert database_config == {}
 
     # Test experiment subconfig
-    exp_config = config.pop('experiment')
-    assert exp_config.pop('max_trials') == orion.core.config.experiment.max_trials
-    assert exp_config.pop('max_broken') == orion.core.config.experiment.max_broken
-    assert exp_config.pop('working_dir') == orion.core.config.experiment.working_dir
-    assert exp_config.pop('pool_size') == orion.core.config.experiment.pool_size
-    assert exp_config.pop('algorithms') == orion.core.config.experiment.algorithms
-    assert exp_config.pop('strategy') == orion.core.config.experiment.strategy
+    exp_config = config.pop("experiment")
+    assert exp_config.pop("max_trials") == orion.core.config.experiment.max_trials
+    assert exp_config.pop("max_broken") == orion.core.config.experiment.max_broken
+    assert exp_config.pop("working_dir") == orion.core.config.experiment.working_dir
+    assert exp_config.pop("pool_size") == orion.core.config.experiment.pool_size
+    assert exp_config.pop("algorithms") == orion.core.config.experiment.algorithms
+    assert exp_config.pop("strategy") == orion.core.config.experiment.strategy
 
     assert exp_config == {}
 
     # Test worker subconfig
-    worker_config = config.pop('worker')
-    assert worker_config.pop('heartbeat') == orion.core.config.worker.heartbeat
-    assert worker_config.pop('max_trials') == orion.core.config.worker.max_trials
-    assert worker_config.pop('max_broken') == orion.core.config.worker.max_broken
-    assert worker_config.pop('max_idle_time') == orion.core.config.worker.max_idle_time
-    assert (worker_config.pop('interrupt_signal_code') ==
-            orion.core.config.worker.interrupt_signal_code)
-    assert (worker_config.pop('user_script_config') ==
-            orion.core.config.worker.user_script_config)
+    worker_config = config.pop("worker")
+    assert worker_config.pop("heartbeat") == orion.core.config.worker.heartbeat
+    assert worker_config.pop("max_trials") == orion.core.config.worker.max_trials
+    assert worker_config.pop("max_broken") == orion.core.config.worker.max_broken
+    assert worker_config.pop("max_idle_time") == orion.core.config.worker.max_idle_time
+    assert (
+        worker_config.pop("interrupt_signal_code")
+        == orion.core.config.worker.interrupt_signal_code
+    )
+    assert (
+        worker_config.pop("user_script_config")
+        == orion.core.config.worker.user_script_config
+    )
 
     assert worker_config == {}
 
     # Test evc subconfig
-    evc_config = config.pop('evc')
-    assert evc_config.pop('auto_resolution') == orion.core.config.evc.auto_resolution
-    assert evc_config.pop('manual_resolution') == orion.core.config.evc.manual_resolution
-    assert (evc_config.pop('non_monitored_arguments') ==
-            orion.core.config.evc.non_monitored_arguments)
-    assert evc_config.pop('ignore_code_changes') == orion.core.config.evc.ignore_code_changes
-    assert evc_config.pop('algorithm_change') == orion.core.config.evc.algorithm_change
-    assert evc_config.pop('code_change_type') == orion.core.config.evc.code_change_type
-    assert evc_config.pop('cli_change_type') == orion.core.config.evc.cli_change_type
-    assert evc_config.pop('config_change_type') == orion.core.config.evc.config_change_type
+    evc_config = config.pop("evc")
+    assert evc_config.pop("auto_resolution") == orion.core.config.evc.auto_resolution
+    assert (
+        evc_config.pop("manual_resolution") == orion.core.config.evc.manual_resolution
+    )
+    assert (
+        evc_config.pop("non_monitored_arguments")
+        == orion.core.config.evc.non_monitored_arguments
+    )
+    assert (
+        evc_config.pop("ignore_code_changes")
+        == orion.core.config.evc.ignore_code_changes
+    )
+    assert evc_config.pop("algorithm_change") == orion.core.config.evc.algorithm_change
+    assert evc_config.pop("code_change_type") == orion.core.config.evc.code_change_type
+    assert evc_config.pop("cli_change_type") == orion.core.config.evc.cli_change_type
+    assert (
+        evc_config.pop("config_change_type") == orion.core.config.evc.config_change_type
+    )
 
     assert evc_config == {}
 
@@ -299,286 +322,300 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
 
 def test_fetch_config_dash(monkeypatch, config_file):
     """Verify fetch_config supports dash."""
+
     def mocked_config(file_object):
-        return {'experiment': {'max-broken': 10, 'algorithms': {'dont-change': 'me'}}}
-    monkeypatch.setattr('yaml.safe_load', mocked_config)
+        return {"experiment": {"max-broken": 10, "algorithms": {"dont-change": "me"}}}
 
-    config = resolve_config.fetch_config({"config": config_file})
-
-    assert config == {'experiment': {'max_broken': 10, 'algorithms': {'dont-change': 'me'}}}
-
-
-def test_fetch_config_underscore(monkeypatch, config_file):
-    """Verify fetch_config supports underscore as well."""
-    def mocked_config(file_object):
-        return {'experiment': {'max_broken': 10, 'algorithms': {'dont-change': 'me'}}}
-    monkeypatch.setattr('yaml.safe_load', mocked_config)
-
-    config = resolve_config.fetch_config({"config": config_file})
-
-    assert config == {'experiment': {'max_broken': 10, 'algorithms': {'dont-change': 'me'}}}
-
-
-def test_fetch_config_deprecated_max_trials(monkeypatch, config_file):
-    """Verify fetch_config will overwrite deprecated value if also properly defined."""
-    def mocked_config(file_object):
-        return {'experiment': {'max_trials': 10}, 'max_trials': 20}
-    monkeypatch.setattr('yaml.safe_load', mocked_config)
-
-    config = resolve_config.fetch_config({"config": config_file})
-
-    assert config == {'experiment': {'max_trials': 10}}
-
-
-def test_fetch_config_deprecate_tricky_names(monkeypatch, config_file):
-    """Verify fetch_config assigns values properly for the similar names."""
-    def mocked_config(file_object):
-        return {
-            'experiment': {
-                'worker_trials': 'should_be_ignored'},
-            'max_trials': 'exp_max_trials',
-            'max_broken': 'exp_max_broken',
-            'worker_trials': 'worker_max_trials',
-            'name': 'exp_name'
-        }
-    monkeypatch.setattr('yaml.safe_load', mocked_config)
+    monkeypatch.setattr("yaml.safe_load", mocked_config)
 
     config = resolve_config.fetch_config({"config": config_file})
 
     assert config == {
-        'experiment': {
-            'name': 'exp_name',
-            'max_trials': 'exp_max_trials',
-            'max_broken': 'exp_max_broken'},
-        'worker': {'max_trials': 'worker_max_trials'}}
+        "experiment": {"max_broken": 10, "algorithms": {"dont-change": "me"}}
+    }
+
+
+def test_fetch_config_underscore(monkeypatch, config_file):
+    """Verify fetch_config supports underscore as well."""
+
+    def mocked_config(file_object):
+        return {"experiment": {"max_broken": 10, "algorithms": {"dont-change": "me"}}}
+
+    monkeypatch.setattr("yaml.safe_load", mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {
+        "experiment": {"max_broken": 10, "algorithms": {"dont-change": "me"}}
+    }
+
+
+def test_fetch_config_deprecated_max_trials(monkeypatch, config_file):
+    """Verify fetch_config will overwrite deprecated value if also properly defined."""
+
+    def mocked_config(file_object):
+        return {"experiment": {"max_trials": 10}, "max_trials": 20}
+
+    monkeypatch.setattr("yaml.safe_load", mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {"experiment": {"max_trials": 10}}
+
+
+def test_fetch_config_deprecate_tricky_names(monkeypatch, config_file):
+    """Verify fetch_config assigns values properly for the similar names."""
+
+    def mocked_config(file_object):
+        return {
+            "experiment": {"worker_trials": "should_be_ignored"},
+            "max_trials": "exp_max_trials",
+            "max_broken": "exp_max_broken",
+            "worker_trials": "worker_max_trials",
+            "name": "exp_name",
+        }
+
+    monkeypatch.setattr("yaml.safe_load", mocked_config)
+
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config == {
+        "experiment": {
+            "name": "exp_name",
+            "max_trials": "exp_max_trials",
+            "max_broken": "exp_max_broken",
+        },
+        "worker": {"max_trials": "worker_max_trials"},
+    }
 
 
 def test_merge_configs_update_two():
     """Ensure update on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'a': 3}
+    a = {"a": 1, "b": 2}
+    b = {"a": 3}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 3, 'b': 2}
+    assert m == {"a": 3, "b": 2}
 
 
 def test_merge_configs_update_three():
     """Ensure two updates on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'a': 3}
-    c = {'b': 4}
+    a = {"a": 1, "b": 2}
+    b = {"a": 3}
+    c = {"b": 4}
 
     m = resolve_config.merge_configs(a, b, c)
 
-    assert m == {'a': 3, 'b': 4}
+    assert m == {"a": 3, "b": 4}
 
 
 def test_merge_configs_update_four():
     """Ensure three updates on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'a': 3}
-    c = {'b': 4}
-    d = {'a': 5, 'b': 6}
+    a = {"a": 1, "b": 2}
+    b = {"a": 3}
+    c = {"b": 4}
+    d = {"a": 5, "b": 6}
 
     m = resolve_config.merge_configs(a, b, c, d)
 
-    assert m == {'a': 5, 'b': 6}
+    assert m == {"a": 5, "b": 6}
 
 
 def test_merge_configs_extend_two():
     """Ensure extension on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'c': 3}
+    a = {"a": 1, "b": 2}
+    b = {"c": 3}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': 2, 'c': 3}
+    assert m == {"a": 1, "b": 2, "c": 3}
 
 
 def test_merge_configs_extend_three():
     """Ensure two extensions on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'c': 3}
-    c = {'d': 4}
+    a = {"a": 1, "b": 2}
+    b = {"c": 3}
+    c = {"d": 4}
 
     m = resolve_config.merge_configs(a, b, c)
 
-    assert m == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+    assert m == {"a": 1, "b": 2, "c": 3, "d": 4}
 
 
 def test_merge_configs_extend_four():
     """Ensure three extensions on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'c': 3}
-    c = {'d': 4}
-    d = {'e': 5}
+    a = {"a": 1, "b": 2}
+    b = {"c": 3}
+    c = {"d": 4}
+    d = {"e": 5}
 
     m = resolve_config.merge_configs(a, b, c, d)
 
-    assert m == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
+    assert m == {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
 
 
 def test_merge_configs_update_extend_two():
     """Ensure update and extension on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'b': 3, 'c': 4}
+    a = {"a": 1, "b": 2}
+    b = {"b": 3, "c": 4}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': 3, 'c': 4}
+    assert m == {"a": 1, "b": 3, "c": 4}
 
 
 def test_merge_configs_update_extend_three():
     """Ensure two updates and extensions on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'b': 3, 'c': 4}
-    c = {'a': 5, 'd': 6}
+    a = {"a": 1, "b": 2}
+    b = {"b": 3, "c": 4}
+    c = {"a": 5, "d": 6}
 
     m = resolve_config.merge_configs(a, b, c)
 
-    assert m == {'a': 5, 'b': 3, 'c': 4, 'd': 6}
+    assert m == {"a": 5, "b": 3, "c": 4, "d": 6}
 
 
 def test_merge_configs_update_extend_four():
     """Ensure three updates and extensions on first level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'b': 3, 'c': 4}
-    c = {'a': 5, 'd': 6}
-    d = {'d': 7, 'e': 8}
+    a = {"a": 1, "b": 2}
+    b = {"b": 3, "c": 4}
+    c = {"a": 5, "d": 6}
+    d = {"d": 7, "e": 8}
 
     m = resolve_config.merge_configs(a, b, c, d)
 
-    assert m == {'a': 5, 'b': 3, 'c': 4, 'd': 7, 'e': 8}
+    assert m == {"a": 5, "b": 3, "c": 4, "d": 7, "e": 8}
 
 
 def test_merge_sub_configs_update_two():
     """Ensure updating to second level is fine"""
-    a = {'a': 1, 'b': 2}
-    b = {'b': {'c': 3}}
+    a = {"a": 1, "b": 2}
+    b = {"b": {"c": 3}}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': {'c': 3}}
+    assert m == {"a": 1, "b": {"c": 3}}
 
 
 def test_merge_sub_configs_sub_update_two():
     """Ensure updating on second level is fine"""
-    a = {'a': 1, 'b': {'c': 2}}
-    b = {'b': {'c': 3}}
+    a = {"a": 1, "b": {"c": 2}}
+    b = {"b": {"c": 3}}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': {'c': 3}}
+    assert m == {"a": 1, "b": {"c": 3}}
 
-    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
-    b = {'b': {'c': 4}}
+    a = {"a": 1, "b": {"c": 2, "d": 3}}
+    b = {"b": {"c": 4}}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': {'c': 4, 'd': 3}}
+    assert m == {"a": 1, "b": {"c": 4, "d": 3}}
 
 
 def test_merge_sub_configs_sub_extend_two():
     """Ensure updating to third level from second level is fine"""
-    a = {'a': 1, 'b': {'c': 2}}
-    b = {'d': {'e': 3}}
+    a = {"a": 1, "b": {"c": 2}}
+    b = {"d": {"e": 3}}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': {'c': 2}, 'd': {'e': 3}}
+    assert m == {"a": 1, "b": {"c": 2}, "d": {"e": 3}}
 
-    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
-    b = {'b': {'e': {'f': 4}}}
+    a = {"a": 1, "b": {"c": 2, "d": 3}}
+    b = {"b": {"e": {"f": 4}}}
 
     m = resolve_config.merge_configs(a, b)
 
-    assert m == {'a': 1, 'b': {'c': 2, 'd': 3, 'e': {'f': 4}}}
+    assert m == {"a": 1, "b": {"c": 2, "d": 3, "e": {"f": 4}}}
 
 
 def test_merge_sub_configs_update_three():
     """Ensure updating twice to third level from second level is fine"""
-    a = {'a': 1, 'b': {'c': 2}}
-    b = {'b': {'c': 3}}
-    c = {'b': {'c': {'d': 4}}}
+    a = {"a": 1, "b": {"c": 2}}
+    b = {"b": {"c": 3}}
+    c = {"b": {"c": {"d": 4}}}
 
     m = resolve_config.merge_configs(a, b, c)
 
-    assert m == {'a': 1, 'b': {'c': {'d': 4}}}
+    assert m == {"a": 1, "b": {"c": {"d": 4}}}
 
-    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
-    b = {'b': {'c': 4}}
-    c = {'b': {'c': {'e': 5}}}
+    a = {"a": 1, "b": {"c": 2, "d": 3}}
+    b = {"b": {"c": 4}}
+    c = {"b": {"c": {"e": 5}}}
 
     m = resolve_config.merge_configs(a, b, c)
 
-    assert m == {'a': 1, 'b': {'c': {'e': 5}, 'd': 3}}
+    assert m == {"a": 1, "b": {"c": {"e": 5}, "d": 3}}
 
 
 def test_merge_matching_type_configs():
     """Test that configs with matching type are merged properly"""
-    a = {'a': 1, 'b': {'c': 2, 't': 'match'}}
-    b = {'b': {'c': 3, 'd': 4, 't': 'match'}}
-    c = {'b': {'c': {'d': 4}, 'e': 5, 't': 'match'}}
+    a = {"a": 1, "b": {"c": 2, "t": "match"}}
+    b = {"b": {"c": 3, "d": 4, "t": "match"}}
+    c = {"b": {"c": {"d": 4}, "e": 5, "t": "match"}}
 
-    m = resolve_config.merge_configs(a, b, c, differentiators=['t'])
+    m = resolve_config.merge_configs(a, b, c, differentiators=["t"])
 
-    assert m == {'a': 1, 'b': {'c': {'d': 4}, 'd': 4, 'e': 5, 't': 'match'}}
+    assert m == {"a": 1, "b": {"c": {"d": 4}, "d": 4, "e": 5, "t": "match"}}
 
 
 def test_merge_diff_type_configs():
     """Test that configs with diff type are not merged"""
-    a = {'a': 1, 'b': {'c': 2, 't': 1}}
-    b = {'a': 1, 'b': {'c': 3, 'd': 4, 't': 2}}
-    c = {'b': {'c': {'d': 4}, 'e': 5, 't': 3}}
+    a = {"a": 1, "b": {"c": 2, "t": 1}}
+    b = {"a": 1, "b": {"c": 3, "d": 4, "t": 2}}
+    c = {"b": {"c": {"d": 4}, "e": 5, "t": 3}}
 
-    m = resolve_config.merge_configs(a, b, differentiators=['t'])
+    m = resolve_config.merge_configs(a, b, differentiators=["t"])
 
-    assert m == {'a': 1, 'b': {'c': 3, 'd': 4, 't': 2}}
+    assert m == {"a": 1, "b": {"c": 3, "d": 4, "t": 2}}
 
-    m = resolve_config.merge_configs(b, c, differentiators=['t'])
-    assert m == {'a': 1, 'b': {'c': {'d': 4}, 'e': 5, 't': 3}}
+    m = resolve_config.merge_configs(b, c, differentiators=["t"])
+    assert m == {"a": 1, "b": {"c": {"d": 4}, "e": 5, "t": 3}}
 
-    assert (resolve_config.merge_configs(b, c, differentiators=['t']) ==
-            resolve_config.merge_configs(a, b, c, differentiators=['t']))
+    assert resolve_config.merge_configs(
+        b, c, differentiators=["t"]
+    ) == resolve_config.merge_configs(a, b, c, differentiators=["t"])
 
 
 def test_merge_diff_type_sub_configs():
     """Test that configs with nested diff type are not merged"""
-    a = {'a': 1, 'b': {'c': 2, 't': 1, 'd': {'t': 2, 'e': 3}}}
-    b = {'b': {'a': 3, 't': 1, 'd': {'t': 2, 'f': 4}}}
+    a = {"a": 1, "b": {"c": 2, "t": 1, "d": {"t": 2, "e": 3}}}
+    b = {"b": {"a": 3, "t": 1, "d": {"t": 2, "f": 4}}}
 
-    m = resolve_config.merge_configs(a, b, differentiators=['t'])
-    assert m == {'a': 1, 'b': {'a': 3, 'c': 2, 't': 1, 'd': {'t': 2, 'e': 3, 'f': 4}}}
+    m = resolve_config.merge_configs(a, b, differentiators=["t"])
+    assert m == {"a": 1, "b": {"a": 3, "c": 2, "t": 1, "d": {"t": 2, "e": 3, "f": 4}}}
 
-    c = {'b': {'a': 3, 't': 1, 'd': {'t': 3, 'f': 4}}}
+    c = {"b": {"a": 3, "t": 1, "d": {"t": 3, "f": 4}}}
 
-    m = resolve_config.merge_configs(a, c, differentiators=['t'])
-    assert m == {'a': 1, 'b': {'a': 3, 'c': 2, 't': 1, 'd': {'t': 3, 'f': 4}}}
+    m = resolve_config.merge_configs(a, c, differentiators=["t"])
+    assert m == {"a": 1, "b": {"a": 3, "c": 2, "t": 1, "d": {"t": 3, "f": 4}}}
 
-    d = {'b': {'a': 3, 't': 2, 'd': {'t': 2, 'f': 4}}}
+    d = {"b": {"a": 3, "t": 2, "d": {"t": 2, "f": 4}}}
 
-    m = resolve_config.merge_configs(a, d, differentiators=['t'])
-    assert m == {'a': 1, 'b': {'a': 3, 't': 2, 'd': {'t': 2, 'f': 4}}}
+    m = resolve_config.merge_configs(a, d, differentiators=["t"])
+    assert m == {"a": 1, "b": {"a": 3, "t": 2, "d": {"t": 2, "f": 4}}}
 
 
 @pytest.fixture
 def repo():
     """Create a dummy repo for the tests."""
-    os.chdir('../')
-    os.makedirs('dummy_orion')
-    os.chdir('dummy_orion')
-    repo = git.Repo.init('.')
-    with open('README.md', 'w+') as f:
-        f.write('dummy content')
-    repo.git.add('README.md')
-    repo.index.commit('initial commit')
-    repo.create_head('master')
-    repo.git.checkout('master')
+    os.chdir("../")
+    os.makedirs("dummy_orion")
+    os.chdir("dummy_orion")
+    repo = git.Repo.init(".")
+    with open("README.md", "w+") as f:
+        f.write("dummy content")
+    repo.git.add("README.md")
+    repo.index.commit("initial commit")
+    repo.create_head("master")
+    repo.git.checkout("master")
     yield repo
-    os.chdir('../')
-    shutil.rmtree('dummy_orion')
-    os.chdir('orion')
+    os.chdir("../")
+    shutil.rmtree("dummy_orion")
+    os.chdir("orion")
 
 
 def test_infer_versioning_metadata_on_clean_repo(repo):
@@ -587,11 +624,11 @@ def test_infer_versioning_metadata_on_clean_repo(repo):
     when the user's repo is clean:
     `is_dirty`, `active_branch` and `diff_sha`.
     """
-    vcs = resolve_config.infer_versioning_metadata('.git')
-    assert not vcs['is_dirty']
-    assert vcs['active_branch'] == 'master'
+    vcs = resolve_config.infer_versioning_metadata(".git")
+    assert not vcs["is_dirty"]
+    assert vcs["active_branch"] == "master"
     # the diff should be empty so the diff_sha should be equal to the diff sha of an empty string
-    assert vcs['diff_sha'] == hashlib.sha256(''.encode('utf-8')).hexdigest()
+    assert vcs["diff_sha"] == hashlib.sha256("".encode("utf-8")).hexdigest()
 
 
 def test_infer_versioning_metadata_on_dirty_repo(repo):
@@ -601,28 +638,28 @@ def test_infer_versioning_metadata_on_dirty_repo(repo):
     `is_dirty`, `HEAD_sha`, `active_branch` and `diff_sha`.
     """
     existing_metadata = {}
-    existing_metadata['user_script'] = '.git'
-    vcs = resolve_config.infer_versioning_metadata('.git')
-    repo.create_head('feature')
-    repo.git.checkout('feature')
-    with open('README.md', 'w+') as f:
-        f.write('dummy dummy content')
-    vcs = resolve_config.infer_versioning_metadata('.git')
-    assert vcs['is_dirty']
-    assert vcs['active_branch'] == 'feature'
-    assert vcs['diff_sha'] != hashlib.sha256(''.encode('utf-8')).hexdigest()
-    repo.git.add('README.md')
-    commit = repo.index.commit('Added dummy_file')
-    vcs = resolve_config.infer_versioning_metadata('.git')
-    assert not vcs['is_dirty']
-    assert vcs['HEAD_sha'] == commit.hexsha
-    assert vcs['diff_sha'] == hashlib.sha256(''.encode('utf-8')).hexdigest()
+    existing_metadata["user_script"] = ".git"
+    vcs = resolve_config.infer_versioning_metadata(".git")
+    repo.create_head("feature")
+    repo.git.checkout("feature")
+    with open("README.md", "w+") as f:
+        f.write("dummy dummy content")
+    vcs = resolve_config.infer_versioning_metadata(".git")
+    assert vcs["is_dirty"]
+    assert vcs["active_branch"] == "feature"
+    assert vcs["diff_sha"] != hashlib.sha256("".encode("utf-8")).hexdigest()
+    repo.git.add("README.md")
+    commit = repo.index.commit("Added dummy_file")
+    vcs = resolve_config.infer_versioning_metadata(".git")
+    assert not vcs["is_dirty"]
+    assert vcs["HEAD_sha"] == commit.hexsha
+    assert vcs["diff_sha"] == hashlib.sha256("".encode("utf-8")).hexdigest()
 
 
 def test_fetch_user_repo_on_non_repo(caplog):
     """Test if `fetch_user_repo` logs a warning when user's script is not a git repo."""
     with caplog.at_level(logging.WARNING):
-        resolve_config.fetch_user_repo('.')
+        resolve_config.fetch_user_repo(".")
     messages = [rec.message for rec in caplog.records]
     assert len(messages) == 1
     assert "Script {} is not in a git repository".format(os.getcwd()) in messages[0]
@@ -630,13 +667,13 @@ def test_fetch_user_repo_on_non_repo(caplog):
 
 def test_infer_versioning_metadata_on_detached_head(repo):
     """Test in the case of a detached head."""
-    with open('README.md', 'w+') as f:
-        f.write('dummy contentt')
-    repo.git.add('README.md')
-    repo.index.commit('2nd commit')
+    with open("README.md", "w+") as f:
+        f.write("dummy contentt")
+    repo.git.add("README.md")
+    repo.index.commit("2nd commit")
     existing_metadata = {}
-    existing_metadata['user_script'] = '.git'
-    repo.head.reference = repo.commit('HEAD~1')
+    existing_metadata["user_script"] = ".git"
+    repo.head.reference = repo.commit("HEAD~1")
     assert repo.head.is_detached
-    vcs = resolve_config.infer_versioning_metadata('.git')
-    assert vcs['active_branch'] is None
+    vcs = resolve_config.infer_versioning_metadata(".git")
+    assert vcs["active_branch"] is None

--- a/tests/unittests/core/io/test_space_builder.py
+++ b/tests/unittests/core/io/test_space_builder.py
@@ -4,17 +4,17 @@
 import pytest
 from scipy.stats import distributions as dists
 
-from orion.algo.space import (Categorical, Fidelity, Integer, Real)
-from orion.core.io.space_builder import (DimensionBuilder, SpaceBuilder)
+from orion.algo.space import Categorical, Fidelity, Integer, Real
+from orion.core.io.space_builder import DimensionBuilder, SpaceBuilder
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dimbuilder():
     """Return a `DimensionBuilder` instance."""
     return DimensionBuilder()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def spacebuilder():
     """Return a `SpaceBuilder` instance."""
     return SpaceBuilder()
@@ -25,33 +25,33 @@ class TestDimensionBuilder(object):
 
     def test_build_loguniform(self, dimbuilder):
         """Check that loguniform is built into reciprocal correctly."""
-        dim = dimbuilder.build('yolo', 'loguniform(0.001, 10)')
+        dim = dimbuilder.build("yolo", "loguniform(0.001, 10)")
         assert isinstance(dim, Real)
-        assert dim.name == 'yolo'
-        assert dim._prior_name == 'reciprocal'
+        assert dim.name == "yolo"
+        assert dim._prior_name == "reciprocal"
         assert 3.3 in dim and 11.1 not in dim
         assert isinstance(dim.prior, dists.reciprocal_gen)
 
-        dim = dimbuilder.build('yolo2', 'loguniform(1, 1000, discrete=True)')
+        dim = dimbuilder.build("yolo2", "loguniform(1, 1000, discrete=True)")
         assert isinstance(dim, Integer)
-        assert dim.name == 'yolo2'
-        assert dim._prior_name == 'reciprocal'
+        assert dim.name == "yolo2"
+        assert dim._prior_name == "reciprocal"
         assert 3 in dim and 0 not in dim and 3.3 not in dim
         assert isinstance(dim.prior, dists.reciprocal_gen)
 
     def test_eval_nonono(self, dimbuilder):
         """Make malevolent/naive eval access more difficult. I think."""
         with pytest.raises(RuntimeError):
-            dimbuilder.build('la', "__class__")
+            dimbuilder.build("la", "__class__")
 
     def test_build_a_good_real(self, dimbuilder):
         """Check that non registered names are good, as long as they are in
         `scipy.stats.distributions`.
         """
-        dim = dimbuilder.build('yolo2', 'alpha(0.9, low=0, high=10, shape=2)')
+        dim = dimbuilder.build("yolo2", "alpha(0.9, low=0, high=10, shape=2)")
         assert isinstance(dim, Real)
-        assert dim.name == 'yolo2'
-        assert dim._prior_name == 'alpha'
+        assert dim.name == "yolo2"
+        assert dim._prior_name == "alpha"
         assert 3.3 not in dim
         assert (3.3, 11.1) not in dim
         assert (3.3, 6) in dim
@@ -61,143 +61,143 @@ class TestDimensionBuilder(object):
         """Check that non registered names are good, as long as they are in
         `scipy.stats.distributions`.
         """
-        dim = dimbuilder.build('yolo3', 'poisson(5)')
+        dim = dimbuilder.build("yolo3", "poisson(5)")
         assert isinstance(dim, Integer)
-        assert dim.name == 'yolo3'
-        assert dim._prior_name == 'poisson'
+        assert dim.name == "yolo3"
+        assert dim._prior_name == "poisson"
         assert isinstance(dim.prior, dists.poisson_gen)
 
     def test_build_a_good_real_discrete(self, dimbuilder):
         """Check that non registered names are good, as long as they are in
         `scipy.stats.distributions`.
         """
-        dim = dimbuilder.build('yolo3', 'alpha(1.1, discrete=True)')
+        dim = dimbuilder.build("yolo3", "alpha(1.1, discrete=True)")
         assert isinstance(dim, Integer)
-        assert dim.name == 'yolo3'
-        assert dim._prior_name == 'alpha'
+        assert dim.name == "yolo3"
+        assert dim._prior_name == "alpha"
         assert isinstance(dim.prior, dists.alpha_gen)
 
     def test_build_a_good_fidelity(self, dimbuilder):
         """Check that a Fidelity dimension is correctly built."""
-        dim = dimbuilder.build('epoch', 'fidelity(1, 16, 4)')
+        dim = dimbuilder.build("epoch", "fidelity(1, 16, 4)")
         assert isinstance(dim, Fidelity)
-        assert dim.name == 'epoch'
+        assert dim.name == "epoch"
         assert dim.low == 1
         assert dim.high == 16
         assert dim.base == 4
-        assert dim._prior_name == 'None'
+        assert dim._prior_name == "None"
         assert dim.prior is None
 
     def test_build_fidelity_default_base(self, dimbuilder):
         """Check that a Fidelity dimension is correctly built with default base."""
-        dim = dimbuilder.build('epoch', 'fidelity(1, 16)')
+        dim = dimbuilder.build("epoch", "fidelity(1, 16)")
         assert isinstance(dim, Fidelity)
-        assert dim.name == 'epoch'
+        assert dim.name == "epoch"
         assert dim.low == 1
         assert dim.high == 16
         assert dim.base == 2
-        assert dim._prior_name == 'None'
+        assert dim._prior_name == "None"
         assert dim.prior is None
 
     def test_build_fails_because_of_name(self, dimbuilder):
         """Build fails because distribution name is not supported..."""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo3', 'lalala(1.1, discrete=True)')
-        assert 'Parameter' in str(exc.value)
-        assert 'supported' in str(exc.value)
+            dimbuilder.build("yolo3", "lalala(1.1, discrete=True)")
+        assert "Parameter" in str(exc.value)
+        assert "supported" in str(exc.value)
 
     def test_build_fails_because_of_unexpected_args(self, dimbuilder):
         """Build fails because argument is not supported..."""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo3', 'alpha(1.1, whatisthis=5, discrete=True)')
-        assert 'Parameter' in str(exc.value)
-        assert 'unexpected' in str(exc.value.__cause__)
+            dimbuilder.build("yolo3", "alpha(1.1, whatisthis=5, discrete=True)")
+        assert "Parameter" in str(exc.value)
+        assert "unexpected" in str(exc.value.__cause__)
 
     def test_build_fails_because_of_ValueError_on_run(self, dimbuilder):
         """Build fails because ValueError happens on init."""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo2', 'alpha(0.9, low=5, high=6, shape=2)')
-        assert 'Parameter' in str(exc.value)
-        assert 'Improbable bounds' in str(exc.value.__cause__)
+            dimbuilder.build("yolo2", "alpha(0.9, low=5, high=6, shape=2)")
+        assert "Parameter" in str(exc.value)
+        assert "Improbable bounds" in str(exc.value.__cause__)
 
     def test_build_fails_because_of_ValueError_on_init(self, dimbuilder):
         """Build fails because ValueError happens on init."""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo2', 'alpha(0.9, low=4, high=10, size=2)')
-        assert 'Parameter' in str(exc.value)
-        assert 'size' in str(exc.value.__cause__)
+            dimbuilder.build("yolo2", "alpha(0.9, low=4, high=10, size=2)")
+        assert "Parameter" in str(exc.value)
+        assert "size" in str(exc.value.__cause__)
 
     def test_build_gaussian(self, dimbuilder):
         """Check that gaussian/normal/norm is built into reciprocal correctly."""
-        dim = dimbuilder.build('yolo', 'gaussian(3, 5)')
+        dim = dimbuilder.build("yolo", "gaussian(3, 5)")
         assert isinstance(dim, Real)
-        assert dim.name == 'yolo'
-        assert dim._prior_name == 'norm'
+        assert dim.name == "yolo"
+        assert dim._prior_name == "norm"
         assert isinstance(dim.prior, dists.norm_gen)
 
-        dim = dimbuilder.build('yolo2', 'gaussian(1, 0.5, discrete=True)')
+        dim = dimbuilder.build("yolo2", "gaussian(1, 0.5, discrete=True)")
         assert isinstance(dim, Integer)
-        assert dim.name == 'yolo2'
-        assert dim._prior_name == 'norm'
+        assert dim.name == "yolo2"
+        assert dim._prior_name == "norm"
         assert isinstance(dim.prior, dists.norm_gen)
 
     def test_build_normal(self, dimbuilder):
         """Check that gaussian/normal/norm is built into reciprocal correctly."""
-        dim = dimbuilder.build('yolo', 'normal(0.001, 10)')
+        dim = dimbuilder.build("yolo", "normal(0.001, 10)")
         assert isinstance(dim, Real)
-        assert dim.name == 'yolo'
-        assert dim._prior_name == 'norm'
+        assert dim.name == "yolo"
+        assert dim._prior_name == "norm"
         assert isinstance(dim.prior, dists.norm_gen)
 
-        dim = dimbuilder.build('yolo2', 'normal(1, 0.5, discrete=True)')
+        dim = dimbuilder.build("yolo2", "normal(1, 0.5, discrete=True)")
         assert isinstance(dim, Integer)
-        assert dim.name == 'yolo2'
-        assert dim._prior_name == 'norm'
+        assert dim.name == "yolo2"
+        assert dim._prior_name == "norm"
         assert isinstance(dim.prior, dists.norm_gen)
 
     def test_build_choices(self, dimbuilder):
         """Create correctly a `Categorical` dimension."""
-        dim = dimbuilder.build('yolo', "choices('adfa', 1, 0.3, 'asaga', shape=4)")
+        dim = dimbuilder.build("yolo", "choices('adfa', 1, 0.3, 'asaga', shape=4)")
         assert isinstance(dim, Categorical)
-        assert dim.name == 'yolo'
-        assert dim._prior_name == 'Distribution'
+        assert dim.name == "yolo"
+        assert dim._prior_name == "Distribution"
         assert isinstance(dim.prior, dists.rv_discrete)
 
-        dim = dimbuilder.build('yolo', "choices(['adfa', 1])")
+        dim = dimbuilder.build("yolo", "choices(['adfa', 1])")
         assert isinstance(dim, Categorical)
-        assert dim.name == 'yolo'
-        assert dim._prior_name == 'Distribution'
+        assert dim.name == "yolo"
+        assert dim._prior_name == "Distribution"
         assert isinstance(dim.prior, dists.rv_discrete)
 
-        dim = dimbuilder.build('yolo2', "choices({'adfa': 0.1, 3: 0.4, 5: 0.5})")
+        dim = dimbuilder.build("yolo2", "choices({'adfa': 0.1, 3: 0.4, 5: 0.5})")
         assert isinstance(dim, Categorical)
-        assert dim.name == 'yolo2'
-        assert dim._prior_name == 'Distribution'
+        assert dim.name == "yolo2"
+        assert dim._prior_name == "Distribution"
         assert isinstance(dim.prior, dists.rv_discrete)
 
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo2', "choices({'adfa': 0.1, 3: 0.4})")
-        assert 'Parameter' in str(exc.value)
-        assert 'sum' in str(exc.value.__cause__)
+            dimbuilder.build("yolo2", "choices({'adfa': 0.1, 3: 0.4})")
+        assert "Parameter" in str(exc.value)
+        assert "sum" in str(exc.value.__cause__)
 
     def test_build_fails_because_empty_args(self, dimbuilder):
         """What happens if somebody 'forgets' stuff?"""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo', "choices()")
-        assert 'Parameter' in str(exc.value)
-        assert 'categories' in str(exc.value)
+            dimbuilder.build("yolo", "choices()")
+        assert "Parameter" in str(exc.value)
+        assert "categories" in str(exc.value)
 
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('what', "alpha()")
-        assert 'Parameter' in str(exc.value)
-        assert 'positional' in str(exc.value.__cause__)
+            dimbuilder.build("what", "alpha()")
+        assert "Parameter" in str(exc.value)
+        assert "positional" in str(exc.value.__cause__)
 
     def test_build_fails_because_troll(self, dimbuilder):
         """What happens if somebody does not fit regular expression expected?"""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo', "lalalala")
-        assert 'Parameter' in str(exc.value)
-        assert 'form for prior' in str(exc.value)
+            dimbuilder.build("yolo", "lalalala")
+        assert "Parameter" in str(exc.value)
+        assert "form for prior" in str(exc.value)
 
 
 class TestSpaceBuilder(object):
@@ -205,19 +205,22 @@ class TestSpaceBuilder(object):
 
     def test_configuration_rebuild(self, spacebuilder):
         """Test that configuration can be used to recreate a space."""
-        prior = {'x': 'uniform(0, 10, discrete=True)',
-                 'y': 'loguniform(1e-08, 1)',
-                 'z': 'choices([\'voici\', \'voila\', 2])'}
+        prior = {
+            "x": "uniform(0, 10, discrete=True)",
+            "y": "loguniform(1e-08, 1)",
+            "z": "choices(['voici', 'voila', 2])",
+        }
         space = spacebuilder.build(prior)
         assert space.configuration == prior
 
     def test_subdict_dimensions(self, spacebuilder):
         """Test space can have hierarchical structure."""
-        prior = {'a': {'x': 'uniform(0, 10, discrete=True)'},
-                 'b': {'y': 'loguniform(1e-08, 1)',
-                       'z': 'choices([\'voici\', \'voila\', 2])'}}
+        prior = {
+            "a": {"x": "uniform(0, 10, discrete=True)"},
+            "b": {"y": "loguniform(1e-08, 1)", "z": "choices(['voici', 'voila', 2])"},
+        }
         space = spacebuilder.build(prior)
         assert len(space) == 3
-        assert 'a.x' in space
-        assert 'b.y' in space
-        assert 'b.z' in space
+        assert "a.x" in space
+        assert "b.y" in space
+        assert "b.z" in space

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -14,25 +14,26 @@ from orion.core.io.database import Database, DatabaseError, DuplicateKeyError
 from orion.core.io.database.mongodb import AUTH_FAILED_MESSAGES, MongoDB
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def orion_db():
     """Return MongoDB wrapper instance initiated with test opts."""
     MongoDB.instance = None
-    orion_db = MongoDB(username='user', password='pass', name='orion_test')
+    orion_db = MongoDB(username="user", password="pass", name="orion_test")
     return orion_db
 
 
 @pytest.fixture()
 def patch_mongo_client(monkeypatch):
     """Patch ``pymongo.MongoClient`` to force serverSelectionTimeoutMS to 1."""
+
     def mock_class(*args, **kwargs):
         # 1 sec, defaults to 20 secs otherwise
-        kwargs['serverSelectionTimeoutMS'] = 1.
+        kwargs["serverSelectionTimeoutMS"] = 1.0
         # NOTE: Can't use pymongo.MongoClient otherwise there is an infinit
         # recursion; mock(mock(mock(mock(...(MongoClient)...))))
         return MongoClient(*args, **kwargs)
 
-    monkeypatch.setattr('pymongo.MongoClient', mock_class)
+    monkeypatch.setattr("pymongo.MongoClient", mock_class)
 
 
 @pytest.mark.usefixtures("null_db_instances")
@@ -43,74 +44,96 @@ class TestConnection(object):
     def test_bad_connection(self, monkeypatch):
         """Raise when connection cannot be achieved."""
         monkeypatch.setattr(
-            MongoDB, "initiate_connection",
-            MongoDB.initiate_connection.__wrapped__)
+            MongoDB, "initiate_connection", MongoDB.initiate_connection.__wrapped__
+        )
         with pytest.raises(pymongo.errors.ConnectionFailure) as exc_info:
-            MongoDB(host='asdfada', port=123, name='orion',
-                    username='uasdfaf', password='paasdfss')
+            MongoDB(
+                host="asdfada",
+                port=123,
+                name="orion",
+                username="uasdfaf",
+                password="paasdfss",
+            )
 
         monkeypatch.undo()
 
         # Verify that the wrapper converts it properly to DatabaseError
         with pytest.raises(DatabaseError) as exc_info:
-            MongoDB(host='asdfada', port=123, name='orion',
-                    username='uasdfaf', password='paasdfss')
+            MongoDB(
+                host="asdfada",
+                port=123,
+                name="orion",
+                username="uasdfaf",
+                password="paasdfss",
+            )
         assert "Connection" in str(exc_info.value)
 
     def test_bad_authentication(self, monkeypatch):
         """Raise when authentication cannot be achieved."""
         monkeypatch.setattr(
-            MongoDB, "initiate_connection",
-            MongoDB.initiate_connection.__wrapped__)
+            MongoDB, "initiate_connection", MongoDB.initiate_connection.__wrapped__
+        )
         with pytest.raises(pymongo.errors.OperationFailure) as exc_info:
-            MongoDB(name='orion_test', username='uasdfaf', password='paasdfss')
+            MongoDB(name="orion_test", username="uasdfaf", password="paasdfss")
         assert any(m in str(exc_info.value) for m in AUTH_FAILED_MESSAGES)
 
         monkeypatch.undo()
 
         with pytest.raises(DatabaseError) as exc_info:
-            MongoDB(name='orion_test', username='uasdfaf', password='paasdfss')
+            MongoDB(name="orion_test", username="uasdfaf", password="paasdfss")
         assert "Authentication" in str(exc_info.value)
 
     def test_connection_with_uri(self):
         """Check the case when connecting with ready `uri`."""
-        orion_db = MongoDB('mongodb://user:pass@localhost/orion_test')
-        assert orion_db.host == 'localhost'
+        orion_db = MongoDB("mongodb://user:pass@localhost/orion_test")
+        assert orion_db.host == "localhost"
         assert orion_db.port == 27017
-        assert orion_db.username == 'user'
-        assert orion_db.password == 'pass'
-        assert orion_db.name == 'orion_test'
+        assert orion_db.username == "user"
+        assert orion_db.password == "pass"
+        assert orion_db.name == "orion_test"
 
     def test_overwrite_uri(self):
         """Check the case when connecting with ready `uri`."""
-        orion_db = MongoDB('mongodb://user:pass@localhost:27017/orion_test',
-                           port=1231, name='orion', username='lala',
-                           password='pass')
-        assert orion_db.host == 'localhost'
+        orion_db = MongoDB(
+            "mongodb://user:pass@localhost:27017/orion_test",
+            port=1231,
+            name="orion",
+            username="lala",
+            password="pass",
+        )
+        assert orion_db.host == "localhost"
         assert orion_db.port == 27017
-        assert orion_db.username == 'user'
-        assert orion_db.password == 'pass'
-        assert orion_db.name == 'orion_test'
+        assert orion_db.username == "user"
+        assert orion_db.password == "pass"
+        assert orion_db.name == "orion_test"
 
     def test_overwrite_partial_uri(self, monkeypatch):
         """Check the case when connecting with partial `uri`."""
-        monkeypatch.setattr(MongoDB, 'initiate_connection', lambda self: None)
+        monkeypatch.setattr(MongoDB, "initiate_connection", lambda self: None)
 
-        orion_db = MongoDB('mongodb://localhost',
-                           port=1231, name='orion', username='lala',
-                           password='none')
+        orion_db = MongoDB(
+            "mongodb://localhost",
+            port=1231,
+            name="orion",
+            username="lala",
+            password="none",
+        )
         orion_db._sanitize_attrs()
-        assert orion_db.host == 'localhost'
+        assert orion_db.host == "localhost"
         assert orion_db.port == 1231
-        assert orion_db.username == 'lala'
-        assert orion_db.password == 'none'
-        assert orion_db.name == 'orion'
+        assert orion_db.username == "lala"
+        assert orion_db.password == "none"
+        assert orion_db.name == "orion"
 
     def test_singleton(self):
         """Test that MongoDB class is a singleton."""
-        orion_db = MongoDB('mongodb://localhost',
-                           port=27017, name='orion_test', username='user',
-                           password='pass')
+        orion_db = MongoDB(
+            "mongodb://localhost",
+            port=27017,
+            name="orion_test",
+            username="user",
+            password="pass",
+        )
         # reinit connection does not change anything
         orion_db.initiate_connection()
         orion_db.close_connection()
@@ -118,8 +141,18 @@ class TestConnection(object):
 
     def test_change_server_timeout(self):
         """Test that the server timeout is correctly changed."""
-        assert timeit(lambda: MongoDB(username='user', password='pass', name='orion_test',
-                                      serverSelectionTimeoutMS=1000), number=1) <= 2
+        assert (
+            timeit(
+                lambda: MongoDB(
+                    username="user",
+                    password="pass",
+                    name="orion_test",
+                    serverSelectionTimeoutMS=1000,
+                ),
+                number=1,
+            )
+            <= 2
+        )
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -129,29 +162,32 @@ class TestExceptionWrapper(object):
     def test_duplicate_key_error(self, monkeypatch, orion_db, exp_config):
         """Should raise generic DuplicateKeyError."""
         # Add unique indexes to force trigger of DuplicateKeyError on write()
-        orion_db.ensure_index('experiments',
-                              [('name', Database.ASCENDING),
-                               ('metadata.user', Database.ASCENDING)],
-                              unique=True)
+        orion_db.ensure_index(
+            "experiments",
+            [("name", Database.ASCENDING), ("metadata.user", Database.ASCENDING)],
+            unique=True,
+        )
 
         config_to_add = exp_config[0][0]
-        config_to_add.pop('_id')
+        config_to_add.pop("_id")
 
-        query = {'_id': exp_config[0][1]['_id']}
+        query = {"_id": exp_config[0][1]["_id"]}
 
         # Make sure it raises pymongo.errors.DuplicateKeyError when there is no
         # wrapper
         monkeypatch.setattr(
-            orion_db, "read_and_write",
-            functools.partial(orion_db.read_and_write.__wrapped__, orion_db))
+            orion_db,
+            "read_and_write",
+            functools.partial(orion_db.read_and_write.__wrapped__, orion_db),
+        )
         with pytest.raises(pymongo.errors.DuplicateKeyError) as exc_info:
-            orion_db.read_and_write('experiments', query, config_to_add)
+            orion_db.read_and_write("experiments", query, config_to_add)
 
         monkeypatch.undo()
 
         # Verify that the wrapper converts it properly to DuplicateKeyError
         with pytest.raises(DuplicateKeyError) as exc_info:
-            orion_db.read_and_write('experiments', query, config_to_add)
+            orion_db.read_and_write("experiments", query, config_to_add)
         assert "duplicate key error" in str(exc_info.value)
 
     def test_bulk_duplicate_key_error(self, monkeypatch, orion_db, exp_config):
@@ -159,16 +195,16 @@ class TestExceptionWrapper(object):
         # Make sure it raises pymongo.errors.BulkWriteError when there is no
         # wrapper
         monkeypatch.setattr(
-            orion_db, "write",
-            functools.partial(orion_db.write.__wrapped__, orion_db))
+            orion_db, "write", functools.partial(orion_db.write.__wrapped__, orion_db)
+        )
         with pytest.raises(pymongo.errors.BulkWriteError) as exc_info:
-            orion_db.write('experiments', exp_config[0])
+            orion_db.write("experiments", exp_config[0])
 
         monkeypatch.undo()
 
         # Verify that the wrapper converts it properly to DuplicateKeyError
         with pytest.raises(DuplicateKeyError) as exc_info:
-            orion_db.write('experiments', exp_config[0])
+            orion_db.write("experiments", exp_config[0])
         assert "duplicate key error" in str(exc_info.value)
 
     def test_non_converted_errors(self, orion_db, exp_config):
@@ -180,10 +216,10 @@ class TestExceptionWrapper(object):
         """
         config_to_add = exp_config[0][0]
 
-        query = {'_id': exp_config[0][1]['_id']}
+        query = {"_id": exp_config[0][1]["_id"]}
 
         with pytest.raises(pymongo.errors.OperationFailure):
-            orion_db.read_and_write('experiments', query, config_to_add)
+            orion_db.read_and_write("experiments", query, config_to_add)
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -193,41 +229,47 @@ class TestEnsureIndex(object):
     def test_new_index(self, orion_db):
         """Index should be added to mongo database"""
         assert "status_1" not in orion_db._db.trials.index_information()
-        orion_db.ensure_index('trials', 'status')
+        orion_db.ensure_index("trials", "status")
         assert "status_1" in orion_db._db.trials.index_information()
 
     def test_existing_index(self, orion_db):
         """Index should be added to mongo database and reattempt should do nothing"""
         assert "status_1" not in orion_db._db.trials.index_information()
-        orion_db.ensure_index('trials', 'status')
+        orion_db.ensure_index("trials", "status")
         assert "status_1" in orion_db._db.trials.index_information()
-        orion_db.ensure_index('trials', 'status')
+        orion_db.ensure_index("trials", "status")
         assert "status_1" in orion_db._db.trials.index_information()
 
     def test_ordered_index(self, orion_db):
         """Sort order should be added to index"""
         assert "end_time_-1" not in orion_db._db.trials.index_information()
-        orion_db.ensure_index('trials', [('end_time', MongoDB.DESCENDING)])
+        orion_db.ensure_index("trials", [("end_time", MongoDB.DESCENDING)])
         assert "end_time_-1" in orion_db._db.trials.index_information()
 
     def test_compound_index(self, orion_db):
         """Tuple of Index should be added as a compound index."""
-        assert "name_1_metadata.user_1" not in orion_db._db.experiments.index_information()
-        orion_db.ensure_index('experiments',
-                              [('name', MongoDB.ASCENDING),
-                               ('metadata.user', MongoDB.ASCENDING)])
+        assert (
+            "name_1_metadata.user_1" not in orion_db._db.experiments.index_information()
+        )
+        orion_db.ensure_index(
+            "experiments",
+            [("name", MongoDB.ASCENDING), ("metadata.user", MongoDB.ASCENDING)],
+        )
         assert "name_1_metadata.user_1" in orion_db._db.experiments.index_information()
 
     def test_unique_index(self, orion_db):
         """Index should be set as unique in mongo database's index information."""
-        assert "name_1_metadata.user_1" not in orion_db._db.experiments.index_information()
-        orion_db.ensure_index('experiments',
-                              [('name', MongoDB.ASCENDING),
-                               ('metadata.user', MongoDB.ASCENDING)],
-                              unique=True)
+        assert (
+            "name_1_metadata.user_1" not in orion_db._db.experiments.index_information()
+        )
+        orion_db.ensure_index(
+            "experiments",
+            [("name", MongoDB.ASCENDING), ("metadata.user", MongoDB.ASCENDING)],
+            unique=True,
+        )
         index_information = orion_db._db.experiments.index_information()
         assert "name_1_metadata.user_1" in index_information
-        assert index_information["name_1_metadata.user_1"]['unique']
+        assert index_information["name_1_metadata.user_1"]["unique"]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -237,47 +279,61 @@ class TestRead(object):
     def test_read_experiment(self, exp_config, orion_db):
         """Fetch a whole experiment entries."""
         loaded_config = orion_db.read(
-            'trials', {'experiment': 'supernaedo2-dendi', 'status': 'new'})
+            "trials", {"experiment": "supernaedo2-dendi", "status": "new"}
+        )
         assert loaded_config == [exp_config[1][3], exp_config[1][4]]
 
         loaded_config = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': exp_config[1][3]['submit_time']})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": exp_config[1][3]["submit_time"],
+            },
+        )
         assert loaded_config == [exp_config[1][3]]
-        assert loaded_config[0]['_id'] == exp_config[1][3]['_id']
+        assert loaded_config[0]["_id"] == exp_config[1][3]["_id"]
 
     def test_read_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
-        loaded_config = orion_db.read('experiments', {'_id': exp_config[0][2]['_id']})
+        loaded_config = orion_db.read("experiments", {"_id": exp_config[0][2]["_id"]})
         assert loaded_config == [exp_config[0][2]]
 
     def test_read_default(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'experiments', {'name': 'supernaedo2', 'metadata.user': 'tsirif'},
-            selection={'algorithms': 1, '_id': 0})
-        assert value == [{'algorithms': exp_config[0][0]['algorithms']}]
+            "experiments",
+            {"name": "supernaedo2", "metadata.user": "tsirif"},
+            selection={"algorithms": 1, "_id": 0},
+        )
+        assert value == [{"algorithms": exp_config[0][0]["algorithms"]}]
 
     def test_read_nothing(self, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'experiments', {'name': 'not_found', 'metadata.user': 'tsirif'},
-            selection={'algorithms': 1})
+            "experiments",
+            {"name": "not_found", "metadata.user": "tsirif"},
+            selection={"algorithms": 1},
+        )
         assert value == []
 
     def test_read_trials(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": {"$gte": datetime(2017, 11, 23, 0, 0, 0)},
+            },
+        )
         assert value == [exp_config[1][1]] + exp_config[1][3:7]
 
         value = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": {"$gt": datetime(2017, 11, 23, 0, 0, 0)},
+            },
+        )
         assert value == exp_config[1][3:7]
 
 
@@ -287,59 +343,61 @@ class TestWrite(object):
 
     def test_insert_one(self, database, orion_db):
         """Should insert a single new entry in the collection."""
-        item = {'exp_name': 'supernaekei',
-                'user': 'tsirif'}
+        item = {"exp_name": "supernaekei", "user": "tsirif"}
         count_before = database.experiments.count_documents({})
         # call interface
-        assert orion_db.write('experiments', item) == 1
+        assert orion_db.write("experiments", item) == 1
         assert database.experiments.count_documents({}) == count_before + 1
-        value = database.experiments.find_one({'exp_name': 'supernaekei'})
+        value = database.experiments.find_one({"exp_name": "supernaekei"})
         assert value == item
 
     def test_insert_many(self, database, orion_db):
         """Should insert two new entry (as a list) in the collection."""
-        item = [{'exp_name': 'supernaekei2',
-                 'user': 'tsirif'},
-                {'exp_name': 'supernaekei3',
-                 'user': 'tsirif'}]
+        item = [
+            {"exp_name": "supernaekei2", "user": "tsirif"},
+            {"exp_name": "supernaekei3", "user": "tsirif"},
+        ]
         count_before = database.experiments.count_documents({})
         # call interface
-        assert orion_db.write('experiments', item) == 2
+        assert orion_db.write("experiments", item) == 2
         assert database.experiments.count_documents({}) == count_before + 2
-        value = database.experiments.find_one({'exp_name': 'supernaekei2'})
+        value = database.experiments.find_one({"exp_name": "supernaekei2"})
         assert value == item[0]
-        value = database.experiments.find_one({'exp_name': 'supernaekei3'})
+        value = database.experiments.find_one({"exp_name": "supernaekei3"})
         assert value == item[1]
 
     def test_update_many_default(self, database, orion_db):
         """Should match existing entries, and update some of their keys."""
-        filt = {'metadata.user': 'dendi'}
+        filt = {"metadata.user": "dendi"}
         count_before = database.experiments.count_documents({})
         count_filt = database.experiments.count_documents(filt)
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 16}, filt) == count_filt
+        assert orion_db.write("experiments", {"pool_size": 16}, filt) == count_filt
         assert database.experiments.count_documents({}) == count_before
         value = list(database.experiments.find({}))
-        assert value[0]['pool_size'] == 16
-        assert value[1]['pool_size'] == 2
-        assert value[2]['pool_size'] == 2
-        assert value[3]['pool_size'] == 2
+        assert value[0]["pool_size"] == 16
+        assert value[1]["pool_size"] == 2
+        assert value[2]["pool_size"] == 2
+        assert value[3]["pool_size"] == 2
 
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
-        filt = {'_id': exp_config[0][1]['_id']}
+        filt = {"_id": exp_config[0][1]["_id"]}
         count_before = database.experiments.count_documents({})
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 36}, filt) == 1
+        assert orion_db.write("experiments", {"pool_size": 36}, filt) == 1
         assert database.experiments.count_documents({}) == count_before
         value = list(database.experiments.find())
-        assert value[0]['pool_size'] == 2
-        assert value[1]['pool_size'] == 36
-        assert value[2]['pool_size'] == 2
+        assert value[0]["pool_size"] == 2
+        assert value[1]["pool_size"] == 36
+        assert value[2]["pool_size"] == 2
 
     def test_no_upsert(self, database, orion_db):
         """Query with a non-existent ``_id`` should no upsert something."""
-        assert orion_db.write('experiments', {'pool_size': 66}, {'_id': 'lalalathisisnew'}) == 0
+        assert (
+            orion_db.write("experiments", {"pool_size": 66}, {"_id": "lalalathisisnew"})
+            == 0
+        )
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -349,45 +407,40 @@ class TestReadAndWrite(object):
     def test_read_and_write_one(self, database, orion_db, exp_config):
         """Should read and update a single entry in the collection."""
         # Make sure there is only one match
-        documents = orion_db.read(
-            'experiments',
-            {'name': 'supernaedo4'})
+        documents = orion_db.read("experiments", {"name": "supernaedo4"})
         assert len(documents) == 1
 
         # Find and update atomically
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'name': 'supernaedo4'},
-            {'pool_size': 'lalala'})
-        exp_config[0][3]['pool_size'] = 'lalala'
+            "experiments", {"name": "supernaedo4"}, {"pool_size": "lalala"}
+        )
+        exp_config[0][3]["pool_size"] = "lalala"
         assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, database, orion_db, exp_config):
         """Should update only one entry."""
         # Make sure there is many matches
-        documents = orion_db.read('experiments', {'metadata.user': 'tsirif'})
+        documents = orion_db.read("experiments", {"metadata.user": "tsirif"})
         assert len(documents) > 1
 
         # Find many and update first one only
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'metadata.user': 'tsirif'},
-            {'pool_size': 'lalala'})
+            "experiments", {"metadata.user": "tsirif"}, {"pool_size": "lalala"}
+        )
 
-        exp_config[0][1]['pool_size'] = 'lalala'
+        exp_config[0][1]["pool_size"] = "lalala"
         assert loaded_config == exp_config[0][1]
 
         # Make sure it only changed the first document found
-        documents = orion_db.read('experiments', {'metadata.user': 'tsirif'})
-        assert documents[0]['pool_size'] == 'lalala'
-        assert documents[1]['pool_size'] != 'lalala'
+        documents = orion_db.read("experiments", {"metadata.user": "tsirif"})
+        assert documents[0]["pool_size"] == "lalala"
+        assert documents[1]["pool_size"] != "lalala"
 
     def test_read_and_write_no_match(self, database, orion_db):
         """Should return None when there is no match."""
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'name': 'lalala'},
-            {'pool_size': 'lalala'})
+            "experiments", {"name": "lalala"}, {"pool_size": "lalala"}
+        )
 
         assert loaded_config is None
 
@@ -398,21 +451,21 @@ class TestRemove(object):
 
     def test_remove_many_default(self, exp_config, database, orion_db):
         """Should match existing entries, and delete them all."""
-        filt = {'metadata.user': 'tsirif'}
+        filt = {"metadata.user": "tsirif"}
         count_before = database.experiments.count_documents({})
         count_filt = database.experiments.count_documents(filt)
         # call interface
-        assert orion_db.remove('experiments', filt) == count_filt
+        assert orion_db.remove("experiments", filt) == count_filt
         assert database.experiments.count_documents({}) == count_before - count_filt
         assert database.experiments.count_documents({}) == 1
         assert list(database.experiments.find()) == [exp_config[0][0]]
 
     def test_remove_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
-        filt = {'_id': exp_config[0][0]['_id']}
+        filt = {"_id": exp_config[0][0]["_id"]}
         count_before = database.experiments.count_documents({})
         # call interface
-        assert orion_db.remove('experiments', filt) == 1
+        assert orion_db.remove("experiments", filt) == 1
         assert database.experiments.count_documents({}) == count_before - 1
         assert list(database.experiments.find()) == exp_config[0][1:]
 
@@ -423,22 +476,22 @@ class TestCount(object):
 
     def test_count_default(self, exp_config, orion_db):
         """Call just with collection name."""
-        found = orion_db.count('trials')
+        found = orion_db.count("trials")
         assert found == len(exp_config[1])
 
     def test_count_query(self, exp_config, orion_db):
         """Call with a query."""
-        found = orion_db.count('trials', {'status': 'completed'})
-        assert found == len([x for x in exp_config[1] if x['status'] == 'completed'])
+        found = orion_db.count("trials", {"status": "completed"})
+        assert found == len([x for x in exp_config[1] if x["status"] == "completed"])
 
     def test_count_query_with_id(self, exp_config, orion_db):
         """Call querying with unique _id."""
-        found = orion_db.count('trials', {'_id': exp_config[1][2]['_id']})
+        found = orion_db.count("trials", {"_id": exp_config[1][2]["_id"]})
         assert found == 1
 
     def test_count_nothing(self, orion_db):
         """Call with argument that will not find anything."""
-        found = orion_db.count('experiments', {'name': 'lalalanotfound'})
+        found = orion_db.count("experiments", {"name": "lalalanotfound"})
         assert found == 0
 
 
@@ -448,35 +501,41 @@ class TestIndexInformation(object):
 
     def test_no_index(self, orion_db):
         """Test that no index is returned when there is none."""
-        assert orion_db.index_information('experiments') == {'_id_': True}
+        assert orion_db.index_information("experiments") == {"_id_": True}
 
     def test_single_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments', [('name', MongoDB.ASCENDING)])
+        orion_db.ensure_index("experiments", [("name", MongoDB.ASCENDING)])
 
-        assert orion_db.index_information('experiments') == {'_id_': True, 'name_1': False}
+        assert orion_db.index_information("experiments") == {
+            "_id_": True,
+            "name_1": False,
+        }
 
     def test_ordered_index(self, orion_db):
         """Test with ordered indexes."""
-        orion_db.ensure_index('experiments', [('name', MongoDB.DESCENDING)])
+        orion_db.ensure_index("experiments", [("name", MongoDB.DESCENDING)])
 
-        assert orion_db.index_information('experiments') == {'_id_': True, 'name_-1': False}
+        assert orion_db.index_information("experiments") == {
+            "_id_": True,
+            "name_-1": False,
+        }
 
     def test_compound_index(self, orion_db):
         """Test representation of compound indexes."""
-        orion_db.ensure_index('experiments',
-                              [('name', MongoDB.DESCENDING),
-                               ('version', MongoDB.ASCENDING)])
+        orion_db.ensure_index(
+            "experiments",
+            [("name", MongoDB.DESCENDING), ("version", MongoDB.ASCENDING)],
+        )
 
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_-1_version_1': False}
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_-1_version_1": False}
 
     def test_unique_index(self, orion_db):
         """Test that unique indexes are correctly inditified."""
-        orion_db.ensure_index('hello',
-                              [('bonjour', MongoDB.DESCENDING)], unique=True)
+        orion_db.ensure_index("hello", [("bonjour", MongoDB.DESCENDING)], unique=True)
 
-        assert orion_db.index_information('hello') == {'_id_': True, 'bonjour_-1': True}
+        assert orion_db.index_information("hello") == {"_id_": True, "bonjour_-1": True}
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -486,56 +545,66 @@ class TestDropIndex(object):
     def test_no_index(self, orion_db):
         """Test DatabaseError is raised when index does not exist."""
         with pytest.raises(DatabaseError) as exc:
-            orion_db.drop_index('experiments', 'i_dont_exist')
-        assert 'index not found with name' in str(exc.value)
+            orion_db.drop_index("experiments", "i_dont_exist")
+        assert "index not found with name" in str(exc.value)
 
     def test_drop_single_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments', [('name', MongoDB.ASCENDING)])
-        assert orion_db.index_information('experiments') == {'_id_': True, 'name_1': False}
-        orion_db.drop_index('experiments', 'name_1')
-        assert orion_db.index_information('experiments') == {'_id_': True}
+        orion_db.ensure_index("experiments", [("name", MongoDB.ASCENDING)])
+        assert orion_db.index_information("experiments") == {
+            "_id_": True,
+            "name_1": False,
+        }
+        orion_db.drop_index("experiments", "name_1")
+        assert orion_db.index_information("experiments") == {"_id_": True}
 
     def test_drop_ordered_single_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments', [('name', MongoDB.ASCENDING)])
-        orion_db.ensure_index('experiments', [('name', MongoDB.DESCENDING)])
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_1': False, 'name_-1': False}
-        orion_db.drop_index('experiments', 'name_1')
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_-1': False}
+        orion_db.ensure_index("experiments", [("name", MongoDB.ASCENDING)])
+        orion_db.ensure_index("experiments", [("name", MongoDB.DESCENDING)])
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_1": False, "name_-1": False}
+        orion_db.drop_index("experiments", "name_1")
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_-1": False}
         with pytest.raises(DatabaseError) as exc:
-            orion_db.drop_index('experiments', 'name_1')
-        assert 'index not found with name' in str(exc.value)
-        orion_db.drop_index('experiments', 'name_-1')
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True}
+            orion_db.drop_index("experiments", "name_1")
+        assert "index not found with name" in str(exc.value)
+        orion_db.drop_index("experiments", "name_-1")
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True}
 
     def test_drop_ordered_compound_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments',
-                              [('name', MongoDB.ASCENDING), ('version', MongoDB.DESCENDING)])
-        orion_db.ensure_index('experiments',
-                              [('name', MongoDB.DESCENDING), ('version', MongoDB.ASCENDING)])
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_1_version_-1': False, 'name_-1_version_1': False}
-        orion_db.drop_index('experiments', 'name_1_version_-1')
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_-1_version_1': False}
+        orion_db.ensure_index(
+            "experiments",
+            [("name", MongoDB.ASCENDING), ("version", MongoDB.DESCENDING)],
+        )
+        orion_db.ensure_index(
+            "experiments",
+            [("name", MongoDB.DESCENDING), ("version", MongoDB.ASCENDING)],
+        )
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {
+            "_id_": True,
+            "name_1_version_-1": False,
+            "name_-1_version_1": False,
+        }
+        orion_db.drop_index("experiments", "name_1_version_-1")
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_-1_version_1": False}
         with pytest.raises(DatabaseError) as exc:
-            orion_db.drop_index('experiments', 'name_1_version_-1')
-        assert 'index not found with name' in str(exc.value)
-        orion_db.drop_index('experiments', 'name_-1_version_1')
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True}
+            orion_db.drop_index("experiments", "name_1_version_-1")
+        assert "index not found with name" in str(exc.value)
+        orion_db.drop_index("experiments", "name_-1_version_1")
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True}
 
     def test_drop_unique_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('hello',
-                              [('bonjour', MongoDB.DESCENDING)], unique=True)
-        index_info = orion_db.index_information('hello')
-        assert index_info == {'_id_': True, 'bonjour_-1': True}
-        orion_db.drop_index('hello', 'bonjour_-1')
-        index_info = orion_db.index_information('hello')
-        assert index_info == {'_id_': True}
+        orion_db.ensure_index("hello", [("bonjour", MongoDB.DESCENDING)], unique=True)
+        index_info = orion_db.index_information("hello")
+        assert index_info == {"_id_": True, "bonjour_-1": True}
+        orion_db.drop_index("hello", "bonjour_-1")
+        index_info = orion_db.index_information("hello")
+        assert index_info == {"_id_": True}

--- a/tests/unittests/core/test_branch_config.py
+++ b/tests/unittests/core/test_branch_config.py
@@ -11,9 +11,16 @@ import yaml
 import orion.core
 from orion.core import evc
 from orion.core.evc.conflicts import (
-    AlgorithmConflict, ChangedDimensionConflict, CodeConflict, CommandLineConflict,
-    detect_conflicts, ExperimentNameConflict, MissingDimensionConflict, NewDimensionConflict,
-    ScriptConfigConflict)
+    AlgorithmConflict,
+    ChangedDimensionConflict,
+    CodeConflict,
+    CommandLineConflict,
+    detect_conflicts,
+    ExperimentNameConflict,
+    MissingDimensionConflict,
+    NewDimensionConflict,
+    ScriptConfigConflict,
+)
 from orion.core.io.experiment_branch_builder import ExperimentBranchBuilder
 import orion.core.utils.backward as backward
 
@@ -32,41 +39,51 @@ def filter_false(c):
 def user_config():
     """Generate data dict for user's script's configuration file"""
     data = {
-        'a': 'orion~uniform(-10,10)',
-        'some_other': 'test',
-        'b': 'orion~normal(0,1)',
-        'argument': 'value'}
+        "a": "orion~uniform(-10,10)",
+        "some_other": "test",
+        "b": "orion~normal(0,1)",
+        "argument": "value",
+    }
     return data
 
 
 @pytest.fixture
 def parent_config(user_config):
     """Create a configuration that will not hit the database."""
-    user_script = 'abs_path/black_box.py'
+    user_script = "abs_path/black_box.py"
     config = dict(
-        _id='test',
-        name='test',
-        algorithms='random',
+        _id="test",
+        name="test",
+        algorithms="random",
         version=1,
-        metadata={'VCS': {"type": "git",
-                          "is_dirty": False,
-                          "HEAD_sha": "test",
-                          "active_branch": None,
-                          "diff_sha": "diff",
-                          },
-                  'user_script': user_script,
-                  'user_args': [
-                      user_script, '--nameless=option', '-x~uniform(0,1)', '-y~normal(0,1)',
-                      '-z~uniform(0,10)', '--manual-resolution'],
-                  'user': 'some_user_name'},
-        refers={})
+        metadata={
+            "VCS": {
+                "type": "git",
+                "is_dirty": False,
+                "HEAD_sha": "test",
+                "active_branch": None,
+                "diff_sha": "diff",
+            },
+            "user_script": user_script,
+            "user_args": [
+                user_script,
+                "--nameless=option",
+                "-x~uniform(0,1)",
+                "-y~normal(0,1)",
+                "-z~uniform(0,10)",
+                "--manual-resolution",
+            ],
+            "user": "some_user_name",
+        },
+        refers={},
+    )
 
     config_file_path = "./parent_config.yaml"
 
-    with open(config_file_path, 'w') as f:
+    with open(config_file_path, "w") as f:
         yaml.dump(user_config, f)
 
-    config['metadata']['user_args'].append('--config=%s' % config_file_path)
+    config["metadata"]["user_args"].append("--config=%s" % config_file_path)
 
     backward.populate_space(config)
 
@@ -78,17 +95,17 @@ def parent_config(user_config):
 def child_config(parent_config, create_db_instance):
     """Create a child branching from the test experiment"""
     config = copy.deepcopy(parent_config)
-    config['_id'] = 'test2'
-    config['version'] = 2
-    config['refers']['parent_id'] = parent_config['_id']
+    config["_id"] = "test2"
+    config["version"] = 2
+    config["refers"]["parent_id"] = parent_config["_id"]
     return config
 
 
 @pytest.fixture
 def missing_config(child_config):
     """Create a child config with a missing dimension"""
-    del(child_config['metadata']['user_args'][2])  # del -x
-    del(child_config['metadata']['user_args'][2])  # del -y
+    del child_config["metadata"]["user_args"][2]  # del -x
+    del child_config["metadata"]["user_args"][2]  # del -y
     backward.populate_space(child_config)
     return child_config
 
@@ -96,7 +113,7 @@ def missing_config(child_config):
 @pytest.fixture
 def new_config(child_config):
     """Create a child config with a new dimension"""
-    child_config['metadata']['user_args'].append('-w_d~normal(0,1)')
+    child_config["metadata"]["user_args"].append("-w_d~normal(0,1)")
     backward.populate_space(child_config)
     return child_config
 
@@ -104,9 +121,9 @@ def new_config(child_config):
 @pytest.fixture
 def changed_config(child_config):
     """Create a child config with a changed dimension"""
-    second_element = child_config['metadata']['user_args'][3]
-    second_element = second_element.replace('normal', 'uniform')
-    child_config['metadata']['user_args'][3] = second_element
+    second_element = child_config["metadata"]["user_args"][3]
+    second_element = second_element.replace("normal", "uniform")
+    child_config["metadata"]["user_args"][3] = second_element
     backward.populate_space(child_config)
     return child_config
 
@@ -114,14 +131,14 @@ def changed_config(child_config):
 @pytest.fixture
 def changed_algo_config(child_config):
     """Create a child config with a changed dimension"""
-    child_config['algorithms'] = 'stupid-grid'
+    child_config["algorithms"] = "stupid-grid"
     return child_config
 
 
 @pytest.fixture
 def changed_code_config(child_config):
     """Create a child config with a changed dimension"""
-    child_config['metadata']['VCS']['HEAD_sha'] = 'new_test'
+    child_config["metadata"]["VCS"]["HEAD_sha"] = "new_test"
     return child_config
 
 
@@ -129,9 +146,9 @@ def changed_code_config(child_config):
 def same_userconfig_config(user_config, child_config):
     """Create a child config with a changed dimension"""
     config_file_path = "./same_config.yaml"
-    with open(config_file_path, 'w') as f:
+    with open(config_file_path, "w") as f:
         yaml.dump(user_config, f)
-    child_config['metadata']['user_args'][-1] = '--config=%s' % config_file_path
+    child_config["metadata"]["user_args"][-1] = "--config=%s" % config_file_path
     backward.populate_space(child_config)
     yield child_config
     os.remove(config_file_path)
@@ -140,12 +157,12 @@ def same_userconfig_config(user_config, child_config):
 @pytest.fixture
 def changed_userconfig_config(user_config, child_config):
     """Create a child config with a changed dimension"""
-    config_file_path = './changed_config.yaml'
-    user_config['b'] = 'orion~uniform(-20, 0, precision=None)'
-    user_config['some_other'] = 'hello'
-    with open(config_file_path, 'w') as f:
+    config_file_path = "./changed_config.yaml"
+    user_config["b"] = "orion~uniform(-20, 0, precision=None)"
+    user_config["some_other"] = "hello"
+    with open(config_file_path, "w") as f:
         yaml.dump(user_config, f)
-    child_config['metadata']['user_args'][-1] = '--config=%s' % config_file_path
+    child_config["metadata"]["user_args"][-1] = "--config=%s" % config_file_path
     backward.populate_space(child_config)
     yield child_config
     os.remove(config_file_path)
@@ -154,7 +171,7 @@ def changed_userconfig_config(user_config, child_config):
 @pytest.fixture
 def changed_cli_config(child_config):
     """Create a child config with a changed dimension"""
-    child_config['metadata']['user_args'] += ['-u=0', '--another=test', 'positional']
+    child_config["metadata"]["user_args"] += ["-u=0", "--another=test", "positional"]
     backward.populate_space(child_config)
     return child_config
 
@@ -164,8 +181,7 @@ def list_arg_with_equals_cli_config(child_config):
     """Create a child config with an argument of the
     form --args=1 --args=2 --args=3
     """
-    child_config['metadata']['user_args'] += ['--args=1',
-                                              '--args=2', '--args=3']
+    child_config["metadata"]["user_args"] += ["--args=1", "--args=2", "--args=3"]
     backward.populate_space(child_config)
     return child_config
 
@@ -173,25 +189,41 @@ def list_arg_with_equals_cli_config(child_config):
 @pytest.fixture
 def cl_config(create_db_instance):
     """Create a child config with markers for commandline solving"""
-    user_script = 'abs_path/black_box.py'
+    user_script = "abs_path/black_box.py"
     config = dict(
-        name='test',
-        branch='test2',
-        algorithms='random',
-        metadata={'hash_commit': 'old',
-                  'user_script': user_script,
-                  'user_args': [
-                      user_script, '--nameless=option', '-x~>w_d', '-w_d~+normal(0,1)',
-                      '-y~+uniform(0,1)', '-z~-', '--omega~+normal(0,1)'],
-                  'user': 'some_user_name'})
+        name="test",
+        branch="test2",
+        algorithms="random",
+        metadata={
+            "hash_commit": "old",
+            "user_script": user_script,
+            "user_args": [
+                user_script,
+                "--nameless=option",
+                "-x~>w_d",
+                "-w_d~+normal(0,1)",
+                "-y~+uniform(0,1)",
+                "-z~-",
+                "--omega~+normal(0,1)",
+            ],
+            "user": "some_user_name",
+        },
+    )
     backward.populate_space(config)
     return config
 
 
 @pytest.fixture
-def conflicts(new_dimension_conflict, changed_dimension_conflict, missing_dimension_conflict,
-              algorithm_conflict, code_conflict, experiment_name_conflict, config_conflict,
-              cli_conflict):
+def conflicts(
+    new_dimension_conflict,
+    changed_dimension_conflict,
+    missing_dimension_conflict,
+    algorithm_conflict,
+    code_conflict,
+    experiment_name_conflict,
+    config_conflict,
+    cli_conflict,
+):
     """Create a container for conflicts with one of each types for testing purposes"""
     conflicts = evc.conflicts.Conflicts()
     conflicts.register(new_dimension_conflict)
@@ -223,7 +255,7 @@ class TestConflictDetection(object):
         conflict = conflicts.get()[1]
 
         assert conflict.is_resolved is False
-        assert conflict.dimension.name == '/x'
+        assert conflict.dimension.name == "/x"
         assert isinstance(conflict, MissingDimensionConflict)
 
     def test_new_dim_conflict(self, parent_config, new_config):
@@ -234,7 +266,7 @@ class TestConflictDetection(object):
         conflict = conflicts.get()[1]
 
         assert conflict.is_resolved is False
-        assert conflict.dimension.name == '/w_d'
+        assert conflict.dimension.name == "/w_d"
         assert isinstance(conflict, NewDimensionConflict)
 
     def test_changed_dim_conflict(self, parent_config, changed_config):
@@ -245,10 +277,12 @@ class TestConflictDetection(object):
         conflict = conflicts.get()[0]
 
         assert conflict.is_resolved is False
-        assert conflict.dimension.name == '/y'
+        assert conflict.dimension.name == "/y"
         assert isinstance(conflict, ChangedDimensionConflict)
 
-    def test_changed_dim_userconfig_conflict(self, parent_config, changed_userconfig_config):
+    def test_changed_dim_userconfig_conflict(
+        self, parent_config, changed_userconfig_config
+    ):
         """Test if changed dimension from user's config is currently detected"""
         conflicts = detect_conflicts(parent_config, changed_userconfig_config)
 
@@ -256,7 +290,7 @@ class TestConflictDetection(object):
         conflict = conflicts.get()[0]
 
         assert conflict.is_resolved is False
-        assert conflict.dimension.name == '/b'
+        assert conflict.dimension.name == "/b"
         assert isinstance(conflict, ChangedDimensionConflict)
 
     def test_algo_conflict(self, parent_config, changed_algo_config):
@@ -267,8 +301,8 @@ class TestConflictDetection(object):
         conflict = conflicts.get()[0]
 
         assert conflict.is_resolved is False
-        assert conflict.old_config['algorithms'] == 'random'
-        assert conflict.new_config['algorithms'] == 'stupid-grid'
+        assert conflict.old_config["algorithms"] == "random"
+        assert conflict.new_config["algorithms"] == "stupid-grid"
         assert isinstance(conflict, AlgorithmConflict)
 
     def test_code_conflict(self, parent_config, changed_code_config):
@@ -279,14 +313,15 @@ class TestConflictDetection(object):
         conflict = conflicts.get()[0]
 
         assert conflict.is_resolved is False
-        assert conflict.old_config['metadata']['VCS']['HEAD_sha'] == 'test'
-        assert conflict.new_config['metadata']['VCS']['HEAD_sha'] == 'new_test'
+        assert conflict.old_config["metadata"]["VCS"]["HEAD_sha"] == "test"
+        assert conflict.new_config["metadata"]["VCS"]["HEAD_sha"] == "new_test"
         assert isinstance(conflict, CodeConflict)
 
     def test_ignore_code_conflict(self, parent_config, changed_code_config):
         """Test if ignored code commit hash change is detected as a conflict"""
-        conflicts = detect_conflicts(parent_config, changed_code_config,
-                                     {'ignore_code_changes': True})
+        conflicts = detect_conflicts(
+            parent_config, changed_code_config, {"ignore_code_changes": True}
+        )
 
         assert len(conflicts.get()) == 1
 
@@ -294,10 +329,14 @@ class TestConflictDetection(object):
         """Test if same configuration file with a different name is not detected as a conflict"""
         conflicts = detect_conflicts(parent_config, same_userconfig_config)
 
-        assert parent_config['metadata']['user_args'][-1].startswith('--config=')
-        assert same_userconfig_config['metadata']['user_args'][-1].startswith('--config=')
-        assert (parent_config['metadata']['user_args'][-1] !=
-                same_userconfig_config['metadata']['user_args'][-1])
+        assert parent_config["metadata"]["user_args"][-1].startswith("--config=")
+        assert same_userconfig_config["metadata"]["user_args"][-1].startswith(
+            "--config="
+        )
+        assert (
+            parent_config["metadata"]["user_args"][-1]
+            != same_userconfig_config["metadata"]["user_args"][-1]
+        )
 
         assert len(conflicts.get()) == 2
         assert not conflicts.get([ExperimentNameConflict])[0].is_resolved
@@ -322,9 +361,12 @@ class TestConflictDetection(object):
 
     def test_cli_ignored_conflict(self, parent_config, changed_cli_config):
         """Test if ignored changed command line call is detected as a conflict"""
-        changed_cli_config['metadata']['user_args'].pop()
-        conflicts = detect_conflicts(parent_config, changed_cli_config,
-                                     {'non_monitored_arguments': ['u', 'another']})
+        changed_cli_config["metadata"]["user_args"].pop()
+        conflicts = detect_conflicts(
+            parent_config,
+            changed_cli_config,
+            {"non_monitored_arguments": ["u", "another"]},
+        )
 
         assert len(conflicts.get()) == 1
 
@@ -336,11 +378,11 @@ class TestResolutions(object):
 
     def test_add_single_hit(self, parent_config, new_config):
         """Test if adding a dimension only touches the correct status"""
-        del new_config['metadata']['user_args'][2]
+        del new_config["metadata"]["user_args"][2]
         backward.populate_space(new_config)
         conflicts = detect_conflicts(parent_config, new_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
-        branch_builder.add_dimension('w_d')
+        branch_builder.add_dimension("w_d")
 
         assert len(conflicts.get()) == 3
         assert conflicts.get([ExperimentNameConflict])[0].is_resolved
@@ -351,7 +393,7 @@ class TestResolutions(object):
         """Test if adding a new dimension solves the conflict"""
         conflicts = detect_conflicts(parent_config, new_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
-        branch_builder.add_dimension('w_d')
+        branch_builder.add_dimension("w_d")
 
         assert len(conflicts.get()) == 2
         assert len(conflicts.get_resolved()) == 2
@@ -365,7 +407,7 @@ class TestResolutions(object):
         """Test if adding a changed dimension solves the conflict"""
         conflicts = detect_conflicts(parent_config, changed_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
-        branch_builder.add_dimension('y')
+        branch_builder.add_dimension("y")
 
         assert len(conflicts.get()) == 2
         assert len(conflicts.get_resolved()) == 2
@@ -379,7 +421,7 @@ class TestResolutions(object):
         """Test if removing a missing dimension solves the conflict"""
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
-        branch_builder.remove_dimension('x')
+        branch_builder.remove_dimension("x")
 
         assert len(conflicts.get()) == 3
         assert len(conflicts.get_resolved()) == 2
@@ -391,11 +433,11 @@ class TestResolutions(object):
 
     def test_rename_missing(self, parent_config, missing_config):
         """Test if renaming a dimension to another solves both conflicts"""
-        missing_config['metadata']['user_args'].append('-w_d~uniform(0,1)')
+        missing_config["metadata"]["user_args"].append("-w_d~uniform(0,1)")
         backward.populate_space(missing_config)
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
-        branch_builder.rename_dimension('x', 'w_d')
+        branch_builder.rename_dimension("x", "w_d")
 
         assert len(conflicts.get()) == 4
 
@@ -407,23 +449,28 @@ class TestResolutions(object):
         resolved_conflicts = conflicts.get_resolved()
         assert len(resolved_conflicts) == 3
         assert resolved_conflicts[1].resolution is resolved_conflicts[2].resolution
-        assert isinstance(resolved_conflicts[1].resolution,
-                          resolved_conflicts[1].RenameDimensionResolution)
-        assert resolved_conflicts[1].resolution.conflict.dimension.name == '/x'
-        assert resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name == '/w_d'
+        assert isinstance(
+            resolved_conflicts[1].resolution,
+            resolved_conflicts[1].RenameDimensionResolution,
+        )
+        assert resolved_conflicts[1].resolution.conflict.dimension.name == "/x"
+        assert (
+            resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name
+            == "/w_d"
+        )
 
     def test_rename_missing_changed(self, parent_config, missing_config):
         """Test if renaming a dimension to another with different prior solves both conflicts but
         creates a new one which is not solved
         """
-        missing_config['metadata']['user_args'].append('-w_d~normal(0,1)')
+        missing_config["metadata"]["user_args"].append("-w_d~normal(0,1)")
         backward.populate_space(missing_config)
         conflicts = detect_conflicts(parent_config, missing_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
         assert len(conflicts.get()) == 4
 
-        branch_builder.rename_dimension('x', 'w_d')
+        branch_builder.rename_dimension("x", "w_d")
 
         assert len(conflicts.get()) == 5
 
@@ -436,40 +483,47 @@ class TestResolutions(object):
         resolved_conflicts = conflicts.get_resolved()
         assert len(resolved_conflicts) == 3
         assert resolved_conflicts[1].resolution is resolved_conflicts[2].resolution
-        assert isinstance(resolved_conflicts[1].resolution,
-                          resolved_conflicts[1].RenameDimensionResolution)
-        assert resolved_conflicts[1].resolution.conflict.dimension.name == '/x'
-        assert resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name == '/w_d'
+        assert isinstance(
+            resolved_conflicts[1].resolution,
+            resolved_conflicts[1].RenameDimensionResolution,
+        )
+        assert resolved_conflicts[1].resolution.conflict.dimension.name == "/x"
+        assert (
+            resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name
+            == "/w_d"
+        )
 
     def test_reset_dimension(self, parent_config, new_config):
         """Test if resetting a dimension unsolves the conflict"""
         conflicts = detect_conflicts(parent_config, new_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
-        branch_builder.add_dimension('w_d')
+        branch_builder.add_dimension("w_d")
         assert len(conflicts.get_resolved()) == 2
 
         with pytest.raises(ValueError) as exc:
-            branch_builder.reset('w_d~+')
+            branch_builder.reset("w_d~+")
         assert "'w_d~+' is not in list" in str(exc.value)
         assert len(conflicts.get_resolved()) == 2
 
-        branch_builder.reset('w_d~+norm(0, 1)')
+        branch_builder.reset("w_d~+norm(0, 1)")
 
         assert len(conflicts.get()) == 2
 
-        conflict = conflicts.get(dimension_name='w_d')[0]
+        conflict = conflicts.get(dimension_name="w_d")[0]
 
         assert not conflict.is_resolved
         assert isinstance(conflict, NewDimensionConflict)
         assert len(conflicts.get_resolved()) == 1
 
-    def test_name_experiment(self, bad_exp_parent_config, bad_exp_child_config, create_db_instance):
+    def test_name_experiment(
+        self, bad_exp_parent_config, bad_exp_child_config, create_db_instance
+    ):
         """Test if having the same experiment name does not create a conflict."""
         backward.populate_space(bad_exp_parent_config)
         backward.populate_space(bad_exp_child_config)
-        create_db_instance.write('experiments', bad_exp_parent_config)
-        create_db_instance.write('experiments', bad_exp_child_config)
+        create_db_instance.write("experiments", bad_exp_parent_config)
+        create_db_instance.write("experiments", bad_exp_child_config)
         conflicts = detect_conflicts(bad_exp_parent_config, bad_exp_parent_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -478,27 +532,34 @@ class TestResolutions(object):
 
         conflict = conflicts.get([ExperimentNameConflict])[0]
 
-        assert conflict.new_config['name'] == 'test'
+        assert conflict.new_config["name"] == "test"
         assert not conflict.is_resolved
-        branch_builder.change_experiment_name('test2')
+        branch_builder.change_experiment_name("test2")
         assert len(conflicts.get_resolved()) == 1
-        assert conflict.new_config['name'] == 'test2'
+        assert conflict.new_config["name"] == "test2"
         assert conflict.is_resolved
 
     def test_bad_name_experiment(self, parent_config, child_config, monkeypatch):
         """Test if changing the experiment names does not work for invalid name and revert
         to old one
         """
+
         def _is_unique(self, *args, **kwargs):
             return False
 
         def _versions(self, *args, **kwargs):
             return True
 
-        monkeypatch.setattr(ExperimentNameConflict.ExperimentNameResolution, "_name_is_unique",
-                            _is_unique)
-        monkeypatch.setattr(ExperimentNameConflict.ExperimentNameResolution,
-                            "_check_for_greater_versions", _versions)
+        monkeypatch.setattr(
+            ExperimentNameConflict.ExperimentNameResolution,
+            "_name_is_unique",
+            _is_unique,
+        )
+        monkeypatch.setattr(
+            ExperimentNameConflict.ExperimentNameResolution,
+            "_check_for_greater_versions",
+            _versions,
+        )
 
         conflicts = detect_conflicts(parent_config, child_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -509,9 +570,9 @@ class TestResolutions(object):
         conflict = conflicts.get([ExperimentNameConflict])[0]
 
         assert not conflict.is_resolved
-        branch_builder.change_experiment_name('test2')
+        branch_builder.change_experiment_name("test2")
         assert len(conflicts.get_resolved()) == 0
-        assert conflict.new_config['name'] == 'test'
+        assert conflict.new_config["name"] == "test"
         assert not conflict.is_resolved
 
     def test_algo_change(self, parent_config, changed_algo_config):
@@ -554,9 +615,9 @@ class TestResolutions(object):
         conflicts = detect_conflicts(parent_config, changed_code_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
         capsys.readouterr()
-        branch_builder.set_code_change_type('bad-type')
+        branch_builder.set_code_change_type("bad-type")
         out, err = capsys.readouterr()
-        assert 'Invalid code change type' in out.split("\n")[-3]
+        assert "Invalid code change type" in out.split("\n")[-3]
 
         assert len(conflicts.get()) == 2
         assert len(conflicts.get_resolved()) == 1
@@ -569,7 +630,9 @@ class TestResolutions(object):
         assert len(conflicts.get()) == 4
         assert len(conflicts.get_resolved()) == 1
 
-        branch_builder.set_script_config_change_type(evc.adapters.ScriptConfigChange.types[0])
+        branch_builder.set_script_config_change_type(
+            evc.adapters.ScriptConfigChange.types[0]
+        )
 
         assert len(conflicts.get()) == 4
         assert len(conflicts.get_resolved()) == 2
@@ -583,9 +646,9 @@ class TestResolutions(object):
         conflicts = detect_conflicts(parent_config, changed_userconfig_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
         capsys.readouterr()
-        branch_builder.set_script_config_change_type('bad-type')
+        branch_builder.set_script_config_change_type("bad-type")
         out, err = capsys.readouterr()
-        assert 'Invalid script\'s config change type' in out.split("\n")[-3]
+        assert "Invalid script's config change type" in out.split("\n")[-3]
 
         assert len(conflicts.get()) == 4
         assert len(conflicts.get_resolved()) == 1
@@ -612,9 +675,9 @@ class TestResolutions(object):
         conflicts = detect_conflicts(parent_config, changed_cli_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
         capsys.readouterr()
-        branch_builder.set_cli_change_type('bad-type')
+        branch_builder.set_cli_change_type("bad-type")
         out, err = capsys.readouterr()
-        assert 'Invalid cli change type' in out.split("\n")[-3]
+        assert "Invalid cli change type" in out.split("\n")[-3]
 
         assert len(conflicts.get()) == 2
         assert len(conflicts.get_resolved()) == 1
@@ -631,7 +694,7 @@ class TestResolutionsWithMarkers(object):
 
     def test_add_new(self, parent_config, new_config):
         """Test if new dimension conflict is automatically resolved"""
-        new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1)'
+        new_config["metadata"]["user_args"][-1] = "-w_d~+normal(0,1)"
         conflicts = detect_conflicts(parent_config, new_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -645,7 +708,7 @@ class TestResolutionsWithMarkers(object):
 
     def test_add_new_default(self, parent_config, new_config):
         """Test if new dimension conflict is automatically resolved"""
-        new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1,default_value=0)'
+        new_config["metadata"]["user_args"][-1] = "-w_d~+normal(0,1,default_value=0)"
         backward.populate_space(new_config)
         conflicts = detect_conflicts(parent_config, new_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -661,16 +724,17 @@ class TestResolutionsWithMarkers(object):
 
     def test_add_bad_default(self, parent_config, new_config):
         """Test if new dimension conflict raises an error if marked with invalid default value"""
-        new_config['metadata']['user_args'][-1] = '-w_d~+normal(0,1,default_value=\'a\')'
+        new_config["metadata"]["user_args"][-1] = "-w_d~+normal(0,1,default_value='a')"
         backward.populate_space(new_config)
         with pytest.raises(TypeError) as exc:
             detect_conflicts(parent_config, new_config)
-        assert "Parameter \'/w_d\': Incorrect arguments." in str(exc.value)
+        assert "Parameter '/w_d': Incorrect arguments." in str(exc.value)
 
     def test_add_changed(self, parent_config, changed_config):
         """Test if changed dimension conflict is automatically resolved"""
-        changed_config['metadata']['user_args'][3] = (
-            changed_config['metadata']['user_args'][3].replace("~", "~+"))
+        changed_config["metadata"]["user_args"][3] = changed_config["metadata"][
+            "user_args"
+        ][3].replace("~", "~+")
         conflicts = detect_conflicts(parent_config, changed_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -684,7 +748,7 @@ class TestResolutionsWithMarkers(object):
 
     def test_remove_missing(self, parent_config, child_config):
         """Test if missing dimension conflict is automatically resolved"""
-        child_config['metadata']['user_args'][2] = '-x~-'
+        child_config["metadata"]["user_args"][2] = "-x~-"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -699,7 +763,7 @@ class TestResolutionsWithMarkers(object):
 
     def test_remove_missing_default(self, parent_config, child_config):
         """Test if missing dimension conflict is automatically resolved"""
-        child_config['metadata']['user_args'][2] = '-x~-0.5'
+        child_config["metadata"]["user_args"][2] = "-x~-0.5"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -715,7 +779,7 @@ class TestResolutionsWithMarkers(object):
 
     def test_remove_missing_bad_default(self, parent_config, child_config):
         """Test if missing dimension conflict raises an error if marked with invalid default"""
-        child_config['metadata']['user_args'][2] = '-x~--100'
+        child_config["metadata"]["user_args"][2] = "-x~--100"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -730,9 +794,9 @@ class TestResolutionsWithMarkers(object):
 
     def test_rename_missing(self, parent_config, child_config):
         """Test if renaming is automatically applied with both conflicts resolved"""
-        child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
-        child_config['metadata']['user_args'].append('-w_b~normal(0,1)')
-        child_config['metadata']['user_args'][2] = '-x~>w_a'
+        child_config["metadata"]["user_args"].append("-w_a~uniform(0,1)")
+        child_config["metadata"]["user_args"].append("-w_b~normal(0,1)")
+        child_config["metadata"]["user_args"][2] = "-x~>w_a"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -740,23 +804,28 @@ class TestResolutionsWithMarkers(object):
         assert len(conflicts.get()) == 4
 
         assert conflicts.get([ExperimentNameConflict])[0].is_resolved
-        assert conflicts.get(dimension_name='x')[0].is_resolved
-        assert conflicts.get(dimension_name='w_a')[0].is_resolved
-        assert not conflicts.get(dimension_name='w_b')[0].is_resolved
+        assert conflicts.get(dimension_name="x")[0].is_resolved
+        assert conflicts.get(dimension_name="w_a")[0].is_resolved
+        assert not conflicts.get(dimension_name="w_b")[0].is_resolved
 
         resolved_conflicts = conflicts.get_resolved()
         assert len(resolved_conflicts) == 3
         assert resolved_conflicts[1].resolution is resolved_conflicts[2].resolution
-        assert isinstance(resolved_conflicts[1].resolution,
-                          resolved_conflicts[1].RenameDimensionResolution)
-        assert resolved_conflicts[1].resolution.conflict.dimension.name == '/x'
-        assert resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name == '/w_a'
+        assert isinstance(
+            resolved_conflicts[1].resolution,
+            resolved_conflicts[1].RenameDimensionResolution,
+        )
+        assert resolved_conflicts[1].resolution.conflict.dimension.name == "/x"
+        assert (
+            resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name
+            == "/w_a"
+        )
 
     def test_rename_invalid(self, parent_config, child_config):
         """Test if renaming to invalid dimension raises an error"""
-        child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
-        child_config['metadata']['user_args'].append('-w_b~uniform(0,1)')
-        child_config['metadata']['user_args'][2] = '-x~>w_c'
+        child_config["metadata"]["user_args"].append("-w_a~uniform(0,1)")
+        child_config["metadata"]["user_args"].append("-w_b~uniform(0,1)")
+        child_config["metadata"]["user_args"][2] = "-x~>w_c"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         with pytest.raises(ValueError) as exc:
@@ -767,9 +836,9 @@ class TestResolutionsWithMarkers(object):
         """Test if renaming is automatically applied with both conflicts resolved,
         but not the new one because of prior change
         """
-        child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
-        child_config['metadata']['user_args'].append('-w_b~normal(0,1)')
-        child_config['metadata']['user_args'][2] = '-x~>w_b'
+        child_config["metadata"]["user_args"].append("-w_a~uniform(0,1)")
+        child_config["metadata"]["user_args"].append("-w_b~normal(0,1)")
+        child_config["metadata"]["user_args"][2] = "-x~>w_b"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -777,26 +846,35 @@ class TestResolutionsWithMarkers(object):
         assert len(conflicts.get()) == 5
 
         assert conflicts.get([ExperimentNameConflict])[0].is_resolved
-        assert conflicts.get(dimension_name='x')[0].is_resolved
-        assert conflicts.get([NewDimensionConflict], dimension_name='w_b')[0].is_resolved
-        assert not conflicts.get([ChangedDimensionConflict], dimension_name='w_b')[0].is_resolved
-        assert not conflicts.get(dimension_name='w_a')[0].is_resolved
+        assert conflicts.get(dimension_name="x")[0].is_resolved
+        assert conflicts.get([NewDimensionConflict], dimension_name="w_b")[
+            0
+        ].is_resolved
+        assert not conflicts.get([ChangedDimensionConflict], dimension_name="w_b")[
+            0
+        ].is_resolved
+        assert not conflicts.get(dimension_name="w_a")[0].is_resolved
 
         resolved_conflicts = conflicts.get_resolved()
         assert len(resolved_conflicts) == 3
         assert resolved_conflicts[1].resolution is resolved_conflicts[2].resolution
-        assert isinstance(resolved_conflicts[1].resolution,
-                          resolved_conflicts[1].RenameDimensionResolution)
-        assert resolved_conflicts[1].resolution.conflict.dimension.name == '/x'
-        assert resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name == '/w_b'
+        assert isinstance(
+            resolved_conflicts[1].resolution,
+            resolved_conflicts[1].RenameDimensionResolution,
+        )
+        assert resolved_conflicts[1].resolution.conflict.dimension.name == "/x"
+        assert (
+            resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name
+            == "/w_b"
+        )
 
     def test_rename_missing_changed_marked(self, parent_config, child_config):
         """Test if renaming is automatically applied with all conflicts resolved including
         the new one caused by prior change
         """
-        child_config['metadata']['user_args'].append('-w_a~uniform(0,1)')
-        child_config['metadata']['user_args'].append('-w_b~+normal(0,1)')
-        child_config['metadata']['user_args'][2] = '-x~>w_b'
+        child_config["metadata"]["user_args"].append("-w_a~uniform(0,1)")
+        child_config["metadata"]["user_args"].append("-w_b~+normal(0,1)")
+        child_config["metadata"]["user_args"][2] = "-x~>w_b"
         backward.populate_space(child_config)
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -804,25 +882,36 @@ class TestResolutionsWithMarkers(object):
         assert len(conflicts.get()) == 5
 
         assert conflicts.get([ExperimentNameConflict])[0].is_resolved
-        assert conflicts.get(dimension_name='x')[0].is_resolved
-        assert conflicts.get([NewDimensionConflict], dimension_name='w_b')[0].is_resolved
-        assert conflicts.get([ChangedDimensionConflict], dimension_name='w_b')[0].is_resolved
-        assert not conflicts.get(dimension_name='w_a')[0].is_resolved
+        assert conflicts.get(dimension_name="x")[0].is_resolved
+        assert conflicts.get([NewDimensionConflict], dimension_name="w_b")[
+            0
+        ].is_resolved
+        assert conflicts.get([ChangedDimensionConflict], dimension_name="w_b")[
+            0
+        ].is_resolved
+        assert not conflicts.get(dimension_name="w_a")[0].is_resolved
 
         resolved_conflicts = conflicts.get_resolved()
         assert len(resolved_conflicts) == 4
         assert resolved_conflicts[1].resolution is resolved_conflicts[2].resolution
-        assert isinstance(resolved_conflicts[1].resolution,
-                          resolved_conflicts[1].RenameDimensionResolution)
-        assert resolved_conflicts[1].resolution.conflict.dimension.name == '/x'
-        assert resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name == '/w_b'
+        assert isinstance(
+            resolved_conflicts[1].resolution,
+            resolved_conflicts[1].RenameDimensionResolution,
+        )
+        assert resolved_conflicts[1].resolution.conflict.dimension.name == "/x"
+        assert (
+            resolved_conflicts[1].resolution.new_dimension_conflict.dimension.name
+            == "/w_b"
+        )
 
-    def test_name_experiment_version_update(self, parent_config, child_config, create_db_instance):
+    def test_name_experiment_version_update(
+        self, parent_config, child_config, create_db_instance
+    ):
         """Test if experiment name conflict is automatically resolved with version update"""
-        old_name = 'test'
+        old_name = "test"
         new_version = 2
-        create_db_instance.write('experiments', parent_config)
-        child_config['version'] = 1
+        create_db_instance.write("experiments", parent_config)
+        child_config["version"] = 1
         conflicts = detect_conflicts(parent_config, child_config)
         ExperimentBranchBuilder(conflicts)
 
@@ -833,17 +922,19 @@ class TestResolutionsWithMarkers(object):
 
         assert conflict.resolution.new_name == old_name
         assert conflict.resolution.new_version == 2
-        assert conflict.new_config['name'] == old_name
-        assert conflict.new_config['version'] == new_version
+        assert conflict.new_config["name"] == old_name
+        assert conflict.new_config["version"] == new_version
         assert conflict.is_resolved
 
-    def test_name_experiment_name_change(self, parent_config, child_config, create_db_instance):
+    def test_name_experiment_name_change(
+        self, parent_config, child_config, create_db_instance
+    ):
         """Test if experiment name conflict is automatically resolved when new name provided"""
-        new_name = 'test2'
-        create_db_instance.write('experiments', parent_config)
-        create_db_instance.write('experiments', child_config)
+        new_name = "test2"
+        create_db_instance.write("experiments", parent_config)
+        create_db_instance.write("experiments", child_config)
         child_config2 = copy.deepcopy(child_config)
-        child_config2['version'] = 1
+        child_config2["version"] = 1
         conflicts = detect_conflicts(parent_config, child_config2)
         ExperimentBranchBuilder(conflicts, branch_to=new_name)
 
@@ -854,20 +945,24 @@ class TestResolutionsWithMarkers(object):
 
         assert conflict.resolution.new_name == new_name
         assert conflict.resolution.new_version == 1
-        assert conflict.new_config['name'] == new_name
-        assert conflict.new_config['version'] == 1
+        assert conflict.new_config["name"] == new_name
+        assert conflict.new_config["version"] == 1
         assert conflict.is_resolved
 
     def test_bad_name_experiment(self, parent_config, child_config, monkeypatch):
         """Test if experiment name conflict is not resolved when invalid name is marked"""
+
         def _is_unique(self, *args, **kwargs):
             return False
 
-        monkeypatch.setattr(ExperimentNameConflict.ExperimentNameResolution, "_name_is_unique",
-                            _is_unique)
+        monkeypatch.setattr(
+            ExperimentNameConflict.ExperimentNameResolution,
+            "_name_is_unique",
+            _is_unique,
+        )
 
         conflicts = detect_conflicts(parent_config, child_config)
-        ExperimentBranchBuilder(conflicts, branch_to='test2')
+        ExperimentBranchBuilder(conflicts, branch_to="test2")
 
         assert len(conflicts.get()) == 1
         assert len(conflicts.get_resolved()) == 0
@@ -875,7 +970,7 @@ class TestResolutionsWithMarkers(object):
     def test_code_change(self, parent_config, changed_code_config):
         """Test if code conflict is resolved automatically"""
         change_type = evc.adapters.CodeChange.types[0]
-        changed_code_config['code_change_type'] = change_type
+        changed_code_config["code_change_type"] = change_type
         conflicts = detect_conflicts(parent_config, changed_code_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -890,7 +985,7 @@ class TestResolutionsWithMarkers(object):
 
     def test_algo_change(self, parent_config, changed_algo_config):
         """Test if algorithm conflict is resolved automatically"""
-        changed_algo_config['algorithm_change'] = True
+        changed_algo_config["algorithm_change"] = True
         conflicts = detect_conflicts(parent_config, changed_algo_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -905,7 +1000,7 @@ class TestResolutionsWithMarkers(object):
     def test_config_change(self, parent_config, changed_userconfig_config):
         """Test if user's script's config conflict is resolved automatically"""
         change_type = evc.adapters.ScriptConfigChange.types[0]
-        changed_userconfig_config['config_change_type'] = change_type
+        changed_userconfig_config["config_change_type"] = change_type
         conflicts = detect_conflicts(parent_config, changed_userconfig_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -921,7 +1016,7 @@ class TestResolutionsWithMarkers(object):
     def test_cli_change(self, parent_config, changed_cli_config):
         """Test if command line conflict is resolved automatically"""
         change_type = evc.adapters.CommandLineChange.types[0]
-        changed_cli_config['cli_change_type'] = change_type
+        changed_cli_config["cli_change_type"] = change_type
         conflicts = detect_conflicts(parent_config, changed_cli_config)
         ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
@@ -940,7 +1035,7 @@ class TestAdapters(object):
 
     def test_adapter_add_new(self, parent_config, cl_config):
         """Test if a DimensionAddition is created when solving a new conflict"""
-        cl_config['metadata']['user_args'] = ['-w_d~+normal(0,1)']
+        cl_config["metadata"]["user_args"] = ["-w_d~+normal(0,1)"]
 
         conflicts = detect_conflicts(parent_config, cl_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -953,7 +1048,7 @@ class TestAdapters(object):
 
     def test_adapter_add_changed(self, parent_config, cl_config):
         """Test if a DimensionPriorChange is created when solving a new conflict"""
-        cl_config['metadata']['user_args'] = ['-y~+uniform(0,1)']
+        cl_config["metadata"]["user_args"] = ["-y~+uniform(0,1)"]
 
         conflicts = detect_conflicts(parent_config, cl_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -966,7 +1061,7 @@ class TestAdapters(object):
 
     def test_adapter_remove_missing(self, parent_config, cl_config):
         """Test if a DimensionDeletion is created when solving a new conflict"""
-        cl_config['metadata']['user_args'] = ['-z~-']
+        cl_config["metadata"]["user_args"] = ["-z~-"]
 
         conflicts = detect_conflicts(parent_config, cl_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -979,7 +1074,7 @@ class TestAdapters(object):
 
     def test_adapter_rename_missing(self, parent_config, cl_config):
         """Test if a DimensionRenaming is created when solving a new conflict"""
-        cl_config['metadata']['user_args'] = ['-x~>w_d', '-w_d~+uniform(0,1)']
+        cl_config["metadata"]["user_args"] = ["-x~>w_d", "-w_d~+uniform(0,1)"]
         backward.populate_space(cl_config)
 
         conflicts = detect_conflicts(parent_config, cl_config)
@@ -993,7 +1088,7 @@ class TestAdapters(object):
 
     def test_adapter_rename_different_prior(self, parent_config, cl_config):
         """Test if a DimensionRenaming is created when solving a new conflict"""
-        cl_config['metadata']['user_args'] = ['-x~>w_d', '-w_d~+normal(0,1)']
+        cl_config["metadata"]["user_args"] = ["-x~>w_d", "-w_d~+normal(0,1)"]
 
         conflicts = detect_conflicts(parent_config, cl_config)
         branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
@@ -1012,7 +1107,7 @@ class TestResolutionsConfig(object):
     def test_cli_change(self, parent_config, changed_cli_config):
         """Test if giving a proper change-type solves the command line conflict"""
         conflicts = detect_conflicts(parent_config, changed_cli_config)
-        orion.core.config.evc.cli_change_type = 'noeffect'
+        orion.core.config.evc.cli_change_type = "noeffect"
         ExperimentBranchBuilder(conflicts)
 
         assert len(conflicts.get()) == 2
@@ -1021,23 +1116,23 @@ class TestResolutionsConfig(object):
         conflict = conflicts.get_resolved()[0]
         assert conflict.is_resolved
         assert isinstance(conflict, CommandLineConflict)
-        assert conflict.resolution.type == 'noeffect'
-        orion.core.config.evc.cli_change_type = 'break'
+        assert conflict.resolution.type == "noeffect"
+        orion.core.config.evc.cli_change_type = "break"
 
     def test_bad_cli_change(self, capsys, parent_config, changed_cli_config):
         """Test if giving an invalid change-type fails the the resolution"""
         conflicts = detect_conflicts(parent_config, changed_cli_config)
-        orion.core.config.evc.cli_change_type = 'bad-type'
+        orion.core.config.evc.cli_change_type = "bad-type"
         ExperimentBranchBuilder(conflicts)
 
         assert len(conflicts.get()) == 2
         assert len(conflicts.get_resolved()) == 1
-        orion.core.config.evc.cli_change_type = 'break'
+        orion.core.config.evc.cli_change_type = "break"
 
     def test_code_change(self, parent_config, changed_code_config):
         """Test if giving a proper change-type solves the code conflict"""
         conflicts = detect_conflicts(parent_config, changed_code_config)
-        orion.core.config.evc.code_change_type = 'noeffect'
+        orion.core.config.evc.code_change_type = "noeffect"
         ExperimentBranchBuilder(conflicts)
 
         assert len(conflicts.get()) == 2
@@ -1046,23 +1141,23 @@ class TestResolutionsConfig(object):
         conflict = conflicts.get_resolved()[0]
         assert conflict.is_resolved
         assert isinstance(conflict, CodeConflict)
-        assert conflict.resolution.type == 'noeffect'
-        orion.core.config.evc.code_change_type = 'break'
+        assert conflict.resolution.type == "noeffect"
+        orion.core.config.evc.code_change_type = "break"
 
     def test_bad_code_change(self, capsys, parent_config, changed_code_config):
         """Test if giving an invalid change-type prints error message and do nothing"""
         conflicts = detect_conflicts(parent_config, changed_code_config)
-        orion.core.config.evc.code_change_type = 'bad-type'
+        orion.core.config.evc.code_change_type = "bad-type"
         ExperimentBranchBuilder(conflicts)
 
         assert len(conflicts.get()) == 2
         assert len(conflicts.get_resolved()) == 1
-        orion.core.config.evc.code_change_type = 'break'
+        orion.core.config.evc.code_change_type = "break"
 
     def test_config_change(self, parent_config, changed_userconfig_config):
         """Test if giving a proper change-type solves the user script config conflict"""
         conflicts = detect_conflicts(parent_config, changed_userconfig_config)
-        orion.core.config.evc.config_change_type = 'noeffect'
+        orion.core.config.evc.config_change_type = "noeffect"
         ExperimentBranchBuilder(conflicts)
 
         assert len(conflicts.get()) == 4
@@ -1071,12 +1166,12 @@ class TestResolutionsConfig(object):
         conflict = conflicts.get_resolved()[3]
         assert conflict.is_resolved
         assert isinstance(conflict, ScriptConfigConflict)
-        assert conflict.resolution.type == 'noeffect'
+        assert conflict.resolution.type == "noeffect"
 
     def test_bad_config_change(self, capsys, parent_config, changed_userconfig_config):
         """Test if giving an invalid change-type prints error message and do nothing"""
         conflicts = detect_conflicts(parent_config, changed_userconfig_config)
-        orion.core.config.evc.config_change_type = 'bad-type'
+        orion.core.config.evc.config_change_type = "bad-type"
         ExperimentBranchBuilder(conflicts)
 
         assert len(conflicts.get()) == 4

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -7,21 +7,26 @@ from datetime import datetime
 import pytest
 
 from orion.core.io.database import Database, DatabaseError, DuplicateKeyError
-from orion.core.io.database.ephemeraldb import EphemeralCollection, EphemeralDB, EphemeralDocument
+from orion.core.io.database.ephemeraldb import (
+    EphemeralCollection,
+    EphemeralDB,
+    EphemeralDocument,
+)
 import orion.core.utils.backward as backward
 
 
 @pytest.fixture()
 def document():
     """Return EphemeralDocument."""
-    return EphemeralDocument({'_id': 1, 'hello': 'there', 'mighty': 'duck'})
+    return EphemeralDocument({"_id": 1, "hello": "there", "mighty": "duck"})
 
 
 @pytest.fixture()
 def subdocument():
     """Return EphemeralDocument with a subdocument."""
-    return EphemeralDocument({'_id': 1, 'hello': 'there', 'mighty': 'duck',
-                              'and': {'the': 'drake'}})
+    return EphemeralDocument(
+        {"_id": 1, "hello": "there", "mighty": "duck", "and": {"the": "drake"}}
+    )
 
 
 @pytest.fixture()
@@ -50,14 +55,14 @@ def database(orion_db):
 @pytest.fixture()
 def clean_db(database, exp_config):
     """Clean insert example experiment entries to collections."""
-    database['experiments'].drop()
-    database['experiments'].insert_many(exp_config[0])
-    database['trials'].drop()
-    database['trials'].insert_many(exp_config[1])
-    database['workers'].drop()
-    database['workers'].insert_many(exp_config[2])
-    database['resources'].drop()
-    database['resources'].insert_many(exp_config[3])
+    database["experiments"].drop()
+    database["experiments"].insert_many(exp_config[0])
+    database["trials"].drop()
+    database["trials"].insert_many(exp_config[1])
+    database["workers"].drop()
+    database["workers"].insert_many(exp_config[2])
+    database["resources"].drop()
+    database["resources"].insert_many(exp_config[3])
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -66,32 +71,34 @@ class TestEnsureIndex(object):
 
     def test_new_index(self, orion_db):
         """Index should be added to ephemeral database"""
-        assert "new_field_1" not in orion_db._db['new_collection']._indexes
+        assert "new_field_1" not in orion_db._db["new_collection"]._indexes
 
-        orion_db.ensure_index('new_collection', 'new_field', unique=False)
-        assert "new_field_1" not in orion_db._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=False)
+        assert "new_field_1" not in orion_db._db["new_collection"]._indexes
 
-        orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert "new_field_1" in orion_db._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=True)
+        assert "new_field_1" in orion_db._db["new_collection"]._indexes
 
     def test_existing_index(self, orion_db):
         """Index should be added to ephemeral database and reattempt should do nothing"""
-        assert "new_field_1" not in orion_db._db['new_collection']._indexes
+        assert "new_field_1" not in orion_db._db["new_collection"]._indexes
 
-        orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert "new_field_1" in orion_db._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=True)
+        assert "new_field_1" in orion_db._db["new_collection"]._indexes
 
         # reattempt
-        orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert "new_field_1" in orion_db._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=True)
+        assert "new_field_1" in orion_db._db["new_collection"]._indexes
 
     def test_compound_index(self, orion_db):
         """Tuple of Index should be added as a compound index."""
-        assert "name_1_metadata.user_1" not in orion_db._db['experiments']._indexes
-        orion_db.ensure_index('experiments',
-                              [('name', Database.ASCENDING),
-                               ('metadata.user', Database.ASCENDING)], unique=True)
-        assert "name_1_metadata.user_1" in orion_db._db['experiments']._indexes
+        assert "name_1_metadata.user_1" not in orion_db._db["experiments"]._indexes
+        orion_db.ensure_index(
+            "experiments",
+            [("name", Database.ASCENDING), ("metadata.user", Database.ASCENDING)],
+            unique=True,
+        )
+        assert "name_1_metadata.user_1" in orion_db._db["experiments"]._indexes
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -101,62 +108,82 @@ class TestRead(object):
     def test_read_experiment(self, exp_config, orion_db):
         """Fetch a whole experiment entries."""
         loaded_config = orion_db.read(
-            'trials', {'experiment': 'supernaedo2-dendi', 'status': 'new'})
+            "trials", {"experiment": "supernaedo2-dendi", "status": "new"}
+        )
         assert loaded_config == [exp_config[1][3], exp_config[1][4]]
 
         loaded_config = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': exp_config[1][3]['submit_time']})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": exp_config[1][3]["submit_time"],
+            },
+        )
         assert loaded_config == [exp_config[1][3]]
-        assert loaded_config[0]['_id'] == exp_config[1][3]['_id']
+        assert loaded_config[0]["_id"] == exp_config[1][3]["_id"]
 
     def test_read_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
-        loaded_config = orion_db.read('experiments', {'_id': exp_config[0][2]['_id']})
+        loaded_config = orion_db.read("experiments", {"_id": exp_config[0][2]["_id"]})
         backward.populate_space(loaded_config[0])
         assert loaded_config == [exp_config[0][2]]
 
     def test_read_default(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'experiments', {'name': 'supernaedo2', 'metadata.user': 'tsirif'},
-            selection={'algorithms': 1, '_id': 0})
-        assert value == [{'algorithms': exp_config[0][0]['algorithms']}]
+            "experiments",
+            {"name": "supernaedo2", "metadata.user": "tsirif"},
+            selection={"algorithms": 1, "_id": 0},
+        )
+        assert value == [{"algorithms": exp_config[0][0]["algorithms"]}]
 
     def test_read_nothing(self, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'experiments', {'name': 'not_found', 'metadata.user': 'tsirif'},
-            selection={'algorithms': 1})
+            "experiments",
+            {"name": "not_found", "metadata.user": "tsirif"},
+            selection={"algorithms": 1},
+        )
         assert value == []
 
     def test_read_trials(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": {"$gte": datetime(2017, 11, 23, 0, 0, 0)},
+            },
+        )
         assert value == [exp_config[1][1]] + exp_config[1][3:7]
 
         value = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": {"$gt": datetime(2017, 11, 23, 0, 0, 0)},
+            },
+        )
         assert value == exp_config[1][3:7]
 
     def test_null_comp(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         all_values = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "end_time": {"$gte": datetime(2017, 11, 1, 0, 0, 0)},
+            },
+        )
 
-        orion_db._db['trials']._documents[0]._data['end_time'] = None
+        orion_db._db["trials"]._documents[0]._data["end_time"] = None
         values = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "end_time": {"$gte": datetime(2017, 11, 1, 0, 0, 0)},
+            },
+        )
         assert len(values) == len(all_values) - 1
 
 
@@ -166,80 +193,81 @@ class TestWrite(object):
 
     def test_insert_one(self, database, orion_db):
         """Should insert a single new entry in the collection."""
-        item = {'exp_name': 'supernaekei',
-                'user': 'tsirif'}
-        count_before = database['experiments'].count()
+        item = {"exp_name": "supernaekei", "user": "tsirif"}
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.write('experiments', item) == 1
-        assert database['experiments'].count() == count_before + 1
-        value = database['experiments'].find({'exp_name': 'supernaekei'})[0]
+        assert orion_db.write("experiments", item) == 1
+        assert database["experiments"].count() == count_before + 1
+        value = database["experiments"].find({"exp_name": "supernaekei"})[0]
         assert value == item
 
     def test_insert_many(self, database, orion_db):
         """Should insert two new entry (as a list) in the collection."""
-        item = [{'exp_name': 'supernaekei2',
-                 'user': 'tsirif'},
-                {'exp_name': 'supernaekei3',
-                 'user': 'tsirif'}]
-        count_before = database['experiments'].count()
+        item = [
+            {"exp_name": "supernaekei2", "user": "tsirif"},
+            {"exp_name": "supernaekei3", "user": "tsirif"},
+        ]
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.write('experiments', item) == 2
-        assert database['experiments'].count() == count_before + 2
-        value = database['experiments'].find({'exp_name': 'supernaekei2'})[0]
+        assert orion_db.write("experiments", item) == 2
+        assert database["experiments"].count() == count_before + 2
+        value = database["experiments"].find({"exp_name": "supernaekei2"})[0]
         assert value == item[0]
-        value = database['experiments'].find({'exp_name': 'supernaekei3'})[0]
+        value = database["experiments"].find({"exp_name": "supernaekei3"})[0]
         assert value == item[1]
 
     def test_update_many_default(self, database, orion_db):
         """Should match existing entries, and update some of their keys."""
-        filt = {'metadata.user': 'dendi'}
-        count_before = database['experiments'].count()
-        count_query = database['experiments'].count(filt)
+        filt = {"metadata.user": "dendi"}
+        count_before = database["experiments"].count()
+        count_query = database["experiments"].count(filt)
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 16}, filt) == count_query
-        assert database['experiments'].count() == count_before
-        value = list(database['experiments'].find({}))
-        assert value[0]['pool_size'] == 16
-        assert value[1]['pool_size'] == 2
-        assert value[2]['pool_size'] == 2
-        assert value[3]['pool_size'] == 2
+        assert orion_db.write("experiments", {"pool_size": 16}, filt) == count_query
+        assert database["experiments"].count() == count_before
+        value = list(database["experiments"].find({}))
+        assert value[0]["pool_size"] == 16
+        assert value[1]["pool_size"] == 2
+        assert value[2]["pool_size"] == 2
+        assert value[3]["pool_size"] == 2
 
     def test_update_with_set(self, database, orion_db):
         """Should override matching subdict, not update it"""
-        filt = {'metadata.user': 'dendi'}
-        count_before = database['experiments'].count()
-        count_query = database['experiments'].count(filt)
+        filt = {"metadata.user": "dendi"}
+        count_before = database["experiments"].count()
+        count_query = database["experiments"].count(filt)
         # call interface
-        new_algo = {'random': {'seed': 1}}
-        assert orion_db.write('experiments', {'algorithms': new_algo}, filt) == count_query
+        new_algo = {"random": {"seed": 1}}
+        assert (
+            orion_db.write("experiments", {"algorithms": new_algo}, filt) == count_query
+        )
 
-        assert database['experiments'].count() == count_before
-        value = list(database['experiments'].find(filt))
+        assert database["experiments"].count() == count_before
+        value = list(database["experiments"].find(filt))
         assert len(value) == 1
-        assert value[0]['algorithms'] == new_algo
+        assert value[0]["algorithms"] == new_algo
 
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
-        filt = {'_id': exp_config[0][1]['_id']}
-        count_before = database['experiments'].count()
+        filt = {"_id": exp_config[0][1]["_id"]}
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 36}, filt) == 1
-        assert database['experiments'].count() == count_before
-        value = list(database['experiments'].find())
-        assert value[0]['pool_size'] == 2
-        assert value[1]['pool_size'] == 36
-        assert value[2]['pool_size'] == 2
+        assert orion_db.write("experiments", {"pool_size": 36}, filt) == 1
+        assert database["experiments"].count() == count_before
+        value = list(database["experiments"].find())
+        assert value[0]["pool_size"] == 2
+        assert value[1]["pool_size"] == 36
+        assert value[2]["pool_size"] == 2
 
     def test_insert_duplicate(self, database, orion_db):
         """Verify that duplicates cannot by inserted if index is unique"""
-        orion_db.ensure_index('some_doc', 'unique_field', unique=True)
+        orion_db.ensure_index("some_doc", "unique_field", unique=True)
         # call interface
-        orion_db.write('some_doc', {'unique_field': 1})
+        orion_db.write("some_doc", {"unique_field": 1})
 
         with pytest.raises(DuplicateKeyError) as exc:
-            orion_db.write('some_doc', {'unique_field': 1})
+            orion_db.write("some_doc", {"unique_field": 1})
 
-        assert 'unique_field' in str(exc.value)
+        assert "unique_field" in str(exc.value)
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -249,47 +277,42 @@ class TestReadAndWrite(object):
     def test_read_and_write_one(self, database, orion_db, exp_config):
         """Should read and update a single entry in the collection."""
         # Make sure there is only one match
-        documents = orion_db.read(
-            'experiments',
-            {'name': 'supernaedo4'})
+        documents = orion_db.read("experiments", {"name": "supernaedo4"})
         assert len(documents) == 1
 
         # Find and update atomically
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'name': 'supernaedo4'},
-            {'pool_size': 'lalala'})
-        exp_config[0][3]['pool_size'] = 'lalala'
+            "experiments", {"name": "supernaedo4"}, {"pool_size": "lalala"}
+        )
+        exp_config[0][3]["pool_size"] = "lalala"
         backward.populate_space(loaded_config)
         assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, database, orion_db, exp_config):
         """Should update only one entry."""
         # Make sure there is many matches
-        documents = orion_db.read('experiments', {'metadata.user': 'tsirif'})
+        documents = orion_db.read("experiments", {"metadata.user": "tsirif"})
         assert len(documents) > 1
 
         # Find many and update first one only
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'metadata.user': 'tsirif'},
-            {'pool_size': 'lalala'})
+            "experiments", {"metadata.user": "tsirif"}, {"pool_size": "lalala"}
+        )
 
-        exp_config[0][1]['pool_size'] = 'lalala'
+        exp_config[0][1]["pool_size"] = "lalala"
         backward.populate_space(loaded_config)
         assert loaded_config == exp_config[0][1]
 
         # Make sure it only changed the first document found
-        documents = orion_db.read('experiments', {'metadata.user': 'tsirif'})
-        assert documents[0]['pool_size'] == 'lalala'
-        assert documents[1]['pool_size'] != 'lalala'
+        documents = orion_db.read("experiments", {"metadata.user": "tsirif"})
+        assert documents[0]["pool_size"] == "lalala"
+        assert documents[1]["pool_size"] != "lalala"
 
     def test_read_and_write_no_match(self, database, orion_db):
         """Should return None when there is no match."""
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'name': 'lalala'},
-            {'pool_size': 'lalala'})
+            "experiments", {"name": "lalala"}, {"pool_size": "lalala"}
+        )
 
         assert loaded_config is None
 
@@ -300,26 +323,26 @@ class TestRemove(object):
 
     def test_remove_many_default(self, exp_config, database, orion_db):
         """Should match existing entries, and delete them all."""
-        filt = {'metadata.user': 'tsirif'}
-        count_before = database['experiments'].count()
-        count_filt = database['experiments'].count(filt)
+        filt = {"metadata.user": "tsirif"}
+        count_before = database["experiments"].count()
+        count_filt = database["experiments"].count(filt)
         # call interface
-        assert orion_db.remove('experiments', filt) == count_filt
-        assert database['experiments'].count() == count_before - count_filt
-        assert database['experiments'].count() == 1
-        loaded_config = list(database['experiments'].find())
+        assert orion_db.remove("experiments", filt) == count_filt
+        assert database["experiments"].count() == count_before - count_filt
+        assert database["experiments"].count() == 1
+        loaded_config = list(database["experiments"].find())
         backward.populate_space(loaded_config[0])
         assert loaded_config == [exp_config[0][0]]
 
     def test_remove_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
-        filt = {'_id': exp_config[0][0]['_id']}
+        filt = {"_id": exp_config[0][0]["_id"]}
 
-        count_before = database['experiments'].count()
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.remove('experiments', filt) == 1
-        assert database['experiments'].count() == count_before - 1
-        loaded_configs = database['experiments'].find()
+        assert orion_db.remove("experiments", filt) == 1
+        assert database["experiments"].count() == count_before - 1
+        loaded_configs = database["experiments"].find()
         for loaded_config in loaded_configs:
             backward.populate_space(loaded_config)
         assert loaded_configs == exp_config[0][1:]
@@ -327,22 +350,22 @@ class TestRemove(object):
     def test_remove_update_indexes(self, exp_config, database, orion_db):
         """Verify that indexes are properly update after deletion."""
         with pytest.raises(DuplicateKeyError):
-            orion_db.write('experiments', {'_id': exp_config[0][0]['_id']})
+            orion_db.write("experiments", {"_id": exp_config[0][0]["_id"]})
         with pytest.raises(DuplicateKeyError):
-            orion_db.write('experiments', {'_id': exp_config[0][1]['_id']})
+            orion_db.write("experiments", {"_id": exp_config[0][1]["_id"]})
 
-        filt = {'_id': exp_config[0][0]['_id']}
+        filt = {"_id": exp_config[0][0]["_id"]}
 
-        count_before = database['experiments'].count()
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.remove('experiments', filt) == 1
-        assert database['experiments'].count() == count_before - 1
+        assert orion_db.remove("experiments", filt) == 1
+        assert database["experiments"].count() == count_before - 1
         # Should not fail now, otherwise it means the indexes were not updated properly during
         # remove()
-        orion_db.write('experiments', filt)
+        orion_db.write("experiments", filt)
         # And this should still fail
         with pytest.raises(DuplicateKeyError):
-            orion_db.write('experiments', {'_id': exp_config[0][1]['_id']})
+            orion_db.write("experiments", {"_id": exp_config[0][1]["_id"]})
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -351,22 +374,22 @@ class TestCount(object):
 
     def test_count_default(self, exp_config, orion_db):
         """Call just with collection name."""
-        found = orion_db.count('trials')
+        found = orion_db.count("trials")
         assert found == len(exp_config[1])
 
     def test_count_query(self, exp_config, orion_db):
         """Call with a query."""
-        found = orion_db.count('trials', {'status': 'completed'})
-        assert found == len([x for x in exp_config[1] if x['status'] == 'completed'])
+        found = orion_db.count("trials", {"status": "completed"})
+        assert found == len([x for x in exp_config[1] if x["status"] == "completed"])
 
     def test_count_query_with_id(self, exp_config, orion_db):
         """Call querying with unique _id."""
-        found = orion_db.count('trials', {'_id': exp_config[1][2]['_id']})
+        found = orion_db.count("trials", {"_id": exp_config[1][2]["_id"]})
         assert found == 1
 
     def test_count_nothing(self, orion_db):
         """Call with argument that will not find anything."""
-        found = orion_db.count('experiments', {'name': 'lalalanotfound'})
+        found = orion_db.count("experiments", {"name": "lalalanotfound"})
         assert found == 0
 
 
@@ -376,38 +399,44 @@ class TestIndex(object):
 
     def test_create_index(self, collection):
         """Test if new index added property."""
-        collection.create_index('hello')
-        assert collection._indexes == {'_id_': (('_id',), {(1, )})}
+        collection.create_index("hello")
+        assert collection._indexes == {"_id_": (("_id",), {(1,)})}
 
-        collection.create_index('hello', unique=True)
-        assert collection._indexes == {'_id_': (('_id',), {(1, )}),
-                                       'hello_1': (('hello', ), {('there', )})}
+        collection.create_index("hello", unique=True)
+        assert collection._indexes == {
+            "_id_": (("_id",), {(1,)}),
+            "hello_1": (("hello",), {("there",)}),
+        }
 
     def test_track_index(self, collection):
         """Test if index values are tracked property."""
-        collection.create_index('hello', unique=True)
-        collection.insert_many([{'hello': 'here'}, {'hello': 2}])
-        assert (
-            collection._indexes ==
-            {'_id_': (('_id',), {(1, ), (2, ), (3, )}),
-             'hello_1': (('hello', ), {('there', ), ('here', ), (2, )})})
+        collection.create_index("hello", unique=True)
+        collection.insert_many([{"hello": "here"}, {"hello": 2}])
+        assert collection._indexes == {
+            "_id_": (("_id",), {(1,), (2,), (3,)}),
+            "hello_1": (("hello",), {("there",), ("here",), (2,)}),
+        }
 
     def test_index_over_non_existing_field(self, collection):
         """Test if index values are tracked property."""
-        collection.create_index([('hello', EphemeralDB.DESCENDING),
-                                 ('idontexist', EphemeralDB.ASCENDING)], unique=True)
+        collection.create_index(
+            [("hello", EphemeralDB.DESCENDING), ("idontexist", EphemeralDB.ASCENDING)],
+            unique=True,
+        )
 
-        collection.insert_many([{'hello': 'here'}, {'hello': 2}])
-        assert (
-            collection._indexes ==
-            {'_id_': (('_id',), {(1, ), (2, ), (3, )}),
-             'hello_1_idontexist_1': (('hello', 'idontexist'),
-                                      {('there', None), ('here', None), (2, None)})})
-        assert (
-            collection.find({}, selection={'hello': 1, 'idontexist': 1}) ==
-            [{'_id': 1, 'hello': 'there', 'idontexist': None},
-             {'_id': 2, 'hello': 'here', 'idontexist': None},
-             {'_id': 3, 'hello': 2, 'idontexist': None}])
+        collection.insert_many([{"hello": "here"}, {"hello": 2}])
+        assert collection._indexes == {
+            "_id_": (("_id",), {(1,), (2,), (3,)}),
+            "hello_1_idontexist_1": (
+                ("hello", "idontexist"),
+                {("there", None), ("here", None), (2, None)},
+            ),
+        }
+        assert collection.find({}, selection={"hello": 1, "idontexist": 1}) == [
+            {"_id": 1, "hello": "there", "idontexist": None},
+            {"_id": 2, "hello": "here", "idontexist": None},
+            {"_id": 3, "hello": 2, "idontexist": None},
+        ]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -416,91 +445,93 @@ class TestSelect(object):
 
     def test_select_all(self, document):
         """Select only one field."""
-        assert document.select({}) == {'_id': 1, 'hello': 'there', 'mighty': 'duck'}
+        assert document.select({}) == {"_id": 1, "hello": "there", "mighty": "duck"}
 
     def test_select_id(self, document):
         """Select only one field."""
-        assert document.select({'_id': 1}) == {'_id': 1}
+        assert document.select({"_id": 1}) == {"_id": 1}
 
     def test_select_one(self, document):
         """Select only one field."""
-        assert document.select({'hello': 1}) == {'_id': 1, 'hello': 'there'}
+        assert document.select({"hello": 1}) == {"_id": 1, "hello": "there"}
 
     def test_select_two(self, document):
         """Select only two field."""
-        assert (
-            document.select({'hello': 1, 'mighty': 1}) ==
-            {'_id': 1, 'hello': 'there', 'mighty': 'duck'})
+        assert document.select({"hello": 1, "mighty": 1}) == {
+            "_id": 1,
+            "hello": "there",
+            "mighty": "duck",
+        }
 
     def test_unselect_one(self, document):
         """Unselect only one field."""
-        assert document.select({'hello': 0}) == {'_id': 1, 'mighty': 'duck'}
+        assert document.select({"hello": 0}) == {"_id": 1, "mighty": "duck"}
 
     def test_unselect_two(self, document):
         """Unselect two field."""
-        assert document.select({'_id': 0, 'hello': 0}) == {'mighty': 'duck'}
+        assert document.select({"_id": 0, "hello": 0}) == {"mighty": "duck"}
 
     def test_mixed_select(self, document):
         """Select one field and unselect _id."""
-        assert document.select({'_id': 0, 'hello': 1}) == {'hello': 'there'}
+        assert document.select({"_id": 0, "hello": 1}) == {"hello": "there"}
 
     def test_select_unexisting_field(self, document):
         """Select field that does not exist and should return None."""
-        assert document.select({'idontexist': 1}) == {'_id': 1, 'idontexist': None}
+        assert document.select({"idontexist": 1}) == {"_id": 1, "idontexist": None}
 
 
-@pytest.mark.usefixtures('clean_db')
+@pytest.mark.usefixtures("clean_db")
 class TestMatch:
     """Calls :meth:`orion.core.io.database.ephemeraldb.EphemeralDocument.match`."""
 
     def test_match_eq(self, document):
         """Test eq operator"""
-        assert document.match({'hello': 'there'})
-        assert not document.match({'hello': 'not there'})
+        assert document.match({"hello": "there"})
+        assert not document.match({"hello": "not there"})
 
     def test_match_sub_eq(self, subdocument):
         """Test eq operator with sub document"""
-        assert subdocument.match({'and.the': 'drake'})
-        assert not subdocument.match({'and.no': 'drake'})
+        assert subdocument.match({"and.the": "drake"})
+        assert not subdocument.match({"and.no": "drake"})
 
     def test_match_in(self, subdocument):
         """Test $in operator with document"""
-        assert subdocument.match({'hello': {'$in': ['there', 'here']}})
-        assert not subdocument.match({'hello': {'$in': ['ici', 'here']}})
+        assert subdocument.match({"hello": {"$in": ["there", "here"]}})
+        assert not subdocument.match({"hello": {"$in": ["ici", "here"]}})
 
     def test_match_sub_in(self, subdocument):
         """Test $in operator with sub document"""
-        assert subdocument.match({'and.the': {'$in': ['duck', 'drake']}})
-        assert not subdocument.match({'and.the': {'$in': ['hyppo', 'lion']}})
+        assert subdocument.match({"and.the": {"$in": ["duck", "drake"]}})
+        assert not subdocument.match({"and.the": {"$in": ["hyppo", "lion"]}})
 
     def test_match_gte(self, document):
         """Test $gte operator with document"""
-        assert document.match({'_id': {'$gte': 1}})
-        assert document.match({'_id': {'$gte': 0}})
-        assert not document.match({'_id': {'$gte': 2}})
+        assert document.match({"_id": {"$gte": 1}})
+        assert document.match({"_id": {"$gte": 0}})
+        assert not document.match({"_id": {"$gte": 2}})
 
     def test_match_gt(self, document):
         """Test $gt operator with document"""
-        assert document.match({'_id': {'$gt': 0}})
-        assert not document.match({'_id': {'$gt': 1}})
+        assert document.match({"_id": {"$gt": 0}})
+        assert not document.match({"_id": {"$gt": 1}})
 
     def test_match_lte(self, document):
         """Test $lte operator with document"""
-        assert document.match({'_id': {'$lte': 2}})
-        assert document.match({'_id': {'$lte': 1}})
-        assert not document.match({'_id': {'$lte': 0}})
+        assert document.match({"_id": {"$lte": 2}})
+        assert document.match({"_id": {"$lte": 1}})
+        assert not document.match({"_id": {"$lte": 0}})
 
     def test_match_ne(self, document):
         """Test $ne operator with document"""
-        assert document.match({'hello': {'$ne': 'here'}})
-        assert not document.match({'hello': {'$ne': 'there'}})
+        assert document.match({"hello": {"$ne": "here"}})
+        assert not document.match({"hello": {"$ne": "there"}})
 
     def test_match_bad_operator(self, document):
         """Test invalid operator handling"""
         with pytest.raises(ValueError) as exc:
-            document.match({'_id': {'$voici_voila': 0}})
+            document.match({"_id": {"$voici_voila": 0}})
 
-        assert 'Operator \'$voici_voila\' is not supported' in str(exc.value)
+        assert "Operator '$voici_voila' is not supported" in str(exc.value)
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -509,34 +540,46 @@ class TestIndexInformation(object):
 
     def test_no_index(self, orion_db):
         """Test that no index is returned when there is none."""
-        assert orion_db.index_information('experiments') == {'_id_': True}
+        assert orion_db.index_information("experiments") == {"_id_": True}
 
     def test_single_index(self, orion_db):
         """Test that single indexes are ignored if not unique."""
-        orion_db.ensure_index('experiments', [('name', EphemeralDB.ASCENDING)])
+        orion_db.ensure_index("experiments", [("name", EphemeralDB.ASCENDING)])
 
-        assert orion_db.index_information('experiments') == {'_id_': True}
+        assert orion_db.index_information("experiments") == {"_id_": True}
 
     def test_single_index_unique(self, orion_db):
         """Test with single unique indexes."""
-        orion_db.ensure_index('experiments', [('name', EphemeralDB.ASCENDING)], unique=True)
+        orion_db.ensure_index(
+            "experiments", [("name", EphemeralDB.ASCENDING)], unique=True
+        )
 
-        assert orion_db.index_information('experiments') == {'_id_': True, 'name_1': True}
+        assert orion_db.index_information("experiments") == {
+            "_id_": True,
+            "name_1": True,
+        }
 
     def test_ordered_index(self, orion_db):
         """Test that ordered indexes are not taken into account."""
-        orion_db.ensure_index('experiments', [('name', EphemeralDB.DESCENDING)], unique=True)
+        orion_db.ensure_index(
+            "experiments", [("name", EphemeralDB.DESCENDING)], unique=True
+        )
 
-        assert orion_db.index_information('experiments') == {'_id_': True, 'name_1': True}
+        assert orion_db.index_information("experiments") == {
+            "_id_": True,
+            "name_1": True,
+        }
 
     def test_compound_index(self, orion_db):
         """Test representation of compound indexes."""
-        orion_db.ensure_index('experiments',
-                              [('name', EphemeralDB.DESCENDING),
-                               ('version', EphemeralDB.ASCENDING)], unique=True)
+        orion_db.ensure_index(
+            "experiments",
+            [("name", EphemeralDB.DESCENDING), ("version", EphemeralDB.ASCENDING)],
+            unique=True,
+        )
 
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_1_version_1': True}
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_1_version_1": True}
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -546,33 +589,41 @@ class TestDropIndex(object):
     def test_no_index(self, orion_db):
         """Test that no index is returned when there is none."""
         with pytest.raises(DatabaseError) as exc:
-            orion_db.drop_index('experiments', 'i_dont_exist')
-        assert 'index not found with name' in str(exc.value)
+            orion_db.drop_index("experiments", "i_dont_exist")
+        assert "index not found with name" in str(exc.value)
 
     def test_drop_single_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments', [('name', EphemeralDB.ASCENDING)], unique=True)
-        assert orion_db.index_information('experiments') == {'_id_': True, 'name_1': True}
-        orion_db.drop_index('experiments', 'name_1')
-        assert orion_db.index_information('experiments') == {'_id_': True}
+        orion_db.ensure_index(
+            "experiments", [("name", EphemeralDB.ASCENDING)], unique=True
+        )
+        assert orion_db.index_information("experiments") == {
+            "_id_": True,
+            "name_1": True,
+        }
+        orion_db.drop_index("experiments", "name_1")
+        assert orion_db.index_information("experiments") == {"_id_": True}
 
     def test_drop_ordered_single_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments', [('name', EphemeralDB.DESCENDING)], unique=True)
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_1': True}
-        orion_db.drop_index('experiments', 'name_1')
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True}
+        orion_db.ensure_index(
+            "experiments", [("name", EphemeralDB.DESCENDING)], unique=True
+        )
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_1": True}
+        orion_db.drop_index("experiments", "name_1")
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True}
 
     def test_drop_ordered_compound_index(self, orion_db):
         """Test with single indexes."""
-        orion_db.ensure_index('experiments',
-                              [('name', EphemeralDB.ASCENDING),
-                               ('version', EphemeralDB.DESCENDING)],
-                              unique=True)
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True, 'name_1_version_1': True}
-        orion_db.drop_index('experiments', 'name_1_version_1')
-        index_info = orion_db.index_information('experiments')
-        assert index_info == {'_id_': True}
+        orion_db.ensure_index(
+            "experiments",
+            [("name", EphemeralDB.ASCENDING), ("version", EphemeralDB.DESCENDING)],
+            unique=True,
+        )
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True, "name_1_version_1": True}
+        orion_db.drop_index("experiments", "name_1_version_1")
+        index_info = orion_db.index_information("experiments")
+        assert index_info == {"_id_": True}

--- a/tests/unittests/core/test_insert.py
+++ b/tests/unittests/core/test_insert.py
@@ -29,7 +29,7 @@ def categorical_space():
 
 def test_validate_input_value_real_real(real_space):
     """Test if real value passed to real space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
     is_valid, casted_value = _validate_input_value("10.0", real_space, namespace)
     assert is_valid
     assert isinstance(casted_value, numbers.Number)
@@ -37,7 +37,7 @@ def test_validate_input_value_real_real(real_space):
 
 def test_validate_input_value_real_integer(real_space):
     """Test if integer value passed to real space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
     is_valid, casted_value = _validate_input_value("10", real_space, namespace)
     assert is_valid
     assert isinstance(casted_value, numbers.Number)
@@ -45,14 +45,14 @@ def test_validate_input_value_real_integer(real_space):
 
 def test_validate_input_value_real_string(real_space):
     """Test if string value passed to real space is rejected properly"""
-    namespace = 'x'
+    namespace = "x"
     is_valid, casted_value = _validate_input_value("string", real_space, namespace)
     assert not is_valid
 
 
 def test_validate_input_value_real_out_of_bound(real_space):
     """Test if out of bound values passed to real space are rejected properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("100.0", real_space, namespace)
     assert not is_valid
@@ -63,7 +63,7 @@ def test_validate_input_value_real_out_of_bound(real_space):
 
 def test_validate_input_value_integer_real(integer_space):
     """Test if real value passed to integer space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("10.0", integer_space, namespace)
     assert is_valid
@@ -72,7 +72,7 @@ def test_validate_input_value_integer_real(integer_space):
 
 def test_validate_input_value_integer_integer(integer_space):
     """Test if integer value passed to integer space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("10", integer_space, namespace)
     assert is_valid
@@ -81,7 +81,7 @@ def test_validate_input_value_integer_integer(integer_space):
 
 def test_validate_input_value_integer_string(integer_space):
     """Test if string value passed to integer space is rejected properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("string", integer_space, namespace)
     assert not is_valid
@@ -89,7 +89,7 @@ def test_validate_input_value_integer_string(integer_space):
 
 def test_validate_input_value_integer_out_of_bound(integer_space):
     """Test if out of bound values passed to integer space are rejected properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("100.0", integer_space, namespace)
     assert not is_valid
@@ -100,7 +100,7 @@ def test_validate_input_value_integer_out_of_bound(integer_space):
 
 def test_validate_input_value_categorical_real_hit(categorical_space):
     """Test if real value passed to categorical space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("10.1", categorical_space, namespace)
     assert is_valid
@@ -109,7 +109,7 @@ def test_validate_input_value_categorical_real_hit(categorical_space):
 
 def test_validate_input_value_categorical_real_nohit(categorical_space):
     """Test if bad real value passed to categorical space is rejected properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("10", categorical_space, namespace)
     assert not is_valid
@@ -123,7 +123,7 @@ def test_validate_input_value_categorical_real_nohit(categorical_space):
 
 def test_validate_input_value_categorical_integer_hit(categorical_space):
     """Test if integer value passed to categorical space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("11", categorical_space, namespace)
     assert is_valid
@@ -136,7 +136,7 @@ def test_validate_input_value_categorical_integer_hit(categorical_space):
 
 def test_validate_input_value_categorical_integer_nohit(categorical_space):
     """Test if bad integer value passed to categorical space is rejected properly"""
-    namespace = 'x'
+    namespace = "x"
 
     is_valid, casted_value = _validate_input_value("15", categorical_space, namespace)
     assert not is_valid
@@ -144,7 +144,7 @@ def test_validate_input_value_categorical_integer_nohit(categorical_space):
 
 def test_validate_input_value_categorical_string_number(categorical_space):
     """Test if string number value passed to categorical space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
 
     # Make sure integer 12 does not pass
     is_valid, casted_value = _validate_input_value("12", categorical_space, namespace)
@@ -158,11 +158,15 @@ def test_validate_input_value_categorical_string_number(categorical_space):
 
 def test_validate_input_value_categorical_string_value(categorical_space):
     """Test if literal string value passed to categorical space is validated properly"""
-    namespace = 'x'
+    namespace = "x"
 
-    is_valid, casted_value = _validate_input_value("random", categorical_space, namespace)
+    is_valid, casted_value = _validate_input_value(
+        "random", categorical_space, namespace
+    )
     assert not is_valid
 
-    is_valid, casted_value = _validate_input_value("string", categorical_space, namespace)
+    is_valid, casted_value = _validate_input_value(
+        "string", categorical_space, namespace
+    )
     assert is_valid
     assert isinstance(casted_value, str)

--- a/tests/unittests/core/test_pickleddb.py
+++ b/tests/unittests/core/test_pickleddb.py
@@ -11,7 +11,11 @@ import pytest
 
 from orion.core.io.database import Database, DatabaseTimeout, DuplicateKeyError
 from orion.core.io.database.ephemeraldb import EphemeralCollection
-from orion.core.io.database.pickleddb import find_unpickable_doc, find_unpickable_field, PickledDB
+from orion.core.io.database.pickleddb import (
+    find_unpickable_doc,
+    find_unpickable_field,
+    PickledDB,
+)
 import orion.core.utils.backward as backward
 
 
@@ -19,7 +23,7 @@ import orion.core.utils.backward as backward
 def orion_db():
     """Return PickledDB wrapper instance initiated with test opts."""
     PickledDB.instance = None
-    orion_db = PickledDB(host='orion_db.pkl')
+    orion_db = PickledDB(host="orion_db.pkl")
     yield orion_db
 
 
@@ -31,14 +35,14 @@ def clean_db(orion_db, exp_config):
 
     ephemeral_db = orion_db._get_database()
     database = ephemeral_db._db
-    database['experiments'].drop()
-    database['experiments'].insert_many(exp_config[0])
-    database['trials'].drop()
-    database['trials'].insert_many(exp_config[1])
-    database['workers'].drop()
-    database['workers'].insert_many(exp_config[2])
-    database['resources'].drop()
-    database['resources'].insert_many(exp_config[3])
+    database["experiments"].drop()
+    database["experiments"].insert_many(exp_config[0])
+    database["trials"].drop()
+    database["trials"].insert_many(exp_config[1])
+    database["workers"].drop()
+    database["workers"].insert_many(exp_config[2])
+    database["resources"].drop()
+    database["resources"].insert_many(exp_config[3])
     orion_db._dump_database(ephemeral_db)
 
 
@@ -48,32 +52,46 @@ class TestEnsureIndex(object):
 
     def test_new_index(self, orion_db):
         """Index should be added to pickled database"""
-        assert "new_field_1" not in orion_db._get_database()._db['new_collection']._indexes
+        assert (
+            "new_field_1" not in orion_db._get_database()._db["new_collection"]._indexes
+        )
 
-        orion_db.ensure_index('new_collection', 'new_field', unique=False)
-        assert "new_field_1" not in orion_db._get_database()._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=False)
+        assert (
+            "new_field_1" not in orion_db._get_database()._db["new_collection"]._indexes
+        )
 
-        orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert "new_field_1" in orion_db._get_database()._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=True)
+        assert "new_field_1" in orion_db._get_database()._db["new_collection"]._indexes
 
     def test_existing_index(self, orion_db):
         """Index should be added to pickled database and reattempt should do nothing"""
-        assert "new_field_1" not in orion_db._get_database()._db['new_collection']._indexes
+        assert (
+            "new_field_1" not in orion_db._get_database()._db["new_collection"]._indexes
+        )
 
-        orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert "new_field_1" in orion_db._get_database()._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=True)
+        assert "new_field_1" in orion_db._get_database()._db["new_collection"]._indexes
 
         # reattempt
-        orion_db.ensure_index('new_collection', 'new_field', unique=True)
-        assert "new_field_1" in orion_db._get_database()._db['new_collection']._indexes
+        orion_db.ensure_index("new_collection", "new_field", unique=True)
+        assert "new_field_1" in orion_db._get_database()._db["new_collection"]._indexes
 
     def test_compound_index(self, orion_db):
         """Tuple of Index should be added as a compound index."""
-        assert "name_1_metadata.user_1" not in orion_db._get_database()._db['experiments']._indexes
-        orion_db.ensure_index('experiments',
-                              [('name', Database.ASCENDING),
-                               ('metadata.user', Database.ASCENDING)], unique=True)
-        assert "name_1_metadata.user_1" in orion_db._get_database()._db['experiments']._indexes
+        assert (
+            "name_1_metadata.user_1"
+            not in orion_db._get_database()._db["experiments"]._indexes
+        )
+        orion_db.ensure_index(
+            "experiments",
+            [("name", Database.ASCENDING), ("metadata.user", Database.ASCENDING)],
+            unique=True,
+        )
+        assert (
+            "name_1_metadata.user_1"
+            in orion_db._get_database()._db["experiments"]._indexes
+        )
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -83,65 +101,85 @@ class TestRead(object):
     def test_read_experiment(self, exp_config, orion_db):
         """Fetch a whole experiment entries."""
         loaded_config = orion_db.read(
-            'trials', {'experiment': 'supernaedo2-dendi', 'status': 'new'})
+            "trials", {"experiment": "supernaedo2-dendi", "status": "new"}
+        )
         assert loaded_config == [exp_config[1][3], exp_config[1][4]]
 
         loaded_config = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': exp_config[1][3]['submit_time']})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": exp_config[1][3]["submit_time"],
+            },
+        )
         assert loaded_config == [exp_config[1][3]]
-        assert loaded_config[0]['_id'] == exp_config[1][3]['_id']
+        assert loaded_config[0]["_id"] == exp_config[1][3]["_id"]
 
     def test_read_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
-        loaded_config = orion_db.read('experiments', {'_id': exp_config[0][2]['_id']})
+        loaded_config = orion_db.read("experiments", {"_id": exp_config[0][2]["_id"]})
         backward.populate_space(loaded_config[0])
         assert loaded_config == [exp_config[0][2]]
 
     def test_read_default(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'experiments', {'name': 'supernaedo2', 'metadata.user': 'tsirif'},
-            selection={'algorithms': 1, '_id': 0})
-        assert value == [{'algorithms': exp_config[0][0]['algorithms']}]
+            "experiments",
+            {"name": "supernaedo2", "metadata.user": "tsirif"},
+            selection={"algorithms": 1, "_id": 0},
+        )
+        assert value == [{"algorithms": exp_config[0][0]["algorithms"]}]
 
     def test_read_nothing(self, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'experiments', {'name': 'not_found', 'metadata.user': 'tsirif'},
-            selection={'algorithms': 1})
+            "experiments",
+            {"name": "not_found", "metadata.user": "tsirif"},
+            selection={"algorithms": 1},
+        )
         assert value == []
 
     def test_read_trials(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         value = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": {"$gte": datetime(2017, 11, 23, 0, 0, 0)},
+            },
+        )
         assert value == [exp_config[1][1]] + exp_config[1][3:7]
 
         value = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "submit_time": {"$gt": datetime(2017, 11, 23, 0, 0, 0)},
+            },
+        )
         assert value == exp_config[1][3:7]
 
     def test_null_comp(self, exp_config, orion_db):
         """Fetch value(s) from an entry."""
         all_values = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "end_time": {"$gte": datetime(2017, 11, 1, 0, 0, 0)},
+            },
+        )
 
         db = orion_db._get_database()
-        db._db['trials']._documents[0]._data['end_time'] = None
+        db._db["trials"]._documents[0]._data["end_time"] = None
         orion_db._dump_database(db)
 
         values = orion_db.read(
-            'trials',
-            {'experiment': 'supernaedo2-dendi',
-             'end_time': {'$gte': datetime(2017, 11, 1, 0, 0, 0)}})
+            "trials",
+            {
+                "experiment": "supernaedo2-dendi",
+                "end_time": {"$gte": datetime(2017, 11, 1, 0, 0, 0)},
+            },
+        )
         assert len(values) == len(all_values) - 1
 
 
@@ -151,58 +189,61 @@ class TestWrite(object):
 
     def test_insert_one(self, orion_db):
         """Should insert a single new entry in the collection."""
-        item = {'exp_name': 'supernaekei',
-                'user': 'tsirif'}
-        count_before = orion_db._get_database().count('experiments')
+        item = {"exp_name": "supernaekei", "user": "tsirif"}
+        count_before = orion_db._get_database().count("experiments")
         # call interface
-        assert orion_db.write('experiments', item) == 1
-        assert orion_db._get_database().count('experiments') == count_before + 1
-        value = orion_db._get_database()._db['experiments'].find({'exp_name': 'supernaekei'})[0]
+        assert orion_db.write("experiments", item) == 1
+        assert orion_db._get_database().count("experiments") == count_before + 1
+        value = (
+            orion_db._get_database()
+            ._db["experiments"]
+            .find({"exp_name": "supernaekei"})[0]
+        )
         assert value == item
 
     def test_insert_many(self, orion_db):
         """Should insert two new entry (as a list) in the collection."""
-        item = [{'exp_name': 'supernaekei2',
-                 'user': 'tsirif'},
-                {'exp_name': 'supernaekei3',
-                 'user': 'tsirif'}]
-        count_before = orion_db._get_database()._db['experiments'].count()
+        item = [
+            {"exp_name": "supernaekei2", "user": "tsirif"},
+            {"exp_name": "supernaekei3", "user": "tsirif"},
+        ]
+        count_before = orion_db._get_database()._db["experiments"].count()
         # call interface
-        assert orion_db.write('experiments', item) == 2
+        assert orion_db.write("experiments", item) == 2
         database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before + 2
-        value = database['experiments'].find({'exp_name': 'supernaekei2'})[0]
+        assert database["experiments"].count() == count_before + 2
+        value = database["experiments"].find({"exp_name": "supernaekei2"})[0]
         assert value == item[0]
-        value = database['experiments'].find({'exp_name': 'supernaekei3'})[0]
+        value = database["experiments"].find({"exp_name": "supernaekei3"})[0]
         assert value == item[1]
 
     def test_update_many_default(self, orion_db):
         """Should match existing entries, and update some of their keys."""
-        filt = {'metadata.user': 'dendi'}
-        count_before = orion_db._get_database().count('experiments')
-        count_query = orion_db._get_database().count('experiments', filt)
+        filt = {"metadata.user": "dendi"}
+        count_before = orion_db._get_database().count("experiments")
+        count_query = orion_db._get_database().count("experiments", filt)
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 16}, filt) == count_query
+        assert orion_db.write("experiments", {"pool_size": 16}, filt) == count_query
         database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before
-        value = list(database['experiments'].find({}))
-        assert value[0]['pool_size'] == 16
-        assert value[1]['pool_size'] == 2
-        assert value[2]['pool_size'] == 2
-        assert value[3]['pool_size'] == 2
+        assert database["experiments"].count() == count_before
+        value = list(database["experiments"].find({}))
+        assert value[0]["pool_size"] == 16
+        assert value[1]["pool_size"] == 2
+        assert value[2]["pool_size"] == 2
+        assert value[3]["pool_size"] == 2
 
     def test_update_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
-        filt = {'_id': exp_config[0][1]['_id']}
-        count_before = orion_db._get_database().count('experiments')
+        filt = {"_id": exp_config[0][1]["_id"]}
+        count_before = orion_db._get_database().count("experiments")
         # call interface
-        assert orion_db.write('experiments', {'pool_size': 36}, filt) == 1
+        assert orion_db.write("experiments", {"pool_size": 36}, filt) == 1
         database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before
-        value = list(database['experiments'].find())
-        assert value[0]['pool_size'] == 2
-        assert value[1]['pool_size'] == 36
-        assert value[2]['pool_size'] == 2
+        assert database["experiments"].count() == count_before
+        value = list(database["experiments"].find())
+        assert value[0]["pool_size"] == 2
+        assert value[1]["pool_size"] == 36
+        assert value[2]["pool_size"] == 2
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -212,46 +253,41 @@ class TestReadAndWrite(object):
     def test_read_and_write_one(self, orion_db, exp_config):
         """Should read and update a single entry in the collection."""
         # Make sure there is only one match
-        documents = orion_db.read(
-            'experiments',
-            {'name': 'supernaedo4'})
+        documents = orion_db.read("experiments", {"name": "supernaedo4"})
         assert len(documents) == 1
 
         # Find and update atomically
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'name': 'supernaedo4'},
-            {'pool_size': 'lalala'})
-        exp_config[0][3]['pool_size'] = 'lalala'
+            "experiments", {"name": "supernaedo4"}, {"pool_size": "lalala"}
+        )
+        exp_config[0][3]["pool_size"] = "lalala"
         backward.populate_space(loaded_config)
         assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, orion_db, exp_config):
         """Should update only one entry."""
-        documents = orion_db.read('experiments', {'metadata.user': 'tsirif'})
+        documents = orion_db.read("experiments", {"metadata.user": "tsirif"})
         assert len(documents) > 1
 
         # Find many and update first one only
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'metadata.user': 'tsirif'},
-            {'pool_size': 'lalala'})
+            "experiments", {"metadata.user": "tsirif"}, {"pool_size": "lalala"}
+        )
 
-        exp_config[0][1]['pool_size'] = 'lalala'
+        exp_config[0][1]["pool_size"] = "lalala"
         backward.populate_space(loaded_config)
         assert loaded_config == exp_config[0][1]
 
         # Make sure it only changed the first document found
-        documents = orion_db.read('experiments', {'metadata.user': 'tsirif'})
-        assert documents[0]['pool_size'] == 'lalala'
-        assert documents[1]['pool_size'] != 'lalala'
+        documents = orion_db.read("experiments", {"metadata.user": "tsirif"})
+        assert documents[0]["pool_size"] == "lalala"
+        assert documents[1]["pool_size"] != "lalala"
 
     def test_read_and_write_no_match(self, orion_db):
         """Should return None when there is no match."""
         loaded_config = orion_db.read_and_write(
-            'experiments',
-            {'name': 'lalala'},
-            {'pool_size': 'lalala'})
+            "experiments", {"name": "lalala"}, {"pool_size": "lalala"}
+        )
 
         assert loaded_config is None
 
@@ -261,11 +297,9 @@ class TestReadAndWrite(object):
         caplog.clear()
         caplog.set_level(logging.ERROR)
         # any operation will trigger the lock.
-        orion_db.read(
-            'experiments',
-            {'name': 'supernaedo2', 'metadata.user': 'dendi'})
+        orion_db.read("experiments", {"name": "supernaedo2", "metadata.user": "dendi"})
 
-        assert 'acquired on orion_db.pkl.lock' not in caplog.text
+        assert "acquired on orion_db.pkl.lock" not in caplog.text
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -274,30 +308,30 @@ class TestRemove(object):
 
     def test_remove_many_default(self, exp_config, orion_db):
         """Should match existing entries, and delete them all."""
-        filt = {'metadata.user': 'tsirif'}
+        filt = {"metadata.user": "tsirif"}
         database = orion_db._get_database()._db
-        count_before = database['experiments'].count()
-        count_filt = database['experiments'].count(filt)
+        count_before = database["experiments"].count()
+        count_filt = database["experiments"].count(filt)
         # call interface
-        assert orion_db.remove('experiments', filt) == count_filt
+        assert orion_db.remove("experiments", filt) == count_filt
         database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before - count_filt
-        assert database['experiments'].count() == 1
-        loaded_config = list(database['experiments'].find())
+        assert database["experiments"].count() == count_before - count_filt
+        assert database["experiments"].count() == 1
+        loaded_config = list(database["experiments"].find())
         backward.populate_space(loaded_config[0])
         assert loaded_config == [exp_config[0][0]]
 
     def test_remove_with_id(self, exp_config, orion_db):
         """Query using ``_id`` key."""
-        filt = {'_id': exp_config[0][0]['_id']}
+        filt = {"_id": exp_config[0][0]["_id"]}
 
         database = orion_db._get_database()._db
-        count_before = database['experiments'].count()
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.remove('experiments', filt) == 1
+        assert orion_db.remove("experiments", filt) == 1
         database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before - 1
-        loaded_configs = database['experiments'].find()
+        assert database["experiments"].count() == count_before - 1
+        loaded_configs = database["experiments"].find()
         for loaded_config in loaded_configs:
             backward.populate_space(loaded_config)
         assert loaded_configs == exp_config[0][1:]
@@ -305,24 +339,24 @@ class TestRemove(object):
     def test_remove_update_indexes(self, exp_config, orion_db):
         """Verify that indexes are properly update after deletion."""
         with pytest.raises(DuplicateKeyError):
-            orion_db.write('experiments', {'_id': exp_config[0][0]['_id']})
+            orion_db.write("experiments", {"_id": exp_config[0][0]["_id"]})
         with pytest.raises(DuplicateKeyError):
-            orion_db.write('experiments', {'_id': exp_config[0][1]['_id']})
+            orion_db.write("experiments", {"_id": exp_config[0][1]["_id"]})
 
-        filt = {'_id': exp_config[0][0]['_id']}
+        filt = {"_id": exp_config[0][0]["_id"]}
 
         database = orion_db._get_database()._db
-        count_before = database['experiments'].count()
+        count_before = database["experiments"].count()
         # call interface
-        assert orion_db.remove('experiments', filt) == 1
+        assert orion_db.remove("experiments", filt) == 1
         database = orion_db._get_database()._db
-        assert database['experiments'].count() == count_before - 1
+        assert database["experiments"].count() == count_before - 1
         # Should not fail now, otherwise it means the indexes were not updated properly during
         # remove()
-        orion_db.write('experiments', filt)
+        orion_db.write("experiments", filt)
         # And this should still fail
         with pytest.raises(DuplicateKeyError):
-            orion_db.write('experiments', {'_id': exp_config[0][1]['_id']})
+            orion_db.write("experiments", {"_id": exp_config[0][1]["_id"]})
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -331,33 +365,33 @@ class TestCount(object):
 
     def test_count_default(self, exp_config, orion_db):
         """Call just with collection name."""
-        found = orion_db.count('trials')
+        found = orion_db.count("trials")
         assert found == len(exp_config[1])
 
     def test_count_query(self, exp_config, orion_db):
         """Call with a query."""
-        found = orion_db.count('trials', {'status': 'completed'})
-        assert found == len([x for x in exp_config[1] if x['status'] == 'completed'])
+        found = orion_db.count("trials", {"status": "completed"})
+        assert found == len([x for x in exp_config[1] if x["status"] == "completed"])
 
     def test_count_query_with_id(self, exp_config, orion_db):
         """Call querying with unique _id."""
-        found = orion_db.count('trials', {'_id': exp_config[1][2]['_id']})
+        found = orion_db.count("trials", {"_id": exp_config[1][2]["_id"]})
         assert found == 1
 
     def test_count_nothing(self, orion_db):
         """Call with argument that will not find anything."""
-        found = orion_db.count('experiments', {'name': 'lalalanotfound'})
+        found = orion_db.count("experiments", {"name": "lalalanotfound"})
         assert found == 0
 
 
 def write(field, i):
     """Write the given value to the pickled db."""
     PickledDB.instance = None
-    orion_db = PickledDB(host='orion_db.pkl')
+    orion_db = PickledDB(host="orion_db.pkl")
     try:
-        orion_db.write('concurrent', {field: i})
+        orion_db.write("concurrent", {field: i})
     except DuplicateKeyError:
-        print('dup')
+        print("dup")
         pass
 
     print(field, i)
@@ -369,63 +403,51 @@ class TestConcurreny(object):
 
     def test_concurrent_writes(self, orion_db):
         """Test that concurrent writes all get written properly"""
-        orion_db.ensure_index('concurrent', 'diff')
+        orion_db.ensure_index("concurrent", "diff")
 
-        assert orion_db.count('concurrent', {'diff': {'$gt': -1}}) == 0
+        assert orion_db.count("concurrent", {"diff": {"$gt": -1}}) == 0
 
-        Pool(10).starmap(write, (('diff', i) for i in range(10)))
+        Pool(10).starmap(write, (("diff", i) for i in range(10)))
 
-        assert orion_db.count('concurrent', {'diff': {'$gt': -1}}) == 10
+        assert orion_db.count("concurrent", {"diff": {"$gt": -1}}) == 10
 
     def test_concurrent_unique_writes(self, orion_db):
         """Test that concurrent writes cannot duplicate unique fields"""
-        orion_db.ensure_index('concurrent', 'unique', unique=True)
+        orion_db.ensure_index("concurrent", "unique", unique=True)
 
-        assert orion_db.count('concurrent', {'unique': 1}) == 0
+        assert orion_db.count("concurrent", {"unique": 1}) == 0
 
-        Pool(10).starmap(write, (('unique', 1) for i in range(10)))
+        Pool(10).starmap(write, (("unique", 1) for i in range(10)))
 
-        assert orion_db.count('concurrent', {'unique': 1}) == 1
+        assert orion_db.count("concurrent", {"unique": 1}) == 1
 
 
 def test_empty_file(orion_db):
     """Check that db loading can handle empty files"""
-    with open(orion_db.host, 'wb') as f:
-        f.write(b'')
+    with open(orion_db.host, "wb") as f:
+        f.write(b"")
     orion_db._get_database()
 
 
 def test_unpickable_error_find_document():
     """Check error messages for pickledb"""
+
     class UnpickableClass:
         i_am_not_pickable = None
 
     unpickable_doc = {
-        '_id': 2,
-        'a_pickable': 1,
-        'b_unpickable': UnpickableClass(),
-        'c_pickable': 3
+        "_id": 2,
+        "a_pickable": 1,
+        "b_unpickable": UnpickableClass(),
+        "c_pickable": 3,
     }
 
     def make_pickable(uid):
-        return {
-            '_id': uid,
-            'a_pickable': 1,
-            'b_pickable': 2,
-            'c_pickable': 3
-        }
+        return {"_id": uid, "a_pickable": 1, "b_pickable": 2, "c_pickable": 3}
 
-    unpickable_dict_of_dict = [
-        make_pickable(1),
-        unpickable_doc,
-        make_pickable(3)
-    ]
+    unpickable_dict_of_dict = [make_pickable(1), unpickable_doc, make_pickable(3)]
 
-    pickable_dict_of_dict = [
-        make_pickable(1),
-        make_pickable(2),
-        make_pickable(3)
-    ]
+    pickable_dict_of_dict = [make_pickable(1), make_pickable(2), make_pickable(3)]
 
     unpickable_collection = EphemeralCollection()
     unpickable_collection.insert_many(unpickable_dict_of_dict)
@@ -434,16 +456,18 @@ def test_unpickable_error_find_document():
     pickable_collection.insert_many(pickable_dict_of_dict)
 
     database = {
-        'pickable_collection': pickable_collection,
-        'unpickable_collection': unpickable_collection
+        "pickable_collection": pickable_collection,
+        "unpickable_collection": unpickable_collection,
     }
 
     collection, doc = find_unpickable_doc(database)
-    assert collection == 'unpickable_collection', 'should return the unpickable document'
+    assert (
+        collection == "unpickable_collection"
+    ), "should return the unpickable document"
 
     key, value = find_unpickable_field(doc)
-    assert key == 'b_unpickable', 'should return the unpickable field'
-    assert isinstance(value, UnpickableClass), 'should return the unpickable value'
+    assert key == "b_unpickable", "should return the unpickable field"
+    assert isinstance(value, UnpickableClass), "should return the unpickable value"
 
 
 def test_query_timeout(monkeypatch, orion_db):
@@ -454,9 +478,9 @@ def test_query_timeout(monkeypatch, orion_db):
         """Do not try to acquire, raise timeout"""
         raise Timeout(self)
 
-    monkeypatch.setattr(FileLock, 'acquire', never_acquire)
+    monkeypatch.setattr(FileLock, "acquire", never_acquire)
 
     with pytest.raises(DatabaseTimeout) as exc:
-        orion_db.read('whatever', {'it should': 'fail'})
+        orion_db.read("whatever", {"it should": "fail"})
 
-    assert exc.match('Could not acquire lock for PickledDB after 0.1 seconds.')
+    assert exc.match("Could not acquire lock for PickledDB after 0.1 seconds.")

--- a/tests/unittests/core/test_primary_algo.py
+++ b/tests/unittests/core/test_primary_algo.py
@@ -10,13 +10,12 @@ from orion.core.worker.primary_algo import PrimaryAlgo
 @pytest.fixture()
 def palgo(dumbalgo, space, fixed_suggestion):
     """Set up a PrimaryAlgo with dumb configuration."""
-    algo_config = {'DumbAlgo': {
-        'value': fixed_suggestion,
-        'subone': {'DumbAlgo': dict(
-            value=6,
-            scoring=5
-            )}
-        }}
+    algo_config = {
+        "DumbAlgo": {
+            "value": fixed_suggestion,
+            "subone": {"DumbAlgo": dict(value=6, scoring=5)},
+        }
+    }
     palgo = PrimaryAlgo(space, algo_config)
 
     return palgo
@@ -32,25 +31,25 @@ class TestPrimaryAlgoWraps(object):
         """Check if initialization works."""
         assert isinstance(palgo.algorithm, dumbalgo)
         assert palgo.configuration == {
-            'dumbalgo': {
-                'seed': None,
-                'value': fixed_suggestion,
-                'scoring': 0,
-                'judgement': None,
-                'suspend': False,
-                'done': False,
-                'subone': {
-                    'dumbalgo': {
-                        'seed': None,
-                        'value': 6,
-                        'scoring': 5,
-                        'judgement': None,
-                        'suspend': False,
-                        'done': False,
-                        }
+            "dumbalgo": {
+                "seed": None,
+                "value": fixed_suggestion,
+                "scoring": 0,
+                "judgement": None,
+                "suspend": False,
+                "done": False,
+                "subone": {
+                    "dumbalgo": {
+                        "seed": None,
+                        "value": 6,
+                        "scoring": 5,
+                        "judgement": None,
+                        "suspend": False,
+                        "done": False,
                     }
-                }
+                },
             }
+        }
 
     def test_space_can_only_retrieved(self, palgo, space):
         """Set space is forbidden, getter works as supposed."""
@@ -98,8 +97,8 @@ class TestPrimaryAlgoWraps(object):
 
     def test_judge(self, palgo, fixed_suggestion):
         """Wrap judge."""
-        palgo.algorithm.judgement = 'naedw'
-        assert palgo.judge(fixed_suggestion, 8) == 'naedw'
+        palgo.algorithm.judgement = "naedw"
+        assert palgo.judge(fixed_suggestion, 8) == "naedw"
         assert palgo.algorithm._judge_point == fixed_suggestion
         assert palgo.algorithm._measurements == 8
         with pytest.raises(AssertionError):

--- a/tests/unittests/core/test_strategy.py
+++ b/tests/unittests/core/test_strategy.py
@@ -6,7 +6,12 @@ import logging
 import pytest
 
 from orion.core.worker.strategy import (
-    MaxParallelStrategy, MeanParallelStrategy, NoParallelStrategy, Strategy, StubParallelStrategy)
+    MaxParallelStrategy,
+    MeanParallelStrategy,
+    NoParallelStrategy,
+    Strategy,
+    StubParallelStrategy,
+)
 from orion.core.worker.trial import Trial
 
 
@@ -14,7 +19,7 @@ from orion.core.worker.trial import Trial
 def observations():
     """10 objective observations"""
     points = [i for i in range(10)]
-    results = [{'objective': points[i]} for i in range(10)]
+    results = [{"objective": points[i]} for i in range(10)]
 
     return points, results
 
@@ -22,35 +27,43 @@ def observations():
 @pytest.fixture
 def incomplete_trial():
     """Return a single trial without results"""
-    return Trial(params=[{'name': 'a', 'type': 'integer', 'value': 6}])
+    return Trial(params=[{"name": "a", "type": "integer", "value": 6}])
 
 
 @pytest.fixture
 def corrupted_trial():
     """Return a corrupted trial with results but status reserved"""
-    return Trial(params=[{'name': 'a', 'type': 'integer', 'value': 6}],
-                 results=[{'name': 'objective', 'type': 'objective', 'value': 1}],
-                 status='reserved')
+    return Trial(
+        params=[{"name": "a", "type": "integer", "value": 6}],
+        results=[{"name": "objective", "type": "objective", "value": 1}],
+        status="reserved",
+    )
 
 
 strategies = [
-    'MaxParallelStrategy', 'MeanParallelStrategy', 'NoParallelStrategy', 'StubParallelStrategy']
+    "MaxParallelStrategy",
+    "MeanParallelStrategy",
+    "NoParallelStrategy",
+    "StubParallelStrategy",
+]
 
 
-@pytest.mark.parametrize('strategy', strategies)
+@pytest.mark.parametrize("strategy", strategies)
 def test_handle_corrupted_trials(caplog, strategy, corrupted_trial):
     """Verify that corrupted trials are handled properly"""
     with caplog.at_level(logging.WARNING, logger="orion.core.worker.strategy"):
         lie = Strategy(strategy).lie(corrupted_trial)
 
-    match = "Trial `{}` has an objective but status is not completed".format(corrupted_trial.id)
+    match = "Trial `{}` has an objective but status is not completed".format(
+        corrupted_trial.id
+    )
     assert match in caplog.text
 
     assert lie is not None
     assert lie.value == corrupted_trial.objective.value
 
 
-@pytest.mark.parametrize('strategy', strategies)
+@pytest.mark.parametrize("strategy", strategies)
 def test_handle_uncorrupted_trials(caplog, strategy, incomplete_trial):
     """Verify that no warning is logged if trial is valid"""
     with caplog.at_level(logging.WARNING, logger="orion.core.worker.strategy"):
@@ -64,12 +77,12 @@ class TestStrategyFactory:
 
     def test_create_noparallel(self):
         """Test creating a NoParallelStrategy class"""
-        strategy = Strategy('NoParallelStrategy')
+        strategy = Strategy("NoParallelStrategy")
         assert isinstance(strategy, NoParallelStrategy)
 
     def test_create_meanparallel(self):
         """Test creating a MeanParallelStrategy class"""
-        strategy = Strategy('MeanParallelStrategy')
+        strategy = Strategy("MeanParallelStrategy")
         assert isinstance(strategy, MeanParallelStrategy)
 
 
@@ -84,7 +97,7 @@ class TestParallelStrategies:
         strategy.observe(points, results)
         lying_result = strategy.lie(incomplete_trial)
 
-        max_value = max(result['objective'] for result in results)
+        max_value = max(result["objective"] for result in results)
         assert lying_result.value == max_value
 
     def test_mean_parallel_strategy(self, observations, incomplete_trial):
@@ -95,8 +108,9 @@ class TestParallelStrategies:
         strategy.observe(points, results)
         lying_result = strategy.lie(incomplete_trial)
 
-        mean_value = (sum(result['objective'] for result in results) /
-                      float(len(results)))
+        mean_value = sum(result["objective"] for result in results) / float(
+            len(results)
+        )
         assert lying_result.value == mean_value
 
     def test_no_parallel_strategy(self, observations, incomplete_trial):

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -8,11 +8,29 @@ import itertools
 import numpy
 import pytest
 
-from orion.algo.space import (Categorical, Dimension, Integer, Real, Space,)
+from orion.algo.space import (
+    Categorical,
+    Dimension,
+    Integer,
+    Real,
+    Space,
+)
 from orion.core.worker.transformer import (
-    build_required_space, Compose, Enumerate, Identity, Linearize, OneHotEncode,
-    Precision, Quantize, ReshapedDimension, ReshapedSpace, Reverse,
-    TransformedDimension, TransformedSpace, View)
+    build_required_space,
+    Compose,
+    Enumerate,
+    Identity,
+    Linearize,
+    OneHotEncode,
+    Precision,
+    Quantize,
+    ReshapedDimension,
+    ReshapedSpace,
+    Reverse,
+    TransformedDimension,
+    TransformedSpace,
+    View,
+)
 
 
 class TestIdentity(object):
@@ -32,19 +50,19 @@ class TestIdentity(object):
         assert t.domain_type is None
         assert t.target_type is None
 
-        t = Identity('mpogias')
-        assert t.domain_type == 'mpogias'
-        assert t.target_type == 'mpogias'
+        t = Identity("mpogias")
+        assert t.domain_type == "mpogias"
+        assert t.target_type == "mpogias"
 
     def test_transform(self):
         """Check if it transforms properly."""
         t = Identity()
-        assert t.transform('yo') == 'yo'
+        assert t.transform("yo") == "yo"
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
         t = Identity()
-        assert t.reverse('yo') == 'yo'
+        assert t.reverse("yo") == "yo"
 
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
@@ -54,7 +72,7 @@ class TestIdentity(object):
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
         t = Identity()
-        assert t.repr_format('asfa') == 'asfa'
+        assert t.repr_format("asfa") == "asfa"
 
 
 class TestReverse(object):
@@ -71,15 +89,15 @@ class TestReverse(object):
         what's expected.
         """
         t = Reverse(Quantize())
-        assert t.domain_type == 'integer'
-        assert t.target_type == 'real'
+        assert t.domain_type == "integer"
+        assert t.target_type == "real"
 
     def test_transform(self):
         """Check if it transforms properly."""
         t = Reverse(Quantize())
-        assert t.transform(9) == 9.
-        assert t.transform(5) == 5.
-        assert numpy.all(t.transform([9, 5]) == numpy.array([9., 5.], dtype=float))
+        assert t.transform(9) == 9.0
+        assert t.transform(5) == 5.0
+        assert numpy.all(t.transform([9, 5]) == numpy.array([9.0, 5.0], dtype=float))
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
@@ -101,7 +119,7 @@ class TestReverse(object):
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
         t = Reverse(Quantize())
-        assert t.repr_format('asfa') == 'ReverseQuantize(asfa)'
+        assert t.repr_format("asfa") == "ReverseQuantize(asfa)"
 
 
 class TestCompose(object):
@@ -109,7 +127,7 @@ class TestCompose(object):
 
     def test_deepcopy(self):
         """Verify that the transformation object can be copied"""
-        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
+        t = Compose([Enumerate([2, "asfa", "ipsi"]), OneHotEncode(3)], "categorical")
         t.transform([2])
         copy.deepcopy(t)
 
@@ -121,88 +139,108 @@ class TestCompose(object):
         assert t.domain_type is None
         assert t.target_type is None
 
-        t = Compose([], 'real')
-        assert t.domain_type == 'real'
-        assert t.target_type == 'real'
+        t = Compose([], "real")
+        assert t.domain_type == "real"
+        assert t.target_type == "real"
 
-        t = Compose([Quantize()], 'real')
-        assert t.domain_type == 'real'
-        assert t.target_type == 'integer'
+        t = Compose([Quantize()], "real")
+        assert t.domain_type == "real"
+        assert t.target_type == "integer"
 
-        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
-        assert t.domain_type == 'categorical'
-        assert t.target_type == 'real'
+        t = Compose([Enumerate([2, "asfa", "ipsi"]), OneHotEncode(3)], "categorical")
+        assert t.domain_type == "categorical"
+        assert t.target_type == "real"
 
     def test_transform(self):
         """Check if it transforms properly."""
-        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
-        assert numpy.all(t.transform(2) == numpy.array((1., 0., 0.)))
-        assert numpy.all(t.transform('asfa') == numpy.array((0., 1., 0.)))
-        assert numpy.all(t.transform('ipsi') == numpy.array((0., 0., 1.)))
+        t = Compose([Enumerate([2, "asfa", "ipsi"]), OneHotEncode(3)], "categorical")
+        assert numpy.all(t.transform(2) == numpy.array((1.0, 0.0, 0.0)))
+        assert numpy.all(t.transform("asfa") == numpy.array((0.0, 1.0, 0.0)))
+        assert numpy.all(t.transform("ipsi") == numpy.array((0.0, 0.0, 1.0)))
         with pytest.raises(KeyError):
-            t.transform('aafdasfa')
-        assert(numpy.all(t.transform([['ipsi', 'asfa'], [2, 'ipsi']]) ==
-               numpy.array([[(0., 0., 1.), (0., 1., 0.)], [(1., 0., 0.), (0., 0., 1.)]])))
+            t.transform("aafdasfa")
+        assert numpy.all(
+            t.transform([["ipsi", "asfa"], [2, "ipsi"]])
+            == numpy.array(
+                [[(0.0, 0.0, 1.0), (0.0, 1.0, 0.0)], [(1.0, 0.0, 0.0), (0.0, 0.0, 1.0)]]
+            )
+        )
 
-        t = Compose([Enumerate([2, 'asfa']), OneHotEncode(2)], 'categorical')
-        assert t.transform(2) == 0.
-        assert t.transform('asfa') == 1.
+        t = Compose([Enumerate([2, "asfa"]), OneHotEncode(2)], "categorical")
+        assert t.transform(2) == 0.0
+        assert t.transform("asfa") == 1.0
         with pytest.raises(KeyError):
-            t.transform('ipsi')
-        assert(numpy.all(t.transform([['asfa', 'asfa'], [2, 'asfa']]) ==
-               numpy.array([[1., 1.], [0., 1.]])))
+            t.transform("ipsi")
+        assert numpy.all(
+            t.transform([["asfa", "asfa"], [2, "asfa"]])
+            == numpy.array([[1.0, 1.0], [0.0, 1.0]])
+        )
 
         # for the crazy enough
-        t = Compose([Enumerate([2]), OneHotEncode(1)], 'categorical')
-        assert t.transform(2) == 0.
+        t = Compose([Enumerate([2]), OneHotEncode(1)], "categorical")
+        assert t.transform(2) == 0.0
         with pytest.raises(KeyError):
-            t.transform('ipsi')
+            t.transform("ipsi")
         assert numpy.all(t.transform([[2, 2], [2, 2]]) == [[0, 0], [0, 0]])
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
-        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
+        t = Compose([Enumerate([2, "asfa", "ipsi"]), OneHotEncode(3)], "categorical")
         assert t.reverse((0.9, 0.8, 0.3)) == 2
-        assert t.reverse((-0.3, 2., 0.)) == 'asfa'
-        assert t.reverse((0., 0., 1.)) == 'ipsi'
+        assert t.reverse((-0.3, 2.0, 0.0)) == "asfa"
+        assert t.reverse((0.0, 0.0, 1.0)) == "ipsi"
         with pytest.raises(AssertionError):
-            t.reverse((0., 0., 0., 1.))
-        assert(numpy.all(t.reverse(numpy.array([[(0., 0., 1.), (0., 1., 0.)],
-                                                [(1., 0., 0.), (0., 0., 1.)]])) ==
-               numpy.array([['ipsi', 'asfa'], [2, 'ipsi']], dtype=numpy.object)))
+            t.reverse((0.0, 0.0, 0.0, 1.0))
+        assert numpy.all(
+            t.reverse(
+                numpy.array(
+                    [
+                        [(0.0, 0.0, 1.0), (0.0, 1.0, 0.0)],
+                        [(1.0, 0.0, 0.0), (0.0, 0.0, 1.0)],
+                    ]
+                )
+            )
+            == numpy.array([["ipsi", "asfa"], [2, "ipsi"]], dtype=numpy.object)
+        )
 
-        t = Compose([Enumerate([2, 'asfa']), OneHotEncode(2)], 'categorical')
+        t = Compose([Enumerate([2, "asfa"]), OneHotEncode(2)], "categorical")
         assert t.reverse(0.3) == 2
-        assert t.reverse(2.) == 'asfa'
-        assert numpy.all(t.reverse((0., 0., 0., 1.)) == numpy.array([2, 2, 2, 'asfa'],
-                                                                    dtype=numpy.object))
-        assert(numpy.all(t.reverse(numpy.array([[0.55, 3.], [-0.6, 1.]])) ==
-               numpy.array([['asfa', 'asfa'], [2, 'asfa']], dtype=numpy.object)))
+        assert t.reverse(2.0) == "asfa"
+        assert numpy.all(
+            t.reverse((0.0, 0.0, 0.0, 1.0))
+            == numpy.array([2, 2, 2, "asfa"], dtype=numpy.object)
+        )
+        assert numpy.all(
+            t.reverse(numpy.array([[0.55, 3.0], [-0.6, 1.0]]))
+            == numpy.array([["asfa", "asfa"], [2, "asfa"]], dtype=numpy.object)
+        )
 
         # for the crazy enough
-        t = Compose([Enumerate([2]), OneHotEncode(1)], 'categorical')
+        t = Compose([Enumerate([2]), OneHotEncode(1)], "categorical")
         assert t.reverse(0) == 2
         assert t.reverse(5.0) == 2
         assert t.reverse(0.2) == 2
         assert t.reverse(-0.2) == 2
-        assert numpy.all(t.reverse([[0.5, 0], [1.0, 55]]) == numpy.array([[2, 2], [2, 2]],
-                                                                         dtype=numpy.object))
+        assert numpy.all(
+            t.reverse([[0.5, 0], [1.0, 55]])
+            == numpy.array([[2, 2], [2, 2]], dtype=numpy.object)
+        )
 
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
-        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
+        t = Compose([Enumerate([2, "asfa", "ipsi"]), OneHotEncode(3)], "categorical")
         assert t.infer_target_shape((2, 5)) == (2, 5, 3)
 
-        t = Compose([Enumerate([2, 'asfa']), OneHotEncode(2)], 'categorical')
+        t = Compose([Enumerate([2, "asfa"]), OneHotEncode(2)], "categorical")
         assert t.infer_target_shape((2, 5)) == (2, 5)
 
-        t = Compose([Enumerate([2]), OneHotEncode(1)], 'categorical')
+        t = Compose([Enumerate([2]), OneHotEncode(1)], "categorical")
         assert t.infer_target_shape((2, 5)) == (2, 5)
 
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
-        t = Compose([Enumerate([2, 'asfa', 'ipsi']), OneHotEncode(3)], 'categorical')
-        assert t.repr_format('asfa') == 'OneHotEncode(Enumerate(asfa))'
+        t = Compose([Enumerate([2, "asfa", "ipsi"]), OneHotEncode(3)], "categorical")
+        assert t.repr_format("asfa") == "OneHotEncode(Enumerate(asfa))"
 
 
 class TestPrecision(object):
@@ -219,23 +257,25 @@ class TestPrecision(object):
         what's expected.
         """
         t = Precision()
-        assert t.domain_type == 'real'
-        assert t.target_type == 'real'
+        assert t.domain_type == "real"
+        assert t.target_type == "real"
 
     def test_transform(self):
         """Check if it transforms properly."""
         t = Precision(precision=4)
         assert t.transform(8.654321098) == 8.654
         assert t.transform(0.000123456789) == 0.0001235
-        assert numpy.all(t.transform([8.654321098, 0.000123456789]) ==
-                         numpy.array([8.654, 0.0001235], dtype=float))
+        assert numpy.all(
+            t.transform([8.654321098, 0.000123456789])
+            == numpy.array([8.654, 0.0001235], dtype=float)
+        )
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
         t = Precision()
-        assert t.reverse(9.) == 9.
-        assert t.reverse(5.) == 5.
-        assert numpy.all(t.reverse([9., 5.]) == numpy.array([9., 5.], dtype=float))
+        assert t.reverse(9.0) == 9.0
+        assert t.reverse(5.0) == 5.0
+        assert numpy.all(t.reverse([9.0, 5.0]) == numpy.array([9.0, 5.0], dtype=float))
 
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
@@ -245,7 +285,7 @@ class TestPrecision(object):
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
         t = Precision()
-        assert t.repr_format('asfa') == 'Precision(4, asfa)'
+        assert t.repr_format("asfa") == "Precision(4, asfa)"
 
 
 class TestQuantize(object):
@@ -262,8 +302,8 @@ class TestQuantize(object):
         what's expected.
         """
         t = Quantize()
-        assert t.domain_type == 'real'
-        assert t.target_type == 'integer'
+        assert t.domain_type == "real"
+        assert t.target_type == "integer"
 
     def test_transform(self):
         """Check if it transforms properly."""
@@ -275,9 +315,9 @@ class TestQuantize(object):
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
         t = Quantize()
-        assert t.reverse(9) == 9.
-        assert t.reverse(5) == 5.
-        assert numpy.all(t.reverse([9, 5]) == numpy.array([9., 5.], dtype=float))
+        assert t.reverse(9) == 9.0
+        assert t.reverse(5) == 5.0
+        assert numpy.all(t.reverse([9, 5]) == numpy.array([9.0, 5.0], dtype=float))
 
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
@@ -287,7 +327,7 @@ class TestQuantize(object):
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
         t = Quantize()
-        assert t.repr_format('asfa') == 'Quantize(asfa)'
+        assert t.repr_format("asfa") == "Quantize(asfa)"
 
 
 class TestEnumerate(object):
@@ -295,7 +335,7 @@ class TestEnumerate(object):
 
     def test_deepcopy(self):
         """Verify that the transformation object can be copied"""
-        t = Enumerate([2, 'asfa', 'ipsi'])
+        t = Enumerate([2, "asfa", "ipsi"])
         # Copy won't fail if vectorized function is not called at least once.
         t.transform([2])
         copy.deepcopy(t)
@@ -304,55 +344,61 @@ class TestEnumerate(object):
         """Check if attribute-like `domain_type` and `target_type` do
         what's expected.
         """
-        t = Enumerate([2, 'asfa', 'ipsi'])
-        assert t.domain_type == 'categorical'
-        assert t.target_type == 'integer'
+        t = Enumerate([2, "asfa", "ipsi"])
+        assert t.domain_type == "categorical"
+        assert t.target_type == "integer"
 
     def test_transform(self):
         """Check if it transforms properly."""
-        t = Enumerate([2, 'asfa', 'ipsi'])
+        t = Enumerate([2, "asfa", "ipsi"])
         assert t.transform(2) == 0
-        assert t.transform('asfa') == 1
-        assert t.transform('ipsi') == 2
+        assert t.transform("asfa") == 1
+        assert t.transform("ipsi") == 2
         with pytest.raises(KeyError):
-            t.transform('aafdasfa')
-        assert numpy.all(t.transform([['ipsi', 'asfa'], [2, 'ipsi']]) == [[2, 1], [0, 2]])
+            t.transform("aafdasfa")
+        assert numpy.all(
+            t.transform([["ipsi", "asfa"], [2, "ipsi"]]) == [[2, 1], [0, 2]]
+        )
 
         # for the crazy enough
         t = Enumerate([2])
         assert t.transform(2) == 0
         with pytest.raises(KeyError):
-            t.transform('aafdasfa')
+            t.transform("aafdasfa")
         assert numpy.all(t.transform([[2, 2], [2, 2]]) == [[0, 0], [0, 0]])
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
-        t = Enumerate([2, 'asfa', 'ipsi'])
+        t = Enumerate([2, "asfa", "ipsi"])
         assert t.reverse(0) == 2
-        assert t.reverse(1) == 'asfa'
-        assert t.reverse(2) == 'ipsi'
+        assert t.reverse(1) == "asfa"
+        assert t.reverse(2) == "ipsi"
         with pytest.raises(IndexError):
             t.reverse(3)
-        assert numpy.all(t.reverse([[2, 1], [0, 2]]) == numpy.array([['ipsi', 'asfa'], [2, 'ipsi']],
-                                                                    dtype=numpy.object))
+        assert numpy.all(
+            t.reverse([[2, 1], [0, 2]])
+            == numpy.array([["ipsi", "asfa"], [2, "ipsi"]], dtype=numpy.object)
+        )
 
         # for the crazy enough
         t = Enumerate([2])
         assert t.reverse(0) == 2
         with pytest.raises(IndexError):
             t.reverse(1)
-        assert numpy.all(t.reverse([[0, 0], [0, 0]]) == numpy.array([[2, 2], [2, 2]],
-                                                                    dtype=numpy.object))
+        assert numpy.all(
+            t.reverse([[0, 0], [0, 0]])
+            == numpy.array([[2, 2], [2, 2]], dtype=numpy.object)
+        )
 
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
-        t = Enumerate([2, 'asfa', 'ipsi'])
+        t = Enumerate([2, "asfa", "ipsi"])
         assert t.infer_target_shape((5,)) == (5,)
 
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
-        t = Enumerate([2, 'asfa', 'ipsi'])
-        assert t.repr_format('asfa') == 'Enumerate(asfa)'
+        t = Enumerate([2, "asfa", "ipsi"])
+        assert t.repr_format("asfa") == "Enumerate(asfa)"
 
 
 class TestOneHotEncode(object):
@@ -369,58 +415,74 @@ class TestOneHotEncode(object):
         what's expected.
         """
         t = OneHotEncode(3)
-        assert t.domain_type == 'integer'
-        assert t.target_type == 'real'
+        assert t.domain_type == "integer"
+        assert t.target_type == "real"
 
     def test_transform(self):
         """Check if it transforms properly."""
         t = OneHotEncode(3)
-        assert numpy.all(t.transform(0) == numpy.array((1., 0., 0.)))
-        assert numpy.all(t.transform(1) == numpy.array((0., 1., 0.)))
-        assert numpy.all(t.transform(2) == numpy.array((0., 0., 1.)))
+        assert numpy.all(t.transform(0) == numpy.array((1.0, 0.0, 0.0)))
+        assert numpy.all(t.transform(1) == numpy.array((0.0, 1.0, 0.0)))
+        assert numpy.all(t.transform(2) == numpy.array((0.0, 0.0, 1.0)))
         with pytest.raises(AssertionError):
             t.transform(4)
         with pytest.raises(AssertionError):
             t.transform(-1)
         with pytest.raises(AssertionError):
             t.transform(2.2)
-        assert(numpy.all(t.transform([[2, 1], [0, 2]]) ==
-               numpy.array([[(0., 0., 1.), (0., 1., 0.)], [(1., 0., 0.), (0., 0., 1.)]])))
+        assert numpy.all(
+            t.transform([[2, 1], [0, 2]])
+            == numpy.array(
+                [[(0.0, 0.0, 1.0), (0.0, 1.0, 0.0)], [(1.0, 0.0, 0.0), (0.0, 0.0, 1.0)]]
+            )
+        )
 
         t = OneHotEncode(2)
-        assert t.transform(0) == 0.
-        assert t.transform(1) == 1.
+        assert t.transform(0) == 0.0
+        assert t.transform(1) == 1.0
         with pytest.raises(TypeError):
-            t.transform('ipsi')
-        assert(numpy.all(t.transform([[1, 1], [0, 1]]) ==
-               numpy.array([[1., 1.], [0., 1.]])))
+            t.transform("ipsi")
+        assert numpy.all(
+            t.transform([[1, 1], [0, 1]]) == numpy.array([[1.0, 1.0], [0.0, 1.0]])
+        )
 
         # for the crazy enough
         t = OneHotEncode(1)
-        assert t.transform(0) == 0.
+        assert t.transform(0) == 0.0
         with pytest.raises(TypeError):
-            t.transform('ipsi')
-        assert numpy.all(t.transform([[0, 0], [0, 0]]) == [[0., 0.], [0., 0.]])
+            t.transform("ipsi")
+        assert numpy.all(t.transform([[0, 0], [0, 0]]) == [[0.0, 0.0], [0.0, 0.0]])
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
         t = OneHotEncode(3)
         assert t.reverse((0.9, 0.8, 0.3)) == 0
-        assert t.reverse((-0.3, 2., 0.)) == 1
-        assert t.reverse((0., 0., 1.)) == 2
+        assert t.reverse((-0.3, 2.0, 0.0)) == 1
+        assert t.reverse((0.0, 0.0, 1.0)) == 2
         with pytest.raises(AssertionError):
-            t.reverse((0., 0., 0., 1.))
-        assert(numpy.all(t.reverse(numpy.array([[[0., 0., 1.], [0., 1., 0.]],
-                                                [[1., 0., 0.], [0., 0., 1.]]])) ==
-               numpy.array([[2, 1], [0, 2]], dtype=int)))
+            t.reverse((0.0, 0.0, 0.0, 1.0))
+        assert numpy.all(
+            t.reverse(
+                numpy.array(
+                    [
+                        [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+                        [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                    ]
+                )
+            )
+            == numpy.array([[2, 1], [0, 2]], dtype=int)
+        )
 
         t = OneHotEncode(2)
         assert t.reverse(0.3) == 0
-        assert t.reverse(2.) == 1
-        assert numpy.all(t.reverse((0., 0., 0., 1.)) == numpy.array([0, 0, 0, 1],
-                                                                    dtype=int))
-        assert(numpy.all(t.reverse(numpy.array([[0.55, 3.], [-0.6, 1.]])) ==
-               numpy.array([[1, 1], [0, 1]], dtype=int)))
+        assert t.reverse(2.0) == 1
+        assert numpy.all(
+            t.reverse((0.0, 0.0, 0.0, 1.0)) == numpy.array([0, 0, 0, 1], dtype=int)
+        )
+        assert numpy.all(
+            t.reverse(numpy.array([[0.55, 3.0], [-0.6, 1.0]]))
+            == numpy.array([[1, 1], [0, 1]], dtype=int)
+        )
 
         # for the crazy enough
         t = OneHotEncode(1)
@@ -428,8 +490,9 @@ class TestOneHotEncode(object):
         assert t.reverse(5.0) == 0
         assert t.reverse(0.2) == 0
         assert t.reverse(-0.2) == 0
-        assert numpy.all(t.reverse([[0.5, 0], [1.0, 55]]) == numpy.array([[0, 0], [0, 0]],
-                                                                         dtype=int))
+        assert numpy.all(
+            t.reverse([[0.5, 0], [1.0, 55]]) == numpy.array([[0, 0], [0, 0]], dtype=int)
+        )
 
     def test_interval(self):
         """Test that the onehot interval has the proper dimensions"""
@@ -457,7 +520,7 @@ class TestOneHotEncode(object):
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
         t = OneHotEncode(3)
-        assert t.repr_format('asfa') == 'OneHotEncode(asfa)'
+        assert t.repr_format("asfa") == "OneHotEncode(asfa)"
 
 
 class TestLinearize(object):
@@ -468,8 +531,8 @@ class TestLinearize(object):
         what's expected.
         """
         t = Linearize()
-        assert t.domain_type == 'real'
-        assert t.target_type == 'real'
+        assert t.domain_type == "real"
+        assert t.target_type == "real"
 
     def test_transform(self):
         """Check if it transforms properly."""
@@ -485,7 +548,7 @@ class TestLinearize(object):
     def test_repr_format(self):
         """Check representation of a transformed dimension."""
         t = Linearize()
-        assert t.repr_format(1.0) == 'Linearize(1.0)'
+        assert t.repr_format(1.0) == "Linearize(1.0)"
 
 
 class TestView(object):
@@ -493,9 +556,9 @@ class TestView(object):
 
     def test_domain_and_target_type(self):
         """Check if attribute-like `domain_type` and `target_type` do what's expected."""
-        t = View(shape=None, index=None, domain_type='some fancy type')
-        assert t.domain_type == 'some fancy type'
-        assert t.target_type == 'some fancy type'
+        t = View(shape=None, index=None, domain_type="some fancy type")
+        assert t.domain_type == "some fancy type"
+        assert t.target_type == "some fancy type"
 
     def test_transform(self):
         """Check if it transforms properly."""
@@ -528,31 +591,31 @@ class TestView(object):
         shape = (3, 4, 5)
         index = (0, 2, 1)
         t = View(shape=shape, index=index)
-        assert t.repr_format(1.0) == 'View(shape=(3, 4, 5), index=(0, 2, 1), 1.0)'
+        assert t.repr_format(1.0) == "View(shape=(3, 4, 5), index=(0, 2, 1), 1.0)"
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dim():
     """Create an example of `Dimension`."""
-    dim = Real('yolo0', 'norm', 0.9, shape=(3, 2))
+    dim = Real("yolo0", "norm", 0.9, shape=(3, 2))
     return dim
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def logdim():
     """Create an log example of `Dimension`."""
-    dim = Real('yolo4', 'reciprocal', 1.0, 10.0, shape=(3, 2))
+    dim = Real("yolo4", "reciprocal", 1.0, 10.0, shape=(3, 2))
     return dim
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def logintdim():
     """Create an log integer example of `Dimension`."""
-    dim = Integer('yolo5', 'reciprocal', 1, 10, shape=(3, 2))
+    dim = Integer("yolo5", "reciprocal", 1, 10, shape=(3, 2))
     return dim
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def tdim(dim):
     """Create an example of `TransformedDimension`."""
     transformers = [Quantize()]
@@ -560,7 +623,7 @@ def tdim(dim):
     return tdim
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rdims(tdim):
     """Create an example of `ReshapedDimension`."""
     transformations = {}
@@ -576,32 +639,31 @@ def rdims(tdim):
     return transformations
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rdim(dim, rdims):
     """Single ReshapedDimension"""
-    return rdims[f'{dim.name}[0,1]']
+    return rdims[f"{dim.name}[0,1]"]
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dim2():
     """Create a second example of `Dimension`."""
     probs = (0.1, 0.2, 0.3, 0.4)
-    categories = ('asdfa', '2', '3', '4')
+    categories = ("asdfa", "2", "3", "4")
     categories = OrderedDict(zip(categories, probs))
-    dim2 = Categorical('yolo2', categories)
+    dim2 = Categorical("yolo2", categories)
     return dim2
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def tdim2(dim2):
     """Create a second example of `TransformedDimension`."""
     transformers = [Enumerate(dim2.categories), OneHotEncode(len(dim2.categories))]
-    tdim2 = TransformedDimension(Compose(transformers, dim2.type),
-                                 dim2)
+    tdim2 = TransformedDimension(Compose(transformers, dim2.type), dim2)
     return tdim2
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rdims2(tdim2):
     """Create a categorical example of `ReshapedDimension`."""
     transformations = {}
@@ -611,37 +673,35 @@ def rdims2(tdim2):
             transformer=View(tdim2.shape, index, tdim2.type),
             original_dimension=tdim2,
             name=key,
-            index=1
+            index=1,
         )
 
     return transformations
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rdim2(dim2, rdims2):
     """Single ReshapedDimension"""
-    return rdims2[f'{dim2.name}[1]']
+    return rdims2[f"{dim2.name}[1]"]
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def dim3():
     """Create an example of integer `Dimension`."""
-    return Integer('yolo3', 'uniform', 3, 7)
+    return Integer("yolo3", "uniform", 3, 7)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def tdim3(dim3):
     """Create an example of integer `Dimension`."""
     return TransformedDimension(Compose([], dim3.type), dim3)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rdims3(tdim3):
     """Create an example of integer `Dimension`."""
     rdim3 = ReshapedDimension(
-        transformer=Identity(tdim3.type),
-        original_dimension=tdim3,
-        index=2
+        transformer=Identity(tdim3.type), original_dimension=tdim3, index=2
     )
 
     return {tdim3.name: rdim3}
@@ -658,9 +718,9 @@ class TestTransformedDimension(object):
 
     def test_reverse(self, tdim):
         """Check method `reverse`."""
-        assert tdim.reverse(9) == 9.
-        assert tdim.reverse(5) == 5.
-        assert numpy.all(tdim.reverse([9, 5]) == numpy.array([9., 5.], dtype=float))
+        assert tdim.reverse(9) == 9.0
+        assert tdim.reverse(5) == 5.0
+        assert numpy.all(tdim.reverse([9, 5]) == numpy.array([9.0, 5.0], dtype=float))
 
     def test_interval(self, tdim):
         """Check method `interval`."""
@@ -714,13 +774,43 @@ class TestTransformedDimension(object):
         """Test that hashable members of the transformed dimensions are the aggregation of
         transformer's and original dimension's hashable members.
         """
-        assert (tdim._get_hashable_members() ==
-                ('Compose', 'Quantize', 'real', 'integer', 'Identity', 'real', 'real',
-                 'yolo0', (3, 2), 'real', (0.9,), (), None, 'norm'))
-        assert (tdim2._get_hashable_members() ==
-                ('Compose', 'OneHotEncode', 'integer', 'real', 4, 'Compose', 'Enumerate',
-                 'categorical', 'integer', 'Identity', 'categorical', 'categorical', 'yolo2', (),
-                 'categorical', (), (), None, 'Distribution'))
+        assert tdim._get_hashable_members() == (
+            "Compose",
+            "Quantize",
+            "real",
+            "integer",
+            "Identity",
+            "real",
+            "real",
+            "yolo0",
+            (3, 2),
+            "real",
+            (0.9,),
+            (),
+            None,
+            "norm",
+        )
+        assert tdim2._get_hashable_members() == (
+            "Compose",
+            "OneHotEncode",
+            "integer",
+            "real",
+            4,
+            "Compose",
+            "Enumerate",
+            "categorical",
+            "integer",
+            "Identity",
+            "categorical",
+            "categorical",
+            "yolo2",
+            (),
+            "categorical",
+            (),
+            (),
+            None,
+            "Distribution",
+        )
 
     def test_validate(self, tdim, tdim2):
         """Validate original_dimension"""
@@ -729,8 +819,8 @@ class TestTransformedDimension(object):
         tdim2.validate()
 
         # We break it
-        tdim.original_dimension._kwargs['size'] = (2, )
-        tdim2.original_dimension._default_value = 'bad-default'
+        tdim.original_dimension._kwargs["size"] = (2,)
+        tdim2.original_dimension._default_value = "bad-default"
 
         # It does not pass
         with pytest.raises(ValueError) as exc:
@@ -741,26 +831,29 @@ class TestTransformedDimension(object):
             tdim2.validate()
         assert "bad-default is not a valid value for this Dimension." in str(exc.value)
 
-        tdim.original_dimension._kwargs.pop('size')
+        tdim.original_dimension._kwargs.pop("size")
         tdim2.original_dimension._default_value = Dimension.NO_DEFAULT_VALUE
 
     def test_repr(self, tdim):
         """Check method `__repr__`."""
-        assert str(tdim) == "Quantize(Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None))"  # noqa
+        assert (
+            str(tdim)
+            == "Quantize(Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None))"
+        )  # noqa
 
     def test_name_property(self, tdim):
         """Check property `name`."""
-        assert tdim.name == 'yolo0'
+        assert tdim.name == "yolo0"
 
     def test_type_property(self, tdim, tdim2):
         """Check property `type`."""
-        assert tdim.type == 'integer'
-        assert tdim2.type == 'real'
+        assert tdim.type == "integer"
+        assert tdim2.type == "real"
 
     def test_prior_name_property(self, tdim, tdim2):
         """Check property `prior_name`."""
-        assert tdim.prior_name == 'norm'
-        assert tdim2.prior_name == 'choices'
+        assert tdim.prior_name == "norm"
+        assert tdim2.prior_name == "choices"
 
     def test_shape_property(self, tdim, tdim2):
         """Check property `shape`."""
@@ -788,9 +881,10 @@ class TestReshapedDimension(object):
 
     def test_interval(self, rdim):
         """Check method `interval`."""
-        assert (rdim.interval() == (
+        assert rdim.interval() == (
             -numpy.array(numpy.inf).astype(int) + 1,
-            numpy.array(numpy.inf).astype(int) - 1))
+            numpy.array(numpy.inf).astype(int) - 1,
+        )
 
     def test_interval_from_categorical(self, rdim2):
         """Check how we should treat interval when original dimension is categorical."""
@@ -810,41 +904,80 @@ class TestReshapedDimension(object):
         """Test that hashable members of the transformed dimensions are the aggregation of
         transformer's and original dimension's hashable members.
         """
-        assert (rdim._get_hashable_members() ==
-                ('View', 'integer', 'integer', 'Compose', 'Quantize', 'real', 'integer', 'Identity',
-                 'real', 'real', 'yolo0', (3, 2), 'real', (0.9,), (), None, 'norm'))
-        assert (rdim2._get_hashable_members() ==
-                ('View', 'real', 'real', 'Compose', 'OneHotEncode', 'integer', 'real', 4, 'Compose',
-                 'Enumerate', 'categorical', 'integer', 'Identity', 'categorical', 'categorical',
-                 'yolo2', (), 'categorical', (), (), None, 'Distribution'))
+        assert rdim._get_hashable_members() == (
+            "View",
+            "integer",
+            "integer",
+            "Compose",
+            "Quantize",
+            "real",
+            "integer",
+            "Identity",
+            "real",
+            "real",
+            "yolo0",
+            (3, 2),
+            "real",
+            (0.9,),
+            (),
+            None,
+            "norm",
+        )
+        assert rdim2._get_hashable_members() == (
+            "View",
+            "real",
+            "real",
+            "Compose",
+            "OneHotEncode",
+            "integer",
+            "real",
+            4,
+            "Compose",
+            "Enumerate",
+            "categorical",
+            "integer",
+            "Identity",
+            "categorical",
+            "categorical",
+            "yolo2",
+            (),
+            "categorical",
+            (),
+            (),
+            None,
+            "Distribution",
+        )
 
     def test_repr(self, rdim):
         """Check method `__repr__`."""
-        assert str(rdim) == "View(shape=(3, 2), index=(0, 1), Quantize(Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)))"  # noqa
+        assert (
+            str(rdim)
+            == "View(shape=(3, 2), index=(0, 1), Quantize(Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)))"
+        )  # noqa
 
     def test_name_property(self, rdim):
         """Check property `name`."""
-        assert rdim.name == 'yolo0[0,1]'
+        assert rdim.name == "yolo0[0,1]"
 
     def test_type_property(self, rdim, rdim2):
         """Check property `type`."""
-        assert rdim.type == 'integer'
-        assert rdim2.type == 'real'
+        assert rdim.type == "integer"
+        assert rdim2.type == "real"
 
     def test_prior_name_property(self, rdim, rdim2):
         """Check property `prior_name`."""
-        assert rdim.prior_name == 'norm'
-        assert rdim2.prior_name == 'choices'
+        assert rdim.prior_name == "norm"
+        assert rdim2.prior_name == "choices"
 
     def test_shape_property(self, rdim, rdim2):
         """Check property `shape`."""
         assert rdim.original_dimension.shape == (3, 2)
         assert rdim.shape == ()
-        assert rdim2.original_dimension.shape == (4, )
+        assert rdim2.original_dimension.shape == (4,)
         assert rdim2.shape == ()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def space(dim, dim2, dim3):
     """Create an example `Space`."""
     space = Space()
@@ -854,7 +987,7 @@ def space(dim, dim2, dim3):
     return space
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def tspace(space, tdim, tdim2, tdim3):
     """Create an example `TransformedSpace`."""
     tspace = TransformedSpace(space)
@@ -864,7 +997,7 @@ def tspace(space, tdim, tdim2, tdim3):
     return tspace
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rspace(tspace, rdims, rdims2, rdims3):
     """Create an example `ReshapedSpace`."""
     rspace = ReshapedSpace(tspace)
@@ -909,17 +1042,21 @@ class TestReshapedSpace(object):
 
     def test_reverse(self, space, tspace, rspace, seed):
         """Check method `reverse`."""
-        ryo = (numpy.zeros(tspace['yolo0'].shape).reshape(-1).tolist() +
-               numpy.zeros(tspace['yolo2'].shape).reshape(-1).tolist() +
-               [10])
+        ryo = (
+            numpy.zeros(tspace["yolo0"].shape).reshape(-1).tolist()
+            + numpy.zeros(tspace["yolo2"].shape).reshape(-1).tolist()
+            + [10]
+        )
         yo = rspace.reverse(ryo)
         assert yo in space
 
     def test_contains(self, tspace, rspace, seed):
         """Check method `transform`."""
-        ryo = (numpy.zeros(tspace['yolo0'].shape).reshape(-1).tolist() +
-               numpy.zeros(tspace['yolo2'].shape).reshape(-1).tolist() +
-               [10])
+        ryo = (
+            numpy.zeros(tspace["yolo0"].shape).reshape(-1).tolist()
+            + numpy.zeros(tspace["yolo2"].shape).reshape(-1).tolist()
+            + [10]
+        )
 
         assert ryo in rspace
 
@@ -944,15 +1081,17 @@ class TestReshapedSpace(object):
         assert len(interval) == 3 * 2 + 4 + 1
         for i in range(3 * 2):
             # assert interval[i] == (-float('inf'), float('inf'))
-            assert interval[i] == (-numpy.array(numpy.inf).astype(int) + 1,
-                                   numpy.array(numpy.inf).astype(int) - 1)
+            assert interval[i] == (
+                -numpy.array(numpy.inf).astype(int) + 1,
+                numpy.array(numpy.inf).astype(int) - 1,
+            )
         for i in range(3 * 2, 3 * 2 + 4):
             assert interval[i] == (0, 1)
         assert interval[-1] == (3, 10)
 
     def test_reshape(self, rspace):
         """Verify that the dimension are reshaped properly, forward and backward"""
-        point = [numpy.arange(6).reshape(3, 2), '3', 10]
+        point = [numpy.arange(6).reshape(3, 2), "3", 10]
         rpoint = point[0].reshape(-1).tolist() + [0.0, 0.0, 1.0, 0.0] + [10]
         assert rspace.transform(point) == tuple(rpoint)
         numpy.testing.assert_equal(rspace.reverse(rpoint)[0], point[0])
@@ -962,21 +1101,19 @@ class TestReshapedSpace(object):
     def test_cardinality(self, dim2):
         """Check cardinality of reshaped space"""
         space = Space()
-        space.register(Real('yolo0', 'uniform', 0, 2, shape=(2, 2)))
+        space.register(Real("yolo0", "uniform", 0, 2, shape=(2, 2)))
         space.register(dim2)
 
-        rspace = build_required_space(
-            space,
-            shape_requirement='flattened')
+        rspace = build_required_space(space, shape_requirement="flattened")
         assert rspace.cardinality == numpy.inf
 
         rspace = build_required_space(
-            space, type_requirement='integer',
-            shape_requirement='flattened')
+            space, type_requirement="integer", shape_requirement="flattened"
+        )
         assert rspace.cardinality == (3 ** (2 * 2)) * 4
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def space_each_type(dim, dim2, dim3, logdim, logintdim):
     """Create an example `Space`."""
     space = Space()
@@ -991,168 +1128,185 @@ def space_each_type(dim, dim2, dim3, logdim, logintdim):
 class TestRequiredSpaceBuilder(object):
     """Check functionality of builder function `build_required_space`."""
 
-    @pytest.mark.xfail(reason='Bring it back when testing new builder and extend to shape and dist')
+    @pytest.mark.xfail(
+        reason="Bring it back when testing new builder and extend to shape and dist"
+    )
     def test_not_supported_requirement(self, space_each_type):
         """Require something which is not supported."""
         with pytest.raises(TypeError) as exc:
-            build_required_space(space_each_type, type_requirement='fasdfasf')
-        assert 'Unsupported' in str(exc.value)
+            build_required_space(space_each_type, type_requirement="fasdfasf")
+        assert "Unsupported" in str(exc.value)
 
     def test_no_requirement(self, space_each_type):
         """Check what is built using 'None' requirement."""
         tspace = build_required_space(space_each_type)
         assert len(tspace) == 5
-        assert tspace[0].type == 'real'
-        assert tspace[1].type == 'categorical'
+        assert tspace[0].type == "real"
+        assert tspace[1].type == "categorical"
         # NOTE:HEAD
-        assert tspace[2].type == 'integer'
-        assert tspace[3].type == 'real'
-        assert tspace[4].type == 'integer'
-        assert (str(tspace) == """\
+        assert tspace[2].type == "integer"
+        assert tspace[3].type == "real"
+        assert tspace[4].type == "integer"
+        assert (
+            str(tspace)
+            == """\
 Space([Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),
        Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None),
        Integer(name=yolo3, prior={uniform: (3, 7), {}}, shape=(), default value=None),
        Precision(4, Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None)),
        Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None)])\
-""")  # noqa
+"""
+        )  # noqa
 
     def test_integer_requirement(self, space_each_type):
         """Check what is built using 'integer' requirement."""
-        tspace = build_required_space(space_each_type, type_requirement='integer')
+        tspace = build_required_space(space_each_type, type_requirement="integer")
         assert len(tspace) == 5
-        assert tspace[0].type == 'integer'
-        assert tspace[1].type == 'integer'
-        assert tspace[2].type == 'integer'
-        assert tspace[3].type == 'integer'
-        assert tspace[4].type == 'integer'
-        assert(str(tspace) == """\
+        assert tspace[0].type == "integer"
+        assert tspace[1].type == "integer"
+        assert tspace[2].type == "integer"
+        assert tspace[3].type == "integer"
+        assert tspace[4].type == "integer"
+        assert (
+            str(tspace)
+            == """\
 Space([Quantize(Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None))),
        Enumerate(Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None)),
        Integer(name=yolo3, prior={uniform: (3, 7), {}}, shape=(), default value=None),
        Quantize(Precision(4, Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None))),
        Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None)])\
-""")  # noqa
+"""
+        )  # noqa
 
     def test_real_requirement(self, space_each_type):
         """Check what is built using 'real' requirement."""
-        tspace = build_required_space(space_each_type, type_requirement='real')
+        tspace = build_required_space(space_each_type, type_requirement="real")
         assert len(tspace) == 5
-        assert tspace[0].type == 'real'
-        assert tspace[1].type == 'real'
-        assert tspace[2].type == 'real'
-        assert tspace[3].type == 'real'
-        assert tspace[4].type == 'real'
-        assert(str(tspace) == """\
+        assert tspace[0].type == "real"
+        assert tspace[1].type == "real"
+        assert tspace[2].type == "real"
+        assert tspace[3].type == "real"
+        assert tspace[4].type == "real"
+        assert (
+            str(tspace)
+            == """\
 Space([Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),
        OneHotEncode(Enumerate(Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None))),
        ReverseQuantize(Integer(name=yolo3, prior={uniform: (3, 7), {}}, shape=(), default value=None)),
        Precision(4, Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None)),
        ReverseQuantize(Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None))])\
-""")  # noqa
+"""
+        )  # noqa
 
     def test_numerical_requirement(self, space_each_type):
         """Check what is built using 'integer' requirement."""
-        tspace = build_required_space(space_each_type, type_requirement='numerical')
+        tspace = build_required_space(space_each_type, type_requirement="numerical")
         assert len(tspace) == 5
-        assert tspace[0].type == 'real'
-        assert tspace[1].type == 'integer'
-        assert tspace[2].type == 'integer'
-        assert tspace[3].type == 'real'
-        assert tspace[4].type == 'integer'
-        assert(str(tspace) == """\
+        assert tspace[0].type == "real"
+        assert tspace[1].type == "integer"
+        assert tspace[2].type == "integer"
+        assert tspace[3].type == "real"
+        assert tspace[4].type == "integer"
+        assert (
+            str(tspace)
+            == """\
 Space([Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),
        Enumerate(Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None)),
        Integer(name=yolo3, prior={uniform: (3, 7), {}}, shape=(), default value=None),
        Precision(4, Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None)),
        Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None)])\
-""")  # noqa
+"""
+        )  # noqa
 
     def test_linear_requirement(self, space_each_type):
         """Check what is built using 'linear' requirement."""
-        tspace = build_required_space(space_each_type, dist_requirement='linear')
+        tspace = build_required_space(space_each_type, dist_requirement="linear")
         assert len(tspace) == 5
-        assert tspace[0].type == 'real'
-        assert tspace[1].type == 'categorical'
-        assert tspace[2].type == 'integer'
-        assert tspace[3].type == 'real'
-        assert tspace[4].type == 'integer'
-        assert(str(tspace) == """\
+        assert tspace[0].type == "real"
+        assert tspace[1].type == "categorical"
+        assert tspace[2].type == "integer"
+        assert tspace[3].type == "real"
+        assert tspace[4].type == "integer"
+        assert (
+            str(tspace)
+            == """\
 Space([Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), default value=None)),
        Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None),
        Integer(name=yolo3, prior={uniform: (3, 7), {}}, shape=(), default value=None),
        Linearize(Precision(4, Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None))),
        Quantize(Linearize(ReverseQuantize(Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None))))])\
-""")  # noqa
+"""
+        )  # noqa
 
     def test_flatten_requirement(self, space_each_type):
         """Check what is built using 'flatten' requirement."""
-        tspace = build_required_space(
-            space_each_type, shape_requirement='flattened')
+        tspace = build_required_space(space_each_type, shape_requirement="flattened")
 
         # 1 integer + 1 categorical + 1 * (3, 2) shapes
         assert len(tspace) == 1 + 1 + 3 * (3 * 2)
-        assert str(tspace).count('View') == 3 * (3 * 2)
+        assert str(tspace).count("View") == 3 * (3 * 2)
 
         i = 0
         for _ in range(3 * 2):
-            assert tspace[i].type == 'real'
+            assert tspace[i].type == "real"
             i += 1
 
-        assert tspace[i].type == 'categorical'
+        assert tspace[i].type == "categorical"
         i += 1
 
-        assert tspace[i].type == 'integer'
+        assert tspace[i].type == "integer"
         i += 1
 
         for _ in range(3 * 2):
-            assert tspace[i].type == 'real'
+            assert tspace[i].type == "real"
             i += 1
 
         for _ in range(3 * 2):
-            assert tspace[i].type == 'integer'
+            assert tspace[i].type == "integer"
             i += 1
 
         tspace = build_required_space(
-            space_each_type, shape_requirement='flattened', type_requirement='real')
+            space_each_type, shape_requirement="flattened", type_requirement="real"
+        )
 
         # 1 integer + 4 categorical + 1 * (3, 2) shapes
         assert len(tspace) == 1 + 4 + 3 * (3 * 2)
-        assert str(tspace).count('View') == 4 + 3 * (3 * 2)
+        assert str(tspace).count("View") == 4 + 3 * (3 * 2)
 
     def test_capacity(self, space_each_type):
         """Check transformer space capacity"""
-        tspace = build_required_space(space_each_type, type_requirement='real')
+        tspace = build_required_space(space_each_type, type_requirement="real")
         assert tspace.cardinality == numpy.inf
 
         space = Space()
         probs = (0.1, 0.2, 0.3, 0.4)
-        categories = ('asdfa', 2, 3, 4)
-        dim = Categorical('yolo0', OrderedDict(zip(categories, probs)), shape=2)
+        categories = ("asdfa", 2, 3, 4)
+        dim = Categorical("yolo0", OrderedDict(zip(categories, probs)), shape=2)
         space.register(dim)
-        dim = Integer('yolo2', 'uniform', -3, 6)
+        dim = Integer("yolo2", "uniform", -3, 6)
         space.register(dim)
-        tspace = build_required_space(space, type_requirement='integer')
+        tspace = build_required_space(space, type_requirement="integer")
         assert tspace.cardinality == (4 ** 2) * (6 + 1)
 
-        dim = Integer('yolo3', 'uniform', -3, 6, shape=(2, 1))
+        dim = Integer("yolo3", "uniform", -3, 6, shape=(2, 1))
         space.register(dim)
-        tspace = build_required_space(space, type_requirement='integer')
+        tspace = build_required_space(space, type_requirement="integer")
         assert tspace.cardinality == (4 ** 2) * (6 + 1) * ((6 + 1) ** (2 * 1))
 
         tspace = build_required_space(
-            space, type_requirement='integer',
-            shape_requirement='flattened')
+            space, type_requirement="integer", shape_requirement="flattened"
+        )
         assert tspace.cardinality == (4 ** 2) * (6 + 1) * ((6 + 1) ** (2 * 1))
 
         tspace = build_required_space(
-            space, type_requirement='integer',
-            dist_requirement='linear')
+            space, type_requirement="integer", dist_requirement="linear"
+        )
         assert tspace.cardinality == (4 ** 2) * (6 + 1) * ((6 + 1) ** (2 * 1))
 
 
 def test_quantization_does_not_violate_bounds():
     """Regress on bug that converts valid float in tdim to non valid excl. upper bound."""
-    dim = Integer('yo', 'uniform', 3, 7)
+    dim = Integer("yo", "uniform", 3, 7)
     transformers = [Reverse(Quantize())]
     tdim = TransformedDimension(Compose(transformers, dim.type), dim)
     assert 11 not in dim

--- a/tests/unittests/core/test_utils.py
+++ b/tests/unittests/core/test_utils.py
@@ -9,6 +9,7 @@ from orion.core.utils import Factory
 
 def test_factory_subclasses_detection():
     """Verify that meta-class Factory finds all subclasses"""
+
     class Base(object):
         pass
 
@@ -45,4 +46,6 @@ def test_factory_subclasses_detection():
 
     with pytest.raises(NotImplementedError) as exc_info:
         MyFactory(of_type="random")
-    assert "Could not find implementation of Base, type = 'random'" in str(exc_info.value)
+    assert "Could not find implementation of Base, type = 'random'" in str(
+        exc_info.value
+    )

--- a/tests/unittests/core/test_utils_format.py
+++ b/tests/unittests/core/test_utils_format.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from orion.core.utils.format_trials import (dict_to_trial, trial_to_tuple, tuple_to_trial)
+from orion.core.utils.format_trials import dict_to_trial, trial_to_tuple, tuple_to_trial
 from orion.core.worker.trial import Trial
 
 
@@ -12,22 +12,10 @@ from orion.core.worker.trial import Trial
 def trial():
     """Stab trial to match tuple from fixture `fixed_suggestion`."""
     params = [
-        dict(
-            name='yolo',
-            type='categorical',
-            value=('asdfa', 2)
-            ),
-        dict(
-            name='yolo2',
-            type='integer',
-            value=0
-            ),
-        dict(
-            name='yolo3',
-            type='real',
-            value=3.5
-            )
-        ]
+        dict(name="yolo", type="categorical", value=("asdfa", 2)),
+        dict(name="yolo2", type="integer", value=0),
+        dict(name="yolo3", type="real", value=3.5),
+    ]
     return Trial(params=params)
 
 
@@ -35,35 +23,23 @@ def trial():
 def hierarchical_trial():
     """Stab trial with hierarchical params."""
     params = [
-        dict(
-            name='yolo.first',
-            type='categorical',
-            value=('asdfa', 2)
-            ),
-        dict(
-            name='yolo.second',
-            type='integer',
-            value=0
-            ),
-        dict(
-            name='yoloflat',
-            type='real',
-            value=3.5
-            )
-        ]
+        dict(name="yolo.first", type="categorical", value=("asdfa", 2)),
+        dict(name="yolo.second", type="integer", value=0),
+        dict(name="yoloflat", type="real", value=3.5),
+    ]
     return Trial(params=params)
 
 
 @pytest.fixture()
 def dict_params():
     """Return dictionary of params to build a trial like `fixed_suggestion`"""
-    return {'yolo': ('asdfa', 2), 'yolo2': 0, 'yolo3': 3.5}
+    return {"yolo": ("asdfa", 2), "yolo2": 0, "yolo3": 3.5}
 
 
 @pytest.fixture()
 def hierarchical_dict_params():
     """Return dictionary of params to build a hierarchical trial"""
-    return {'yolo': {'first': ('asdfa', 2), 'second': 0}, 'yoloflat': 3.5}
+    return {"yolo": {"first": ("asdfa", 2), "second": 0}, "yoloflat": 3.5}
 
 
 def test_trial_to_tuple(space, trial, fixed_suggestion):
@@ -71,24 +47,24 @@ def test_trial_to_tuple(space, trial, fixed_suggestion):
     data = trial_to_tuple(trial, space)
     assert data == fixed_suggestion
 
-    trial._params[0].name = 'lalala'
+    trial._params[0].name = "lalala"
     with pytest.raises(ValueError) as exc:
         trial_to_tuple(trial, space)
 
-    assert "Trial params: [\'lalala\', \'yolo2\', \'yolo3\']" in str(exc.value)
+    assert "Trial params: ['lalala', 'yolo2', 'yolo3']" in str(exc.value)
 
     trial._params.pop(0)
     with pytest.raises(ValueError) as exc:
         trial_to_tuple(trial, space)
 
-    assert "Trial params: [\'yolo2\', \'yolo3\']" in str(exc.value)
+    assert "Trial params: ['yolo2', 'yolo3']" in str(exc.value)
 
 
 def test_tuple_to_trial(space, trial, fixed_suggestion):
     """Check if sample is recovered successfully from trial."""
     t = tuple_to_trial(fixed_suggestion, space)
     assert t.experiment is None
-    assert t.status == 'new'
+    assert t.status == "new"
     assert t.worker is None
     assert t.submit_time is None
     assert t.start_time is None
@@ -103,7 +79,7 @@ def test_dict_to_trial(space, trial, dict_params):
     """Check if dict is converted successfully to trial."""
     t = dict_to_trial(dict_params, space)
     assert t.experiment is None
-    assert t.status == 'new'
+    assert t.status == "new"
     assert t.worker is None
     assert t.submit_time is None
     assert t.start_time is None
@@ -121,7 +97,7 @@ def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
 
     t = tuple_to_trial(trial_to_tuple(trial, space), space)
     assert t.experiment is None
-    assert t.status == 'new'
+    assert t.status == "new"
     assert t.worker is None
     assert t.submit_time is None
     assert t.start_time is None
@@ -132,13 +108,17 @@ def test_tuple_to_trial_to_tuple(space, trial, fixed_suggestion):
         assert t._params[i].to_dict() == trial._params[i].to_dict()
 
 
-def test_hierarchical_trial_to_tuple(hierarchical_space, hierarchical_trial, fixed_suggestion):
+def test_hierarchical_trial_to_tuple(
+    hierarchical_space, hierarchical_trial, fixed_suggestion
+):
     """Check if hierarchical trial is correctly created from a sample/tuple."""
     data = trial_to_tuple(hierarchical_trial, hierarchical_space)
     assert data == fixed_suggestion
 
 
-def test_tuple_to_hierarchical_trial(hierarchical_space, hierarchical_trial, fixed_suggestion):
+def test_tuple_to_hierarchical_trial(
+    hierarchical_space, hierarchical_trial, fixed_suggestion
+):
     """Check if sample is recovered successfully from hierarchical trial."""
     t = tuple_to_trial(fixed_suggestion, hierarchical_space)
     assert len(t._params) == len(hierarchical_trial._params)
@@ -146,8 +126,9 @@ def test_tuple_to_hierarchical_trial(hierarchical_space, hierarchical_trial, fix
         assert t._params[i].to_dict() == hierarchical_trial._params[i].to_dict()
 
 
-def test_hierarchical_dict_to_trial(hierarchical_space, hierarchical_trial,
-                                    hierarchical_dict_params):
+def test_hierarchical_dict_to_trial(
+    hierarchical_space, hierarchical_trial, hierarchical_dict_params
+):
     """Check if hierarchical dict is converted successfully to trial."""
     t = dict_to_trial(hierarchical_dict_params, hierarchical_space)
     assert len(t._params) == len(hierarchical_trial._params)

--- a/tests/unittests/core/utils/test_backward.py
+++ b/tests/unittests/core/utils/test_backward.py
@@ -7,58 +7,61 @@ import orion.core.utils.backward as backward
 
 def create_algo_class(**attributes):
     """Create algo class with given requirements attributes"""
-    return type('Algo', (BaseAlgorithm, ), attributes)
+    return type("Algo", (BaseAlgorithm,), attributes)
 
 
-TYPE_REQUIREMENTS = ['real', 'integer', 'numerical']
+TYPE_REQUIREMENTS = ["real", "integer", "numerical"]
 
 
-@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+@pytest.mark.parametrize("requirement", TYPE_REQUIREMENTS)
 def test_type_requirements(requirement):
     """Test algorithms type requirement defined in old requirements API"""
     algo_class = create_algo_class(requires=[requirement])
     requirements = backward.get_algo_requirements(algo_class)
     assert len(requirements) == 3
     assert requirements == {
-        'type_requirement': requirement,
-        'shape_requirement': None,
-        'dist_requirement': None}
+        "type_requirement": requirement,
+        "shape_requirement": None,
+        "dist_requirement": None,
+    }
 
 
-@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+@pytest.mark.parametrize("requirement", TYPE_REQUIREMENTS)
 def test_shape_requirements(requirement):
     """Test algorithms shape requirement defined in old requirements API"""
-    algo_class = create_algo_class(requires=[requirement, 'flattened'])
+    algo_class = create_algo_class(requires=[requirement, "flattened"])
     requirements = backward.get_algo_requirements(algo_class)
     assert len(requirements) == 3
     assert requirements == {
-        'type_requirement': requirement,
-        'shape_requirement': 'flattened',
-        'dist_requirement': None}
+        "type_requirement": requirement,
+        "shape_requirement": "flattened",
+        "dist_requirement": None,
+    }
 
 
-@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+@pytest.mark.parametrize("requirement", TYPE_REQUIREMENTS)
 def test_dist_requirements(requirement):
     """Test algorithms dist requirement defined in old requirements API"""
-    algo_class = create_algo_class(requires=[requirement, 'linear'])
+    algo_class = create_algo_class(requires=[requirement, "linear"])
     requirements = backward.get_algo_requirements(algo_class)
     assert len(requirements) == 3
     assert requirements == {
-        'type_requirement': requirement,
-        'shape_requirement': None,
-        'dist_requirement': 'linear'}
+        "type_requirement": requirement,
+        "shape_requirement": None,
+        "dist_requirement": "linear",
+    }
 
 
-@pytest.mark.parametrize('requirement', TYPE_REQUIREMENTS)
+@pytest.mark.parametrize("requirement", TYPE_REQUIREMENTS)
 def test_no_changes(requirement):
     """Test algorithms following new requirements API"""
     algo_class = create_algo_class(
-        requires_type=requirement,
-        requires_shape='flattened',
-        requires_dist='linear')
+        requires_type=requirement, requires_shape="flattened", requires_dist="linear"
+    )
     requirements = backward.get_algo_requirements(algo_class)
     assert len(requirements) == 3
     assert requirements == {
-        'type_requirement': requirement,
-        'shape_requirement': 'flattened',
-        'dist_requirement': 'linear'}
+        "type_requirement": requirement,
+        "shape_requirement": "flattened",
+        "dist_requirement": "linear",
+    }

--- a/tests/unittests/core/utils/test_flatten.py
+++ b/tests/unittests/core/utils/test_flatten.py
@@ -4,19 +4,19 @@ from orion.core.utils.flatten import flatten, unflatten
 
 def test_basic():
     """Test basic functionality of flatten"""
-    d = {'a': {'b': 2, 'c': 3}, 'c': {'d': 3, 'e': 4}}
-    assert flatten(d) == {'a.b': 2, 'a.c': 3, 'c.d': 3, 'c.e': 4}
+    d = {"a": {"b": 2, "c": 3}, "c": {"d": 3, "e": 4}}
+    assert flatten(d) == {"a.b": 2, "a.c": 3, "c.d": 3, "c.e": 4}
 
 
 def test_handle_double_ref():
     """Test proper handling of double references in dicts"""
-    a = {'b': 2, 'c': 3}
-    d = {'a': a, 'd': {'e': a}}
-    assert flatten(d) == {'a.b': 2, 'a.c': 3, 'd.e.b': 2, 'd.e.c': 3}
+    a = {"b": 2, "c": 3}
+    d = {"a": a, "d": {"e": a}}
+    assert flatten(d) == {"a.b": 2, "a.c": 3, "d.e.b": 2, "d.e.c": 3}
 
 
 def test_unflatten():
     """Test than unflatten(flatten(x)) is idempotent"""
-    a = {'b': 2, 'c': 3}
-    d = {'a': a, 'd': {'e': a}}
+    a = {"b": 2, "c": 3}
+    d = {"a": a, "d": {"e": a}}
     assert unflatten(flatten(d)) == d

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -23,19 +23,21 @@ Consumer = consumer.Consumer
 def config(exp_config):
     """Return a configuration."""
     config = exp_config[0][0]
-    config['metadata']['user_args'] = ['--x~uniform(-50, 50)']
-    config['metadata']['VCS'] = resolve_config.infer_versioning_metadata(
-        config['metadata']['user_script'])
-    config['name'] = 'exp'
-    config['working_dir'] = "/tmp/orion"
+    config["metadata"]["user_args"] = ["--x~uniform(-50, 50)"]
+    config["metadata"]["VCS"] = resolve_config.infer_versioning_metadata(
+        config["metadata"]["user_script"]
+    )
+    config["name"] = "exp"
+    config["working_dir"] = "/tmp/orion"
     backward.populate_space(config)
-    config['space'] = config['metadata']['priors']
+    config["space"] = config["metadata"]["priors"]
     return config
 
 
 @pytest.mark.usefixtures("create_db_instance")
 def test_trials_interrupted_keyboard_int(config, monkeypatch):
     """Check if a trial is set as interrupted when a KeyboardInterrupt is raised."""
+
     def mock_Popen(*args, **kwargs):
         raise KeyboardInterrupt
 
@@ -52,7 +54,7 @@ def test_trials_interrupted_keyboard_int(config, monkeypatch):
     with pytest.raises(KeyboardInterrupt):
         con.consume(trial)
 
-    trials = exp.fetch_trials_by_status('interrupted')
+    trials = exp.fetch_trials_by_status("interrupted")
     assert len(trials)
     assert trials[0].id == trial.id
 
@@ -60,6 +62,7 @@ def test_trials_interrupted_keyboard_int(config, monkeypatch):
 @pytest.mark.usefixtures("create_db_instance")
 def test_trials_interrupted_sigterm(config, monkeypatch):
     """Check if a trial is set as interrupted when a signal is raised."""
+
     def mock_popen(*args, **kwargs):
         os.kill(os.getpid(), signal.SIGTERM)
 
@@ -76,7 +79,7 @@ def test_trials_interrupted_sigterm(config, monkeypatch):
     with pytest.raises(KeyboardInterrupt):
         con.consume(trial)
 
-    trials = exp.fetch_trials_by_status('interrupted')
+    trials = exp.fetch_trials_by_status("interrupted")
     assert len(trials)
     assert trials[0].id == trial.id
 
@@ -88,7 +91,7 @@ def test_pacemaker_termination(config):
 
     trial = tuple_to_trial((1.0,), exp.space)
 
-    exp.register_trial(trial, status='reserved')
+    exp.register_trial(trial, status="reserved")
 
     con = Consumer(exp)
 
@@ -109,7 +112,7 @@ def test_trial_working_dir_is_changed(config):
 
     trial = tuple_to_trial((1.0,), exp.space)
 
-    exp.register_trial(trial, status='reserved')
+    exp.register_trial(trial, status="reserved")
 
     con = Consumer(exp)
     con.consume(trial)
@@ -125,21 +128,22 @@ def test_code_changed(config, monkeypatch):
 
     trial = tuple_to_trial((1.0,), exp.space)
 
-    exp.register_trial(trial, status='reserved')
+    exp.register_trial(trial, status="reserved")
 
     con = Consumer(exp)
 
     def code_changed(user_script):
         return dict(
-            type='git',
+            type="git",
             is_dirty=True,
-            HEAD_sha='changed',
-            active_branch='new_branch',
-            diff_sha='new_diff')
+            HEAD_sha="changed",
+            active_branch="new_branch",
+            diff_sha="new_diff",
+        )
 
-    monkeypatch.setattr(consumer, 'infer_versioning_metadata', code_changed)
+    monkeypatch.setattr(consumer, "infer_versioning_metadata", code_changed)
 
     with pytest.raises(BranchingEvent) as exc:
         con.consume(trial)
 
-    assert exc.match('Code changed between execution of 2 trials')
+    assert exc.match("Code changed between execution of 2 trials")

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -26,30 +26,34 @@ from orion.testing import OrionState
 def new_config(random_dt):
     """Create a configuration that will not hit the database."""
     new_config = dict(
-        name='supernaekei',
+        name="supernaekei",
         # refers is missing on purpose
-        metadata={'user': 'tsirif',
-                  'orion_version': 0.1,
-                  'user_script': 'abs_path/to_yoyoy.py',
-                  'user_config': 'abs_path/hereitis.yaml',
-                  'user_args': ['--mini-batch~uniform(32, 256, discrete=True)'],
-                  'VCS': {"type": "git",
-                          "is_dirty": False,
-                          "HEAD_sha": "fsa7df7a8sdf7a8s7",
-                          "active_branch": None,
-                          "diff_sha": "diff"}},
+        metadata={
+            "user": "tsirif",
+            "orion_version": 0.1,
+            "user_script": "abs_path/to_yoyoy.py",
+            "user_config": "abs_path/hereitis.yaml",
+            "user_args": ["--mini-batch~uniform(32, 256, discrete=True)"],
+            "VCS": {
+                "type": "git",
+                "is_dirty": False,
+                "HEAD_sha": "fsa7df7a8sdf7a8s7",
+                "active_branch": None,
+                "diff_sha": "diff",
+            },
+        },
         version=1,
         pool_size=10,
         max_trials=1000,
         max_broken=5,
         working_dir=None,
-        algorithms={'dumbalgo': {}},
-        producer={'strategy': 'NoParallelStrategy'},
+        algorithms={"dumbalgo": {}},
+        producer={"strategy": "NoParallelStrategy"},
         # attrs starting with '_' also
         # _id='fasdfasfa',
         # and in general anything which is not in Experiment's slots
-        something_to_be_ignored='asdfa'
-        )
+        something_to_be_ignored="asdfa",
+    )
 
     backward.populate_space(new_config)
 
@@ -60,12 +64,16 @@ def new_config(random_dt):
 def parent_version_config():
     """Return a configuration for an experiment."""
     config = dict(
-        _id='parent_config',
+        _id="parent_config",
         name="old_experiment",
         version=1,
-        algorithms='random',
-        metadata={'user': 'corneauf', 'datetime': datetime.datetime.utcnow(),
-                  'user_args': ['--x~normal(0,1)']})
+        algorithms="random",
+        metadata={
+            "user": "corneauf",
+            "datetime": datetime.datetime.utcnow(),
+            "user_args": ["--x~normal(0,1)"],
+        },
+    )
 
     backward.populate_space(config)
 
@@ -76,11 +84,11 @@ def parent_version_config():
 def child_version_config(parent_version_config):
     """Return a configuration for an experiment."""
     config = copy.deepcopy(parent_version_config)
-    config['_id'] = 'child_config'
-    config['version'] = 2
-    config['refers'] = {'parent_id': 'parent_config'}
-    config['metadata']['datetime'] = datetime.datetime.utcnow()
-    config['metadata']['user_args'].append('--y~+normal(0,1)')
+    config["_id"] = "child_config"
+    config["version"] = 2
+    config["refers"] = {"parent_id": "parent_config"}
+    config["metadata"]["datetime"] = datetime.datetime.utcnow()
+    config["metadata"]["user_args"].append("--y~+normal(0,1)")
     backward.populate_space(config)
     return config
 
@@ -100,49 +108,47 @@ def _generate(obj, *args, value):
 
 
 base_trial = {
-    'experiment': 0,
-    'status': 'new',  # new, reserved, suspended, completed, broken
-    'worker': None,
-    'submit_time': '2017-11-23T02:00:00',
-    'start_time': None,
-    'end_time': None,
-    'heartbeat': None,
-    'results': [
-        {'name': 'loss',
-         'type': 'objective',  # objective, constraint
-         'value': 2}
+    "experiment": 0,
+    "status": "new",  # new, reserved, suspended, completed, broken
+    "worker": None,
+    "submit_time": "2017-11-23T02:00:00",
+    "start_time": None,
+    "end_time": None,
+    "heartbeat": None,
+    "results": [
+        {"name": "loss", "type": "objective", "value": 2}  # objective, constraint
     ],
-    'params': [
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'},
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'lstm_with_attention'}
-    ]
+    "params": [
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+        {
+            "name": "/decoding_layer",
+            "type": "categorical",
+            "value": "lstm_with_attention",
+        },
+    ],
 }
 
 
 def generate_trials(status):
     """Generate Trials with different configurations"""
-    new_trials = [_generate(base_trial, 'status', value=s) for s in status]
+    new_trials = [_generate(base_trial, "status", value=s) for s in status]
 
     for i, trial in enumerate(new_trials):
-        if trial['status'] != 'new':
-            trial['start_time'] = datetime.datetime.utcnow() + datetime.timedelta(seconds=i)
+        if trial["status"] != "new":
+            trial["start_time"] = datetime.datetime.utcnow() + datetime.timedelta(
+                seconds=i
+            )
 
     for i, trial in enumerate(new_trials):
-        if trial['status'] == 'completed':
-            trial['end_time'] = datetime.datetime.utcnow() + datetime.timedelta(seconds=i)
+        if trial["status"] == "completed":
+            trial["end_time"] = datetime.datetime.utcnow() + datetime.timedelta(
+                seconds=i
+            )
 
     # make each trial unique
     for i, trial in enumerate(new_trials):
-        trial['results'][0]['value'] = i
-        trial['params'].append({
-            'name': '/index',
-            'type': 'categorical',
-            'value': i
-        })
+        trial["results"][0]["value"] = i
+        trial["params"].append({"name": "/index", "type": "categorical", "value": i})
 
     return new_trials
 
@@ -165,13 +171,13 @@ def get_db_from_view(exp):
 @pytest.fixture()
 def space():
     """Build a space object"""
-    return SpaceBuilder().build({'/index': 'uniform(0, 10)'})
+    return SpaceBuilder().build({"/index": "uniform(0, 10)"})
 
 
 @pytest.fixture()
 def algorithm(space):
     """Build a dumb algo object"""
-    return PrimaryAlgo(space, 'dumbalgo')
+    return PrimaryAlgo(space, "dumbalgo")
 
 
 class TestReserveTrial(object):
@@ -181,33 +187,34 @@ class TestReserveTrial(object):
     def test_reserve_none(self):
         """Find nothing, return None."""
         with OrionState(experiments=[], trials=[]):
-            exp = Experiment('supernaekei')
+            exp = Experiment("supernaekei")
             trial = exp.reserve_trial()
             assert trial is None
 
     def test_reserve_success(self, random_dt):
         """Successfully find new trials in db and reserve the first one"""
-        storage_config = {'type': 'legacy', 'database': {'type': 'EphemeralDB'}}
-        with OrionState(trials=generate_trials(['new', 'reserved']),
-                        storage=storage_config) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+        storage_config = {"type": "legacy", "database": {"type": "EphemeralDB"}}
+        with OrionState(
+            trials=generate_trials(["new", "reserved"]), storage=storage_config
+        ) as cfg:
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
 
             trial = exp.reserve_trial()
 
             # Trials are sorted according to hash and 'new' gets position second
-            cfg.trials[1]['status'] = 'reserved'
-            cfg.trials[1]['start_time'] = random_dt
-            cfg.trials[1]['heartbeat'] = random_dt
+            cfg.trials[1]["status"] = "reserved"
+            cfg.trials[1]["start_time"] = random_dt
+            cfg.trials[1]["heartbeat"] = random_dt
 
             assert trial.to_dict() == cfg.trials[1]
 
     def test_reserve_when_exhausted(self):
         """Return None once all the trials have been allocated"""
-        stati = ['new', 'reserved', 'interrupted', 'completed', 'broken']
+        stati = ["new", "reserved", "interrupted", "completed", "broken"]
         with OrionState(trials=generate_trials(stati)) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
             assert exp.reserve_trial() is not None
             assert exp.reserve_trial() is not None
             assert exp.reserve_trial() is None
@@ -215,125 +222,130 @@ class TestReserveTrial(object):
     def test_fix_lost_trials(self):
         """Test that a running trial with an old heartbeat is set to interrupted."""
         trial = copy.deepcopy(base_trial)
-        trial['status'] = 'reserved'
-        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 10)
+        trial["status"] = "reserved"
+        trial["heartbeat"] = datetime.datetime.utcnow() - datetime.timedelta(
+            seconds=60 * 10
+        )
         with OrionState(trials=[trial]) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
 
-            assert len(exp.fetch_trials_by_status('reserved')) == 1
+            assert len(exp.fetch_trials_by_status("reserved")) == 1
             exp.fix_lost_trials()
-            assert len(exp.fetch_trials_by_status('reserved')) == 0
+            assert len(exp.fetch_trials_by_status("reserved")) == 0
 
     def test_fix_only_lost_trials(self):
         """Test that an old trial is set to interrupted but not a recent one."""
-        lost_trial, running_trial = generate_trials(['reserved'] * 2)
-        lost_trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 10)
-        running_trial['heartbeat'] = datetime.datetime.utcnow()
+        lost_trial, running_trial = generate_trials(["reserved"] * 2)
+        lost_trial["heartbeat"] = datetime.datetime.utcnow() - datetime.timedelta(
+            seconds=60 * 10
+        )
+        running_trial["heartbeat"] = datetime.datetime.utcnow()
 
         with OrionState(trials=[lost_trial, running_trial]) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
 
-            assert len(exp.fetch_trials_by_status('reserved')) == 2
+            assert len(exp.fetch_trials_by_status("reserved")) == 2
 
             exp.fix_lost_trials()
 
-            reserved_trials = exp.fetch_trials_by_status('reserved')
+            reserved_trials = exp.fetch_trials_by_status("reserved")
             assert len(reserved_trials) == 1
-            assert reserved_trials[0].to_dict()['params'] == running_trial['params']
+            assert reserved_trials[0].to_dict()["params"] == running_trial["params"]
 
-            failedover_trials = exp.fetch_trials_by_status('interrupted')
+            failedover_trials = exp.fetch_trials_by_status("interrupted")
             assert len(failedover_trials) == 1
-            assert failedover_trials[0].to_dict()['params'] == lost_trial['params']
+            assert failedover_trials[0].to_dict()["params"] == lost_trial["params"]
 
     def test_fix_lost_trials_race_condition(self, monkeypatch, caplog):
         """Test that a lost trial fixed by a concurrent process does not cause error."""
         trial = copy.deepcopy(base_trial)
-        trial['status'] = 'interrupted'
-        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 10)
+        trial["status"] = "interrupted"
+        trial["heartbeat"] = datetime.datetime.utcnow() - datetime.timedelta(
+            seconds=60 * 10
+        )
         with OrionState(trials=[trial]) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
 
-            assert len(exp.fetch_trials_by_status('interrupted')) == 1
+            assert len(exp.fetch_trials_by_status("interrupted")) == 1
 
             assert len(exp._storage.fetch_lost_trials(exp)) == 0
 
             def fetch_lost_trials(self, query):
                 trial_object = Trial(**trial)
-                trial_object.status = 'reserved'
+                trial_object.status = "reserved"
                 return [trial_object]
 
             # Force the fetch of a trial marked as reserved (and lost) while actually interrupted
             # (as if already failed-over by another process).
             with monkeypatch.context() as m:
-                m.setattr(exp._storage.__class__, 'fetch_lost_trials', fetch_lost_trials)
+                m.setattr(
+                    exp._storage.__class__, "fetch_lost_trials", fetch_lost_trials
+                )
 
                 assert len(exp._storage.fetch_lost_trials(exp)) == 1
 
                 with caplog.at_level(logging.DEBUG):
                     exp.fix_lost_trials()
 
-            assert caplog.records[-1].levelname == 'DEBUG'
-            assert caplog.records[-1].msg == 'failed'
-            assert len(exp.fetch_trials_by_status('interrupted')) == 1
-            assert len(exp.fetch_trials_by_status('reserved')) == 0
+            assert caplog.records[-1].levelname == "DEBUG"
+            assert caplog.records[-1].msg == "failed"
+            assert len(exp.fetch_trials_by_status("interrupted")) == 1
+            assert len(exp.fetch_trials_by_status("reserved")) == 0
 
     def test_fix_lost_trials_configurable_hb(self):
         """Test that heartbeat is correctly being configured."""
         trial = copy.deepcopy(base_trial)
-        trial['status'] = 'reserved'
-        trial['heartbeat'] = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 2)
+        trial["status"] = "reserved"
+        trial["heartbeat"] = datetime.datetime.utcnow() - datetime.timedelta(
+            seconds=60 * 2
+        )
         with OrionState(trials=[trial]) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
 
-            assert len(exp.fetch_trials_by_status('reserved')) == 1
+            assert len(exp.fetch_trials_by_status("reserved")) == 1
 
             orion.core.config.worker.heartbeat = 60 * 2
 
             exp.fix_lost_trials()
 
-            assert len(exp.fetch_trials_by_status('reserved')) == 1
+            assert len(exp.fetch_trials_by_status("reserved")) == 1
 
-            orion.core.config.worker.heartbeat = 60 * 2 / 10.
+            orion.core.config.worker.heartbeat = 60 * 2 / 10.0
 
             exp.fix_lost_trials()
 
-            assert len(exp.fetch_trials_by_status('reserved')) == 0
+            assert len(exp.fetch_trials_by_status("reserved")) == 0
 
 
 def test_update_completed_trial(random_dt):
     """Successfully push a completed trial into database."""
-    with OrionState(trials=generate_trials(['new'])) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+    with OrionState(trials=generate_trials(["new"])) as cfg:
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         trial = exp.reserve_trial()
 
         results_file = tempfile.NamedTemporaryFile(
-            mode='w', prefix='results_', suffix='.log', dir='.', delete=True
+            mode="w", prefix="results_", suffix=".log", dir=".", delete=True
         )
 
         # Generate fake result
-        with open(results_file.name, 'w') as file:
-            json.dump([{
-                'name': 'loss',
-                'type': 'objective',
-                'value': 2}],
-                file
-            )
+        with open(results_file.name, "w") as file:
+            json.dump([{"name": "loss", "type": "objective", "value": 2}], file)
         # --
 
         exp.update_completed_trial(trial, results_file=results_file)
 
         yo = get_storage().fetch_trials(exp)[0].to_dict()
 
-        assert len(yo['results']) == len(trial.results)
-        assert yo['results'][0] == trial.results[0].to_dict()
-        assert yo['status'] == 'completed'
-        assert yo['end_time'] == random_dt
+        assert len(yo["results"]) == len(trial.results)
+        assert yo["results"][0] == trial.results[0].to_dict()
+        assert yo["status"] == "completed"
+        assert yo["end_time"] == random_dt
 
         results_file.close()
 
@@ -342,66 +354,77 @@ def test_update_completed_trial(random_dt):
 def test_register_trials(random_dt):
     """Register a list of newly proposed trials/parameters."""
     with OrionState():
-        exp = Experiment('supernaekei')
+        exp = Experiment("supernaekei")
         exp._id = 0
 
         trials = [
-            Trial(params=[{'name': 'a', 'type': 'integer', 'value': 5}]),
-            Trial(params=[{'name': 'b', 'type': 'integer', 'value': 6}]),
-            ]
+            Trial(params=[{"name": "a", "type": "integer", "value": 5}]),
+            Trial(params=[{"name": "b", "type": "integer", "value": 6}]),
+        ]
         for trial in trials:
             exp.register_trial(trial)
 
         yo = list(map(lambda trial: trial.to_dict(), get_storage().fetch_trials(exp)))
         assert len(yo) == len(trials)
-        assert yo[0]['params'] == list(map(lambda x: x.to_dict(), trials[0]._params))
-        assert yo[1]['params'] == list(map(lambda x: x.to_dict(), trials[1]._params))
-        assert yo[0]['status'] == 'new'
-        assert yo[1]['status'] == 'new'
-        assert yo[0]['submit_time'] == random_dt
-        assert yo[1]['submit_time'] == random_dt
+        assert yo[0]["params"] == list(map(lambda x: x.to_dict(), trials[0]._params))
+        assert yo[1]["params"] == list(map(lambda x: x.to_dict(), trials[1]._params))
+        assert yo[0]["status"] == "new"
+        assert yo[1]["status"] == "new"
+        assert yo[0]["submit_time"] == random_dt
+        assert yo[1]["submit_time"] == random_dt
 
 
-class TestToPandas():
+class TestToPandas:
     """Test suite for ``Experiment.to_pandas``"""
 
     def test_empty(self, space):
         """Test panda frame creation when there is no trials"""
         with OrionState():
-            exp = Experiment('supernaekei')
+            exp = Experiment("supernaekei")
             exp.space = space
             assert exp.to_pandas().shape == (0, 8)
             assert list(exp.to_pandas().columns) == [
-                'id', 'experiment_id', 'status', 'suggested', 'reserved', 'completed',
-                'objective', '/index']
+                "id",
+                "experiment_id",
+                "status",
+                "suggested",
+                "reserved",
+                "completed",
+                "objective",
+                "/index",
+            ]
 
     def test_data(self, space):
         """Verify the data in the panda frame is coherent with database"""
-        with OrionState(trials=generate_trials(['new', 'reserved', 'completed'])) as cfg:
-            exp = Experiment('supernaekei')
-            exp._id = cfg.trials[0]['experiment']
+        with OrionState(
+            trials=generate_trials(["new", "reserved", "completed"])
+        ) as cfg:
+            exp = Experiment("supernaekei")
+            exp._id = cfg.trials[0]["experiment"]
             exp.space = space
             df = exp.to_pandas()
             assert df.shape == (3, 8)
-            assert list(df['id']) == [trial['_id'] for trial in cfg.trials]
-            assert all(df['experiment_id'] == exp._id)
-            assert list(df['status']) == ['completed', 'reserved', 'new']
-            assert list(df['suggested']) == [trial['submit_time'] for trial in cfg.trials]
-            assert df['reserved'][0] == cfg.trials[0]['start_time']
-            assert df['reserved'][1] == cfg.trials[1]['start_time']
-            assert df['reserved'][2] is pandas.NaT
-            assert df['completed'][0] == cfg.trials[0]['end_time']
-            assert df['completed'][1] is pandas.NaT
-            assert df['completed'][2] is pandas.NaT
-            assert list(df['objective']) == [2, 1, 0]
-            assert list(df['/index']) == [2, 1, 0]
+            assert list(df["id"]) == [trial["_id"] for trial in cfg.trials]
+            assert all(df["experiment_id"] == exp._id)
+            assert list(df["status"]) == ["completed", "reserved", "new"]
+            assert list(df["suggested"]) == [
+                trial["submit_time"] for trial in cfg.trials
+            ]
+            assert df["reserved"][0] == cfg.trials[0]["start_time"]
+            assert df["reserved"][1] == cfg.trials[1]["start_time"]
+            assert df["reserved"][2] is pandas.NaT
+            assert df["completed"][0] == cfg.trials[0]["end_time"]
+            assert df["completed"][1] is pandas.NaT
+            assert df["completed"][2] is pandas.NaT
+            assert list(df["objective"]) == [2, 1, 0]
+            assert list(df["/index"]) == [2, 1, 0]
 
 
 def test_fetch_all_trials():
     """Fetch a list of all trials"""
-    with OrionState(trials=generate_trials(['new', 'reserved', 'completed'])) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+    with OrionState(trials=generate_trials(["new", "reserved", "completed"])) as cfg:
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         trials = list(map(lambda trial: trial.to_dict(), exp.fetch_trials({})))
         assert trials == cfg.trials
@@ -412,11 +435,11 @@ def test_fetch_non_completed_trials():
 
     trials.status in ['new', 'interrupted', 'suspended', 'broken']
     """
-    non_completed_stati = ['new', 'interrupted', 'suspended', 'reserved']
-    stati = non_completed_stati + ['completed']
+    non_completed_stati = ["new", "interrupted", "suspended", "reserved"]
+    stati = non_completed_stati + ["completed"]
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         trials = exp.fetch_noncompleted_trials()
         assert len(trials) == 4
@@ -425,11 +448,11 @@ def test_fetch_non_completed_trials():
 
 def test_is_done_property_with_pending(algorithm):
     """Check experiment stopping conditions when there is pending trials."""
-    completed = ['completed'] * 10
-    reserved = ['reserved'] * 5
+    completed = ["completed"] * 10
+    reserved = ["reserved"] * 5
     with OrionState(trials=generate_trials(completed + reserved)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp.algorithms = algorithm
         exp.max_trials = 10
@@ -449,11 +472,11 @@ def test_is_done_property_with_pending(algorithm):
 
 def test_is_done_property_no_pending(algorithm):
     """Check experiment stopping conditions when there is no pending trials."""
-    completed = ['completed'] * 10
-    broken = ['broken'] * 5
+    completed = ["completed"] * 10
+    broken = ["broken"] * 5
     with OrionState(trials=generate_trials(completed + broken)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp.algorithms = algorithm
 
@@ -472,19 +495,19 @@ def test_broken_property():
     """Check experiment stopping conditions for maximum number of broken."""
     MAX_BROKEN = 5
 
-    stati = (['reserved'] * 10) + (['broken'] * (MAX_BROKEN - 1))
+    stati = (["reserved"] * 10) + (["broken"] * (MAX_BROKEN - 1))
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp.max_broken = MAX_BROKEN
 
         assert not exp.is_broken
 
-    stati = (['reserved'] * 10) + (['broken'] * (MAX_BROKEN))
+    stati = (["reserved"] * 10) + (["broken"] * (MAX_BROKEN))
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp.max_broken = MAX_BROKEN
 
@@ -495,10 +518,10 @@ def test_configurable_broken_property():
     """Check if max_broken changes after configuration."""
     MAX_BROKEN = 5
 
-    stati = (['reserved'] * 10) + (['broken'] * (MAX_BROKEN))
+    stati = (["reserved"] * 10) + (["broken"] * (MAX_BROKEN))
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp.max_broken = MAX_BROKEN
 
@@ -512,42 +535,42 @@ def test_configurable_broken_property():
 def test_experiment_stats():
     """Check that property stats is returning a proper summary of experiment's results."""
     NUM_COMPLETED = 3
-    stati = (['completed'] * NUM_COMPLETED) + (['reserved'] * 2)
+    stati = (["completed"] * NUM_COMPLETED) + (["reserved"] * 2)
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
-        exp.metadata = {'datetime': datetime.datetime.utcnow()}
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
+        exp.metadata = {"datetime": datetime.datetime.utcnow()}
         stats = exp.stats
-        assert stats['trials_completed'] == NUM_COMPLETED
-        assert stats['best_trials_id'] == cfg.trials[3]['_id']
-        assert stats['best_evaluation'] == 0
-        assert stats['start_time'] == exp.metadata['datetime']
-        assert stats['finish_time'] == cfg.trials[0]['end_time']
-        assert stats['duration'] == stats['finish_time'] - stats['start_time']
+        assert stats["trials_completed"] == NUM_COMPLETED
+        assert stats["best_trials_id"] == cfg.trials[3]["_id"]
+        assert stats["best_evaluation"] == 0
+        assert stats["start_time"] == exp.metadata["datetime"]
+        assert stats["finish_time"] == cfg.trials[0]["end_time"]
+        assert stats["duration"] == stats["finish_time"] - stats["start_time"]
         assert len(stats) == 6
 
 
 def test_fetch_completed_trials_from_view():
     """Fetch a list of the unseen yet completed trials."""
-    non_completed_stati = ['new', 'interrupted', 'suspended', 'reserved']
-    stati = non_completed_stati + ['completed']
+    non_completed_stati = ["new", "interrupted", "suspended", "reserved"]
+    stati = non_completed_stati + ["completed"]
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
         exp_view = ExperimentView(exp)
 
-        trials = exp_view.fetch_trials_by_status('completed')
+        trials = exp_view.fetch_trials_by_status("completed")
         assert len(trials) == 1
-        assert trials[0].status == 'completed'
+        assert trials[0].status == "completed"
 
 
 def test_view_is_done_property_with_pending(algorithm):
     """Check experiment stopping conditions from view when there is pending trials."""
-    completed = ['completed'] * 10
-    reserved = ['reserved'] * 5
+    completed = ["completed"] * 10
+    reserved = ["reserved"] * 5
     with OrionState(trials=generate_trials(completed + reserved)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
         exp.algorithms = algorithm
         exp.max_trials = 10
 
@@ -568,11 +591,11 @@ def test_view_is_done_property_with_pending(algorithm):
 
 def test_view_is_done_property_no_pending(algorithm):
     """Check experiment stopping conditions from view when there is no pending trials."""
-    completed = ['completed'] * 10
-    broken = ['broken'] * 5
+    completed = ["completed"] * 10
+    broken = ["broken"] * 5
     with OrionState(trials=generate_trials(completed + broken)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
         exp.algorithms = algorithm
         exp.max_trials = 100
 
@@ -594,28 +617,28 @@ def test_view_is_done_property_no_pending(algorithm):
 def test_experiment_view_stats():
     """Check that property stats from view is consistent."""
     NUM_COMPLETED = 3
-    stati = (['completed'] * NUM_COMPLETED) + (['reserved'] * 2)
+    stati = (["completed"] * NUM_COMPLETED) + (["reserved"] * 2)
     with OrionState(trials=generate_trials(stati)) as cfg:
-        exp = Experiment('supernaekei')
-        exp._id = cfg.trials[0]['experiment']
-        exp.metadata = {'datetime': datetime.datetime.utcnow()}
+        exp = Experiment("supernaekei")
+        exp._id = cfg.trials[0]["experiment"]
+        exp.metadata = {"datetime": datetime.datetime.utcnow()}
 
         exp_view = ExperimentView(exp)
 
         stats = exp_view.stats
-        assert stats['trials_completed'] == NUM_COMPLETED
-        assert stats['best_trials_id'] == cfg.trials[3]['_id']
-        assert stats['best_evaluation'] == 0
-        assert stats['start_time'] == exp_view.metadata['datetime']
-        assert stats['finish_time'] == cfg.trials[0]['end_time']
-        assert stats['duration'] == stats['finish_time'] - stats['start_time']
+        assert stats["trials_completed"] == NUM_COMPLETED
+        assert stats["best_trials_id"] == cfg.trials[3]["_id"]
+        assert stats["best_evaluation"] == 0
+        assert stats["start_time"] == exp_view.metadata["datetime"]
+        assert stats["finish_time"] == cfg.trials[0]["end_time"]
+        assert stats["duration"] == stats["finish_time"] - stats["start_time"]
         assert len(stats) == 6
 
 
 def test_experiment_view_protocol_read_only():
     """Verify that wrapper experiments' protocol is read-only"""
     with OrionState():
-        exp = Experiment('supernaekei')
+        exp = Experiment("supernaekei")
 
         exp_view = ExperimentView(exp)
 
@@ -628,10 +651,10 @@ def test_experiment_view_protocol_read_only():
 
 def test_view_is_broken():
     """Tests that property ``is_broken`` is accessible in an experiment's view"""
-    broken = ['broken'] * 5
+    broken = ["broken"] * 5
     with OrionState(trials=generate_trials(broken)) as cfg:
-        exp = Experiment('test-experiment')
-        exp._id = cfg.trials[0]['experiment']
+        exp = Experiment("test-experiment")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp.max_broken = 5
 

--- a/tests/unittests/core/worker/test_producer.py
+++ b/tests/unittests/core/worker/test_producer.py
@@ -30,7 +30,7 @@ class DumbParallelStrategy:
         else:
             value = len(self._observed_points)
 
-        self._lie = lie = Trial.Result(name='lie', type='lie', value=value)
+        self._lie = lie = Trial.Result(name="lie", type="lie", value=value)
         return lie
 
 
@@ -41,12 +41,16 @@ def produce_lies(producer):
 
 def update_algorithm(producer):
     """Wrap update of algorithm outside of `Producer.update`"""
-    return producer._update_algorithm(producer.experiment.fetch_trials_by_status('completed'))
+    return producer._update_algorithm(
+        producer.experiment.fetch_trials_by_status("completed")
+    )
 
 
 def update_naive_algorithm(producer):
     """Wrap update of naive algorithm outside of `Producer.update`"""
-    return producer._update_naive_algorithm(producer.experiment.fetch_noncompleted_trials())
+    return producer._update_naive_algorithm(
+        producer.experiment.fetch_noncompleted_trials()
+    )
 
 
 @pytest.fixture()
@@ -58,7 +62,7 @@ def producer(monkeypatch, hacked_exp, random_dt, exp_config, categorical_values)
     hacked_exp.algorithms.algorithm.possible_values = categorical_values
     hacked_exp.algorithms.seed_rng(0)
 
-    hacked_exp.producer['strategy'] = DumbParallelStrategy()
+    hacked_exp.producer["strategy"] = DumbParallelStrategy()
 
     producer = Producer(hacked_exp)
 
@@ -67,7 +71,7 @@ def producer(monkeypatch, hacked_exp, random_dt, exp_config, categorical_values)
         self.update()
         self.failure_count += 1
 
-    monkeypatch.setattr(Producer, 'backoff', backoff)
+    monkeypatch.setattr(Producer, "backoff", backoff)
 
     return producer
 
@@ -80,25 +84,13 @@ def test_algo_observe_completed(producer):
     obs_points = producer.algorithm.algorithm._points
     obs_results = producer.algorithm.algorithm._results
     assert len(obs_points) == 3
-    assert obs_points[0] == ('rnn', 'lstm')
-    assert obs_points[1] == ('rnn', 'rnn')
-    assert obs_points[2] == ('lstm_with_attention', 'gru')
+    assert obs_points[0] == ("rnn", "lstm")
+    assert obs_points[1] == ("rnn", "rnn")
+    assert obs_points[2] == ("lstm_with_attention", "gru")
     assert len(obs_results) == 3
-    assert obs_results[0] == {
-        'objective': 3,
-        'gradient': None,
-        'constraint': []
-        }
-    assert obs_results[1] == {
-        'objective': 2,
-        'gradient': (-0.1, 2),
-        'constraint': []
-        }
-    assert obs_results[2] == {
-        'objective': 10,
-        'gradient': (5, 3),
-        'constraint': [1.2]
-        }
+    assert obs_results[0] == {"objective": 3, "gradient": None, "constraint": []}
+    assert obs_results[1] == {"objective": 2, "gradient": (-0.1, 2), "constraint": []}
+    assert obs_results[2] == {"objective": 10, "gradient": (5, 3), "constraint": [1.2]}
 
 
 def test_strategist_observe_completed(producer):
@@ -109,34 +101,22 @@ def test_strategist_observe_completed(producer):
     obs_points = producer.strategy._observed_points
     obs_results = producer.strategy._observed_results
     assert len(obs_points) == 3
-    assert obs_points[0] == ('rnn', 'lstm')
-    assert obs_points[1] == ('rnn', 'rnn')
-    assert obs_points[2] == ('lstm_with_attention', 'gru')
+    assert obs_points[0] == ("rnn", "lstm")
+    assert obs_points[1] == ("rnn", "rnn")
+    assert obs_points[2] == ("lstm_with_attention", "gru")
     assert len(obs_results) == 3
-    assert obs_results[0] == {
-        'objective': 3,
-        'gradient': None,
-        'constraint': []
-        }
-    assert obs_results[1] == {
-        'objective': 2,
-        'gradient': (-0.1, 2),
-        'constraint': []
-        }
-    assert obs_results[2] == {
-        'objective': 10,
-        'gradient': (5, 3),
-        'constraint': [1.2]
-        }
+    assert obs_results[0] == {"objective": 3, "gradient": None, "constraint": []}
+    assert obs_results[1] == {"objective": 2, "gradient": (-0.1, 2), "constraint": []}
+    assert obs_results[2] == {"objective": 10, "gradient": (5, 3), "constraint": [1.2]}
 
 
 def test_naive_algorithm_is_producing(monkeypatch, producer, database, random_dt):
     """Verify naive algo is used to produce, not original algo"""
     producer.experiment.pool_size = 1
-    producer.algorithm.algorithm.possible_values = [('gru', 'rnn')]
+    producer.algorithm.algorithm.possible_values = [("gru", "rnn")]
     producer.update()
-    monkeypatch.setattr(producer.algorithm.algorithm, 'set_state', lambda value: None)
-    producer.algorithm.algorithm.possible_values = [('gru', 'gru')]
+    monkeypatch.setattr(producer.algorithm.algorithm, "set_state", lambda value: None)
+    producer.algorithm.algorithm.possible_values = [("gru", "gru")]
     producer.produce()
 
     assert producer.naive_algorithm.algorithm._num == 1  # pool size
@@ -145,7 +125,7 @@ def test_naive_algorithm_is_producing(monkeypatch, producer, database, random_dt
 
 def test_update_and_produce(producer, database, random_dt):
     """Test new trials are properly produced"""
-    possible_values = [('gru', 'rnn')]
+    possible_values = [("gru", "rnn")]
     producer.experiment.pool_size = 1
     producer.experiment.algorithms.algorithm.possible_values = possible_values
 
@@ -162,10 +142,10 @@ def test_update_and_produce(producer, database, random_dt):
 def test_register_new_trials(producer, database, random_dt):
     """Test new trials are properly registered"""
     trials_in_db_before = database.trials.count()
-    new_trials_in_db_before = database.trials.count({'status': 'new'})
+    new_trials_in_db_before = database.trials.count({"status": "new"})
 
     producer.experiment.pool_size = 1
-    producer.experiment.algorithms.algorithm.possible_values = [('gru', 'rnn')]
+    producer.experiment.algorithms.algorithm.possible_values = [("gru", "rnn")]
 
     producer.update()
     producer.produce()
@@ -176,27 +156,23 @@ def test_register_new_trials(producer, database, random_dt):
 
     # `num_new_points` new trials were registered at database
     assert database.trials.count() == trials_in_db_before + 1
-    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 1
-    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
-    assert new_trials[0]['experiment'] == producer.experiment.name
-    assert new_trials[0]['start_time'] is None
-    assert new_trials[0]['end_time'] is None
-    assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert database.trials.count({"status": "new"}) == new_trials_in_db_before + 1
+    new_trials = list(database.trials.find({"status": "new", "submit_time": random_dt}))
+    assert new_trials[0]["experiment"] == producer.experiment.name
+    assert new_trials[0]["start_time"] is None
+    assert new_trials[0]["end_time"] is None
+    assert new_trials[0]["results"] == []
+    assert new_trials[0]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+    ]
 
 
 def test_no_lies_if_all_trials_completed(producer, database, random_dt):
     """Verify that no lies are created if all trials are completed"""
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     database.trials.remove(query)
-    trials_in_db_before = database.trials.count({'experiment': producer.experiment.id})
+    trials_in_db_before = database.trials.count({"experiment": producer.experiment.id})
     assert trials_in_db_before == 3
 
     producer.update()
@@ -206,10 +182,10 @@ def test_no_lies_if_all_trials_completed(producer, database, random_dt):
 
 def test_lies_generation(producer, database, random_dt):
     """Verify that lies are created properly"""
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     trials_non_completed = list(database.trials.find(query))
     assert len(trials_non_completed) == 4
-    query = {'status': 'completed', 'experiment': producer.experiment.id}
+    query = {"status": "completed", "experiment": producer.experiment.id}
     trials_completed = list(database.trials.find(query))
     assert len(trials_completed) == 3
 
@@ -219,52 +195,64 @@ def test_lies_generation(producer, database, random_dt):
     assert len(lies) == 4
 
     trials_non_completed = list(
-        sorted(trials_non_completed,
-               key=lambda trial: trial.get('submit_time', datetime.datetime.utcnow())))
+        sorted(
+            trials_non_completed,
+            key=lambda trial: trial.get("submit_time", datetime.datetime.utcnow()),
+        )
+    )
 
     for i in range(4):
-        trials_non_completed[i]['_id'] = lies[i].id
-        trials_non_completed[i]['status'] = 'completed'
-        trials_non_completed[i]['end_time'] = random_dt
-        trials_non_completed[i]['results'].append(producer.strategy._lie.to_dict())
-        trials_non_completed[i]['parents'] = set([trial['_id'] for trial in trials_completed])
+        trials_non_completed[i]["_id"] = lies[i].id
+        trials_non_completed[i]["status"] = "completed"
+        trials_non_completed[i]["end_time"] = random_dt
+        trials_non_completed[i]["results"].append(producer.strategy._lie.to_dict())
+        trials_non_completed[i]["parents"] = set(
+            [trial["_id"] for trial in trials_completed]
+        )
         lies_dict = lies[i].to_dict()
-        lies_dict['parents'] = set(lies_dict['parents'])
+        lies_dict["parents"] = set(lies_dict["parents"])
         assert lies_dict == trials_non_completed[i]
 
 
 def test_register_lies(producer, database, random_dt):
     """Verify that lies are registed in DB properly"""
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     trials_non_completed = list(database.trials.find(query))
     assert len(trials_non_completed) == 4
-    query = {'status': 'completed', 'experiment': producer.experiment.id}
+    query = {"status": "completed", "experiment": producer.experiment.id}
     trials_completed = list(database.trials.find(query))
     assert len(trials_completed) == 3
 
     producer.update()
     produce_lies(producer)
 
-    lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
+    lying_trials = list(
+        database.lying_trials.find({"experiment": producer.experiment.id})
+    )
     assert len(lying_trials) == 4
 
     trials_non_completed = list(
-        sorted(trials_non_completed,
-               key=lambda trial: trial.get('submit_time', datetime.datetime.utcnow())))
+        sorted(
+            trials_non_completed,
+            key=lambda trial: trial.get("submit_time", datetime.datetime.utcnow()),
+        )
+    )
 
     for i in range(4):
-        trials_non_completed[i]['_id'] = lying_trials[i]['_id']
-        trials_non_completed[i]['status'] = 'completed'
-        trials_non_completed[i]['end_time'] = random_dt
-        trials_non_completed[i]['results'].append(producer.strategy._lie.to_dict())
-        trials_non_completed[i]['parents'] = set([trial['_id'] for trial in trials_completed])
-        lying_trials[i]['parents'] = set(lying_trials[i]['parents'])
+        trials_non_completed[i]["_id"] = lying_trials[i]["_id"]
+        trials_non_completed[i]["status"] = "completed"
+        trials_non_completed[i]["end_time"] = random_dt
+        trials_non_completed[i]["results"].append(producer.strategy._lie.to_dict())
+        trials_non_completed[i]["parents"] = set(
+            [trial["_id"] for trial in trials_completed]
+        )
+        lying_trials[i]["parents"] = set(lying_trials[i]["parents"])
         assert lying_trials[i] == trials_non_completed[i]
 
 
 def test_register_duplicate_lies(producer, database, random_dt):
     """Verify that duplicate lies are not registered twice in DB"""
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     trials_non_completed = list(database.trials.find(query))
     assert len(trials_non_completed) == 4
 
@@ -274,11 +262,13 @@ def test_register_duplicate_lies(producer, database, random_dt):
 
     # Set specific output value for to algo to ensure successful creation of a new trial.
     producer.experiment.pool_size = 1
-    producer.experiment.algorithms.algorithm.possible_values = [('gru', 'rnn')]
+    producer.experiment.algorithms.algorithm.possible_values = [("gru", "rnn")]
 
     producer.update()
     assert len(produce_lies(producer)) == 4
-    lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
+    lying_trials = list(
+        database.lying_trials.find({"experiment": producer.experiment.id})
+    )
     assert len(lying_trials) == 4
 
     # Create a new point to make sure additional non-completed trials increase number of lying
@@ -291,18 +281,22 @@ def test_register_duplicate_lies(producer, database, random_dt):
     producer.update()
 
     assert len(produce_lies(producer)) == 5
-    lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
+    lying_trials = list(
+        database.lying_trials.find({"experiment": producer.experiment.id})
+    )
     assert len(lying_trials) == 5
 
     # Make sure trying to generate again does not add more fake trials since they are identical
     assert len(produce_lies(producer)) == 5
-    lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
+    lying_trials = list(
+        database.lying_trials.find({"experiment": producer.experiment.id})
+    )
     assert len(lying_trials) == 5
 
 
 def test_register_duplicate_lies_with_different_results(producer, database, random_dt):
     """Verify that duplicate lies with different results are all registered in DB"""
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     trials_non_completed = list(database.trials.find(query))
     assert len(trials_non_completed) == 4
 
@@ -310,7 +304,9 @@ def test_register_duplicate_lies_with_different_results(producer, database, rand
     producer.strategy._value = 11
 
     assert len(produce_lies(producer)) == 4
-    lying_trials = list(database.lying_trials.find({'experiment': producer.experiment.id}))
+    lying_trials = list(
+        database.lying_trials.find({"experiment": producer.experiment.id})
+    )
     assert len(lying_trials) == 4
 
     # Overwrite value of lying result to force different results.
@@ -318,16 +314,20 @@ def test_register_duplicate_lies_with_different_results(producer, database, rand
 
     lying_trials = produce_lies(producer)
     assert len(lying_trials) == 4
-    nb_lying_trials = database.lying_trials.count({'experiment': producer.experiment.id})
+    nb_lying_trials = database.lying_trials.count(
+        {"experiment": producer.experiment.id}
+    )
     assert nb_lying_trials == 4 + 4
     assert lying_trials[0].lie.value == new_lying_value
 
 
-def test_naive_algo_not_trained_when_all_trials_completed(producer, database, random_dt):
+def test_naive_algo_not_trained_when_all_trials_completed(
+    producer, database, random_dt
+):
     """Verify that naive algo is not trained on additional trials when all completed"""
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     database.trials.remove(query)
-    trials_in_db_before = database.trials.count({'experiment': producer.experiment.id})
+    trials_in_db_before = database.trials.count({"experiment": producer.experiment.id})
     assert trials_in_db_before == 3
 
     producer.update()
@@ -339,19 +339,24 @@ def test_naive_algo_not_trained_when_all_trials_completed(producer, database, ra
 def test_naive_algo_trained_on_all_non_completed_trials(producer, database, random_dt):
     """Verify that naive algo is trained on additional trials"""
     # Set two of completed trials to broken and reserved to have all possible status
-    query = {'status': 'completed', 'experiment': producer.experiment.id}
+    query = {"status": "completed", "experiment": producer.experiment.id}
     completed_trials = database.trials.find(query)
-    database.trials.update({'_id': completed_trials[0]['_id']}, {'$set': {'status': 'broken'}})
-    database.trials.update({'_id': completed_trials[1]['_id']}, {'$set': {'status': 'reserved'}})
+    database.trials.update(
+        {"_id": completed_trials[0]["_id"]}, {"$set": {"status": "broken"}}
+    )
+    database.trials.update(
+        {"_id": completed_trials[1]["_id"]}, {"$set": {"status": "reserved"}}
+    )
 
     # Make sure non completed trials and completed trials are set properly for the unit-test
-    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    query = {"status": {"$ne": "completed"}, "experiment": producer.experiment.id}
     non_completed_trials = list(database.trials.find(query))
     assert len(non_completed_trials) == 6
     # Make sure we have all type of status except completed
-    assert (set(trial['status'] for trial in non_completed_trials) ==
-            set(['new', 'reserved', 'suspended', 'interrupted', 'broken']))
-    query = {'status': 'completed', 'experiment': producer.experiment.id}
+    assert set(trial["status"] for trial in non_completed_trials) == set(
+        ["new", "reserved", "suspended", "interrupted", "broken"]
+    )
+    query = {"status": "completed", "experiment": producer.experiment.id}
     assert database.trials.count(query) == 1
 
     # Executing the actual test
@@ -366,7 +371,7 @@ def test_naive_algo_is_discared(producer, database, monkeypatch):
     """Verify that naive algo is discarded and recopied from original algo"""
     # Set values for predictions
     producer.experiment.pool_size = 1
-    producer.experiment.algorithms.algorithm.possible_values = [('gru', 'rnn')]
+    producer.experiment.algorithms.algorithm.possible_values = [("gru", "rnn")]
 
     producer.update()
     assert len(produce_lies(producer)) == 4
@@ -393,13 +398,13 @@ def test_naive_algo_is_discared(producer, database, monkeypatch):
 def test_concurent_producers(producer, database, random_dt):
     """Test concurrent production of new trials."""
     trials_in_db_before = database.trials.count()
-    new_trials_in_db_before = database.trials.count({'status': 'new'})
+    new_trials_in_db_before = database.trials.count({"status": "new"})
 
     # Set so that first producer's algorithm generate valid point on first time
     # And second producer produce same point and thus must produce next one two.
     # Hence, we know that producer algo will have _num == 1 and
     # second producer algo will have _num == 2
-    producer.algorithm.algorithm.possible_values = [('gru', 'rnn'), ('gru', 'gru')]
+    producer.algorithm.algorithm.possible_values = [("gru", "rnn"), ("gru", "gru")]
     # Make sure it starts from index 0
     producer.algorithm.seed_rng(0)
 
@@ -422,29 +427,21 @@ def test_concurent_producers(producer, database, random_dt):
 
     # `num_new_points` new trials were registered at database
     assert database.trials.count() == trials_in_db_before + 2
-    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
-    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
-    assert new_trials[0]['experiment'] == producer.experiment.name
-    assert new_trials[0]['start_time'] is None
-    assert new_trials[0]['end_time'] is None
-    assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert database.trials.count({"status": "new"}) == new_trials_in_db_before + 2
+    new_trials = list(database.trials.find({"status": "new", "submit_time": random_dt}))
+    assert new_trials[0]["experiment"] == producer.experiment.name
+    assert new_trials[0]["start_time"] is None
+    assert new_trials[0]["end_time"] is None
+    assert new_trials[0]["results"] == []
+    assert new_trials[0]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+    ]
 
-    assert new_trials[1]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
+    assert new_trials[1]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "gru"},
+    ]
 
 
 def test_duplicate_within_pool(producer, database, random_dt):
@@ -452,12 +449,15 @@ def test_duplicate_within_pool(producer, database, random_dt):
     if one of them is a duplicate.
     """
     trials_in_db_before = database.trials.count()
-    new_trials_in_db_before = database.trials.count({'status': 'new'})
+    new_trials_in_db_before = database.trials.count({"status": "new"})
 
     producer.experiment.pool_size = 2
 
     producer.experiment.algorithms.algorithm.possible_values = [
-        ('gru', 'rnn'), ('gru', 'rnn'), ('gru', 'gru')]
+        ("gru", "rnn"),
+        ("gru", "rnn"),
+        ("gru", "gru"),
+    ]
 
     producer.update()
     producer.produce()
@@ -468,29 +468,21 @@ def test_duplicate_within_pool(producer, database, random_dt):
 
     # `num_new_points` new trials were registered at database
     assert database.trials.count() == trials_in_db_before + 2
-    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
-    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
-    assert new_trials[0]['experiment'] == producer.experiment.name
-    assert new_trials[0]['start_time'] is None
-    assert new_trials[0]['end_time'] is None
-    assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert database.trials.count({"status": "new"}) == new_trials_in_db_before + 2
+    new_trials = list(database.trials.find({"status": "new", "submit_time": random_dt}))
+    assert new_trials[0]["experiment"] == producer.experiment.name
+    assert new_trials[0]["start_time"] is None
+    assert new_trials[0]["end_time"] is None
+    assert new_trials[0]["results"] == []
+    assert new_trials[0]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+    ]
 
-    assert new_trials[1]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
+    assert new_trials[1]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "gru"},
+    ]
 
 
 def test_duplicate_within_pool_and_db(producer, database, random_dt):
@@ -498,12 +490,15 @@ def test_duplicate_within_pool_and_db(producer, database, random_dt):
     if one of them is a duplicate with db.
     """
     trials_in_db_before = database.trials.count()
-    new_trials_in_db_before = database.trials.count({'status': 'new'})
+    new_trials_in_db_before = database.trials.count({"status": "new"})
 
     producer.experiment.pool_size = 2
 
     producer.experiment.algorithms.algorithm.possible_values = [
-        ('gru', 'rnn'), ('rnn', 'rnn'), ('gru', 'gru')]
+        ("gru", "rnn"),
+        ("rnn", "rnn"),
+        ("gru", "gru"),
+    ]
 
     producer.update()
     producer.produce()
@@ -514,36 +509,28 @@ def test_duplicate_within_pool_and_db(producer, database, random_dt):
 
     # `num_new_points` new trials were registered at database
     assert database.trials.count() == trials_in_db_before + 2
-    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
-    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
-    assert new_trials[0]['experiment'] == producer.experiment.name
-    assert new_trials[0]['start_time'] is None
-    assert new_trials[0]['end_time'] is None
-    assert new_trials[0]['results'] == []
-    assert new_trials[0]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'}
-        ]
+    assert database.trials.count({"status": "new"}) == new_trials_in_db_before + 2
+    new_trials = list(database.trials.find({"status": "new", "submit_time": random_dt}))
+    assert new_trials[0]["experiment"] == producer.experiment.name
+    assert new_trials[0]["start_time"] is None
+    assert new_trials[0]["end_time"] is None
+    assert new_trials[0]["results"] == []
+    assert new_trials[0]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+    ]
 
-    assert new_trials[1]['params'] == [
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'},
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
+    assert new_trials[1]["params"] == [
+        {"name": "/decoding_layer", "type": "categorical", "value": "gru"},
+        {"name": "/encoding_layer", "type": "categorical", "value": "gru"},
+    ]
 
 
 def test_exceed_max_idle_time_because_of_duplicates(producer, database, random_dt):
     """Test that RuntimeError is raised when algo keep suggesting the same points"""
     timeout = 3
     producer.max_idle_time = timeout  # to limit run-time, default would work as well.
-    producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'rnn')]
+    producer.experiment.algorithms.algorithm.possible_values = [("rnn", "rnn")]
 
     assert producer.experiment.pool_size == 1
 
@@ -557,7 +544,9 @@ def test_exceed_max_idle_time_because_of_duplicates(producer, database, random_d
     assert timeout <= time.time() - start < timeout + 1
 
 
-def test_exceed_max_idle_time_because_of_optout(producer, database, random_dt, monkeypatch):
+def test_exceed_max_idle_time_because_of_optout(
+    producer, database, random_dt, monkeypatch
+):
     """Test that RuntimeError is raised when algo keeps opting out"""
     timeout = 3
     producer.max_idle_time = timeout  # to limit run-time, default would work as well.
@@ -567,7 +556,9 @@ def test_exceed_max_idle_time_because_of_optout(producer, database, random_dt, m
         self._suggested = None
         return None
 
-    monkeypatch.setattr(producer.experiment.algorithms.algorithm.__class__, 'suggest', opt_out)
+    monkeypatch.setattr(
+        producer.experiment.algorithms.algorithm.__class__, "suggest", opt_out
+    )
 
     assert producer.experiment.pool_size == 1
 
@@ -579,15 +570,19 @@ def test_exceed_max_idle_time_because_of_optout(producer, database, random_dt, m
 
 def test_stops_if_algo_done(producer, database, random_dt, monkeypatch):
     """Test that producer stops producing when algo is done."""
+
     def opt_out_and_complete(self, num=1):
         """Return None to always opt out and set id_done to True"""
         self._suggested = None
         self.done = True
-        print('set')
+        print("set")
         return None
 
-    monkeypatch.setattr(producer.experiment.algorithms.algorithm.__class__, 'suggest',
-                        opt_out_and_complete)
+    monkeypatch.setattr(
+        producer.experiment.algorithms.algorithm.__class__,
+        "suggest",
+        opt_out_and_complete,
+    )
 
     assert producer.experiment.pool_size == 1
 
@@ -632,13 +627,15 @@ def test_original_seeding(producer, database):
 def test_evc(monkeypatch, producer):
     """Verify that producer is using available trials from EVC"""
     experiment = producer.experiment
-    new_experiment = build(experiment.name, algorithms='random')
+    new_experiment = build(experiment.name, algorithms="random")
 
     # Replace parent with hacked exp, otherwise parent ID does not match trials in DB
     # and fetch_trials() won't return anything.
     new_experiment._node.parent._item = experiment
 
-    assert len(new_experiment.fetch_trials(with_evc_tree=True)) == len(experiment.fetch_trials())
+    assert len(new_experiment.fetch_trials(with_evc_tree=True)) == len(
+        experiment.fetch_trials()
+    )
 
     producer.experiment = new_experiment
 
@@ -648,8 +645,8 @@ def test_evc(monkeypatch, producer):
     def update_naive_algo(trials):
         assert len(trials) == 4
 
-    monkeypatch.setattr(producer, '_update_algorithm', update_algo)
-    monkeypatch.setattr(producer, '_update_naive_algorithm', update_naive_algo)
+    monkeypatch.setattr(producer, "_update_algorithm", update_algo)
+    monkeypatch.setattr(producer, "_update_naive_algorithm", update_naive_algo)
 
     producer.update()
 
@@ -657,13 +654,15 @@ def test_evc(monkeypatch, producer):
 def test_evc_duplicates(monkeypatch, producer):
     """Verify that producer wont register samples that are available in parent experiment"""
     experiment = producer.experiment
-    new_experiment = build(experiment.name, algorithms='random')
+    new_experiment = build(experiment.name, algorithms="random")
 
     # Replace parent with hacked exp, otherwise parent ID does not match trials in DB
     # and fetch_trials() won't return anything.
     new_experiment._node.parent._item = experiment
 
-    assert len(new_experiment.fetch_trials(with_evc_tree=True)) == len(experiment.fetch_trials())
+    assert len(new_experiment.fetch_trials(with_evc_tree=True)) == len(
+        experiment.fetch_trials()
+    )
 
     def suggest(pool_size):
         return [trial_to_tuple(experiment.fetch_trials()[-1], experiment.space)]
@@ -672,7 +671,7 @@ def test_evc_duplicates(monkeypatch, producer):
     producer.algorithm = new_experiment.algorithms
     producer.max_idle_time = 1
 
-    monkeypatch.setattr(new_experiment.algorithms, 'suggest', suggest)
+    monkeypatch.setattr(new_experiment.algorithms, "suggest", suggest)
 
     producer.update()
     with pytest.raises(SampleTimeout):
@@ -690,11 +689,12 @@ def test_algorithm_is_done(monkeypatch, producer):
 
     def suggest_one_only(self, num=1):
         """Return only one point, whatever `num` is"""
-        return [('gru', 'rnn')]
+        return [("gru", "rnn")]
 
-    monkeypatch.delattr(producer.experiment.algorithms.algorithm.__class__, 'is_done')
-    monkeypatch.setattr(producer.experiment.algorithms.algorithm.__class__, 'suggest',
-                        suggest_one_only)
+    monkeypatch.delattr(producer.experiment.algorithms.algorithm.__class__, "is_done")
+    monkeypatch.setattr(
+        producer.experiment.algorithms.algorithm.__class__, "suggest", suggest_one_only
+    )
 
     assert producer.experiment.pool_size == 10
     trials_in_exp_before = len(producer.experiment.fetch_trials())

--- a/tests/unittests/core/worker/test_trial.py
+++ b/tests/unittests/core/worker/test_trial.py
@@ -15,7 +15,7 @@ class TestTrial(object):
         """Initialize empty trial."""
         t = Trial()
         assert t.experiment is None
-        assert t.status == 'new'
+        assert t.status == "new"
         assert t.worker is None
         assert t.submit_time is None
         assert t.start_time is None
@@ -27,24 +27,26 @@ class TestTrial(object):
     def test_init_full(self, exp_config):
         """Initialize with a dictionary with complete specification."""
         t = Trial(**exp_config[1][1])
-        assert t.experiment == exp_config[1][1]['experiment']
-        assert t.status == exp_config[1][1]['status']
-        assert t.worker == exp_config[1][1]['worker']
-        assert t.submit_time == exp_config[1][1]['submit_time']
-        assert t.start_time == exp_config[1][1]['start_time']
-        assert t.end_time == exp_config[1][1]['end_time']
-        assert list(map(lambda x: x.to_dict(), t.results)) == exp_config[1][1]['results']
-        assert t.results[0].name == exp_config[1][1]['results'][0]['name']
-        assert t.results[0].type == exp_config[1][1]['results'][0]['type']
-        assert t.results[0].value == exp_config[1][1]['results'][0]['value']
-        assert list(map(lambda x: x.to_dict(), t._params)) == exp_config[1][1]['params']
+        assert t.experiment == exp_config[1][1]["experiment"]
+        assert t.status == exp_config[1][1]["status"]
+        assert t.worker == exp_config[1][1]["worker"]
+        assert t.submit_time == exp_config[1][1]["submit_time"]
+        assert t.start_time == exp_config[1][1]["start_time"]
+        assert t.end_time == exp_config[1][1]["end_time"]
+        assert (
+            list(map(lambda x: x.to_dict(), t.results)) == exp_config[1][1]["results"]
+        )
+        assert t.results[0].name == exp_config[1][1]["results"][0]["name"]
+        assert t.results[0].type == exp_config[1][1]["results"][0]["type"]
+        assert t.results[0].value == exp_config[1][1]["results"][0]["value"]
+        assert list(map(lambda x: x.to_dict(), t._params)) == exp_config[1][1]["params"]
         assert t.working_dir is None
 
     def test_higher_shapes_not_ndarray(self):
         """Test that `numpy.ndarray` values are converted to list."""
         value = numpy.zeros([3])
         expected = value.tolist()
-        params = [dict(name='/x', type='real', value=value)]
+        params = [dict(name="/x", type="real", value=value)]
         trial = Trial(params=params)
 
         assert trial._params[0].value == expected
@@ -58,30 +60,30 @@ class TestTrial(object):
     def test_bad_init(self):
         """Other than `Trial.__slots__` are not allowed in __init__ too."""
         with pytest.raises(AttributeError):
-            Trial(ispii='iela')
+            Trial(ispii="iela")
 
     def test_value_bad_init(self):
         """Other than `Trial.Value.__slots__` are not allowed in __init__ too."""
         with pytest.raises(AttributeError):
-            Trial.Value(ispii='iela')
+            Trial.Value(ispii="iela")
 
     def test_param_bad_init(self):
         """Other than `Trial.Param.__slots__` are not allowed in __init__ too."""
         with pytest.raises(AttributeError):
-            Trial.Param(ispii='iela')
+            Trial.Param(ispii="iela")
 
     def test_result_bad_init(self):
         """Other than `Trial.Result.__slots__` are not allowed in __init__ too."""
         with pytest.raises(AttributeError):
-            Trial.Result(ispii='iela')
+            Trial.Result(ispii="iela")
 
     def test_not_allowed_status(self):
         """Other than `Trial.allowed_stati` are not allowed in `Trial.status`."""
         t = Trial()
         with pytest.raises(ValueError):
-            t.status = 'asdf'
+            t.status = "asdf"
         with pytest.raises(ValueError):
-            t = Trial(status='ispi')
+            t = Trial(status="ispi")
 
     def test_value_not_allowed_type(self):
         """Other than `Trial.Result.allowed_types` are not allowed in `Trial.Result.type`.
@@ -89,16 +91,16 @@ class TestTrial(object):
         Same for `Trial.Param`.
         """
         with pytest.raises(ValueError):
-            v = Trial.Result(name='asfda', type='hoho')
+            v = Trial.Result(name="asfda", type="hoho")
         v = Trial.Result()
         with pytest.raises(ValueError):
-            v.type = 'asfda'
+            v.type = "asfda"
 
         with pytest.raises(ValueError):
-            v = Trial.Param(name='asfda', type='hoho')
+            v = Trial.Param(name="asfda", type="hoho")
         v = Trial.Param()
         with pytest.raises(ValueError):
-            v.type = 'asfda'
+            v.type = "asfda"
 
     @pytest.mark.usefixtures("clean_db")
     def test_convertion_to_dict(self, exp_config):
@@ -117,51 +119,57 @@ class TestTrial(object):
         """Compare Param objects using __eq__"""
         trials = Trial.build(exp_config[1])
 
-        assert trials[0]._params[0] == Trial.Param(**exp_config[1][0]['params'][0])
-        assert trials[0]._params[1] != Trial.Param(**exp_config[1][0]['params'][0])
+        assert trials[0]._params[0] == Trial.Param(**exp_config[1][0]["params"][0])
+        assert trials[0]._params[1] != Trial.Param(**exp_config[1][0]["params"][0])
 
     def test_str_trial(self, exp_config):
         """Test representation of `Trial`."""
         t = Trial(**exp_config[1][1])
-        assert str(t) == "Trial(experiment='supernaedo2-dendi', status='completed', " \
-                         "params=/decoding_layer:lstm_with_attention,/encoding_layer:gru)"
+        assert (
+            str(t) == "Trial(experiment='supernaedo2-dendi', status='completed', "
+            "params=/decoding_layer:lstm_with_attention,/encoding_layer:gru)"
+        )
 
     def test_str_value(self, exp_config):
         """Test representation of `Trial.Value`."""
         t = Trial(**exp_config[1][1])
-        assert (str(t._params[1]) ==
-                "Param(name='/encoding_layer', type='categorical', value='gru')")
+        assert (
+            str(t._params[1])
+            == "Param(name='/encoding_layer', type='categorical', value='gru')"
+        )
 
     def test_invalid_result(self, exp_config):
         """Test that invalid objectives cannot be set"""
         t = Trial(**exp_config[1][1])
 
         # Make sure valid ones pass
-        t.results = [Trial.Result(name='asfda', type='constraint', value=None),
-                     Trial.Result(name='asfdb', type='objective', value=1e-5)]
+        t.results = [
+            Trial.Result(name="asfda", type="constraint", value=None),
+            Trial.Result(name="asfdb", type="objective", value=1e-5),
+        ]
 
         # No results at all
         with pytest.raises(ValueError) as exc:
             t.results = []
-        assert 'No objective found' in str(exc.value)
+        assert "No objective found" in str(exc.value)
 
         # No objectives
         with pytest.raises(ValueError) as exc:
-            t.results = [Trial.Result(name='asfda', type='constraint', value=None)]
-        assert 'No objective found' in str(exc.value)
+            t.results = [Trial.Result(name="asfda", type="constraint", value=None)]
+        assert "No objective found" in str(exc.value)
 
         # Bad objective type
         with pytest.raises(ValueError) as exc:
-            t.results = [Trial.Result(name='asfda', type='constraint', value=None),
-                         Trial.Result(name='asfdb', type='objective', value=None)]
-        assert 'Results must contain' in str(exc.value)
+            t.results = [
+                Trial.Result(name="asfda", type="constraint", value=None),
+                Trial.Result(name="asfdb", type="objective", value=None),
+            ]
+        assert "Results must contain" in str(exc.value)
 
     def test_objective_property(self):
         """Check property `Trial.objective`."""
-        base_trial = {
-            'results': []
-        }
-        base_trial['results'].append({'name': 'a', 'type': 'gradient', 'value': 0.5})
+        base_trial = {"results": []}
+        base_trial["results"].append({"name": "a", "type": "gradient", "value": 0.5})
 
         # 0 objective in `results` list
         trial = Trial(**base_trial)
@@ -169,119 +177,111 @@ class TestTrial(object):
         assert trial.objective is None
 
         # 1 results in `results` list
-        expected = Trial.Result(name='b', type='objective', value=42)
+        expected = Trial.Result(name="b", type="objective", value=42)
 
-        base_trial['results'].append({'name': 'b', 'type': 'objective', 'value': 42})
+        base_trial["results"].append({"name": "b", "type": "objective", "value": 42})
         trial = Trial(**base_trial)
 
         assert trial.objective == expected
 
         # >1 results in `results` list
-        base_trial['results'].append({'name': 'c', 'type': 'objective', 'value': 42})
+        base_trial["results"].append({"name": "c", "type": "objective", "value": 42})
         trial = Trial(**base_trial)
 
         assert trial.objective == expected
 
     def test_gradient_property(self):
         """Check property `Trial.gradient`."""
-        base_trial = {
-            'results': []
-        }
+        base_trial = {"results": []}
 
         # 0 result exist
         trial = Trial(**base_trial)
         assert trial.gradient is None
 
         # 0 result of type 'gradient' exist
-        base_trial['results'].append({'name': 'a', 'type': 'objective', 'value': 10})
+        base_trial["results"].append({"name": "a", "type": "objective", "value": 10})
         trial = Trial(**base_trial)
 
         assert trial.gradient is None
 
         # 1 result of type 'gradient' exist
-        expected = Trial.Result(name='b', type='gradient', value=5)
+        expected = Trial.Result(name="b", type="gradient", value=5)
 
-        base_trial['results'].append({'name': 'b', 'type': 'gradient', 'value': 5})
+        base_trial["results"].append({"name": "b", "type": "gradient", "value": 5})
         trial = Trial(**base_trial)
 
         assert trial.gradient == expected
 
         # >1 gradient result
-        base_trial['results'].append({'name': 'c', 'type': 'gradient', 'value': [12, 15]})
+        base_trial["results"].append(
+            {"name": "c", "type": "gradient", "value": [12, 15]}
+        )
         trial = Trial(**base_trial)
 
         assert trial.gradient == expected
 
     def test_constraints_property(self):
         """Tests the property for accessing constraints"""
-        base_trial = {
-            'results': []
-        }
+        base_trial = {"results": []}
 
         # 0 result exist
         trial = Trial(**base_trial)
         assert trial.constraints == []
 
         # 0 result of type 'constraints' exist
-        base_trial['results'].append({'name': 'a', 'type': 'objective', 'value': 10})
+        base_trial["results"].append({"name": "a", "type": "objective", "value": 10})
         trial = Trial(**base_trial)
 
         assert trial.constraints == []
 
         # 1 result of type 'constraint' exist
-        expected = [
-            Trial.Result(name='b', type='constraint', value=5)
-        ]
+        expected = [Trial.Result(name="b", type="constraint", value=5)]
 
-        base_trial['results'].append({'name': 'b', 'type': 'constraint', 'value': 5})
+        base_trial["results"].append({"name": "b", "type": "constraint", "value": 5})
         trial = Trial(**base_trial)
 
         assert expected == trial.constraints
 
         # > 1 results of type 'constraint' exist
         expected = [
-            Trial.Result(name='b', type='constraint', value=5),
-            Trial.Result(name='c', type='constraint', value=20)
+            Trial.Result(name="b", type="constraint", value=5),
+            Trial.Result(name="c", type="constraint", value=20),
         ]
 
-        base_trial['results'].append({'name': 'c', 'type': 'constraint', 'value': 20})
+        base_trial["results"].append({"name": "c", "type": "constraint", "value": 20})
         trial = Trial(**base_trial)
 
         assert expected == trial.constraints
 
     def test_statistics_property(self):
         """Tests the property for accessing statistics"""
-        base_trial = {
-            'results': []
-        }
+        base_trial = {"results": []}
 
         # 0 result exist
         trial = Trial(**base_trial)
         assert trial.statistics == []
 
         # 0 result of type 'statistic' exist
-        base_trial['results'].append({'name': 'a', 'type': 'objective', 'value': 10})
+        base_trial["results"].append({"name": "a", "type": "objective", "value": 10})
         trial = Trial(**base_trial)
 
         assert trial.statistics == []
 
         # 1 result of type 'statistic' exist
-        expected = [
-            Trial.Result(name='b', type='statistic', value=5)
-        ]
+        expected = [Trial.Result(name="b", type="statistic", value=5)]
 
-        base_trial['results'].append({'name': 'b', 'type': 'statistic', 'value': 5})
+        base_trial["results"].append({"name": "b", "type": "statistic", "value": 5})
         trial = Trial(**base_trial)
 
         assert expected == trial.statistics
 
         # > 1 results of type 'statistic' exist
         expected = [
-            Trial.Result(name='b', type='statistic', value=5),
-            Trial.Result(name='c', type='statistic', value=20)
+            Trial.Result(name="b", type="statistic", value=5),
+            Trial.Result(name="c", type="statistic", value=20),
         ]
 
-        base_trial['results'].append({'name': 'c', 'type': 'statistic', 'value': 20})
+        base_trial["results"].append({"name": "c", "type": "statistic", "value": 20})
         trial = Trial(**base_trial)
 
         assert expected == trial.statistics
@@ -289,10 +289,14 @@ class TestTrial(object):
     def test_params_repr_property(self, exp_config):
         """Check property `Trial.params_repr`."""
         t = Trial(**exp_config[1][1])
-        assert Trial.format_params(t._params) == \
-               "/decoding_layer:lstm_with_attention,/encoding_layer:gru"
-        assert Trial.format_params(t._params, sep='\n') == \
-               "/decoding_layer:lstm_with_attention\n/encoding_layer:gru"
+        assert (
+            Trial.format_params(t._params)
+            == "/decoding_layer:lstm_with_attention,/encoding_layer:gru"
+        )
+        assert (
+            Trial.format_params(t._params, sep="\n")
+            == "/decoding_layer:lstm_with_attention\n/encoding_layer:gru"
+        )
 
         t = Trial()
         assert Trial.format_params(t._params) == ""
@@ -305,39 +309,47 @@ class TestTrial(object):
         t = Trial()
         with pytest.raises(ValueError) as exc:
             t.hash_name
-        assert 'params' in str(exc.value)
+        assert "params" in str(exc.value)
 
     def test_param_name_property(self, exp_config):
         """Check property `Trial.hash_params`."""
-        exp_config[1][1]['params'].append({'name': '/max_epoch', 'type': 'fidelity', 'value': '1'})
+        exp_config[1][1]["params"].append(
+            {"name": "/max_epoch", "type": "fidelity", "value": "1"}
+        )
         t1 = Trial(**exp_config[1][1])
-        exp_config[1][1]['params'][-1]['value'] = '2'  # changing the fidelity
+        exp_config[1][1]["params"][-1]["value"] = "2"  # changing the fidelity
         t2 = Trial(**exp_config[1][1])
         assert t1.hash_name != t2.hash_name
         assert t1.hash_params == t2.hash_params
 
     def test_hash_ignore_experiment(self, exp_config):
         """Check property `Trial.compute_trial_hash(ignore_experiment=True)`."""
-        exp_config[1][1]['params'].append({'name': '/max_epoch', 'type': 'fidelity', 'value': '1'})
+        exp_config[1][1]["params"].append(
+            {"name": "/max_epoch", "type": "fidelity", "value": "1"}
+        )
         t1 = Trial(**exp_config[1][1])
-        exp_config[1][1]['experiment'] = 'test'  # changing the experiment name
+        exp_config[1][1]["experiment"] = "test"  # changing the experiment name
         t2 = Trial(**exp_config[1][1])
         assert t1.hash_name != t2.hash_name
         assert t1.hash_params != t2.hash_params
-        assert (Trial.compute_trial_hash(t1, ignore_experiment=True) ==
-                Trial.compute_trial_hash(t2, ignore_experiment=True))
+        assert Trial.compute_trial_hash(
+            t1, ignore_experiment=True
+        ) == Trial.compute_trial_hash(t2, ignore_experiment=True)
 
     def test_hash_ignore_lie(self, exp_config):
         """Check property `Trial.compute_trial_hash(ignore_lie=True)`."""
-        exp_config[1][1]['params'].append({'name': '/max_epoch', 'type': 'fidelity', 'value': '1'})
+        exp_config[1][1]["params"].append(
+            {"name": "/max_epoch", "type": "fidelity", "value": "1"}
+        )
         t1 = Trial(**exp_config[1][1])
         # Add a lie
-        exp_config[1][1]['results'].append({'name': 'lie', 'type': 'lie', 'value': 1})
+        exp_config[1][1]["results"].append({"name": "lie", "type": "lie", "value": 1})
         t2 = Trial(**exp_config[1][1])
         assert t1.hash_name != t2.hash_name
         assert t1.hash_params == t2.hash_params
-        assert (Trial.compute_trial_hash(t1, ignore_lie=True) ==
-                Trial.compute_trial_hash(t2, ignore_lie=True))
+        assert Trial.compute_trial_hash(
+            t1, ignore_lie=True
+        ) == Trial.compute_trial_hash(t2, ignore_lie=True)
 
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""
@@ -347,10 +359,12 @@ class TestTrial(object):
         t = Trial()
         with pytest.raises(ValueError) as exc:
             t.full_name
-        assert 'params' in str(exc.value)
+        assert "params" in str(exc.value)
 
     def test_higher_shape_id_is_same(self):
         """Check if a Trial with a shape > 1 has the same id once it has been through the DB."""
-        x = {'name': '/x', 'value': [1, 2], 'type': 'real'}
+        x = {"name": "/x", "value": [1, 2], "type": "real"}
         trial = Trial(params=[x])
-        assert trial.id == Trial(**bson.BSON.decode(bson.BSON.encode(trial.to_dict()))).id
+        assert (
+            trial.id == Trial(**bson.BSON.decode(bson.BSON.encode(trial.to_dict()))).id
+        )

--- a/tests/unittests/core/worker/test_trial_pacemaker.py
+++ b/tests/unittests/core/worker/test_trial_pacemaker.py
@@ -16,8 +16,8 @@ from orion.storage.base import get_storage
 def config(exp_config):
     """Return a configuration."""
     config = exp_config[0][0]
-    config['space'] = {'x': 'uniform(-50, 50)'}
-    config['name'] = 'exp'
+    config["space"] = {"x": "uniform(-50, 50)"}
+    config["name"] = "exp"
     return config
 
 
@@ -33,7 +33,7 @@ def trial(exp):
     trial = tuple_to_trial((1.0,), exp.space)
     heartbeat = datetime.datetime.utcnow()
     trial.experiment = exp.id
-    trial.status = 'reserved'
+    trial.status = "reserved"
     trial.heartbeat = heartbeat
 
     get_storage().register_trial(trial)
@@ -49,7 +49,7 @@ def test_trial_update_heartbeat(exp, trial):
     trial_monitor.start()
     time.sleep(2)
 
-    trials = exp.fetch_trials_by_status('reserved')
+    trials = exp.fetch_trials_by_status("reserved")
 
     assert trial.heartbeat != trials[0].heartbeat
 
@@ -57,7 +57,7 @@ def test_trial_update_heartbeat(exp, trial):
 
     time.sleep(2)
 
-    trials = exp.fetch_trials_by_status(status='reserved')
+    trials = exp.fetch_trials_by_status(status="reserved")
 
     assert heartbeat != trials[0].heartbeat
     trial_monitor.stop()
@@ -71,11 +71,11 @@ def test_trial_heartbeat_not_updated(exp, trial):
     trial_monitor.start()
     time.sleep(2)
 
-    trials = exp.fetch_trials_by_status('reserved')
+    trials = exp.fetch_trials_by_status("reserved")
 
     assert trial.heartbeat != trials[0].heartbeat
 
-    get_storage().set_trial_status(trial, status='interrupted')
+    get_storage().set_trial_status(trial, status="interrupted")
 
     time.sleep(2)
 
@@ -92,14 +92,16 @@ def test_trial_heartbeat_not_updated_inbetween(exp, trial):
     trial_monitor.start()
     time.sleep(1)
 
-    trials = exp.fetch_trials_by_status('reserved')
-    assert trial.heartbeat.replace(microsecond=0) == trials[0].heartbeat.replace(microsecond=0)
+    trials = exp.fetch_trials_by_status("reserved")
+    assert trial.heartbeat.replace(microsecond=0) == trials[0].heartbeat.replace(
+        microsecond=0
+    )
 
     heartbeat = trials[0].heartbeat
 
     time.sleep(6)
 
-    trials = exp.fetch_trials_by_status(status='reserved')
+    trials = exp.fetch_trials_by_status(status="reserved")
 
     assert heartbeat != trials[0].heartbeat
     trial_monitor.stop()

--- a/tests/unittests/plotting/test_plot_accessor.py
+++ b/tests/unittests/plotting/test_plot_accessor.py
@@ -5,33 +5,37 @@ from orion.plotting.base import PlotAccessor
 from orion.testing import create_experiment
 
 config = dict(
-    name='experiment-name',
-    space={'x': 'uniform(0, 200)'},
-    metadata={'user': 'test-user',
-              'orion_version': 'XYZ',
-              'VCS': {"type": "git",
-                      "is_dirty": False,
-                      "HEAD_sha": "test",
-                      "active_branch": None,
-                      "diff_sha": "diff"}},
+    name="experiment-name",
+    space={"x": "uniform(0, 200)"},
+    metadata={
+        "user": "test-user",
+        "orion_version": "XYZ",
+        "VCS": {
+            "type": "git",
+            "is_dirty": False,
+            "HEAD_sha": "test",
+            "active_branch": None,
+            "diff_sha": "diff",
+        },
+    },
     version=1,
     pool_size=1,
     max_trials=10,
-    working_dir='',
-    algorithms={'random': {'seed': 1}},
-    producer={'strategy': 'NoParallelStrategy'},
+    working_dir="",
+    algorithms={"random": {"seed": 1}},
+    producer={"strategy": "NoParallelStrategy"},
 )
 
 
 trial_config = {
-    'experiment': 0,
-    'status': 'new',  # new, reserved, suspended, completed, broken
-    'worker': None,
-    'start_time': None,
-    'end_time': None,
-    'heartbeat': None,
-    'results': [],
-    'params': []
+    "experiment": 0,
+    "status": "new",  # new, reserved, suspended, completed, broken
+    "worker": None,
+    "start_time": None,
+    "end_time": None,
+    "heartbeat": None,
+    "results": [],
+    "params": [],
 }
 
 
@@ -52,17 +56,17 @@ def test_init_require_experiment():
 
 def test_call_nonexistent_kind():
     """Tests that specifying a non existent kind will fail"""
-    with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+    with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):
         pa = PlotAccessor(experiment)
         with pytest.raises(ValueError) as exception:
-            pa(kind='nonexistent')
+            pa(kind="nonexistent")
 
         assert "Plot of kind 'nonexistent' is not one of" in str(exception.value)
 
 
 def test_regret_is_default_plot():
     """Tests that the regret plot is the default plot"""
-    with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+    with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):
         pa = PlotAccessor(experiment)
         plot = pa()
 
@@ -71,16 +75,16 @@ def test_regret_is_default_plot():
 
 def test_regret_kind():
     """Tests that a regret plot can be created from specifying `kind` as a parameter."""
-    with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+    with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):
         pa = PlotAccessor(experiment)
-        plot = pa(kind='regret')
+        plot = pa(kind="regret")
 
         check_regret_plot(plot)
 
 
 def test_call_to_regret():
     """Tests instance calls to `PlotAccessor.regret()`"""
-    with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+    with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):
         pa = PlotAccessor(experiment)
         plot = pa.regret()
 

--- a/tests/unittests/plotting/test_plotly_backend.py
+++ b/tests/unittests/plotting/test_plotly_backend.py
@@ -10,32 +10,36 @@ from orion.plotting.base import lpi, parallel_coordinates, regret
 from orion.testing import create_experiment
 
 config = dict(
-    name='experiment-name',
-    space={'x': 'uniform(0, 200)'},
-    metadata={'user': 'test-user',
-              'orion_version': 'XYZ',
-              'VCS': {"type": "git",
-                      "is_dirty": False,
-                      "HEAD_sha": "test",
-                      "active_branch": None,
-                      "diff_sha": "diff"}},
+    name="experiment-name",
+    space={"x": "uniform(0, 200)"},
+    metadata={
+        "user": "test-user",
+        "orion_version": "XYZ",
+        "VCS": {
+            "type": "git",
+            "is_dirty": False,
+            "HEAD_sha": "test",
+            "active_branch": None,
+            "diff_sha": "diff",
+        },
+    },
     version=1,
     pool_size=1,
     max_trials=10,
-    working_dir='',
-    algorithms={'random': {'seed': 1}},
-    producer={'strategy': 'NoParallelStrategy'},
+    working_dir="",
+    algorithms={"random": {"seed": 1}},
+    producer={"strategy": "NoParallelStrategy"},
 )
 
 trial_config = {
-    'experiment': 0,
-    'status': 'completed',
-    'worker': None,
-    'start_time': None,
-    'end_time': None,
-    'heartbeat': None,
-    'results': [],
-    'params': []
+    "experiment": 0,
+    "status": "completed",
+    "worker": None,
+    "start_time": None,
+    "end_time": None,
+    "heartbeat": None,
+    "results": [],
+    "params": [],
 }
 
 
@@ -60,11 +64,11 @@ def assert_regret_plot(plot):
     assert not trace2.x
 
 
-def mock_space(x='uniform(0, 6)', y='uniform(0, 3)', **kwargs):
+def mock_space(x="uniform(0, 6)", y="uniform(0, 3)", **kwargs):
     """Build a mocked space"""
     mocked_config = copy.deepcopy(config)
-    mocked_config['space'] = {'x': x, 'y': y}
-    mocked_config['space'].update(kwargs)
+    mocked_config["space"] = {"x": x, "y": y}
+    mocked_config["space"].update(kwargs)
     return mocked_config
 
 
@@ -76,16 +80,18 @@ def mock_experiment(monkeypatch, x=None, y=None):
         y = [1, 2, 0, 3]
 
     def to_pandas(self, with_evc_tree=False):
-        data = pandas.DataFrame(data={
-            'id': ['a', 'b', 'c', 'd'],
-            'x': x,
-            'y': y,
-            'objective': [0.1, 0.2, 0.3, 0.5]
-        })
+        data = pandas.DataFrame(
+            data={
+                "id": ["a", "b", "c", "d"],
+                "x": x,
+                "y": y,
+                "objective": [0.1, 0.2, 0.3, 0.5],
+            }
+        )
 
         return data
 
-    monkeypatch.setattr(Experiment, 'to_pandas', to_pandas)
+    monkeypatch.setattr(Experiment, "to_pandas", to_pandas)
 
 
 def assert_lpi_plot(plot, dims):
@@ -95,8 +101,8 @@ def assert_lpi_plot(plot, dims):
     assert plot.layout.yaxis.title.text == "Local Parameter Importance (LPI)"
 
     trace = plot.data[0]
-    assert trace['x'] == tuple(dims)
-    assert trace['y'][0] > trace['y'][1]
+    assert trace["x"] == tuple(dims)
+    assert trace["y"][0] > trace["y"][1]
 
 
 class TestLPI:
@@ -109,7 +115,11 @@ class TestLPI:
 
     def test_returns_plotly_object(self):
         """Tests that the plotly backend returns a plotly object"""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
             plot = lpi(experiment, random_state=1)
 
         assert type(plot) is plotly.graph_objects.Figure
@@ -118,67 +128,80 @@ class TestLPI:
         """Tests the layout of the plot"""
         config = mock_space()
         mock_experiment(monkeypatch)
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
             plot = lpi(experiment, random_state=1)
 
-        assert_lpi_plot(plot, dims=['x', 'y'])
+        assert_lpi_plot(plot, dims=["x", "y"])
 
     def test_experiment_worker_as_parameter(self, monkeypatch):
         """Tests that ``Experiment`` is a valid parameter"""
         config = mock_space()
         mock_experiment(monkeypatch)
-        with create_experiment(config, trial_config, ['completed']) as (_, experiment, _):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            experiment,
+            _,
+        ):
             plot = lpi(experiment, random_state=1)
 
-        assert_lpi_plot(plot, dims=['x', 'y'])
+        assert_lpi_plot(plot, dims=["x", "y"])
 
     def test_experiment_view_as_parameter(self, monkeypatch):
         """Tests that ``ExperimentView`` is a valid parameter"""
         config = mock_space()
         mock_experiment(monkeypatch)
-        with create_experiment(config, trial_config, ['completed']) as (_, experiment, _):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            experiment,
+            _,
+        ):
             plot = lpi(ExperimentView(experiment), random_state=1)
 
-        assert_lpi_plot(plot, dims=['x', 'y'])
+        assert_lpi_plot(plot, dims=["x", "y"])
 
     def test_multidim(self, monkeypatch):
         """Tests that dimensions with shape > 1 are flattened properly"""
-        config = mock_space(y='uniform(0, 3, shape=2)')
+        config = mock_space(y="uniform(0, 3, shape=2)")
         mock_experiment(monkeypatch, y=[[3, 3], [2, 3], [1, 2], [0, 3]])
         with create_experiment(config, trial_config) as (_, _, experiment):
             plot = lpi(experiment, model_kwargs=dict(random_state=1))
 
-        assert_lpi_plot(plot, dims=['x', 'y[0]', 'y[1]'])
+        assert_lpi_plot(plot, dims=["x", "y[0]", "y[1]"])
 
     def test_fidelity(self, monkeypatch):
         """Tests that fidelity is supported"""
-        config = mock_space(y='fidelity(1, 200, base=3)')
+        config = mock_space(y="fidelity(1, 200, base=3)")
         mock_experiment(monkeypatch, y=[1, 3 ** 2, 1, 3 ** 4])
         with create_experiment(config, trial_config) as (_, _, experiment):
             plot = lpi(experiment, model_kwargs=dict(random_state=1))
 
-        assert_lpi_plot(plot, dims=['x', 'y'])
+        assert_lpi_plot(plot, dims=["x", "y"])
 
     def test_categorical(self, monkeypatch):
         """Tests that categorical is supported"""
         config = mock_space(y='choices(["a", "b", "c"])')
-        mock_experiment(monkeypatch, y=['c', 'c', 'a', 'b'])
+        mock_experiment(monkeypatch, y=["c", "c", "a", "b"])
         with create_experiment(config, trial_config) as (_, _, experiment):
             plot = lpi(experiment, model_kwargs=dict(random_state=1))
 
-        assert_lpi_plot(plot, dims=['x', 'y'])
+        assert_lpi_plot(plot, dims=["x", "y"])
 
     def test_categorical_multidim(self, monkeypatch):
         """Tests that multidim categorical is supported"""
         config = mock_space(y='choices(["a", "b", "c"], shape=3)')
         mock_experiment(
             monkeypatch,
-            y=[['c', 'b', 'a'], ['c', 'a', 'c'], ['a', 'b', 'a'], ['c', 'b', 'b']])
+            y=[["c", "b", "a"], ["c", "a", "c"], ["a", "b", "a"], ["c", "b", "b"]],
+        )
 
         with create_experiment(config, trial_config) as (_, _, experiment):
             plot = lpi(experiment, model_kwargs=dict(random_state=1))
 
-        assert_lpi_plot(plot, dims=['x', 'y[0]', 'y[1]', 'y[2]'])
+        assert_lpi_plot(plot, dims=["x", "y[0]", "y[1]", "y[2]"])
 
 
 class TestRegret:
@@ -191,28 +214,44 @@ class TestRegret:
 
     def test_returns_plotly_object(self):
         """Tests that the plotly backend returns a plotly object"""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
             plot = regret(experiment)
 
         assert type(plot) is plotly.graph_objects.Figure
 
     def test_graph_layout(self):
         """Tests the layout of the plot"""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
             plot = regret(experiment)
 
         assert_regret_plot(plot)
 
     def test_experiment_worker_as_parameter(self):
         """Tests that ``Experiment`` is a valid parameter"""
-        with create_experiment(config, trial_config, ['completed']) as (_, experiment, _):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            experiment,
+            _,
+        ):
             plot = regret(experiment)
 
         assert_regret_plot(plot)
 
     def test_experiment_view_as_parameter(self):
         """Tests that ``ExperimentView`` is a valid parameter"""
-        with create_experiment(config, trial_config, ['completed']) as (_, experiment, _):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            experiment,
+            _,
+        ):
             plot = regret(ExperimentView(experiment))
 
         assert_regret_plot(plot)
@@ -228,12 +267,15 @@ class TestRegret:
         """Tests that unsupported order keys are rejected"""
         with create_experiment(config, trial_config) as (_, _, experiment):
             with pytest.raises(ValueError):
-                regret(experiment, order_by='unsupported')
+                regret(experiment, order_by="unsupported")
 
 
 def assert_parallel_coordinates_plot(plot, order):
     """Checks the layout of a parallel coordinates plot"""
-    assert plot.layout.title.text == "Parallel Coordinates Plot for experiment 'experiment-name'"
+    assert (
+        plot.layout.title.text
+        == "Parallel Coordinates Plot for experiment 'experiment-name'"
+    )
 
     trace = plot.data[0]
     for i in range(len(order)):
@@ -250,87 +292,107 @@ class TestParallelCoordinates:
 
     def test_returns_plotly_object(self):
         """Tests that the plotly backend returns a plotly object"""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
             plot = parallel_coordinates(experiment)
 
         assert type(plot) is plotly.graph_objects.Figure
 
     def test_graph_layout(self):
         """Tests the layout of the plot"""
-        with create_experiment(config, trial_config, ['completed']) as (_, _, experiment):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["x", "loss"])
 
     def test_experiment_worker_as_parameter(self):
         """Tests that ``Experiment`` is a valid parameter"""
-        with create_experiment(config, trial_config, ['completed']) as (_, experiment, _):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            experiment,
+            _,
+        ):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["x", "loss"])
 
     def test_experiment_view_as_parameter(self):
         """Tests that ``ExperimentView`` is a valid parameter"""
-        with create_experiment(config, trial_config, ['completed']) as (_, experiment, _):
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            experiment,
+            _,
+        ):
             plot = parallel_coordinates(ExperimentView(experiment))
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["x", "loss"])
 
     def test_ignore_uncompleted_statuses(self):
         """Tests that uncompleted statuses are ignored"""
         with create_experiment(config, trial_config) as (_, _, experiment):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["x", "loss"])
 
     def test_unsupported_order_key(self):
         """Tests that unsupported order keys are rejected"""
         with create_experiment(config, trial_config) as (_, _, experiment):
             with pytest.raises(ValueError):
-                parallel_coordinates(experiment, order=['unsupported'])
+                parallel_coordinates(experiment, order=["unsupported"])
 
     def test_order_columns(self):
         """Tests that columns are sorted according to ``order``"""
         multidim_config = copy.deepcopy(config)
-        for k in 'yzutv':
-            multidim_config['space'][k] = 'uniform(0, 200)'
+        for k in "yzutv":
+            multidim_config["space"][k] = "uniform(0, 200)"
         with create_experiment(multidim_config, trial_config) as (_, _, experiment):
-            plot = parallel_coordinates(experiment, order='vzyx')
+            plot = parallel_coordinates(experiment, order="vzyx")
 
-        assert_parallel_coordinates_plot(plot, order=['v', 'z', 'y', 'x', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["v", "z", "y", "x", "loss"])
 
     def test_multidim(self):
         """Tests that dimensions with shape > 1 are flattened properly"""
         multidim_config = copy.deepcopy(config)
-        multidim_config['space']['y'] = 'uniform(0, 200, shape=4)'
+        multidim_config["space"]["y"] = "uniform(0, 200, shape=4)"
         with create_experiment(multidim_config, trial_config) as (_, _, experiment):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'y[0]', 'y[1]', 'y[2]', 'y[3]', 'loss'])
+        assert_parallel_coordinates_plot(
+            plot, order=["x", "y[0]", "y[1]", "y[2]", "y[3]", "loss"]
+        )
 
     def test_fidelity(self):
         """Tests that fidelity is set to first column by default"""
         fidelity_config = copy.deepcopy(config)
-        fidelity_config['space']['z'] = 'fidelity(1, 200, base=3)'
+        fidelity_config["space"]["z"] = "fidelity(1, 200, base=3)"
         with create_experiment(fidelity_config, trial_config) as (_, _, experiment):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['z', 'x', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["z", "x", "loss"])
 
     def test_categorical(self):
         """Tests that categorical is supported"""
         categorical_config = copy.deepcopy(config)
-        categorical_config['space']['z'] = 'choices(["a", "b", "c"])'
+        categorical_config["space"]["z"] = 'choices(["a", "b", "c"])'
         with create_experiment(categorical_config, trial_config) as (_, _, experiment):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'z', 'loss'])
+        assert_parallel_coordinates_plot(plot, order=["x", "z", "loss"])
 
     def test_categorical_multidim(self):
         """Tests that multidim categorical is supported"""
         categorical_config = copy.deepcopy(config)
-        categorical_config['space']['z'] = 'choices(["a", "b", "c"], shape=3)'
+        categorical_config["space"]["z"] = 'choices(["a", "b", "c"], shape=3)'
         with create_experiment(categorical_config, trial_config) as (_, _, experiment):
             plot = parallel_coordinates(experiment)
 
-        assert_parallel_coordinates_plot(plot, order=['x', 'z[0]', 'z[1]', 'z[2]', 'loss'])
+        assert_parallel_coordinates_plot(
+            plot, order=["x", "z[0]", "z[1]", "z[2]", "loss"]
+        )

--- a/tests/unittests/storage/test_legacy.py
+++ b/tests/unittests/storage/test_legacy.py
@@ -11,8 +11,11 @@ import pytest
 from orion.core.io.database import Database
 from orion.core.io.database.pickleddb import PickledDB
 from orion.core.utils.exceptions import MissingResultFile
-from orion.core.utils.singleton import SingletonAlreadyInstantiatedError, \
-    SingletonNotInstantiatedError, update_singletons
+from orion.core.utils.singleton import (
+    SingletonAlreadyInstantiatedError,
+    SingletonNotInstantiatedError,
+    update_singletons,
+)
 from orion.core.worker.trial import Trial
 from orion.storage.base import FailedUpdate
 from orion.storage.legacy import get_database, setup_database
@@ -23,54 +26,47 @@ log.setLevel(logging.WARNING)
 
 
 base_experiment = {
-    'name': 'default_name',
-    'version': 0,
-    'metadata': {
-        'user': 'default_user',
-        'user_script': 'abc',
-        'datetime': '2017-11-23T02:00:00'
-    }
+    "name": "default_name",
+    "version": 0,
+    "metadata": {
+        "user": "default_user",
+        "user_script": "abc",
+        "datetime": "2017-11-23T02:00:00",
+    },
 }
 
 base_trial = {
-    'experiment': 'default_name',
-    'status': 'new',  # new, reserved, suspended, completed, broken
-    'worker': None,
-    'submit_time': '2017-11-23T02:00:00',
-    'start_time': None,
-    'end_time': None,
-    'heartbeat': None,
-    'results': [
-        {'name': 'loss',
-         'type': 'objective',  # objective, constraint
-         'value': 2}
+    "experiment": "default_name",
+    "status": "new",  # new, reserved, suspended, completed, broken
+    "worker": None,
+    "submit_time": "2017-11-23T02:00:00",
+    "start_time": None,
+    "end_time": None,
+    "heartbeat": None,
+    "results": [
+        {"name": "loss", "type": "objective", "value": 2}  # objective, constraint
     ],
-    'params': [
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'},
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'lstm_with_attention'}
-    ]
+    "params": [
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+        {
+            "name": "/decoding_layer",
+            "type": "categorical",
+            "value": "lstm_with_attention",
+        },
+    ],
 }
 
 
 mongodb_config = {
-    'database': {
-        'type': 'MongoDB',
-        'name': 'orion_test',
-        'username': 'user',
-        'password': 'pass'
+    "database": {
+        "type": "MongoDB",
+        "name": "orion_test",
+        "username": "user",
+        "password": "pass",
     }
 }
 
-db_backends = [
-    {
-        'type': 'legacy',
-        'database': mongodb_config
-    }
-]
+db_backends = [{"type": "legacy", "database": mongodb_config}]
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
@@ -86,41 +82,41 @@ def test_setup_database_bad():
     """Test how setup fails when configuring with non-existant backends"""
     update_singletons()
     with pytest.raises(NotImplementedError) as exc:
-        setup_database({'type': 'idontexist'})
+        setup_database({"type": "idontexist"})
 
-    assert exc.match('idontexist')
+    assert exc.match("idontexist")
 
 
 def test_setup_database_custom():
     """Test setup with local configuration"""
     update_singletons()
-    setup_database({'type': 'pickleddb', 'host': 'test.pkl'})
+    setup_database({"type": "pickleddb", "host": "test.pkl"})
     database = Database()
     assert isinstance(database, PickledDB)
-    assert database.host == 'test.pkl'
+    assert database.host == "test.pkl"
 
 
 def test_setup_database_bad_override():
     """Test setup with different type than existing singleton"""
     update_singletons()
-    setup_database({'type': 'pickleddb', 'host': 'test.pkl'})
+    setup_database({"type": "pickleddb", "host": "test.pkl"})
     database = Database()
     assert isinstance(database, PickledDB)
     with pytest.raises(SingletonAlreadyInstantiatedError) as exc:
-        setup_database({'type': 'mongodb'})
+        setup_database({"type": "mongodb"})
 
-    assert exc.match('A singleton instance of \(type: Database\)')
+    assert exc.match("A singleton instance of \(type: Database\)")
 
 
-@pytest.mark.xfail(reason='Fix this when introducing #135 in v0.2.0')
+@pytest.mark.xfail(reason="Fix this when introducing #135 in v0.2.0")
 def test_setup_database_bad_config_override():
     """Test setup with different config than existing singleton"""
     update_singletons()
-    setup_database({'type': 'pickleddb', 'host': 'test.pkl'})
+    setup_database({"type": "pickleddb", "host": "test.pkl"})
     database = Database()
     assert isinstance(database, PickledDB)
     with pytest.raises(SingletonAlreadyInstantiatedError):
-        setup_database({'type': 'pickleddb', 'host': 'other.pkl'})
+        setup_database({"type": "pickleddb", "host": "other.pkl"})
 
 
 def test_get_database_uninitiated():
@@ -129,13 +125,13 @@ def test_get_database_uninitiated():
     with pytest.raises(SingletonNotInstantiatedError) as exc:
         get_database()
 
-    assert exc.match('No singleton instance of \(type: Database\) was created')
+    assert exc.match("No singleton instance of \(type: Database\) was created")
 
 
 def test_get_database():
     """Test that get database gets the singleton"""
     update_singletons()
-    setup_database({'type': 'pickleddb', 'host': 'test.pkl'})
+    setup_database({"type": "pickleddb", "host": "test.pkl"})
     database = get_database()
     assert isinstance(database, PickledDB)
     assert get_database() == database
@@ -147,15 +143,15 @@ class TestLegacyStorage:
     def test_push_trial_results(self, storage=None):
         """Successfully push a completed trial into database."""
         reserved_trial = copy.deepcopy(base_trial)
-        reserved_trial['status'] = 'reserved'
-        with OrionState(experiments=[], trials=[reserved_trial], storage=storage) as cfg:
+        reserved_trial["status"] = "reserved"
+        with OrionState(
+            experiments=[], trials=[reserved_trial], storage=storage
+        ) as cfg:
             storage = cfg.storage()
             trial = storage.get_trial(Trial(**reserved_trial))
-            results = [
-                Trial.Result(name='loss', type='objective', value=2)
-            ]
+            results = [Trial.Result(name="loss", type="objective", value=2)]
             trial.results = results
-            assert storage.push_trial_results(trial), 'should update successfully'
+            assert storage.push_trial_results(trial), "should update successfully"
 
             trial2 = storage.get_trial(trial)
             assert trial2.results == results
@@ -165,9 +161,7 @@ class TestLegacyStorage:
         with OrionState(experiments=[], trials=[base_trial], storage=storage) as cfg:
             storage = cfg.storage()
             trial = storage.get_trial(Trial(**base_trial))
-            results = [
-                Trial.Result(name='loss', type='objective', value=2)
-            ]
+            results = [Trial.Result(name="loss", type="objective", value=2)]
             trial.results = results
             with pytest.raises(FailedUpdate):
                 storage.push_trial_results(trial)
@@ -175,7 +169,7 @@ class TestLegacyStorage:
     def retrieve_result(self, storage, generated_result):
         """Test retrieve result"""
         results_file = tempfile.NamedTemporaryFile(
-            mode='w', prefix='results_', suffix='.log', dir='.', delete=True
+            mode="w", prefix="results_", suffix=".log", dir=".", delete=True
         )
 
         # Generate fake result
@@ -198,25 +192,28 @@ class TestLegacyStorage:
 
     def test_retrieve_result(self, storage=None):
         """Test retrieve result"""
-        self.retrieve_result(storage, generated_result={
-            'name': 'loss',
-            'type': 'objective',
-            'value': 2})
+        self.retrieve_result(
+            storage, generated_result={"name": "loss", "type": "objective", "value": 2}
+        )
 
     def test_retrieve_result_incorrect_value(self, storage=None):
         """Test retrieve result"""
         with pytest.raises(ValueError) as exec:
-            self.retrieve_result(storage, generated_result={
-                'name': 'loss',
-                'type': 'objective_unsupported_type',
-                'value': 2})
+            self.retrieve_result(
+                storage,
+                generated_result={
+                    "name": "loss",
+                    "type": "objective_unsupported_type",
+                    "value": 2,
+                },
+            )
 
-        assert exec.match(r'Given type, objective_unsupported_type')
+        assert exec.match(r"Given type, objective_unsupported_type")
 
     def test_retrieve_result_nofile(self, storage=None):
         """Test retrieve result"""
         results_file = tempfile.NamedTemporaryFile(
-            mode='w', prefix='results_', suffix='.log', dir='.', delete=True
+            mode="w", prefix="results_", suffix=".log", dir=".", delete=True
         )
 
         with OrionState(experiments=[], trials=[], storage=storage) as cfg:
@@ -229,4 +226,4 @@ class TestLegacyStorage:
 
         results_file.close()
 
-        assert exec.match(r'Cannot parse result file')
+        assert exec.match(r"Cannot parse result file")

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -12,10 +12,19 @@ import pytest
 import orion.core
 from orion.core.io.database import DuplicateKeyError
 from orion.core.io.database.pickleddb import PickledDB
-from orion.core.utils.singleton import SingletonAlreadyInstantiatedError, \
-    SingletonNotInstantiatedError, update_singletons
+from orion.core.utils.singleton import (
+    SingletonAlreadyInstantiatedError,
+    SingletonNotInstantiatedError,
+    update_singletons,
+)
 from orion.core.worker.trial import Trial
-from orion.storage.base import FailedUpdate, get_storage, MissingArguments, setup_storage, Storage
+from orion.storage.base import (
+    FailedUpdate,
+    get_storage,
+    MissingArguments,
+    setup_storage,
+    Storage,
+)
 from orion.storage.legacy import Legacy
 from orion.storage.track import HAS_TRACK, REASON
 from orion.testing import OrionState
@@ -23,51 +32,44 @@ from orion.testing import OrionState
 log = logging.getLogger(__name__)
 log.setLevel(logging.WARNING)
 
-storage_backends = [
-    None  # defaults to legacy with PickleDB
-]
+storage_backends = [None]  # defaults to legacy with PickleDB
 
 if not HAS_TRACK:
-    log.warning('Track is not tested because: %s!', REASON)
+    log.warning("Track is not tested because: %s!", REASON)
 else:
-    storage_backends.append({
-        'type': 'track',
-        'uri': 'file://${file}?objective=loss'
-    })
+    storage_backends.append({"type": "track", "uri": "file://${file}?objective=loss"})
 
 base_experiment = {
-    'name': 'default_name',
-    'version': 0,
-    'metadata': {
-        'user': 'default_user',
-        'user_script': 'abc',
-        'priors': {'x': 'uniform(0, 10)'},
-        'datetime': '2017-11-23T02:00:00'
-    }
+    "name": "default_name",
+    "version": 0,
+    "metadata": {
+        "user": "default_user",
+        "user_script": "abc",
+        "priors": {"x": "uniform(0, 10)"},
+        "datetime": "2017-11-23T02:00:00",
+    },
 }
 
 
 base_trial = {
-    'experiment': 'default_name',
-    'status': 'new',  # new, reserved, suspended, completed, broken
-    'worker': None,
-    'submit_time': '2017-11-23T02:00:00',
-    'start_time': None,
-    'end_time': None,
-    'heartbeat': None,
-    'results': [
-        {'name': 'loss',
-         'type': 'objective',  # objective, constraint
-         'value': 2}
+    "experiment": "default_name",
+    "status": "new",  # new, reserved, suspended, completed, broken
+    "worker": None,
+    "submit_time": "2017-11-23T02:00:00",
+    "start_time": None,
+    "end_time": None,
+    "heartbeat": None,
+    "results": [
+        {"name": "loss", "type": "objective", "value": 2}  # objective, constraint
     ],
-    'params': [
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'rnn'},
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'lstm_with_attention'}
-    ]
+    "params": [
+        {"name": "/encoding_layer", "type": "categorical", "value": "rnn"},
+        {
+            "name": "/decoding_layer",
+            "type": "categorical",
+            "value": "lstm_with_attention",
+        },
+    ],
 }
 
 
@@ -88,18 +90,17 @@ def _generate(obj, *args, value):
 def make_lost_trial(delay=2):
     """Make a lost trial"""
     obj = copy.deepcopy(base_trial)
-    obj['status'] = 'reserved'
-    obj['heartbeat'] = (datetime.datetime.utcnow() -
-                        datetime.timedelta(seconds=orion.core.config.worker.heartbeat * delay))
-    obj['params'].append({
-        'name': '/index',
-        'type': 'categorical',
-        'value': f'lost_trial_{delay}'
-    })
+    obj["status"] = "reserved"
+    obj["heartbeat"] = datetime.datetime.utcnow() - datetime.timedelta(
+        seconds=orion.core.config.worker.heartbeat * delay
+    )
+    obj["params"].append(
+        {"name": "/index", "type": "categorical", "value": f"lost_trial_{delay}"}
+    )
     return obj
 
 
-all_status = ['completed', 'broken', 'reserved', 'interrupted', 'suspended', 'new']
+all_status = ["completed", "broken", "reserved", "interrupted", "suspended", "new"]
 
 
 def generate_trials(status=None, heartbeat=None):
@@ -107,28 +108,24 @@ def generate_trials(status=None, heartbeat=None):
     if status is None:
         status = all_status
 
-    new_trials = [_generate(base_trial, 'status', value=s) for s in status]
+    new_trials = [_generate(base_trial, "status", value=s) for s in status]
 
     if heartbeat:
         for trial in new_trials:
-            trial['heartbeat'] = heartbeat
+            trial["heartbeat"] = heartbeat
 
     # make each trial unique
     for i, trial in enumerate(new_trials):
-        trial['params'].append({
-            'name': '/index',
-            'type': 'categorical',
-            'value': i
-        })
+        trial["params"].append({"name": "/index", "type": "categorical", "value": i})
 
     return new_trials
 
 
 def generate_experiments():
     """Generate a set of experiments"""
-    users = ['a', 'b', 'c']
-    exps = [_generate(base_experiment, 'metadata', 'user', value=u) for u in users]
-    return [_generate(exp, 'name', value=str(i)) for i, exp in enumerate(exps)]
+    users = ["a", "b", "c"]
+    exps = [_generate(base_experiment, "metadata", "user", value=u) for u in users]
+    return [_generate(exp, "name", value=str(i)) for i, exp in enumerate(exps)]
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
@@ -145,36 +142,38 @@ def test_setup_storage_bad():
     """Test how setup fails when configuring with non-existant backends"""
     update_singletons()
     with pytest.raises(NotImplementedError) as exc:
-        setup_storage({'type': 'idontexist'})
+        setup_storage({"type": "idontexist"})
 
-    assert exc.match('idontexist')
+    assert exc.match("idontexist")
 
 
 def test_setup_storage_custom():
     """Test setup with local configuration"""
     update_singletons()
-    setup_storage({'type': 'legacy', 'database': {'type': 'pickleddb', 'host': 'test.pkl'}})
+    setup_storage(
+        {"type": "legacy", "database": {"type": "pickleddb", "host": "test.pkl"}}
+    )
     storage = Storage()
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, PickledDB)
-    assert storage._db.host == 'test.pkl'
+    assert storage._db.host == "test.pkl"
 
 
 def test_setup_storage_custom_type_missing():
     """Test setup with local configuration with type missing"""
     update_singletons()
-    setup_storage({'database': {'type': 'pickleddb', 'host': 'test.pkl'}})
+    setup_storage({"database": {"type": "pickleddb", "host": "test.pkl"}})
     storage = Storage()
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, PickledDB)
-    assert storage._db.host == 'test.pkl'
+    assert storage._db.host == "test.pkl"
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
 def test_setup_storage_custom_legacy_emtpy():
     """Test setup with local configuration with legacy but no config"""
     update_singletons()
-    setup_storage({'type': 'legacy'})
+    setup_storage({"type": "legacy"})
     storage = Storage()
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, PickledDB)
@@ -184,32 +183,34 @@ def test_setup_storage_custom_legacy_emtpy():
 def test_setup_storage_bad_override():
     """Test setup with different type than existing singleton"""
     update_singletons()
-    setup_storage({'type': 'legacy', 'database': {'type': 'pickleddb', 'host': 'test.pkl'}})
+    setup_storage(
+        {"type": "legacy", "database": {"type": "pickleddb", "host": "test.pkl"}}
+    )
     storage = Storage()
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, PickledDB)
     with pytest.raises(SingletonAlreadyInstantiatedError) as exc:
-        setup_storage({'type': 'track'})
+        setup_storage({"type": "track"})
 
-    assert exc.match('A singleton instance of \(type: Storage\)')
+    assert exc.match("A singleton instance of \(type: Storage\)")
 
 
-@pytest.mark.xfail(reason='Fix this when introducing #135 in v0.2.0')
+@pytest.mark.xfail(reason="Fix this when introducing #135 in v0.2.0")
 def test_setup_storage_bad_config_override():
     """Test setup with different config than existing singleton"""
     update_singletons()
-    setup_storage({'database': {'type': 'pickleddb', 'host': 'test.pkl'}})
+    setup_storage({"database": {"type": "pickleddb", "host": "test.pkl"}})
     storage = Storage()
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, PickledDB)
     with pytest.raises(SingletonAlreadyInstantiatedError):
-        setup_storage({'database': {'type': 'mongodb'}})
+        setup_storage({"database": {"type": "mongodb"}})
 
 
 def test_setup_storage_stateless():
     """Test that passed configuration dictionary is not modified by the fonction"""
     update_singletons()
-    config = {'database': {'type': 'pickleddb', 'host': 'test.pkl'}}
+    config = {"database": {"type": "pickleddb", "host": "test.pkl"}}
     passed_config = copy.deepcopy(config)
     setup_storage(passed_config)
     assert config == passed_config
@@ -221,20 +222,20 @@ def test_get_storage_uninitiated():
     with pytest.raises(SingletonNotInstantiatedError) as exc:
         get_storage()
 
-    assert exc.match('No singleton instance of \(type: Storage\) was created')
+    assert exc.match("No singleton instance of \(type: Storage\) was created")
 
 
 def test_get_storage():
     """Test that get storage gets the singleton"""
     update_singletons()
-    setup_storage({'database': {'type': 'pickleddb', 'host': 'test.pkl'}})
+    setup_storage({"database": {"type": "pickleddb", "host": "test.pkl"}})
     storage = get_storage()
     assert isinstance(storage, Legacy)
     assert isinstance(storage._db, PickledDB)
     assert get_storage() == storage
 
 
-@pytest.mark.parametrize('storage', storage_backends)
+@pytest.mark.parametrize("storage", storage_backends)
 class TestStorage:
     """Test all storage backend"""
 
@@ -246,16 +247,16 @@ class TestStorage:
             storage.create_experiment(base_experiment)
 
             experiments = storage.fetch_experiments({})
-            assert len(experiments) == 1, 'Only one experiment in the database'
+            assert len(experiments) == 1, "Only one experiment in the database"
 
             experiment = experiments[0]
-            assert base_experiment == experiment, 'Local experiment and DB should match'
+            assert base_experiment == experiment, "Local experiment and DB should match"
 
             # Insert it again
             with pytest.raises(DuplicateKeyError):
                 storage.create_experiment(base_experiment)
 
-    def test_fetch_experiments(self, storage, name='0', user='a'):
+    def test_fetch_experiments(self, storage, name="0", user="a"):
         """Test fetch experiments"""
         with OrionState(experiments=generate_experiments(), storage=storage) as cfg:
             storage = cfg.storage()
@@ -263,17 +264,23 @@ class TestStorage:
             experiments = storage.fetch_experiments({})
             assert len(experiments) == len(cfg.experiments)
 
-            experiments = storage.fetch_experiments({'name': name, 'metadata.user': user})
+            experiments = storage.fetch_experiments(
+                {"name": name, "metadata.user": user}
+            )
             assert len(experiments) == 1
 
             experiment = experiments[0]
-            assert experiment['name'] == name, 'name should match query'
-            assert experiment['metadata']['user'] == user, 'user name should match query'
+            assert experiment["name"] == name, "name should match query"
+            assert (
+                experiment["metadata"]["user"] == user
+            ), "user name should match query"
 
-            experiments = storage.fetch_experiments({'name': '-1', 'metadata.user': user})
+            experiments = storage.fetch_experiments(
+                {"name": "-1", "metadata.user": user}
+            )
             assert len(experiments) == 0
 
-    def test_update_experiment(self, monkeypatch, storage, name='0', user='a'):
+    def test_update_experiment(self, monkeypatch, storage, name="0", user="a"):
         """Test fetch experiments"""
         with OrionState(experiments=generate_experiments(), storage=storage) as cfg:
             storage = cfg.storage()
@@ -283,40 +290,46 @@ class TestStorage:
 
             experiment = cfg.experiments[0]
             mocked_experiment = _Dummy()
-            mocked_experiment.id = experiment['_id']
+            mocked_experiment.id = experiment["_id"]
 
             storage.update_experiment(mocked_experiment, test=True)
-            experiments = storage.fetch_experiments({'_id': experiment['_id']})
+            experiments = storage.fetch_experiments({"_id": experiment["_id"]})
             assert len(experiments) == 1
 
             fetched_experiment = experiments[0]
-            assert fetched_experiment['test']
+            assert fetched_experiment["test"]
 
-            assert 'test' not in storage.fetch_experiments({'_id': cfg.experiments[1]['_id']})[0]
+            assert (
+                "test"
+                not in storage.fetch_experiments({"_id": cfg.experiments[1]["_id"]})[0]
+            )
 
-            storage.update_experiment(uid=experiment['_id'], test2=True)
-            assert storage.fetch_experiments({'_id': experiment['_id']})[0]['test2']
-            assert 'test2' not in storage.fetch_experiments({'_id': cfg.experiments[1]['_id']})[0]
+            storage.update_experiment(uid=experiment["_id"], test2=True)
+            assert storage.fetch_experiments({"_id": experiment["_id"]})[0]["test2"]
+            assert (
+                "test2"
+                not in storage.fetch_experiments({"_id": cfg.experiments[1]["_id"]})[0]
+            )
 
             with pytest.raises(MissingArguments):
                 storage.update_experiment()
 
             with pytest.raises(AssertionError):
-                storage.update_experiment(experiment=mocked_experiment, uid='123')
+                storage.update_experiment(experiment=mocked_experiment, uid="123")
 
     def test_delete_experiment(self, storage):
         """Test delete one experiment"""
-        if storage and storage['type'] == 'track':
+        if storage and storage["type"] == "track":
             pytest.xfail("Track does not support deletion yet.")
 
         with OrionState(experiments=generate_experiments(), storage=storage) as cfg:
             storage = cfg.storage()
 
             n_experiments = len(storage.fetch_experiments({}))
-            storage.delete_experiment(uid=cfg.experiments[0]['_id'])
+            storage.delete_experiment(uid=cfg.experiments[0]["_id"])
             experiments = storage.fetch_experiments({})
             assert len(experiments) == n_experiments - 1
-            assert cfg.experiments[0]['_id'] not in [exp['_id'] for exp in experiments]
+            assert cfg.experiments[0]["_id"] not in [exp["_id"] for exp in experiments]
 
     def test_register_trial(self, storage):
         """Test register trial"""
@@ -325,12 +338,15 @@ class TestStorage:
             trial1 = storage.register_trial(Trial(**base_trial))
             trial2 = storage.get_trial(trial1)
 
-            assert trial1.to_dict() == trial2.to_dict(), 'Trials should match after insert'
+            assert (
+                trial1.to_dict() == trial2.to_dict()
+            ), "Trials should match after insert"
 
     def test_register_duplicate_trial(self, storage):
         """Test register trial"""
         with OrionState(
-                experiments=[base_experiment], trials=[base_trial], storage=storage) as cfg:
+            experiments=[base_experiment], trials=[base_trial], storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
             with pytest.raises(DuplicateKeyError):
@@ -344,7 +360,9 @@ class TestStorage:
 
     def test_register_lie_fail(self, storage):
         """Test register lie"""
-        with OrionState(experiments=[base_experiment], lies=[base_trial], storage=storage) as cfg:
+        with OrionState(
+            experiments=[base_experiment], lies=[base_trial], storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
             with pytest.raises(DuplicateKeyError):
@@ -353,57 +371,61 @@ class TestStorage:
     def test_update_trials(self, storage):
         """Test update many trials"""
         with OrionState(
-                experiments=[base_experiment],
-                trials=generate_trials(status=['completed', 'reserved', 'reserved']),
-                storage=storage) as cfg:
+            experiments=[base_experiment],
+            trials=generate_trials(status=["completed", "reserved", "reserved"]),
+            storage=storage,
+        ) as cfg:
             storage = cfg.storage()
 
             class _Dummy:
                 pass
 
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
             trials = storage.fetch_trials(experiment)
-            assert sum(trial.status == 'reserved' for trial in trials) == 2
+            assert sum(trial.status == "reserved" for trial in trials) == 2
             count = storage.update_trials(
-                experiment,
-                where={'status': 'reserved'},
-                status='interrupted')
+                experiment, where={"status": "reserved"}, status="interrupted"
+            )
             assert count == 2
             trials = storage.fetch_trials(experiment)
-            assert sum(trial.status == 'interrupted' for trial in trials) == 2
+            assert sum(trial.status == "interrupted" for trial in trials) == 2
 
     def test_update_trial(self, storage):
         """Test update one trial"""
-        with OrionState(experiments=[base_experiment], trials=[base_trial], storage=storage) as cfg:
+        with OrionState(
+            experiments=[base_experiment], trials=[base_trial], storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
             trial = Trial(**cfg.trials[0])
 
-            assert trial.status != 'interrupted'
-            storage.update_trial(trial, status='interrupted')
-            assert storage.get_trial(trial).status == 'interrupted'
+            assert trial.status != "interrupted"
+            storage.update_trial(trial, status="interrupted")
+            assert storage.get_trial(trial).status == "interrupted"
 
     def test_reserve_trial_success(self, storage):
         """Test reserve trial"""
         with OrionState(
-                experiments=[base_experiment], trials=[base_trial], storage=storage) as cfg:
+            experiments=[base_experiment], trials=[base_trial], storage=storage
+        ) as cfg:
             storage = cfg.storage()
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
 
             trial = storage.reserve_trial(experiment)
 
             assert trial is not None
-            assert trial.status == 'reserved'
+            assert trial.status == "reserved"
 
     def test_reserve_trial_fail(self, storage):
         """Test reserve trial"""
         with OrionState(
-                experiments=[base_experiment],
-                trials=generate_trials(status=['completed', 'reserved']),
-                storage=storage) as cfg:
+            experiments=[base_experiment],
+            trials=generate_trials(status=["completed", "reserved"]),
+            storage=storage,
+        ) as cfg:
 
             storage = cfg.storage()
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
 
             trial = storage.reserve_trial(experiment)
             assert trial is None
@@ -411,9 +433,10 @@ class TestStorage:
     def test_fetch_trials(self, storage):
         """Test fetch experiment trials"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             storage = cfg.storage()
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
 
             trials1 = storage.fetch_trials(experiment=experiment)
             trials2 = storage.fetch_trials(uid=experiment.id)
@@ -422,69 +445,74 @@ class TestStorage:
                 storage.fetch_trials()
 
             with pytest.raises(AssertionError):
-                storage.fetch_trials(experiment=experiment, uid='123')
+                storage.fetch_trials(experiment=experiment, uid="123")
 
-            assert len(trials1) == len(cfg.trials), 'trial count should match'
-            assert len(trials2) == len(cfg.trials), 'trial count should match'
+            assert len(trials1) == len(cfg.trials), "trial count should match"
+            assert len(trials2) == len(cfg.trials), "trial count should match"
 
     def test_delete_all_trials(self, storage):
         """Test delete all trials of an experiment"""
-        if storage and storage['type'] == 'track':
+        if storage and storage["type"] == "track":
             pytest.xfail("Track does not support deletion yet.")
 
         trials = generate_trials()
         trial_from_other_exp = copy.deepcopy(trials[0])
-        trial_from_other_exp['experiment'] = 'other'
+        trial_from_other_exp["experiment"] = "other"
         trials.append(trial_from_other_exp)
         with OrionState(
-                experiments=[base_experiment], trials=trials, storage=storage) as cfg:
+            experiments=[base_experiment], trials=trials, storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
             # Make sure we have sufficient trials to test deletion
-            trials = storage.fetch_trials(uid='default_name')
+            trials = storage.fetch_trials(uid="default_name")
             assert len(trials) > 2
 
-            count = storage.delete_trials(uid='default_name')
+            count = storage.delete_trials(uid="default_name")
             assert count == len(trials)
-            assert storage.fetch_trials(uid='default_name') == []
+            assert storage.fetch_trials(uid="default_name") == []
 
             # Make sure trials from other experiments were not deleted
-            assert len(storage.fetch_trials(uid='other')) == 1
+            assert len(storage.fetch_trials(uid="other")) == 1
 
     def test_delete_trials_with_query(self, storage):
         """Test delete experiment trials matching a query"""
-        if storage and storage['type'] == 'track':
+        if storage and storage["type"] == "track":
             pytest.xfail("Track does not support deletion yet.")
 
         trials = generate_trials()
         trial_from_other_exp = copy.deepcopy(trials[0])
-        trial_from_other_exp['experiment'] = 'other'
+        trial_from_other_exp["experiment"] = "other"
         trials.append(trial_from_other_exp)
         with OrionState(
-                experiments=[base_experiment], trials=trials, storage=storage) as cfg:
+            experiments=[base_experiment], trials=trials, storage=storage
+        ) as cfg:
             storage = cfg.storage()
-            experiment = cfg.get_experiment('default_name')
+            experiment = cfg.get_experiment("default_name")
 
             # Make sure we have sufficient trials to test deletion
-            status = trials[0]['status']
+            status = trials[0]["status"]
             trials = storage.fetch_trials(experiment)
             trials_with_status = storage.fetch_trials_by_status(experiment, status)
             assert len(trials_with_status) > 0
             assert len(trials) > len(trials_with_status)
 
             # Test deletion
-            count = storage.delete_trials(uid='default_name', where={'status': status})
+            count = storage.delete_trials(uid="default_name", where={"status": status})
             assert count == len(trials_with_status)
             assert storage.fetch_trials_by_status(experiment, status) == []
-            assert len(storage.fetch_trials(experiment)) == len(trials) - len(trials_with_status)
+            assert len(storage.fetch_trials(experiment)) == len(trials) - len(
+                trials_with_status
+            )
 
             # Make sure trials from other experiments were not deleted
-            assert len(storage.fetch_trials(uid='other')) == 1
+            assert len(storage.fetch_trials(uid="other")) == 1
 
     def test_get_trial(self, storage):
         """Test get trial"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
             trial_dict = cfg.trials[0]
@@ -496,70 +524,78 @@ class TestStorage:
                 storage.get_trial()
 
             with pytest.raises(AssertionError):
-                storage.get_trial(trial=trial1, uid='123')
+                storage.get_trial(trial=trial1, uid="123")
 
             assert trial1.to_dict() == trial_dict
             assert trial2.to_dict() == trial_dict
 
     def test_fetch_lost_trials(self, storage):
         """Test update heartbeat"""
-        lost_trials = [make_lost_trial(2),  # Is not lost for long enough to be catched
-                       make_lost_trial(10)]  # Is lost for long enough to be catched
+        lost_trials = [
+            make_lost_trial(2),  # Is not lost for long enough to be catched
+            make_lost_trial(10),
+        ]  # Is lost for long enough to be catched
         # Force recent heartbeat to avoid mixing up with lost trials.
         trials = lost_trials + generate_trials(heartbeat=datetime.datetime.utcnow())
-        with OrionState(experiments=[base_experiment], trials=trials, storage=storage) as cfg:
+        with OrionState(
+            experiments=[base_experiment], trials=trials, storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
             trials = storage.fetch_lost_trials(experiment)
 
             assert len(trials) == 1
 
     def test_change_status_success(self, storage):
         """Change the status of a Trial"""
+
         def check_status_change(new_status):
             with OrionState(
-                    experiments=[base_experiment],
-                    trials=generate_trials(), storage=storage) as cfg:
+                experiments=[base_experiment], trials=generate_trials(), storage=storage
+            ) as cfg:
                 trial = get_storage().get_trial(cfg.get_trial(0))
-                assert trial is not None, 'was not able to retrieve trial for test'
+                assert trial is not None, "was not able to retrieve trial for test"
 
                 get_storage().set_trial_status(trial, status=new_status)
-                assert trial.status == new_status, \
-                    'Trial status should have been updated locally'
+                assert (
+                    trial.status == new_status
+                ), "Trial status should have been updated locally"
 
                 trial = get_storage().get_trial(trial)
-                assert trial.status == new_status, \
-                    'Trial status should have been updated in the storage'
+                assert (
+                    trial.status == new_status
+                ), "Trial status should have been updated in the storage"
 
-        check_status_change('completed')
-        check_status_change('broken')
-        check_status_change('reserved')
-        check_status_change('interrupted')
-        check_status_change('suspended')
-        check_status_change('new')
+        check_status_change("completed")
+        check_status_change("broken")
+        check_status_change("reserved")
+        check_status_change("interrupted")
+        check_status_change("suspended")
+        check_status_change("new")
 
     def test_change_status_invalid(self, storage):
         """Attempt to change the status of a Trial with an invalid one"""
         with OrionState(
-                experiments=[base_experiment],
-                trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             trial = get_storage().get_trial(cfg.get_trial(0))
-            assert trial is not None, 'Was not able to retrieve trial for test'
+            assert trial is not None, "Was not able to retrieve trial for test"
 
             with pytest.raises(ValueError) as exc:
-                get_storage().set_trial_status(trial, status='moo')
+                get_storage().set_trial_status(trial, status="moo")
 
-            assert exc.match('Given status `moo` not one of')
+            assert exc.match("Given status `moo` not one of")
 
     def test_change_status_failed_update(self, storage):
         """Change the status of a Trial"""
+
         def check_status_change(new_status):
             with OrionState(
-                    experiments=[base_experiment],
-                    trials=generate_trials(), storage=storage) as cfg:
+                experiments=[base_experiment], trials=generate_trials(), storage=storage
+            ) as cfg:
                 trial = get_storage().get_trial(cfg.get_trial(0))
-                assert trial is not None, 'Was not able to retrieve trial for test'
+                assert trial is not None, "Was not able to retrieve trial for test"
                 assert trial.status != new_status
 
                 if trial.status == new_status:
@@ -569,93 +605,98 @@ class TestStorage:
                     trial.status = new_status
                     get_storage().set_trial_status(trial, status=new_status)
 
-        check_status_change('completed')
-        check_status_change('broken')
-        check_status_change('reserved')
-        check_status_change('interrupted')
-        check_status_change('suspended')
+        check_status_change("completed")
+        check_status_change("broken")
+        check_status_change("reserved")
+        check_status_change("interrupted")
+        check_status_change("suspended")
 
     def test_fetch_pending_trials(self, storage):
         """Test fetch pending trials"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
             trials = storage.fetch_pending_trials(experiment)
 
             count = 0
             for trial in cfg.trials:
-                if trial['status'] in {'new', 'suspended', 'interrupted'}:
+                if trial["status"] in {"new", "suspended", "interrupted"}:
                     count += 1
 
             assert len(trials) == count
             for trial in trials:
-                assert trial.status in {'new', 'suspended', 'interrupted'}
+                assert trial.status in {"new", "suspended", "interrupted"}
 
     def test_fetch_noncompleted_trials(self, storage):
         """Test fetch non completed trials"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             storage = cfg.storage()
 
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
             trials = storage.fetch_noncompleted_trials(experiment)
 
             count = 0
             for trial in cfg.trials:
-                if trial['status'] != 'completed':
+                if trial["status"] != "completed":
                     count += 1
 
             for trial in trials:
-                assert trial.status != 'completed'
+                assert trial.status != "completed"
 
             assert len(trials) == count
 
     def test_fetch_trials_by_status(self, storage):
         """Test fetch completed trials"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             count = 0
             for trial in cfg.trials:
-                if trial['status'] == 'completed':
+                if trial["status"] == "completed":
                     count += 1
 
             storage = cfg.storage()
-            experiment = cfg.get_experiment('default_name', version=None)
-            trials = storage.fetch_trials_by_status(experiment, 'completed')
+            experiment = cfg.get_experiment("default_name", version=None)
+            trials = storage.fetch_trials_by_status(experiment, "completed")
 
             assert len(trials) == count
             for trial in trials:
-                assert trial.status == 'completed', trial
+                assert trial.status == "completed", trial
 
     def test_count_completed_trials(self, storage):
         """Test count completed trials"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             count = 0
             for trial in cfg.trials:
-                if trial['status'] == 'completed':
+                if trial["status"] == "completed":
                     count += 1
 
             storage = cfg.storage()
 
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
             trials = storage.count_completed_trials(experiment)
             assert trials == count
 
     def test_count_broken_trials(self, storage):
         """Test count broken trials"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             count = 0
             for trial in cfg.trials:
-                if trial['status'] == 'broken':
+                if trial["status"] == "broken":
                     count += 1
 
             storage = cfg.storage()
 
-            experiment = cfg.get_experiment('default_name', version=None)
+            experiment = cfg.get_experiment("default_name", version=None)
 
             trials = storage.count_broken_trials(experiment)
 
@@ -664,12 +705,13 @@ class TestStorage:
     def test_update_heartbeat(self, storage):
         """Test update heartbeat"""
         with OrionState(
-                experiments=[base_experiment], trials=generate_trials(), storage=storage) as cfg:
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
             storage_name = storage
             storage = cfg.storage()
 
-            exp = cfg.get_experiment('default_name')
-            trial1 = storage.fetch_trials_by_status(exp, status='reserved')[0]
+            exp = cfg.get_experiment("default_name")
+            trial1 = storage.fetch_trials_by_status(exp, status="reserved")[0]
             trial1b = copy.deepcopy(trial1)
 
             storage.update_heartbeat(trial1)
@@ -686,8 +728,9 @@ class TestStorage:
             assert trial2.heartbeat < datetime.datetime.utcnow()
 
             if storage_name is None:
-                trial3 = storage.fetch_trials_by_status(exp, status='completed')[0]
+                trial3 = storage.fetch_trials_by_status(exp, status="completed")[0]
                 storage.update_heartbeat(trial3)
 
-                assert trial3.heartbeat is None, \
-                    'Legacy does not update trials with a status different from reserved'
+                assert (
+                    trial3.heartbeat is None
+                ), "Legacy does not update trials with a status different from reserved"

--- a/tox.ini
+++ b/tox.ini
@@ -93,27 +93,26 @@ description = Lint code and docs against some standard standards
 basepython = python3
 skip_install = false
 deps =
-    {[testenv:flake8]deps}
+    {[testenv:black]deps}
     {[testenv:pylint]deps}
     {[testenv:doc8]deps}
     {[testenv:packaging]deps}
 commands =
-    {[testenv:flake8]commands}
+    {[testenv:black]commands}
     {[testenv:pylint]commands}
     {[testenv:doc8]commands}
     {[testenv:packaging]commands}
 
-[testenv:flake8] # Will use the configuration file `.flake8` automatically
-description = Use flake8 linter to impose standards on the project
+
+[testenv:black]
+description = Verify code style with black
 basepython = python3
 skip_install = true
 deps =
-    flake8 == 3.8.*
-    flake8-import-order == 0.18.*
-    flake8-docstrings == 1.5.*
-    flake8-bugbear == 20.1.*
+    black == 20.8b1
 commands =
-    flake8 docs/ src/orion/ tests/ setup.py
+    black --check src/orion/ tests/
+
 
 [testenv:pylint] # Will use the configuration file `.pylintrc` automatically
 description = Perform static analysis and output code metrics
@@ -123,6 +122,7 @@ deps =
     pylint == 2.5.*
 commands =
     pylint src/orion/core src/orion/client src/orion/algo
+
 
 [testenv:doc8]
 description = Impose standards on *.rst documentation files


### PR DESCRIPTION
[fixes #492]

pylint already covers flake8's checks anyway and adding black will
silence flake8 if configured to be compatible. Therefore, we should just
drop flake8 and rely on black+pylint instead.