### PR TITLE
Add debugging verbosity

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -52,7 +52,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=abstract-class-instantiated,useless-super-delegation,no-member,keyword-arg-before-vararg,unidiomatic-typecheck,redefined-outer-name,fixme,F0401,intern-builtin,wrong-import-position,wrong-import-order,
-        C0415, F0010, R0205, R1705, R1711, R1720, W0106, W0107, W0127, W0706, C0330, C0326
+        C0415, F0010, R0205, R1705, R1711, R1720, W0106, W0107, W0127, W0706, C0330, C0326, W1203
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -72,7 +72,10 @@ class OrionArgsParser:
 
         verbose = args.pop("verbose", 0)
         levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
-        logging.basicConfig(level=levels.get(verbose, logging.DEBUG))
+        logging.basicConfig(
+            format="%(asctime)-15s::%(levelname)s::%(name)s::%(message)s",
+            level=levels.get(verbose, logging.DEBUG),
+        )
 
         if args["command"] is None:
             self.parser.parse_args(["--help"])

--- a/src/orion/core/worker/__init__.py
+++ b/src/orion/core/worker/__init__.py
@@ -120,7 +120,7 @@ def workon(
             break
 
         if trial is not None:
-            log.debug("#### Successfully reserved %s to evaluate. Consuming...", trial)
+            log.info("#### Successfully reserved %s to evaluate. Consuming...", trial)
             success = consumer.consume(trial)
             if not success:
                 worker_broken_trials += 1

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -240,6 +240,7 @@ class Experiment:
         trial.end_time = datetime.datetime.utcnow()
         self._storage.retrieve_result(trial, results_file)
         # push trial results updates the entire trial status included
+        log.info("Completed trials with results: %s", trial.results)
         self._storage.push_trial_results(trial)
 
     def register_lie(self, lying_trial):

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -140,7 +140,7 @@ class Producer(object):
             return 1
 
         except DuplicateKeyError:
-            log.debug("#### Duplicate sample.")
+            log.debug("#### Duplicate sample: %s", new_trial)
             self.backoff()
             return 0
 


### PR DESCRIPTION
[Fixes #516]

Experiment branching in particular was difficult to debug based on logs.

This also adds timestamps at the beginning of logs to help debug race conditions.