### PR TITLE
Ignore non-completed trials when computing LPI

### DIFF
--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -25,6 +25,7 @@ def lpi(experiment, model="RandomForestRegressor", model_kwargs=None, n=20, **kw
         model_kwargs = {}
 
     df = experiment.to_pandas()
+    df = df.loc[df["status"] == "completed"]
     df = orion.analysis.lpi(df, experiment.space, model=model, n=n, **model_kwargs)
 
     fig = go.Figure(data=[go.Bar(x=df.index.tolist(), y=df["LPI"].tolist())])


### PR DESCRIPTION
[Fixes #518]

Why:

The LPI requires the objective. If we don't filter the non-completed trials, the
computation fails.

How:

Filter out non-completed trials in the plotting function. The analysis
function assumes trials with objectives, otherwise it would required
passing data frames including status.
