### PR TITLE
Support EVC in all algos

### DIFF
--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -119,6 +119,7 @@ class ASHA(BaseAlgorithm):
         )
 
         self.trial_info = {}  # Stores Trial -> Bracket
+        self.sampled = set()
 
         try:
             fidelity_index = self.fidelity_index
@@ -197,7 +198,7 @@ class ASHA(BaseAlgorithm):
     @property
     def state_dict(self):
         """Return a state dict that can be used to reset the state of the algorithm."""
-        return {"rng_state": self.rng.get_state()}
+        return {"rng_state": self.rng.get_state(), "sampled": self.sampled}
 
     def set_state(self, state_dict):
         """Reset the state of the algorithm based on the given state_dict
@@ -206,6 +207,7 @@ class ASHA(BaseAlgorithm):
         """
         self.seed_rng(0)
         self.rng.set_state(state_dict["rng_state"])
+        self.sampled = state_dict["sampled"]
 
     def suggest(self, num=1):
         """Suggest a `num` of new sets of parameters.
@@ -226,6 +228,7 @@ class ASHA(BaseAlgorithm):
 
             if candidate:
                 logger.debug("Promoting")
+                self.sampled.add(self.get_id(candidate, ignore_fidelity=False))
                 return [candidate]
 
         point = self._grow_point_for_bottom_rung()
@@ -247,6 +250,7 @@ class ASHA(BaseAlgorithm):
 
         logger.debug("Sampling for bracket %s %s", idx, self.brackets[idx])
 
+        self.sampled.add(self.get_id(point, ignore_fidelity=False))
         return [tuple(point)]
 
     def _grow_point_for_bottom_rung(self):
@@ -284,13 +288,15 @@ class ASHA(BaseAlgorithm):
 
         return point
 
-    def get_id(self, point):
-        """Compute a unique hash for a point based on params, but not fidelity level."""
+    def get_id(self, point, ignore_fidelity=True):
+        """Compute a unique hash for a point based on params, without fidelity level by default."""
         _point = list(point)
-        non_fidelity_dims = _point[0 : self.fidelity_index]
-        non_fidelity_dims.extend(_point[self.fidelity_index + 1 :])
+        if ignore_fidelity:
+            non_fidelity_dims = _point[0 : self.fidelity_index]
+            non_fidelity_dims.extend(_point[self.fidelity_index + 1 :])
+            _point = non_fidelity_dims
 
-        return hashlib.md5(str(non_fidelity_dims).encode("utf-8")).hexdigest()
+        return hashlib.md5(str(_point).encode("utf-8")).hexdigest()
 
     def observe(self, points, results):
         """Observe evaluation `results` corresponding to list of `points` in
@@ -300,7 +306,16 @@ class ASHA(BaseAlgorithm):
         """
         for point, result in zip(points, results):
 
+            full_id = self.get_id(point, ignore_fidelity=False)
+            if full_id not in self.sampled:
+                logger.info(
+                    "Ignoring point {0} because it was not sampled by current algo.",
+                    full_id,
+                )
+                continue
+
             _id = self.get_id(point)
+
             bracket = self.trial_info.get(_id)
 
             if not bracket:
@@ -316,6 +331,7 @@ class ASHA(BaseAlgorithm):
                             _id, fidelity
                         )
                     )
+
                 bracket = brackets[0]
 
             try:

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -309,7 +309,7 @@ class ASHA(BaseAlgorithm):
             full_id = self.get_id(point, ignore_fidelity=False)
             if full_id not in self.sampled:
                 logger.info(
-                    "Ignoring point {0} because it was not sampled by current algo.",
+                    "Ignoring point %s because it was not sampled by current algo.",
                     full_id,
                 )
                 continue

--- a/src/orion/algo/hyperband.py
+++ b/src/orion/algo/hyperband.py
@@ -126,6 +126,7 @@ class Hyperband(BaseAlgorithm):
         self.trial_info_wo_fidelity = (
             {}
         )  # Stores Point id (with no fidelity) -> Bracket
+        self.sampled = set()
 
         self.points_in_suggest_call = {}
 
@@ -211,6 +212,7 @@ class Hyperband(BaseAlgorithm):
             "rng_state": self.rng.get_state(),
             "seed": self.seed,
             "executed_times": self.executed_times,
+            "sampled": self.sampled,
         }
 
     def set_state(self, state_dict):
@@ -221,6 +223,7 @@ class Hyperband(BaseAlgorithm):
         self.seed_rng(state_dict["seed"])
         self.rng.set_state(state_dict["rng_state"])
         self.executed_times = state_dict["executed_times"]
+        self.sampled = state_dict["sampled"]
 
     def suggest(self, num=1):
         """Suggest a number of new sets of parameters.
@@ -250,6 +253,8 @@ class Hyperband(BaseAlgorithm):
                 samples += bracket.sample()
 
         if samples:
+            for sample in samples:
+                self.sampled.add(self.get_id(sample, ignore_fidelity=False))
             return samples
 
         # All brackets are filled
@@ -259,6 +264,8 @@ class Hyperband(BaseAlgorithm):
                 samples += bracket.promote()
 
         if samples:
+            for sample in samples:
+                self.sampled.add(self.get_id(sample, ignore_fidelity=False))
             return samples
 
         # Either all brackets are done or none are ready and algo needs to wait for some trials to
@@ -348,6 +355,14 @@ class Hyperband(BaseAlgorithm):
         A simple random sampler though does not take anything into account.
         """
         for point, result in zip(points, results):
+
+            full_id = self.get_id(point, ignore_fidelity=False)
+            if full_id not in self.sampled:
+                logger.info(
+                    "Ignoring point {0} because it was not sampled by current algo.",
+                    full_id,
+                )
+                continue
 
             bracket = self._get_bracket(point)
 

--- a/src/orion/algo/hyperband.py
+++ b/src/orion/algo/hyperband.py
@@ -359,7 +359,7 @@ class Hyperband(BaseAlgorithm):
             full_id = self.get_id(point, ignore_fidelity=False)
             if full_id not in self.sampled:
                 logger.info(
-                    "Ignoring point {0} because it was not sampled by current algo.",
+                    "Ignoring point %s because it was not sampled by current algo.",
                     full_id,
                 )
                 continue

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -6,7 +6,8 @@ import random
 
 import pytest
 
-from orion.client import workon
+from orion.client import create_experiment, workon
+from orion.testing.state import OrionState
 
 storage = {"type": "legacy", "database": {"type": "ephemeraldb"}}
 
@@ -150,3 +151,59 @@ def test_with_fidelity(algorithm):
     param = best_trial._params[1]
     assert param.name == "x"
     assert param.type == "real"
+
+
+@pytest.mark.parametrize(
+    "algorithm", algorithm_configs.values(), ids=list(algorithm_configs.keys())
+)
+def test_with_evc(algorithm):
+    """Test a scenario where algos are warm-started with EVC."""
+
+    with OrionState(storage={"type": "legacy", "database": {"type": "EphemeralDB"}}):
+        base_exp = create_experiment(
+            name="exp",
+            space=space_with_fidelity,
+            algorithms=algorithm_configs["random"],
+        )
+        base_exp.workon(rosenbrock, max_trials=10)
+
+        exp = create_experiment(
+            name="exp",
+            space=space_with_fidelity,
+            algorithms=algorithm,
+            branching={"branch_from": "exp"},
+        )
+
+        assert exp.version == 2
+
+        exp.workon(rosenbrock, max_trials=30)
+
+        assert exp.configuration["algorithms"] == algorithm
+
+        trials = exp.fetch_trials(with_evc_tree=False)
+        assert len(trials) >= 30
+
+        trials_with_evc = exp.fetch_trials(with_evc_tree=True)
+        assert len(trials_with_evc) >= 40
+        assert len(trials_with_evc) - len(trials) == 10
+
+        completed_trials = [
+            trial for trial in trials_with_evc if trial.status == "completed"
+        ]
+        assert len(completed_trials) == 40
+
+        results = [trial.objective.value for trial in completed_trials]
+        best_trial = next(
+            iter(sorted(completed_trials, key=lambda trial: trial.objective.value))
+        )
+
+        assert best_trial.objective.name == "objective"
+        assert abs(best_trial.objective.value - 23.4) < 1e-5
+        assert len(best_trial.params) == 2
+        fidelity = best_trial._params[0]
+        assert fidelity.name == "noise"
+        assert fidelity.type == "fidelity"
+        assert fidelity.value == 10
+        param = best_trial._params[1]
+        assert param.name == "x"
+        assert param.type == "real"


### PR DESCRIPTION
[Fixes #488]

Why:

Hyperband and ASHA would fail if they are passed trials that they did
not sample.

How:

Save sampled ids in algos and only observe points that were previously
sampled, otherwise ignore. This way we could still salvages points from
EVC if the current algo sample points that are in EVC (with same
fidelity), otherwise it ignores the points.
