### PR TITLE
Detect code change when no CMDLINE passed

### DIFF
--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -45,10 +45,7 @@ def add_subparser(parser):
 def main(args):
     """Fetch config and insert new point"""
     command_line_user_args = args.pop("user_args", [None])[1:]
-    experiment_view = experiment_builder.build_view_from_args(args)
-    experiment = experiment_builder.build(
-        name=experiment_view.name, version=experiment_view.version
-    )
+    experiment = experiment_builder.build_view_from_args(args)
 
     transformed_args = _build_from(command_line_user_args)
     exp_space = experiment.space
@@ -57,7 +54,9 @@ def main(args):
 
     trial = tuple_to_trial(values, exp_space)
 
-    experiment.register_trial(trial)
+    # TODO Replace this part when we have experiment rights with read/write (but not execute).
+    experiment._experiment._storage = experiment._experiment._storage._storage
+    experiment._experiment.register_trial(trial)
 
 
 def _validate_dimensions(transformed_args, exp_space):

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -274,8 +274,11 @@ def consolidate_config(name, version, config):
     new_config = config
     config = resolve_config.merge_configs(db_config, config)
 
+    metadata = config.get("metadata", {})
     metadata = resolve_config.fetch_metadata(
-        config.get("user"), config.get("user_args"), config.get("user_script_config")
+        metadata.get("user"),
+        metadata.get("user_args"),
+        metadata.get("user_script_config"),
     )
 
     config = resolve_config.merge_configs(config, {"metadata": metadata})

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -274,14 +274,8 @@ def consolidate_config(name, version, config):
     new_config = config
     config = resolve_config.merge_configs(db_config, config)
 
-    metadata = config.get("metadata", {})
-    metadata = resolve_config.fetch_metadata(
-        metadata.get("user"),
-        metadata.get("user_args"),
-        metadata.get("user_script_config"),
-    )
-
-    config = resolve_config.merge_configs(config, {"metadata": metadata})
+    config.setdefault("metadata", {})
+    resolve_config.update_metadata(config["metadata"])
 
     merge_algorithm_config(config, new_config)
     merge_producer_config(config, new_config)

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -130,6 +130,11 @@ class OrionCmdlineParser:
             self.converter = infer_converter_from_file_type(self.file_config_path)
             self.converter.set_state_dict(state["converter"])
 
+        if "user_script" in state:
+            self.user_script = state["user_script"]
+        else:
+            self.infer_user_script(self.parser.format(self.parser.arguments))
+
     def parse(self, commandline):
         """Parse the commandline given for the definition of priors.
 

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -316,7 +316,27 @@ def fetch_metadata(user=None, user_args=None, user_script_config=None):
     if user_args:
         metadata["user_args"] = user_args
         metadata["parser"] = cmdline_parser.get_state_dict()
+        metadata["user_script_config"] = user_script_config
         metadata["priors"] = dict(cmdline_parser.priors)
+
+    return metadata
+
+
+def update_metadata(metadata):
+    """Update information about the process + versioning"""
+    metadata.setdefault("user", getpass.getuser())
+    metadata["orion_version"] = orion.core.__version__
+
+    if not metadata.get("user_args"):
+        return metadata
+
+    cmdline_parser = OrionCmdlineParser()
+    cmdline_parser.set_state_dict(metadata["parser"])
+
+    if cmdline_parser.user_script:
+        # TODO: Remove this, it is all in cmdline_parser now
+        metadata["user_script"] = cmdline_parser.user_script
+        metadata["VCS"] = infer_versioning_metadata(cmdline_parser.user_script)
 
     return metadata
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,6 +305,15 @@ def version_XYZ(monkeypatch):
 
     monkeypatch.setattr(resolve_config, "fetch_metadata", fetch_metadata)
 
+    non_patched_update_metadata = resolve_config.update_metadata
+
+    def update_metadata(metadata):
+        metadata = non_patched_update_metadata(metadata)
+        metadata["orion_version"] = "XYZ"
+        return metadata
+
+    monkeypatch.setattr(resolve_config, "update_metadata", update_metadata)
+
 
 @pytest.fixture()
 def create_db_instance(null_db_instances, clean_db):
@@ -327,7 +336,9 @@ def create_db_instance(null_db_instances, clean_db):
 @pytest.fixture()
 def script_path():
     """Return a script path for mock"""
-    return os.path.join(os.path.dirname(__file__), "functional/demo/black_box.py")
+    return os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "functional/demo/black_box.py"
+    )
 
 
 @pytest.fixture()

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -834,6 +834,23 @@ def test_new_code_triggers_code_conflict(capsys):
 
 
 @pytest.mark.usefixtures("init_full_x", "mock_infer_versioning_metadata")
+def test_new_code_triggers_code_conflict_with_name_only(capsys):
+    """Test that a different git hash is generating a child, even if cmdline is not passed"""
+    name = "full_x"
+    error_code = orion.core.cli.main(
+        ("hunt --init-only -n {name} " "--manual-resolution")
+        .format(name=name)
+        .split(" ")
+    )
+    assert error_code == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Configuration is different and generates a branching event" in captured.err
+    assert "--code-change-type" in captured.err
+
+
+@pytest.mark.usefixtures("init_full_x", "mock_infer_versioning_metadata")
 def test_new_code_ignores_code_conflict():
     """Test that a different git hash is *not* generating a child if --ignore-code-changes"""
     name = "full_x"
@@ -864,6 +881,18 @@ def test_new_cli(init_full_x_new_cli):
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 21
     assert len(experiment.fetch_trials()) == 20
+
+
+@pytest.mark.usefixtures("init_full_x")
+def test_no_cli_no_branching():
+    """Test that no branching occurs when using same code and not passing cmdline"""
+    name = "full_x"
+    error_code = orion.core.cli.main(
+        ("hunt --init-only -n {name} " "--manual-resolution")
+        .format(name=name)
+        .split(" ")
+    )
+    assert error_code == 0
 
 
 def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):

--- a/tests/functional/commands/experiment.yaml
+++ b/tests/functional/commands/experiment.yaml
@@ -11,7 +11,7 @@
     user: corneau
     datetime: 2017-11-22T20:00:00
     orion_version: 0.post246.dev0+g7aae75d
-    user_script: functional/demo/black_box.py
+    user_script: ../demo/black_box.py
     user_args: ["-x~normal(10,10,default_value=1)"]
     VCS:
           type: git

--- a/tests/functional/commands/test_info_command.py
+++ b/tests/functional/commands/test_info_command.py
@@ -65,7 +65,7 @@ def test_missing_conf_file(clean_db, with_experiment_missing_conf_file, capsys):
     assert "--x~uniform(0,1)" in captured
 
 
-def test_info_cmdline_api(clean_db, with_experiment_using_python_api, capsys):
+def test_info_cmdline_api(clean_db, one_experiment, capsys):
     """Test info if config built using cmdline api"""
     orion.core.cli.main(["info", "--name", "test_single_exp"])
 

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -54,12 +54,13 @@ def test_insert_single_trial(database, monkeypatch, script_path):
             "test_insert_normal",
             "-c",
             "./orion_config_random.yaml",
-            script_path,
+            "blabla",
             "-x=1",
         ]
     )
 
     exp = list(database.experiments.find({"name": "test_insert_normal"}))
+
     assert len(exp) == 1
     exp = exp[0]
     assert "_id" in exp

--- a/tests/functional/configuration/test_all_options.py
+++ b/tests/functional/configuration/test_all_options.py
@@ -99,7 +99,9 @@ class ConfigurationTestSuite:
         with self.setup_env_var_config(tmp_path):
             self.check_env_var_config(tmp_path, monkeypatch)
 
-    @pytest.mark.usefixtures("with_user_userxyz")
+    @pytest.mark.usefixtures(
+        "with_user_userxyz", "version_XYZ", "mock_infer_versioning_metadata"
+    )
     def test_db_config(self, tmp_path):
         """Test that exp config in db overrides global config"""
         update_singletons()
@@ -115,7 +117,7 @@ class ConfigurationTestSuite:
         with self.setup_local_config(tmp_path) as conf_file:
             self.check_local_config(tmp_path, conf_file, monkeypatch)
 
-    @pytest.mark.usefixtures("with_user_userxyz")
+    @pytest.mark.usefixtures("with_user_userxyz", "version_XYZ")
     def test_cmd_args_config(self, tmp_path, monkeypatch):
         """Test that cmd_args config overrides local config"""
         update_singletons()
@@ -366,9 +368,15 @@ class TestExperimentConfig(ConfigurationTestSuite):
         "producer": {"strategy": {"sb": {"e": "c", "d": "g"}}},
         "space": {"/x": "uniform(0, 1)"},
         "metadata": {
-            "VCS": {},
+            "VCS": {
+                "HEAD_sha": "test",
+                "active_branch": None,
+                "diff_sha": "diff",
+                "is_dirty": False,
+                "type": "git",
+            },
             "datetime": datetime.datetime.utcnow(),
-            "orion_version": orion.core.__version__,
+            "orion_version": "XYZ",
             "parser": {
                 "cmd_priors": [["/x", "uniform(0, 1)"]],
                 "config_file_data": {},

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -214,7 +214,7 @@ def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_inst
 @pytest.fixture
 def new_config():
     """Generate a new experiment configuration"""
-    user_script = "abs_path/black_box.py"
+    user_script = "tests/functional/demo/black_box.py"
     config = dict(
         name="test",
         algorithms="fancy",
@@ -235,7 +235,7 @@ def new_config():
 @pytest.fixture
 def old_config(create_db_instance):
     """Generate an old experiment configuration"""
-    user_script = "abs_path/black_box.py"
+    user_script = "tests/functional/demo/black_box.py"
     config = dict(
         name="test",
         algorithms="random",
@@ -361,7 +361,11 @@ def bad_exp_parent_config():
     config = dict(
         _id="test",
         name="test",
-        metadata={"user": "corneauf", "user_args": ["--x~normal(0,1)"]},
+        metadata={
+            "user": "corneauf",
+            "user_args": ["--x~normal(0,1)"],
+            "user_script": "tests/functional/demo/black_box.py",
+        },
         version=1,
         algorithms="random",
     )

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -332,11 +332,11 @@ class TestCommandLineConflict(object):
             cli_conflict.try_resolve("bad-change-type")
         assert "Invalid cli change type 'bad-change-type'" in str(exc.value)
 
-    def test_repr(self, cli_conflict):
+    def test_repr(self, cli_conflict, script_path):
         """Verify the representation of conflict for user interface"""
         assert repr(cli_conflict) == (
-            "Old arguments '_pos_0 abs_path/black_box.py' != "
-            "new arguments '_pos_0 abs_path/black_box.py bool-arg True some-new args'"
+            f"Old arguments '_pos_0 {script_path}' != "
+            f"new arguments '_pos_0 {script_path} bool-arg True some-new args'"
         )
 
 
@@ -377,10 +377,14 @@ class TestScriptConfigConflict(object):
         """Verify the representation of conflict for user interface"""
         assert repr(config_conflict) == "Script's configuration file changed"
 
-    def test_comparison(self, yaml_config, yaml_diff_config):
+    def test_comparison(self, yaml_config, yaml_diff_config, script_path):
         """Test that different configs are detected as conflict."""
-        old_config = {"metadata": {"user_args": yaml_config}}
-        new_config = {"metadata": {"user_args": yaml_diff_config}}
+        old_config = {
+            "metadata": {"user_args": yaml_config, "user_script": script_path}
+        }
+        new_config = {
+            "metadata": {"user_args": yaml_diff_config, "user_script": script_path}
+        }
 
         backward.populate_space(old_config)
         backward.populate_space(new_config)
@@ -388,10 +392,17 @@ class TestScriptConfigConflict(object):
         conflicts = list(conflict.ScriptConfigConflict.detect(old_config, new_config))
         assert len(conflicts) == 1
 
-    def test_comparison_idem(self, yaml_config):
+    def test_comparison_idem(self, yaml_config, script_path):
         """Test that identical configs are not detected as conflict."""
-        old_config = {"metadata": {"user_args": yaml_config}}
-        new_config = {"metadata": {"user_args": yaml_config + ["--other", "args"]}}
+        old_config = {
+            "metadata": {"user_args": yaml_config, "user_script": script_path}
+        }
+        new_config = {
+            "metadata": {
+                "user_args": yaml_config + ["--other", "args"],
+                "user_script": script_path,
+            }
+        }
 
         backward.populate_space(old_config)
         backward.populate_space(new_config)

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -84,6 +84,7 @@ def new_config(random_dt, script_path):
             "user": "tsirif",
             "orion_version": "XYZ",
             "user_script": script_path,
+            "user_script_config": "config",
             "user_config": "abs_path/hereitis.yaml",
             "user_args": [script_path, "--mini-batch~uniform(32, 256, discrete=True)"],
             "VCS": {
@@ -123,7 +124,7 @@ def new_config(random_dt, script_path):
 
 
 @pytest.fixture
-def parent_version_config():
+def parent_version_config(script_path):
     """Return a configuration for an experiment."""
     config = dict(
         _id="parent_config",
@@ -134,6 +135,14 @@ def parent_version_config():
             "user": "corneauf",
             "datetime": datetime.datetime.utcnow(),
             "user_args": ["--x~normal(0,1)"],
+            "user_script": script_path,
+            "VCS": {
+                "type": "git",
+                "is_dirty": False,
+                "HEAD_sha": "test",
+                "active_branch": None,
+                "diff_sha": "diff",
+            },
         },
     )
 
@@ -454,7 +463,7 @@ def test_build_no_commandline_config():
 
 
 @pytest.mark.usefixtures(
-    "with_user_dendi", "mock_infer_versioning_metadata", "version_XYZ"
+    "with_user_tsirif", "mock_infer_versioning_metadata", "version_XYZ"
 )
 def test_build_hit(python_api_config):
     """Try building experiment from config when in db (no branch)"""
@@ -470,7 +479,6 @@ def test_build_hit(python_api_config):
     assert exp._id == python_api_config["_id"]
     assert exp.name == python_api_config["name"]
     assert exp.configuration["refers"] == python_api_config["refers"]
-    python_api_config["metadata"]["user"] = "dendi"
     assert exp.metadata == python_api_config["metadata"]
     assert exp.max_trials == python_api_config["max_trials"]
     assert exp.max_broken == python_api_config["max_broken"]
@@ -498,7 +506,9 @@ def test_build_without_config_hit(python_api_config):
     assert exp.algorithms.configuration == python_api_config["algorithms"]
 
 
-@pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
+@pytest.mark.usefixtures(
+    "with_user_tsirif", "version_XYZ", "mock_infer_versioning_metadata"
+)
 def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
     """Try building experiment without commandline when in db (no branch)"""
     name = "supernaekei"
@@ -550,6 +560,7 @@ class TestExperimentVersioning(object):
 
         assert exp.version == 2
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_old_experiment_wout_version(self, parent_version_config):
         """Create an already existing experiment without a version."""
         with OrionState(experiments=[parent_version_config]):
@@ -557,6 +568,7 @@ class TestExperimentVersioning(object):
 
         assert exp.version == 1
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_old_experiment_2_wout_version(
         self, parent_version_config, child_version_config
     ):
@@ -566,6 +578,7 @@ class TestExperimentVersioning(object):
 
         assert exp.version == 2
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_old_experiment_w_version(
         self, parent_version_config, child_version_config
     ):
@@ -577,11 +590,11 @@ class TestExperimentVersioning(object):
 
         assert exp.version == 1
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_old_experiment_w_version_bigger_than_max(
         self, parent_version_config, child_version_config
     ):
         """Create an already existing experiment with a too large version."""
-        print(child_version_config["name"])
         with OrionState(experiments=[parent_version_config, child_version_config]):
             exp = experiment_builder.build(
                 name=parent_version_config["name"], version=8
@@ -594,6 +607,7 @@ class TestExperimentVersioning(object):
 class TestBuild(object):
     """Test building the experiment"""
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_good_set_before_init_hit_no_diffs_exc_max_trials(self, new_config):
         """Trying to set, and NO differences were found from the config pulled from db.
 
@@ -617,6 +631,7 @@ class TestBuild(object):
         new_config.pop("something_to_be_ignored")
         assert exp.configuration == new_config
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_good_set_before_init_no_hit(self, random_dt, new_config):
         """Trying to set, overwrite everything from input."""
         with OrionState(experiments=[], trials=[]):
@@ -685,6 +700,7 @@ class TestBuild(object):
             exp = experiment_builder.build(**found_config)
             assert exp.working_dir == ""
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_configuration_hit_no_diffs(self, new_config):
         """Return a configuration dict according to an experiment object.
 
@@ -716,6 +732,7 @@ class TestBuild(object):
         assert isinstance(exp.space, Space)
         assert isinstance(exp.refers["adapter"], BaseAdapter)
 
+    @pytest.mark.usefixtures("mock_infer_versioning_metadata")
     def test_algo_case_insensitive(self, new_config):
         """Verify that algo with uppercase or lowercase leads to same experiment"""
         with OrionState(experiments=[new_config], trials=[]):

--- a/tests/unittests/core/test_branch_config.py
+++ b/tests/unittests/core/test_branch_config.py
@@ -50,7 +50,7 @@ def user_config():
 @pytest.fixture
 def parent_config(user_config):
     """Create a configuration that will not hit the database."""
-    user_script = "abs_path/black_box.py"
+    user_script = "tests/functional/demo/black_box.py"
     config = dict(
         _id="test",
         name="test",
@@ -189,7 +189,7 @@ def list_arg_with_equals_cli_config(child_config):
 @pytest.fixture
 def cl_config(create_db_instance):
     """Create a child config with markers for commandline solving"""
-    user_script = "abs_path/black_box.py"
+    user_script = "tests/functional/demo/black_box.py"
     config = dict(
         name="test",
         branch="test2",

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -31,7 +31,7 @@ def new_config(random_dt):
         metadata={
             "user": "tsirif",
             "orion_version": 0.1,
-            "user_script": "abs_path/to_yoyoy.py",
+            "user_script": "tests/functional/demo/black_box.py",
             "user_config": "abs_path/hereitis.yaml",
             "user_args": ["--mini-batch~uniform(32, 256, discrete=True)"],
             "VCS": {


### PR DESCRIPTION
Why:

The code version was not infered properly when `orion hunt` is called
with only experiment name, not passing the user script cmdline.

How:

Re-infer code version based on merge of old metadata and new metadata.