### PR TITLE
Branch if Oríon version changes

### DIFF
--- a/docs/src/user/config.rst
+++ b/docs/src/user/config.rst
@@ -119,6 +119,7 @@ Full Example of Global Configuration
         cli_change_type: break
         code_change_type: break
         config_change_type: break
+        orion_version_change: False
         ignore_code_changes: False
         manual_resolution: False
         non_monitored_arguments: []
@@ -482,6 +483,7 @@ Experiment Version Control
         cli_change_type: break
         code_change_type: break
         config_change_type: break
+        orion_version_change: False
         ignore_code_changes: False
         manual_resolution: False
         non_monitored_arguments: []
@@ -618,3 +620,17 @@ config_change_type
     incompatible results. The child cannot access the trials from parent if ``config_change_type``
     is ``break``.  The parent cannot access trials from child if ``config_change_type`` is
     ``unsure`` or ``break``.
+
+
+.. _config_evc_orion_version_change:
+
+orion_version_change
+~~~~~~~~~~~~~~~~~~~~
+
+:Type: bool
+:Default: False
+:Env var: ORION_EVC_ORION_VERSION_CHANGE
+:Description:
+    If ``True``, set orion version change as resolved if branching event occured.
+    Child and parent experiment have access to all trials from each other
+    when the only difference between them is the orion version used during execution.

--- a/docs/src/user/evc.rst
+++ b/docs/src/user/evc.rst
@@ -166,6 +166,7 @@ Source of conflicts
 3. Script configuration file modification
 4. Optimization space modification (new hyper-parameters or change of prior distribution)
 5. Algorithm configuration modification
+6. Orion version change
 
 Iterative Results
 =================

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -150,6 +150,9 @@ def create_experiment(
         algorithm_change: bool, optional
             Whether to automatically solve the algorithm conflict (change of algo config).
             Defaults to True.
+        orion_version_change: bool, optional
+            Whether to automatically solve the orion version conflict.
+            Defaults to True.
         code_change_type: str, optional
             How to resolve code change automatically. Must be one of 'noeffect', 'unsure' or
             'break'.  Defaults to 'break'.

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -393,6 +393,18 @@ def define_evc_config(config):
         ),
     )
 
+    evc_config.add_option(
+        "orion_version_change",
+        option_type=bool,
+        default=False,
+        env_var="ORION_EVC_ORION_VERSION_CHANGE",
+        help=(
+            "Set orion version change as resolved if branching event occured"
+            "Child and parent experiment have access to all trials from each other "
+            "when the only difference between them is the orion version used during execution."
+        ),
+    )
+
     config.evc = evc_config
 
 

--- a/src/orion/core/cli/evc.py
+++ b/src/orion/core/cli/evc.py
@@ -89,6 +89,15 @@ def _add_config_argument(parser, resolution_class):
     )
 
 
+def _add_orion_version_argument(parser, resolution_class):
+    parser.add_argument(
+        resolution_class.ARGUMENT,
+        action="store_true",
+        default=None,
+        help="Set orion version change as resolved if branching event occured",
+    )
+
+
 def _add_branch_to_argument(parser, resolution_class):
     parser.add_argument(
         "-b",
@@ -107,6 +116,7 @@ resolution_arguments = {
     "code_change_type": _add_code_argument,
     "cli_change_type": _add_cli_argument,
     "config_change_type": _add_config_argument,
+    "orion_version_change": _add_orion_version_argument,
     "branch_from": _add_branch_from_argument,
     "branch_to": _add_branch_to_argument,
 }

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -864,6 +864,45 @@ class ScriptConfigChange(BaseAdapter):
         return ret
 
 
+class OrionVersionChange(BaseAdapter):
+    """Adapter for changes of Oríon version
+
+    .. note::
+
+        Does nothing...
+
+    """
+
+    def forward(self, trials):
+        """Pass all trials from parent experiment to child experiment
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return trials
+
+    def backward(self, trials):
+        """Pass all trials from child experiment to parent experiment
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower())
+        return ret
+
+
 # pylint: disable=too-few-public-methods,abstract-method
 class Adapter(BaseAdapter, metaclass=Factory):
     """Class used to inject dependency on an adapter implementation.

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -898,8 +898,7 @@ class OrionVersionChange(BaseAdapter):
 
             :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
         """
-        ret = dict(
-            of_type=self.__class__.__name__.lower())
+        ret = dict(of_type=self.__class__.__name__.lower())
         return ret
 
 

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1809,7 +1809,10 @@ class OrionVersionConflict(Conflict):
     @classmethod
     def detect(cls, old_config, new_config, branching_config=None):
         """Detect if orion versions differs"""
-        if old_config['metadata']['orion_version'] != new_config['metadata']['orion_version']:
+        if (
+            old_config["metadata"]["orion_version"]
+            != new_config["metadata"]["orion_version"]
+        ):
             yield cls(old_config, new_config)
 
     def try_resolve(self):
@@ -1823,14 +1826,16 @@ class OrionVersionConflict(Conflict):
     def diff(self):
         """Produce human-readable differences"""
         return colored_diff(
-            self.old_config['metadata']['orion_version'],
-            self.new_config['metadata']['orion_version'])
+            self.old_config["metadata"]["orion_version"],
+            self.new_config["metadata"]["orion_version"],
+        )
 
     def __repr__(self):
         """Reprensentation of the conflict for user interface"""
-        return "{0}\n   !=\n{1}".format(
-            self.old_config['metadata']['orion_version'],
-            self.new_config['metadata']['orion_version'])
+        return "{0} != {1}".format(
+            self.old_config["metadata"]["orion_version"],
+            self.new_config["metadata"]["orion_version"],
+        )
 
     class OrionVersionResolution(Resolution):
         """Representation of an orion version resolution

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1795,3 +1795,60 @@ class ExperimentNameConflict(Conflict):
             incrementing version of an experiment.
             """
             return True
+
+
+class OrionVersionConflict(Conflict):
+    """Representation of conflict due to different Orion versions
+
+    .. seealso ::
+
+        :class:`orion.core.evc.conflicts.Conflict`
+
+    """
+
+    @classmethod
+    def detect(cls, old_config, new_config, branching_config=None):
+        """Detect if orion versions differs"""
+        if old_config['metadata']['orion_version'] != new_config['metadata']['orion_version']:
+            yield cls(old_config, new_config)
+
+    def try_resolve(self):
+        """Try to create a resolution OrionVersionResolution"""
+        if self.is_resolved:
+            return None
+
+        return self.OrionVersionResolution(self)
+
+    @property
+    def diff(self):
+        """Produce human-readable differences"""
+        return colored_diff(
+            self.old_config['metadata']['orion_version'],
+            self.new_config['metadata']['orion_version'])
+
+    def __repr__(self):
+        """Reprensentation of the conflict for user interface"""
+        return "{0}\n   !=\n{1}".format(
+            self.old_config['metadata']['orion_version'],
+            self.new_config['metadata']['orion_version'])
+
+    class OrionVersionResolution(Resolution):
+        """Representation of an orion version resolution
+
+        .. seealso ::
+
+            :class:`orion.core.evc.conflicts.Resolution`
+
+        """
+
+        ARGUMENT = "--orion-version-change"
+
+        def get_adapters(self):
+            """Return OrionVersionChange adapter"""
+            return [adapters.OrionVersionChange()]
+
+        def __repr__(self):
+            """Representation of the resolution as it should be provided in command line of
+            configuration file by the user
+            """
+            return "{0}".format(self.ARGUMENT)

--- a/src/orion/core/io/experiment_branch_builder.py
+++ b/src/orion/core/io/experiment_branch_builder.py
@@ -218,6 +218,23 @@ class ExperimentBranchBuilder:
 
         self.conflicts.try_resolve(algo_conflicts[0])
 
+    def set_orion_version(self):
+        """Set orion version resolution
+
+        Raises
+        ------
+        RuntimeError
+            If there is no orion version conflict left to resolve.
+
+        """
+        orion_version_conflicts = self.conflicts.get_remaining(
+            [conflicts.OrionVersionConflict]
+        )
+        if not orion_version_conflicts:
+            raise RuntimeError("No orion version conflict to solve")
+
+        self.conflicts.try_resolve(orion_version_conflicts[0])
+
     def add_dimension(self, name, default_value=Dimension.NO_DEFAULT_VALUE):
         """Add dimension with given `name`
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -155,6 +155,9 @@ def build(name, version=None, branching=None, **config):
         algorithm_change: bool, optional
             Whether to automatically solve the algorithm conflict (change of algo config).
             Defaults to True.
+        orion_version_change: bool, optional
+            Whether to automatically solve the orion version conflict.
+            Defaults to True.
         code_change_type: str, optional
             How to resolve code change automatically. Must be one of 'noeffect', 'unsure' or
             'break'.  Defaults to 'break'.

--- a/src/orion/core/io/interactive_commands/branching_prompt.py
+++ b/src/orion/core/io/interactive_commands/branching_prompt.py
@@ -367,6 +367,12 @@ class BranchingPrompt(cmd.Cmd):
         self.do_status("")
 
     @parse_command
+    def do_orion_version(self, options):
+        """Resolve the orion version conflict"""
+        self.branch_builder.set_orion_version()
+        self.do_status("")
+
+    @parse_command
     def do_add(self, options):
         """Add the given `new` or `changed` dimension to the configuration"""
         print(

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -50,6 +50,9 @@ def parallel_coordinates(experiment, order=None, colorscale="YlOrRd", **kwargs):
         df = experiment.to_pandas()
         df = df.loc[df["status"] == "completed"]
 
+        if df.empty:
+            return df
+
         df[names] = df[names].transform(
             functools.partial(_curate_params, space=experiment.space)
         )

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -187,7 +187,7 @@ def regret(experiment, order_by, verbose_hover, **kwargs):
         hovertemplate=_template_best(),
     )
 
-    if trial:
+    if trial is None:
         y_axis_label = "Objective unknown"
     else:
         y_axis_label = f"{trial.objective.type.capitalize()} '{trial.objective.name}'"

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -92,8 +92,12 @@ def parallel_coordinates(experiment, order=None, colorscale="YlOrRd", **kwargs):
     if not experiment:
         raise ValueError("Parameter 'experiment' is None")
 
-    trial = experiment.fetch_trials_by_status("completed")[0]
     df = build_frame()
+
+    if df.empty:
+        return go.Figure()
+
+    trial = experiment.fetch_trials_by_status("completed")[0]
 
     dimensions = []
     for name in infer_order(order):
@@ -159,10 +163,14 @@ def regret(experiment, order_by, verbose_hover, **kwargs):
     if order_by not in ORDER_KEYS:
         raise ValueError(f"Parameter 'order_by' is not one of {ORDER_KEYS}")
 
-    trial = experiment.fetch_trials_by_status("completed")[0]
     df = build_frame()
 
     fig = go.Figure()
+
+    if df.empty:
+        return fig
+
+    trial = experiment.fetch_trials_by_status("completed")[0]
 
     fig.add_scatter(
         y=df["objective"],
@@ -179,7 +187,11 @@ def regret(experiment, order_by, verbose_hover, **kwargs):
         hovertemplate=_template_best(),
     )
 
-    y_axis_label = f"{trial.objective.type.capitalize()} '{trial.objective.name}'"
+    if trial:
+        y_axis_label = "Objective unknown"
+    else:
+        y_axis_label = f"{trial.objective.type.capitalize()} '{trial.objective.name}'"
+
     fig.update_layout(
         title=f"Regret for experiment '{experiment.name}'",
         xaxis_title=f"Trials ordered by {order_by} time",

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -48,13 +48,14 @@ class WebApi(falcon.API):
             trials_resource,
             suffix="trial_in_experiment",
         )
-        self.add_route(
-            "/plots/regret/{experiment_name}", plots_resource, suffix="regret"
-        )
+        self.add_route("/plots/lpi/{experiment_name}", plots_resource, suffix="lpi")
         self.add_route(
             "/plots/parallel_coordinates/{experiment_name}",
             plots_resource,
             suffix="parallel_coordinates",
+        )
+        self.add_route(
+            "/plots/regret/{experiment_name}", plots_resource, suffix="regret"
         )
 
     def start(self):

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -864,6 +864,21 @@ def test_new_code_ignores_code_conflict():
     )
 
 
+@pytest.mark.usefixtures("init_full_x", "version_XYZ")
+def test_new_orion_version_triggers_conflict(capsys):
+    """Test that a different git hash is generating a child"""
+    name = "full_x"
+    error_code = orion.core.cli.main(
+        ("hunt --init-only -n {name} --manual-resolution").format(name=name).split(" ")
+    )
+    assert error_code == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Configuration is different and generates a branching event" in captured.err
+    assert "XYZ" in captured.err
+
+
 def test_new_cli(init_full_x_new_cli):
     """Test that new cli conflict is automatically resolved"""
     experiment = experiment_builder.build_view(name="full_x_new_cli")

--- a/tests/functional/commands/experiment.yaml
+++ b/tests/functional/commands/experiment.yaml
@@ -10,7 +10,7 @@
   metadata:
     user: corneau
     datetime: 2017-11-22T20:00:00
-    orion_version: 0.post246.dev0+g7aae75d
+    orion_version: XYZ
     user_script: ../demo/black_box.py
     user_args: ["-x~normal(10,10,default_value=1)"]
     VCS:
@@ -34,7 +34,7 @@
   metadata:
     user: corneau
     datetime: 2017-11-22T20:00:00
-    orion_version: 0.post246.dev0+g7aae75d
+    orion_version: XYZ
     user_script: functional/demo/black_box.py
     user_args: ["-x~normal(10,10)"]
     VCS:
@@ -58,7 +58,7 @@
   metadata:
     user: corneau
     datetime: 2017-11-22T20:00:00
-    orion_version: 0.post246.dev0+g7aae75d
+    orion_version: XYZ
     user_script: functional/demo/black_box.py
     user_args: ["-x~normal(10,10)", "-y~uniform(1, 30)"]
     VCS:

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -40,8 +40,7 @@ def test_insert_invalid_experiment(database, monkeypatch, capsys):
     assert "Error: No experiment with given name 'dumb_experiment'"
 
 
-@pytest.mark.usefixtures("only_experiments_db")
-@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("only_experiments_db", "null_db_instances", "version_XYZ")
 def test_insert_single_trial(database, monkeypatch, script_path):
     """Try to insert a single trial"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
@@ -75,8 +74,7 @@ def test_insert_single_trial(database, monkeypatch, script_path):
     assert trial["params"][0]["value"] == 1
 
 
-@pytest.mark.usefixtures("only_experiments_db")
-@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("only_experiments_db", "null_db_instances", "version_XYZ")
 def test_insert_single_trial_default_value(database, monkeypatch):
     """Try to insert a single trial using a default value"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
@@ -176,8 +174,7 @@ def test_insert_with_outside_bound_value(database, monkeypatch):
     assert "Value 100 is outside of" in str(exc_info.value)
 
 
-@pytest.mark.usefixtures("only_experiments_db")
-@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("only_experiments_db", "null_db_instances", "version_XYZ")
 def test_insert_two_hyperparameters(database, monkeypatch):
     """Try to insert a single trial with two hyperparameters"""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/functional/configuration/test_all_options.py
+++ b/tests/functional/configuration/test_all_options.py
@@ -730,6 +730,7 @@ class TestEVCConfig(ConfigurationTestSuite):
             "code_change_type": "noeffect",
             "cli_change_type": "noeffect",
             "config_change_type": "noeffect",
+            "orion_version_change": True,
         }
     }
 
@@ -741,6 +742,7 @@ class TestEVCConfig(ConfigurationTestSuite):
         "ORION_EVC_CODE_CHANGE": "unsure",
         "ORION_EVC_CMDLINE_CHANGE": "unsure",
         "ORION_EVC_CONFIG_CHANGE": "unsure",
+        "ORION_EVC_ORION_VERSION_CHANGE": "",
     }
 
     local = {
@@ -752,6 +754,7 @@ class TestEVCConfig(ConfigurationTestSuite):
             "code_change_type": "break",
             "cli_change_type": "break",
             "config_change_type": "noeffect",
+            "orion_version_change": True,
         }
     }
 
@@ -763,6 +766,7 @@ class TestEVCConfig(ConfigurationTestSuite):
         "code-change-type": "noeffect",
         "cli-change-type": "unsure",
         "config-change-type": "break",
+        "orion-version-change": False,
     }
 
     def sanity_check(self):
@@ -864,6 +868,7 @@ class TestEVCConfig(ConfigurationTestSuite):
         assert orion.core.config.evc.code_change_type == "unsure"
         assert orion.core.config.evc.cli_change_type == "unsure"
         assert orion.core.config.evc.config_change_type == "unsure"
+        assert not orion.core.config.evc.orion_version_change
 
         script = os.path.abspath(__file__)
         name = "env-var-test"

--- a/tests/functional/serving/test_plots_resource.py
+++ b/tests/functional/serving/test_plots_resource.py
@@ -1,4 +1,6 @@
 """Perform tests for the REST endpoint `/plots`"""
+import pytest
+
 from orion.testing import create_experiment
 
 config = dict(
@@ -42,6 +44,7 @@ def test_root_not_available(client):
     assert response.status == "404 Not Found"
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestRegretPlots:
     """Tests regret plots"""
 
@@ -68,7 +71,20 @@ class TestRegretPlots:
         assert response.json
         assert list(response.json.keys()) == ["data", "layout"]
 
+    def test_no_trials(self, client):
+        """Tests that the API returns an empty figure when no trials are found."""
+        with create_experiment(config, trial_config, []) as (
+            _,
+            _,
+            experiment,
+        ):
+            response = client.simulate_get("/plots/regret/experiment-name")
 
+        assert response.status == "200 OK"
+        assert list(response.json.keys()) == ["data", "layout"]
+
+
+@pytest.mark.usefixtures("version_XYZ")
 class TestParallelCoordinatesPlots:
     """Tests parallel coordinates plots"""
 
@@ -95,4 +111,58 @@ class TestParallelCoordinatesPlots:
 
         assert response.status == "200 OK"
         assert response.json
+        assert list(response.json.keys()) == ["data", "layout"]
+
+    def test_no_trials(self, client):
+        """Tests that the API returns an empty figure when no trials are found."""
+        with create_experiment(config, trial_config, []) as (
+            _,
+            _,
+            experiment,
+        ):
+            response = client.simulate_get(
+                "/plots/parallel_coordinates/experiment-name"
+            )
+
+        assert response.status == "200 OK"
+        assert list(response.json.keys()) == ["data", "layout"]
+
+
+@pytest.mark.usefixtures("version_XYZ")
+class TestLPIPlots:
+    """Tests lpi plots"""
+
+    def test_unknown_experiment(self, client):
+        """Tests that the API returns a 404 Not Found when an unknown experiment is queried."""
+        response = client.simulate_get("/plots/lpi/unknown-experiment")
+
+        assert response.status == "404 Not Found"
+        assert response.json == {
+            "title": "Experiment not found",
+            "description": 'Experiment "unknown-experiment" does not exist',
+        }
+
+    def test_plot(self, client):
+        """Tests that the API returns the plot in json format."""
+        with create_experiment(config, trial_config, ["completed"]) as (
+            _,
+            _,
+            experiment,
+        ):
+            response = client.simulate_get("/plots/lpi/experiment-name")
+
+        assert response.status == "200 OK"
+        assert response.json
+        assert list(response.json.keys()) == ["data", "layout"]
+
+    def test_no_trials(self, client):
+        """Tests that the API returns an empty figure when no trials are found."""
+        with create_experiment(config, trial_config, []) as (
+            _,
+            _,
+            experiment,
+        ):
+            response = client.simulate_get("/plots/lpi/experiment-name")
+
+        assert response.status == "200 OK"
         assert list(response.json.keys()) == ["data", "layout"]

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -145,6 +145,7 @@ class TestReportResults(object):
         assert reloaded_client._HAS_REPORTED_RESULTS is True
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestCreateExperiment:
     """Test creation of experiment with `client.create_experiment()`"""
 

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -113,6 +113,7 @@ def test_experiment_to_pandas():
         pandas.testing.assert_frame_equal(experiment.to_pandas(), client.to_pandas())
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestInsert:
     """Tests for ExperimentClient.insert"""
 
@@ -253,6 +254,7 @@ class TestInsert:
             assert client._pacemakers == {}
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestReserve:
     """Tests for ExperimentClient.reserve"""
 
@@ -333,6 +335,7 @@ class TestReserve:
             assert client._pacemakers == {}
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestRelease:
     """Tests for ExperimentClient.release"""
 
@@ -424,6 +427,7 @@ class TestRelease:
             assert client._pacemakers == {}
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestClose:
     """Test close method of the client"""
 
@@ -465,6 +469,7 @@ class TestClose:
             client.close()
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestBroken:
     """Test handling of broken trials with atexit()"""
 
@@ -566,6 +571,7 @@ class TestBroken:
             assert client.get_trial(trial).status == "interrupted"
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestSuggest:
     """Tests for ExperimentClient.suggest"""
 
@@ -767,6 +773,7 @@ class TestSuggest:
             client._pacemakers.pop(trial.id).stop()
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestObserve:
     """Tests for ExperimentClient.observe"""
 
@@ -840,6 +847,7 @@ class TestObserve:
             assert client._pacemakers == {}
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestWorkon:
     """Tests for ExperimentClient.workon"""
 

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -224,6 +224,7 @@ def new_config():
             "user_script": user_script,
             "user_args": [user_script, "--new~normal(0,2)", "--changed~normal(0,2)"],
             "user": "some_user_name",
+            "orion_version": "UVW",
         },
     )
 
@@ -255,6 +256,7 @@ def old_config(create_db_instance):
                 "--changed~uniform(-10,10)",
             ],
             "user": "some_user_name",
+            "orion_version": "XYZ",
         },
     )
 
@@ -328,6 +330,12 @@ def algorithm_conflict(old_config, new_config):
 
 
 @pytest.fixture
+def orion_version_conflict(old_config, new_config):
+    """Generate an orion version conflict"""
+    return conflicts.OrionVersionConflict(old_config, new_config)
+
+
+@pytest.fixture
 def code_conflict(old_config, new_config):
     """Generate a code conflict"""
     return conflicts.CodeConflict(old_config, new_config)
@@ -365,6 +373,7 @@ def bad_exp_parent_config():
             "user": "corneauf",
             "user_args": ["--x~normal(0,1)"],
             "user_script": "tests/functional/demo/black_box.py",
+            "orion_version": "XYZ",
         },
         version=1,
         algorithms="random",

--- a/tests/unittests/core/evc/test_adapters.py
+++ b/tests/unittests/core/evc/test_adapters.py
@@ -14,6 +14,7 @@ from orion.core.evc.adapters import (
     DimensionDeletion,
     DimensionPriorChange,
     DimensionRenaming,
+    OrionVersionChange,
 )
 from orion.core.io.space_builder import DimensionBuilder
 from orion.core.worker.trial import Trial
@@ -230,6 +231,14 @@ class TestAlgorithmChangeInit(object):
     def test_algorithm_change_init(self):
         """Test initialization of :class:`orion.core.evc.adapters.AlgorithmChange`"""
         AlgorithmChange()
+
+
+class TestOrionVersionChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.OrionVersionChange`"""
+
+    def test_orion_version_change_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.OrionVersionChange`"""
+        OrionVersionChange()
 
 
 class TestCodeChangeInit(object):
@@ -626,6 +635,34 @@ class TestAlgorithmChangeForwardBackward(object):
         assert adapted_trials[-1] is trials[-1]
 
 
+class TestOrionVersionChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.OrionVersionChange.forward` and
+    :meth:`orion.core.evc.adapters.OrionVersionChange.backward`
+    """
+
+    def test_orion_version_change_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.OrionVersionChange.forward`"""
+        orion_version_change_adaptor = OrionVersionChange()
+
+        adapted_trials = orion_version_change_adaptor.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_orion_version_change_backward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.OrionVersionChange.backward`"""
+        orion_version_change_adaptor = OrionVersionChange()
+
+        adapted_trials = orion_version_change_adaptor.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+
 class TestCodeChangeForwardBackward(object):
     """Test :meth:`orion.core.evc.adapters.CodeChange.forward` and
     :meth:`orion.core.evc.adapters.CodeChange.backward`
@@ -821,6 +858,17 @@ def test_algorithm_change_configuration():
     configuration = algorithm_change_adaptor.configuration[0]
 
     assert configuration["of_type"] == "algorithmchange"
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_orion_version_change_configuration():
+    """Test :meth:`orion.core.evc.adapters.OrionVersionChange.configuration`"""
+    orion_version_change_adaptor = OrionVersionChange()
+
+    configuration = orion_version_change_adaptor.configuration[0]
+
+    assert configuration["of_type"] == "orionversionchange"
 
     assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
 

--- a/tests/unittests/core/evc/test_resolutions.py
+++ b/tests/unittests/core/evc/test_resolutions.py
@@ -45,6 +45,12 @@ def algorithm_resolution(algorithm_conflict):
 
 
 @pytest.fixture
+def orion_version_resolution(orion_version_conflict):
+    """Create a resolution for a new orion version"""
+    return orion_version_conflict.OrionVersionResolution(orion_version_conflict)
+
+
+@pytest.fixture
 def code_resolution(code_conflict):
     """Create a resolution for a code conflict"""
     return code_conflict.CodeResolution(code_conflict, adapters.CodeChange.BREAK)
@@ -405,6 +411,30 @@ class TestAlgorithmResolution(object):
         assert algorithm_resolution.revert() == []
         assert not algorithm_conflict.is_resolved
         assert algorithm_conflict.resolution is None
+
+
+class TestOrionVersionResolution(object):
+    """Test methods for resolution of orion version changes"""
+
+    def test_adapters(self, orion_version_resolution):
+        """Verify shallow adapters for orion version change"""
+        resolution_adapters = orion_version_resolution.get_adapters()
+        assert len(resolution_adapters) == 1
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.OrionVersionChange().configuration
+        )
+
+    def test_repr(self, orion_version_resolution):
+        """Verify resolution representation for user interface"""
+        assert repr(orion_version_resolution) == "--orion-version-change"
+
+    def test_revert(self, orion_version_conflict, orion_version_resolution):
+        """Verify reverting resolution set conflict to unresolved"""
+        assert orion_version_conflict.is_resolved
+        assert orion_version_resolution.revert() == []
+        assert not orion_version_conflict.is_resolved
+        assert orion_version_conflict.resolution is None
 
 
 class TestCodeResolution(object):

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -143,6 +143,7 @@ def parent_version_config(script_path):
                 "active_branch": None,
                 "diff_sha": "diff",
             },
+            "orion_version": "XYZ",
         },
     )
 
@@ -530,7 +531,7 @@ def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
     assert exp.algorithms.configuration == new_config["algorithms"]
 
 
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
 class TestExperimentVersioning(object):
     """Create new Experiment with auto-versioning."""
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -308,6 +308,10 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
         == orion.core.config.evc.ignore_code_changes
     )
     assert evc_config.pop("algorithm_change") == orion.core.config.evc.algorithm_change
+    assert (
+        evc_config.pop("orion_version_change")
+        == orion.core.config.evc.orion_version_change
+    )
     assert evc_config.pop("code_change_type") == orion.core.config.evc.code_change_type
     assert evc_config.pop("cli_change_type") == orion.core.config.evc.cli_change_type
     assert (

--- a/tests/unittests/core/test_branch_config.py
+++ b/tests/unittests/core/test_branch_config.py
@@ -19,6 +19,7 @@ from orion.core.evc.conflicts import (
     ExperimentNameConflict,
     MissingDimensionConflict,
     NewDimensionConflict,
+    OrionVersionConflict,
     ScriptConfigConflict,
     detect_conflicts,
 )
@@ -74,6 +75,7 @@ def parent_config(user_config):
                 "--manual-resolution",
             ],
             "user": "some_user_name",
+            "orion_version": "XYZ",
         },
         refers={},
     )
@@ -130,8 +132,15 @@ def changed_config(child_config):
 
 @pytest.fixture
 def changed_algo_config(child_config):
-    """Create a child config with a changed dimension"""
+    """Create a child config with a new algo"""
     child_config["algorithms"] = "stupid-grid"
+    return child_config
+
+
+@pytest.fixture
+def changed_orion_version_config(child_config):
+    """Create a child config with new orion version"""
+    child_config["metadata"]["orion_version"] = "UVW"
     return child_config
 
 
@@ -207,6 +216,7 @@ def cl_config(create_db_instance):
                 "--omega~+normal(0,1)",
             ],
             "user": "some_user_name",
+            "orion_version": "XYZ",
         },
     )
     backward.populate_space(config)
@@ -219,6 +229,7 @@ def conflicts(
     changed_dimension_conflict,
     missing_dimension_conflict,
     algorithm_conflict,
+    orion_version_conflict,
     code_conflict,
     experiment_name_conflict,
     config_conflict,
@@ -230,6 +241,7 @@ def conflicts(
     conflicts.register(changed_dimension_conflict)
     conflicts.register(missing_dimension_conflict)
     conflicts.register(algorithm_conflict)
+    conflicts.register(orion_version_conflict)
     conflicts.register(code_conflict)
     conflicts.register(experiment_name_conflict)
     conflicts.register(config_conflict)
@@ -304,6 +316,18 @@ class TestConflictDetection(object):
         assert conflict.old_config["algorithms"] == "random"
         assert conflict.new_config["algorithms"] == "stupid-grid"
         assert isinstance(conflict, AlgorithmConflict)
+
+    def test_orion_version_conflict(self, parent_config, changed_orion_version_config):
+        """Test if orion version changes are currently detected"""
+        conflicts = detect_conflicts(parent_config, changed_orion_version_config)
+
+        assert len(conflicts.get()) == 2
+        conflict = conflicts.get()[1]
+
+        assert conflict.is_resolved is False
+        assert conflict.old_config["metadata"]["orion_version"] == "XYZ"
+        assert conflict.new_config["metadata"]["orion_version"] == "UVW"
+        assert isinstance(conflict, OrionVersionConflict)
 
     def test_code_conflict(self, parent_config, changed_code_config):
         """Test if code commit hash change is currently detected"""
@@ -593,6 +617,24 @@ class TestResolutions(object):
         assert conflict.is_resolved
         assert isinstance(conflict.resolution, conflict.AlgorithmResolution)
 
+    def test_orion_version_change(self, parent_config, changed_orion_version_config):
+        """Test if setting the orion version conflict solves it"""
+        conflicts = detect_conflicts(parent_config, changed_orion_version_config)
+        branch_builder = ExperimentBranchBuilder(conflicts, manual_resolution=True)
+
+        assert len(conflicts.get()) == 2
+        assert len(conflicts.get_resolved()) == 1
+
+        branch_builder.set_orion_version()
+
+        assert len(conflicts.get()) == 2
+        assert len(conflicts.get_resolved()) == 2
+
+        conflict = conflicts.get_resolved()[1]
+
+        assert conflict.is_resolved
+        assert isinstance(conflict.resolution, conflict.OrionVersionResolution)
+
     def test_code_change(self, parent_config, changed_code_config):
         """Test if giving a proper change-type solves the code conflict"""
         conflicts = detect_conflicts(parent_config, changed_code_config)
@@ -686,7 +728,7 @@ class TestResolutions(object):
         """Test if all conflicts all automatically resolve by the ExperimentBranchBuilder."""
         ExperimentBranchBuilder(conflicts)
 
-        assert len(conflicts.get_resolved()) == 8
+        assert len(conflicts.get_resolved()) == 9
 
 
 class TestResolutionsWithMarkers(object):
@@ -996,6 +1038,20 @@ class TestResolutionsWithMarkers(object):
 
         assert conflict.is_resolved
         assert isinstance(conflict.resolution, conflict.AlgorithmResolution)
+
+    def test_orion_version_change(self, parent_config, changed_orion_version_config):
+        """Test if orion version conflict is resolved automatically"""
+        changed_orion_version_config["orion_version_change"] = True
+        conflicts = detect_conflicts(parent_config, changed_orion_version_config)
+        ExperimentBranchBuilder(conflicts, manual_resolution=True)
+
+        assert len(conflicts.get()) == 2
+        assert len(conflicts.get_resolved()) == 2
+
+        conflict = conflicts.get_resolved()[1]
+
+        assert conflict.is_resolved
+        assert isinstance(conflict.resolution, conflict.OrionVersionResolution)
 
     def test_config_change(self, parent_config, changed_userconfig_config):
         """Test if user's script's config conflict is resolved automatically"""

--- a/tests/unittests/plotting/test_plotly_backend.py
+++ b/tests/unittests/plotting/test_plotly_backend.py
@@ -79,9 +79,9 @@ def mock_experiment(
     if ids is None:
         ids = ["a", "b", "c", "d"]
     if x is None:
-        x = [0, 1, 2, 3]
+        x = [0, 1, 2, 4]
     if y is None:
-        y = [1, 2, 0, 3]
+        y = [3, 2, 0, 1]
     if objectives is None:
         objectives = [0.1, 0.2, 0.3, 0.5]
     if status is None:
@@ -146,8 +146,8 @@ class TestLPI:
             plot = lpi(experiment, random_state=1)
             # Why is this test failing?
             df = experiment.to_pandas()
-            assert df["x"].tolist() == [0, 1, 2, 3]
-            assert df["y"].tolist() == [1, 2, 0, 3]
+            assert df["x"].tolist() == [0, 1, 2, 4]
+            assert df["y"].tolist() == [3, 2, 0, 1]
             assert df["objective"].tolist() == [0.1, 0.2, 0.3, 0.5]
 
         assert_lpi_plot(plot, dims=["x", "y"])

--- a/tests/unittests/plotting/test_plotly_backend.py
+++ b/tests/unittests/plotting/test_plotly_backend.py
@@ -144,6 +144,11 @@ class TestLPI:
             experiment,
         ):
             plot = lpi(experiment, random_state=1)
+            # Why is this test failing?
+            df = experiment.to_pandas()
+            assert df["x"].tolist() == [0, 1, 2, 3]
+            assert df["y"].tolist() == [1, 2, 0, 3]
+            assert df["objective"].tolist() == [0.1, 0.2, 0.3, 0.5]
 
         assert_lpi_plot(plot, dims=["x", "y"])
 

--- a/tests/unittests/plotting/test_plotly_backend.py
+++ b/tests/unittests/plotting/test_plotly_backend.py
@@ -114,6 +114,7 @@ def assert_lpi_plot(plot, dims):
     assert trace["y"][0] > trace["y"][1]
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestLPI:
     """Tests the ``lpi()`` method provided by the plotly backend"""
 
@@ -238,6 +239,7 @@ class TestLPI:
         assert_lpi_plot(plot, dims=["x", "y[0]", "y[1]", "y[2]"])
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestRegret:
     """Tests the ``regret()`` method provided by the plotly backend"""
 
@@ -316,6 +318,7 @@ def assert_parallel_coordinates_plot(plot, order):
         assert trace.dimensions[i].label == order[i]
 
 
+@pytest.mark.usefixtures("version_XYZ")
 class TestParallelCoordinates:
     """Tests the ``parallel_coordinates()`` method provided by the plotly backend"""
 

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -236,6 +236,7 @@ def test_get_storage():
     assert get_storage() == storage
 
 
+@pytest.mark.usefixture("version_XYZ")
 @pytest.mark.parametrize("storage", storage_backends)
 class TestStorage:
     """Test all storage backend"""

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -236,7 +236,7 @@ def test_get_storage():
     assert get_storage() == storage
 
 
-@pytest.mark.usefixture("version_XYZ")
+@pytest.mark.usefixtures("version_XYZ")
 @pytest.mark.parametrize("storage", storage_backends)
 class TestStorage:
     """Test all storage backend"""

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -47,6 +47,7 @@ base_experiment = {
         "user_script": "abc",
         "priors": {"x": "uniform(0, 10)"},
         "datetime": "2017-11-23T02:00:00",
+        "orion_version": "XYZ",
     },
 }
 


### PR DESCRIPTION
[Fixes #487]

Why:

Changing the version of Oríon could impact the behavior of the HPO,
therefore we should branch to avoid corrupting results.

How:

Add Conflict, Resolution and Adapter to detect and handle changes of
orion version.