### PR TITLE
Add Read/Write/Execution modes for Experiment

### DIFF
--- a/docs/src/user/library/evc_results.rst
+++ b/docs/src/user/library/evc_results.rst
@@ -14,9 +14,9 @@ trials of the specific experiment.
 
    import pprint
 
-   from orion.client import create_experiment
+   from orion.client import get_experiment
 
-   experiment = create_experiment(name="orion-tutorial-with-momentum")
+   experiment = get_experiment(name="orion-tutorial-with-momentum")
 
    print(experiment.name)
    pprint.pprint(experiment.stats)

--- a/docs/src/user/library/results.rst
+++ b/docs/src/user/library/results.rst
@@ -4,21 +4,21 @@ Results
 You can fetch experiments and trials using python code. There is no need to understand the
 specific database backend used (such as MongoDB) since you can fetch results using the
 :class:`orion.client.experiment.ExperimentClient` object.
-The helper function :py:func:`orion.client.create_experiment`
+The helper function :py:func:`orion.client.get_experiment`
 provides a simple way to fetch experiments
 using their unique names. You do not need to explicitly open a connection to the database since it
 will automatically infer its configuration from the global configuration file as when calling Oríon
 in commandline. Otherwise you can specify the configuration directly to
-:py:func:`create_experiment() <orion.client.create_experiment>`. Take a look at the documentation
+:py:func:`get_experiment() <orion.client.get_experiment>`. Take a look at the documentation
 for more details on all configuration arguments that are supported.
 
 .. code-block:: python
 
    # Database automatically inferred
-   create_experiment(name="orion-tutorial")
+   get_experiment(name="orion-tutorial")
 
    # Database manually set
-   create_experiment(
+   get_experiment(
        name="orion-tutorial",
        storage={
            'type': 'legacy',
@@ -33,9 +33,9 @@ For a complete example, here is how you can fetch trials from a given experiment
 
    import pprint
 
-   from orion.client import create_experiment
+   from orion.client import get_experiment
 
-   experiment = create_experiment(name="orion-tutorial")
+   experiment = get_experiment(name="orion-tutorial")
 
    pprint.pprint(experiment.stats)
 

--- a/docs/src/user/storage.rst
+++ b/docs/src/user/storage.rst
@@ -159,14 +159,19 @@ ExperimentClient
 ~~~~~~~~~~~~~~~~
 
 The experiment client must be created with the helper function
-:py:func:`create_experiment() <orion.client.create_experiment>` which will take care of
-initiating the storage backend and create a new experiment if non-existant or simply load
-the corresponding experiment from the storage.
+:py:func:`get_experiment() <orion.client.get_experiment>` which will take care of
+initiating the storage backend and load the corresponding experiment from the storage.
+To create a new experiment use :py:func:`create_experiment() <orion.client.create_experiment>`.
 
-There is a small subset of methods to fetch trials or create new ones. We focus here
+There is a small subset of methods to fetch trials or register new ones. We focus here
 on the methods for loading or creation of trials in particular, see
 :py:class:`ExperimentClient <orion.client.experiment.ExperimentClient>` for documentation
 of all methods.
+
+The experiment client can be loaded in read-only or read/write mode. Make sure to
+load the experiment with the proper mode if you want to edit the database.
+For full read/write/execution rights, use
+:py:func:`create_experiment() <orion.client.create_experiment>`.
 
 Here is a short example to fetch trials or insert a new one.
 

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -265,7 +265,7 @@ def get_experiment(name, version=None, mode="r", storage=None):
 
     Returns
     -------
-    An instance of :class:`orion.core.worker.experiment.ExperimentView` representing the experiment.
+    An instance of :class:`orion.client.experiment.ExperimentClient` representing the experiment.
 
     Raises
     ------

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -301,6 +301,8 @@ class ExperimentClient:
     def insert(self, params, results=None, reserve=False):
         """Insert a new trial.
 
+        Experiment must be in writable ('w') or executable ('x') mode.
+
         Parameters
         ----------
         params: dict
@@ -373,6 +375,8 @@ class ExperimentClient:
     def reserve(self, trial):
         """Reserve a trial.
 
+        Experiment must be in executable ('x') mode.
+
         Set a trial status to reserve to ensure that concurrent process cannot work on it.
         Trials can only be reserved with status 'new', 'interrupted' or 'suspended'.
 
@@ -427,6 +431,8 @@ class ExperimentClient:
 
         Release the reservation and stop the heartbeat.
 
+        Experiment must be in writable ('w') or executable ('x') mode.
+
         Parameters
         ----------
         trial: `orion.core.worker.trial.Trial`
@@ -464,6 +470,8 @@ class ExperimentClient:
 
     def suggest(self):
         """Suggest a trial to execute.
+
+        Experiment must be in executable ('x') mode.
 
         If any trial is available (new or interrupted), it selects one and reserves it.
         Otherwise, the algorithm is used to generate a new trial that is registered in storage and
@@ -523,6 +531,8 @@ class ExperimentClient:
     def observe(self, trial, results):
         """Observe trial results
 
+        Experiment must be in executable ('x') mode.
+
         Parameters
         ----------
         trial: `orion.core.worker.trial.Trial`
@@ -569,6 +579,8 @@ class ExperimentClient:
     def workon(self, fct, max_trials=infinity, **kwargs):
         """Optimize a given function
 
+        Experiment must be in executable ('x') mode.
+
         Parameters
         ----------
         fct: callable
@@ -608,6 +620,8 @@ class ExperimentClient:
 
     def close(self):
         """Verify that no reserved trials are remaining and unregister atexit().
+
+        Experiment must be in executable ('x') mode.
 
         Raises
         ------

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -124,6 +124,11 @@ class ExperimentClient:
         return self._experiment.algorithms
 
     @property
+    def refers(self):
+        """References to the experiment version control"""
+        return self._experiment.refers
+
+    @property
     def is_done(self):
         """Return True, if this experiment is considered to be finished.
 

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -207,16 +207,16 @@ class ExperimentClient:
 
     def _check_if_writable(self):
         if self.mode == "r":
-            foo = inspect.stack()[1].function
+            calling_function = inspect.stack()[1].function
             raise UnsupportedOperation(
-                f"ExperimentClient must have write rights to execute `{foo}()`"
+                f"ExperimentClient must have write rights to execute `{calling_function}()`"
             )
 
     def _check_if_executable(self):
         if self.mode != "x":
-            foo = inspect.stack()[1].function
+            calling_function = inspect.stack()[1].function
             raise UnsupportedOperation(
-                f"ExperimentClient must have execution rights to execute `{foo}()`"
+                f"ExperimentClient must have execution rights to execute `{calling_function}()`"
             )
 
     ###

--- a/src/orion/core/cli/db/rm.py
+++ b/src/orion/core/cli/db/rm.py
@@ -183,7 +183,7 @@ def main(args):
     experiment_builder.setup_storage(config.get("storage"))
 
     # Find root experiment
-    root = experiment_builder.build_view(
+    root = experiment_builder.load(
         name=args["name"], version=args.get("version", None)
     ).node
 

--- a/src/orion/core/cli/db/set.py
+++ b/src/orion/core/cli/db/set.py
@@ -170,7 +170,7 @@ def main(args):
     experiment_builder.setup_storage(config.get("storage"))
 
     # Find root experiment
-    root = experiment_builder.build_view(
+    root = experiment_builder.load(
         name=args["name"], version=args.get("version", None)
     ).node
 

--- a/src/orion/core/cli/info.py
+++ b/src/orion/core/cli/info.py
@@ -35,7 +35,7 @@ def add_subparser(parser):
 def main(args):
     """Fetch config and info experiments"""
     try:
-        experiment = experiment_builder.build_view_from_args(args)
+        experiment = experiment_builder.get_from_args(args, mode="r")
     except ValueError:
         print("Experiment {} not found in db.".format(args.get("name", None)))
         sys.exit(1)

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -45,7 +45,7 @@ def add_subparser(parser):
 def main(args):
     """Fetch config and insert new point"""
     command_line_user_args = args.pop("user_args", [None])[1:]
-    experiment = experiment_builder.build_view_from_args(args)
+    experiment = experiment_builder.get_from_args(args, mode="w")
 
     transformed_args = _build_from(command_line_user_args)
     exp_space = experiment.space
@@ -54,9 +54,7 @@ def main(args):
 
     trial = tuple_to_trial(values, exp_space)
 
-    # TODO Replace this part when we have experiment rights with read/write (but not execute).
-    experiment._experiment._storage = experiment._experiment._storage._storage
-    experiment._experiment.register_trial(trial)
+    experiment.register_trial(trial)
 
 
 def _validate_dimensions(transformed_args, exp_space):

--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -60,7 +60,7 @@ def main(args):
         return
 
     for root_experiment in root_experiments:
-        root = experiment_builder.build_view(
+        root = experiment_builder.load(
             name=root_experiment["name"], version=root_experiment.get("version")
         ).node
         print_tree(root, nameattr="tree_name")

--- a/src/orion/core/cli/status.py
+++ b/src/orion/core/cli/status.py
@@ -112,7 +112,7 @@ def print_evc(
 
     """
     for exp in experiments:
-        experiment = experiment_builder.build_view(exp.name, version)
+        experiment = experiment_builder.load(exp.name, version)
         if version is None:
             expand_experiment = exp
         else:
@@ -148,7 +148,7 @@ def get_experiments(args):
         ]
 
     return [
-        experiment_builder.build_view(name=exp["name"], version=exp.get("version", 1))
+        experiment_builder.load(name=exp["name"], version=exp.get("version", 1))
         for exp in root_experiments
     ]
 

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -36,7 +36,7 @@ class ExperimentNode(TreeNode):
         Name of the experiment
     item: None or :class:`orion.core.worker.experiment.Experiment`
         None if the experiment is not initialized yet. When initializing lazily, it creates an
-        `ExperimentView`.
+        `Experiment` in read only mode.
 
     .. seealso::
 
@@ -75,9 +75,7 @@ class ExperimentNode(TreeNode):
             # TODO: Find another way around the circular import
             import orion.core.io.experiment_builder as experiment_builder
 
-            self._item = experiment_builder.build_view(
-                name=self.name, version=self.version
-            )
+            self._item = experiment_builder.load(name=self.name, version=self.version)
             self._item._node = self
 
         return self._item

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -78,7 +78,7 @@ class ExperimentNode(TreeNode):
             self._item = experiment_builder.build_view(
                 name=self.name, version=self.version
             )
-            self._item._experiment._node = self
+            self._item._node = self
 
         return self._item
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint:disable=too-many-lines
 """
 :mod:`orion.core.io.experiment_builder` -- Create experiment from user options
@@ -706,13 +705,13 @@ def build_from_args(cmdargs):
     return build(**cmd_config)
 
 
-def build_view_from_args(cmdargs):
+def get_from_args(cmdargs, mode="r"):
     """Build an experiment view based on commandline arguments
 
     .. seealso::
 
-        :func:`orion.core.io.experiment_builder.build_view` for more information on experiment view
-        creation.
+        :func:`orion.core.io.experiment_builder.load` for more information on creation of read-only
+        experiments.
 
     """
     cmd_config = get_cmd_config(cmdargs)
@@ -725,7 +724,7 @@ def build_view_from_args(cmdargs):
     name = cmd_config.get("name")
     version = cmd_config.get("version")
 
-    return build_view(name, version)
+    return load(name, version, mode=mode)
 
 
 def get_cmd_config(cmdargs):

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -98,7 +98,6 @@ from orion.core.utils.exceptions import (
     NoConfigurationError,
     NoNameError,
     RaceCondition,
-    UnsupportedOperation,
 )
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.primary_algo import PrimaryAlgo

--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -133,3 +133,7 @@ class InexecutableUserScript(PermissionError):
 
     def __init__(self, cmdline, message=INEXECUTABLE_USER_SCRIPT_ERROR_MESSAGE):
         super().__init__(message.format(cmdline))
+
+
+class UnsupportedOperation(Exception):
+    """The operation is not supported with current access rights"""

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -20,7 +20,7 @@ from orion.core.evc.adapters import BaseAdapter
 from orion.core.evc.experiment import ExperimentNode
 from orion.core.utils.exceptions import UnsupportedOperation
 from orion.core.utils.flatten import flatten
-from orion.storage.base import FailedUpdate, ReadOnlyStorageProtocol, get_storage
+from orion.storage.base import FailedUpdate, get_storage
 
 log = logging.getLogger(__name__)
 
@@ -126,16 +126,16 @@ class Experiment:
 
     def _check_if_writable(self):
         if self.mode == "r":
-            foo = inspect.stack()[1].function
+            calling_function = inspect.stack()[1].function
             raise UnsupportedOperation(
-                f"Experiment must have write rights to execute `{foo}()`"
+                f"Experiment must have write rights to execute `{calling_function}()`"
             )
 
     def _check_if_executable(self):
         if self.mode != "x":
-            foo = inspect.stack()[1].function
+            calling_function = inspect.stack()[1].function
             raise UnsupportedOperation(
-                f"Experiment must have execution rights to execute `{foo}()`"
+                f"Experiment must have execution rights to execute `{calling_function}()`"
             )
 
     def to_pandas(self, with_evc_tree=False):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -424,13 +424,19 @@ class Experiment:
                 continue
             attribute = copy.deepcopy(getattr(self, attrname))
             config[attrname] = attribute
-            if attrname in ["algorithms", "space"]:
+            if attrname == "space":
+                config[attrname] = attribute.configuration
+            elif attrname == "algorithms" and not isinstance(attribute, dict):
                 config[attrname] = attribute.configuration
             elif attrname == "refers" and isinstance(
                 attribute.get("adapter"), BaseAdapter
             ):
                 config[attrname]["adapter"] = config[attrname]["adapter"].configuration
-            elif attrname == "producer" and attribute.get("strategy"):
+            elif (
+                attrname == "producer"
+                and attribute.get("strategy")
+                and not isinstance(attribute["strategy"], dict)
+            ):
                 config[attrname]["strategy"] = config[attrname][
                     "strategy"
                 ].configuration

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -11,12 +11,14 @@
 """
 import copy
 import datetime
+import inspect
 import logging
 
 import pandas
 
 from orion.core.evc.adapters import BaseAdapter
 from orion.core.evc.experiment import ExperimentNode
+from orion.core.utils.exceptions import UnsupportedOperation
 from orion.core.utils.flatten import flatten
 from orion.storage.base import FailedUpdate, ReadOnlyStorageProtocol, get_storage
 
@@ -99,13 +101,15 @@ class Experiment:
         "_id",
         "_node",
         "_storage",
+        "_mode",
     )
     non_branching_attrs = ("pool_size", "max_trials", "max_broken")
 
-    def __init__(self, name, version=None):
+    def __init__(self, name, version=None, mode="r"):
         self._id = None
         self.name = name
         self.version = version if version else 1
+        self._mode = mode
         self._node = None
         self.refers = {}
         self.metadata = {}
@@ -116,10 +120,23 @@ class Experiment:
         self.algorithms = None
         self.working_dir = None
         self.producer = {}
-        # this needs to be an attribute because we override it in ExperienceView
         self._storage = get_storage()
 
         self._node = ExperimentNode(self.name, self.version, experiment=self)
+
+    def _check_if_writable(self):
+        if self.mode == "r":
+            foo = inspect.stack()[1].function
+            raise UnsupportedOperation(
+                f"Experiment must have write rights to execute `{foo}()`"
+            )
+
+    def _check_if_executable(self):
+        if self.mode != "x":
+            foo = inspect.stack()[1].function
+            raise UnsupportedOperation(
+                f"Experiment must have execution rights to execute `{foo}()`"
+            )
 
     def to_pandas(self, with_evc_tree=False):
         """Builds a dataframe with the trials of the experiment
@@ -179,6 +196,7 @@ class Experiment:
 
     def set_trial_status(self, *args, **kwargs):
         """See :func:`~orion.storage.BaseStorageProtocol.set_trial_status`"""
+        self._check_if_writable()
         return self._storage.set_trial_status(*args, **kwargs)
 
     def reserve_trial(self, score_handle=None):
@@ -197,6 +215,7 @@ class Experiment:
         Selected `Trial` object, None if could not find any.
 
         """
+        self._check_if_executable()
         log.debug("reserving trial with (score: %s)", score_handle)
 
         self.fix_lost_trials()
@@ -214,6 +233,7 @@ class Experiment:
         trials and set them as interrupted so they can be launched again.
 
         """
+        self._check_if_writable()
         trials = self._storage.fetch_lost_trials(self)
 
         for trial in trials:
@@ -236,6 +256,7 @@ class Experiment:
             Change status from *reserved* to *completed*.
 
         """
+        self._check_if_executable()
         trial.status = "completed"
         trial.end_time = datetime.datetime.utcnow()
         self._storage.retrieve_result(trial, results_file)
@@ -265,6 +286,7 @@ class Experiment:
             in the database.
 
         """
+        self._check_if_writable()
         lying_trial.status = "completed"
         lying_trial.end_time = datetime.datetime.utcnow()
         self._storage.register_lie(lying_trial)
@@ -288,6 +310,7 @@ class Experiment:
             in the database.
 
         """
+        self._check_if_writable()
         stamp = datetime.datetime.utcnow()
         trial.experiment = self._id
         trial.status = status
@@ -332,6 +355,14 @@ class Experiment:
         Value is `None` if the experiment is not configured.
         """
         return self._id
+
+    @property
+    def mode(self):
+        """Return the access right of the experiment
+
+        {'r': read, 'w': read/write, 'x': read/write/execute}
+        """
+        return self._mode
 
     @property
     def node(self):
@@ -462,63 +493,6 @@ class Experiment:
     def __repr__(self):
         """Represent the object as a string."""
         return "Experiment(name=%s, metadata.user=%s, version=%s)" % (
-            self.name,
-            self.metadata["user"],
-            self.version,
-        )
-
-
-# pylint: disable=too-few-public-methods
-class ExperimentView(object):
-    """Non-writable view of an experiment
-
-    .. seealso::
-
-        :py:class:`orion.core.worker.experiment.Experiment` for writable experiments.
-
-    """
-
-    __slots__ = ("_experiment",)
-
-    #                     Attributes
-    valid_attributes = (
-        [
-            "_id",
-            "name",
-            "refers",
-            "metadata",
-            "pool_size",
-            "max_trials",
-            "max_broken",
-            "version",
-            "space",
-            "working_dir",
-            "producer",
-        ]
-        +
-        # Properties
-        ["id", "node", "is_done", "is_broken", "algorithms", "stats", "configuration"]
-        +
-        # Methods
-        ["to_pandas", "fetch_trials", "fetch_trials_by_status", "get_trial"]
-    )
-
-    def __init__(self, experiment):
-        self._experiment = experiment
-        self._experiment._storage = ReadOnlyStorageProtocol(experiment._storage)
-
-    def __getattr__(self, name):
-        """Get attribute only if valid"""
-        if name not in self.valid_attributes:
-            raise AttributeError(
-                "Cannot access attribute %s on view-only experiments." % name
-            )
-
-        return getattr(self._experiment, name)
-
-    def __repr__(self):
-        """Represent the object as a string."""
-        return "ExperimentView(name=%s, metadata.user=%s, version=%s)" % (
             self.name,
             self.metadata["user"],
             self.version,

--- a/src/orion/plotting/base.py
+++ b/src/orion/plotting/base.py
@@ -22,7 +22,7 @@ def lpi(experiment, model="RandomForestRegressor", model_kwargs=None, n=20, **kw
 
     Parameters
     ----------
-    experiment: ExperimentClient, Experiment or ExperimentView
+    experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
 
     model: str
@@ -64,7 +64,7 @@ def parallel_coordinates(experiment, order=None, **kwargs):
 
     Parameters
     ----------
-    experiment: ExperimentClient, Experiment or ExperimentView
+    experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
 
     order: list of str or None
@@ -97,7 +97,7 @@ def regret(experiment, order_by="suggested", verbose_hover=True, **kwargs):
 
     Parameters
     ----------
-    experiment: ExperimentClient, Experiment or ExperimentView
+    experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
 
     order_by: str

--- a/src/orion/serving/parameters.py
+++ b/src/orion/serving/parameters.py
@@ -79,7 +79,7 @@ def retrieve_experiment(
         When the experiment doesn't exist
     """
     try:
-        experiment = experiment_builder.build_view(experiment_name, version)
+        experiment = experiment_builder.load(experiment_name, version)
         if version and experiment.version != version:
             raise falcon.HTTPNotFound(
                 title=ERROR_EXPERIMENT_NOT_FOUND,

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -369,7 +369,7 @@ def get_name_value_pairs(trials):
 
 def test_init(init_full_x, create_db_instance):
     """Test if original experiment contains trial 0"""
-    experiment = experiment_builder.build_view(name="full_x")
+    experiment = experiment_builder.load(name="full_x")
 
     assert experiment.refers["adapter"].configuration == []
 
@@ -379,7 +379,7 @@ def test_init(init_full_x, create_db_instance):
 
 def test_full_x_full_y(init_full_x_full_y, create_db_instance):
     """Test if full x full y is properly initialized and can fetch original trial"""
-    experiment = experiment_builder.build_view(name="full_x_full_y")
+    experiment = experiment_builder.load(name="full_x_full_y")
 
     assert experiment.refers["adapter"].configuration == [
         {"change_type": "noeffect", "of_type": "commandlinechange"},
@@ -409,7 +409,7 @@ def test_full_x_full_y(init_full_x_full_y, create_db_instance):
 
 def test_half_x_full_y(init_half_x_full_y, create_db_instance):
     """Test if half x full y is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name="half_x_full_y")
+    experiment = experiment_builder.load(name="half_x_full_y")
 
     assert experiment.refers["adapter"].configuration == [
         {
@@ -435,7 +435,7 @@ def test_half_x_full_y(init_half_x_full_y, create_db_instance):
 
 def test_full_x_half_y(init_full_x_half_y, create_db_instance):
     """Test if full x half y is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name="full_x_half_y")
+    experiment = experiment_builder.load(name="full_x_half_y")
 
     assert experiment.refers["adapter"].configuration == [
         {
@@ -461,7 +461,7 @@ def test_full_x_half_y(init_full_x_half_y, create_db_instance):
 
 def test_full_x_rename_y_z(init_full_x_rename_y_z, create_db_instance):
     """Test if full x full z is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name="full_x_rename_y_z")
+    experiment = experiment_builder.load(name="full_x_rename_y_z")
 
     assert experiment.refers["adapter"].configuration == [
         {"of_type": "commandlinechange", "change_type": "noeffect"},
@@ -494,7 +494,7 @@ def test_full_x_rename_half_y_half_z(
     init_full_x_rename_half_y_half_z, create_db_instance
 ):
     """Test if full x half z is properly initialized and can fetch from its 3 parents"""
-    experiment = experiment_builder.build_view(name="full_x_rename_half_y_half_z")
+    experiment = experiment_builder.load(name="full_x_rename_half_y_half_z")
 
     assert experiment.refers["adapter"].configuration == [
         {"of_type": "commandlinechange", "change_type": "noeffect"},
@@ -520,7 +520,7 @@ def test_full_x_rename_half_y_full_z(
     init_full_x_rename_half_y_full_z, create_db_instance
 ):
     """Test if full x half->full z is properly initialized and can fetch from its 3 parents"""
-    experiment = experiment_builder.build_view(name="full_x_rename_half_y_full_z")
+    experiment = experiment_builder.load(name="full_x_rename_half_y_full_z")
 
     assert experiment.refers["adapter"].configuration == [
         {"of_type": "commandlinechange", "change_type": "noeffect"},
@@ -557,7 +557,7 @@ def test_full_x_rename_half_y_full_z(
 
 def test_full_x_remove_y(init_full_x_remove_y, create_db_instance):
     """Test if full x removed y is properly initialized and can fetch from its 2 parents"""
-    experiment = experiment_builder.build_view(name="full_x_remove_y")
+    experiment = experiment_builder.load(name="full_x_remove_y")
 
     assert experiment.refers["adapter"].configuration == [
         {"of_type": "commandlinechange", "change_type": "noeffect"},
@@ -584,7 +584,7 @@ def test_full_x_full_y_add_z_remove_y(
     init_full_x_full_y_add_z_remove_y, create_db_instance
 ):
     """Test that if z is added and y removed at the same time, both are correctly detected"""
-    experiment = experiment_builder.build_view(name="full_x_full_z_remove_y")
+    experiment = experiment_builder.load(name="full_x_full_z_remove_y")
 
     assert experiment.refers["adapter"].configuration == [
         {"of_type": "commandlinechange", "change_type": "noeffect"},
@@ -613,7 +613,7 @@ def test_full_x_full_y_add_z_remove_y(
 
 def test_full_x_remove_z(init_full_x_remove_z, create_db_instance):
     """Test if full x removed z is properly initialized and can fetch from 2 of its 3 parents"""
-    experiment = experiment_builder.build_view(name="full_x_remove_z")
+    experiment = experiment_builder.load(name="full_x_remove_z")
 
     assert experiment.refers["adapter"].configuration == [
         {"change_type": "noeffect", "of_type": "commandlinechange"},
@@ -641,7 +641,7 @@ def test_full_x_remove_z_default_4(init_full_x_remove_z_default_4, create_db_ins
     """Test if full x removed z  (default 4) is properly initialized and can fetch
     from 1 of its 3 parents
     """
-    experiment = experiment_builder.build_view(name="full_x_remove_z_default_4")
+    experiment = experiment_builder.load(name="full_x_remove_z_default_4")
 
     assert experiment.refers["adapter"].configuration == [
         {"change_type": "noeffect", "of_type": "commandlinechange"},
@@ -661,7 +661,7 @@ def test_full_x_remove_z_default_4(init_full_x_remove_z_default_4, create_db_ins
 
 def test_entire_full_x_full_y(init_entire, create_db_instance):
     """Test if full x full y can fetch from its parent and all children"""
-    experiment = experiment_builder.build_view(name="full_x_full_y")
+    experiment = experiment_builder.load(name="full_x_full_y")
 
     assert experiment.refers["adapter"].configuration == [
         {"change_type": "noeffect", "of_type": "commandlinechange"},
@@ -720,7 +720,7 @@ def test_entire_full_x_full_y(init_entire, create_db_instance):
 
 def test_run_entire_full_x_full_y(init_entire, create_db_instance):
     """Test if branched experiment can be executed without triggering a branching event again"""
-    experiment = experiment_builder.build_view(name="full_x_full_y")
+    experiment = experiment_builder.load(name="full_x_full_y")
 
     assert experiment.refers["adapter"].configuration == [
         {"change_type": "noeffect", "of_type": "commandlinechange"},
@@ -748,7 +748,7 @@ def test_run_entire_full_x_full_y(init_entire, create_db_instance):
 
 def test_run_entire_full_x_full_y_no_args(init_entire, create_db_instance):
     """Test if branched experiment can be executed without script arguments"""
-    experiment = experiment_builder.build_view(name="full_x_full_y")
+    experiment = experiment_builder.load(name="full_x_full_y")
 
     assert len(experiment.fetch_trials(with_evc_tree=True)) == 23
     assert len(experiment.fetch_trials()) == 4
@@ -763,7 +763,7 @@ def test_run_entire_full_x_full_y_no_args(init_entire, create_db_instance):
 
 def test_new_algo(init_full_x_new_algo):
     """Test that new algo conflict is automatically resolved"""
-    experiment = experiment_builder.build_view(name="full_x_new_algo")
+    experiment = experiment_builder.load(name="full_x_new_algo")
 
     assert experiment.refers["adapter"].configuration == [
         {"of_type": "algorithmchange"}
@@ -881,7 +881,7 @@ def test_new_orion_version_triggers_conflict(capsys):
 
 def test_new_cli(init_full_x_new_cli):
     """Test that new cli conflict is automatically resolved"""
-    experiment = experiment_builder.build_view(name="full_x_new_cli")
+    experiment = experiment_builder.load(name="full_x_new_cli")
 
     assert experiment.refers["adapter"].configuration == [
         {"change_type": "noeffect", "of_type": "commandlinechange"}
@@ -929,7 +929,7 @@ def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):
         .split(" ")
     )
 
-    experiment = experiment_builder.build_view(name=branch)
+    experiment = experiment_builder.load(name=branch)
 
     assert experiment.refers["adapter"].configuration == [
         {
@@ -968,7 +968,7 @@ def test_auto_resolution_with_fidelity(init_full_x_full_y, monkeypatch):
         .split(" ")
     )
 
-    experiment = experiment_builder.build_view(name=branch)
+    experiment = experiment_builder.load(name=branch)
 
     assert experiment.refers["adapter"].configuration == [
         {

--- a/tests/functional/commands/test_db_set.py
+++ b/tests/functional/commands/test_db_set.py
@@ -115,9 +115,9 @@ def test_update_no_match_query(clean_db, single_with_trials, capsys):
 
 def test_update_child_only(clean_db, three_experiments_same_name_with_trials, capsys):
     """Test trials of the parent experiment are not updated"""
-    exp1 = experiment_builder.build_view(name="test_single_exp", version=1)
-    exp2 = experiment_builder.build_view(name="test_single_exp", version=2)
-    exp3 = experiment_builder.build_view(name="test_single_exp", version=3)
+    exp1 = experiment_builder.load(name="test_single_exp", version=1)
+    exp2 = experiment_builder.load(name="test_single_exp", version=2)
+    exp3 = experiment_builder.load(name="test_single_exp", version=3)
     execute("db set -f test_single_exp --version 2 status=broken status=interrupted")
     assert len(exp1.fetch_trials_by_status("broken")) > 0
     assert len(exp2.fetch_trials_by_status("broken")) == 0
@@ -130,9 +130,9 @@ def test_update_child_only(clean_db, three_experiments_same_name_with_trials, ca
 
 def test_update_default_leaf(clean_db, three_experiments_same_name_with_trials, capsys):
     """Test trials of the parent experiment are not updated"""
-    exp1 = experiment_builder.build_view(name="test_single_exp", version=1)
-    exp2 = experiment_builder.build_view(name="test_single_exp", version=2)
-    exp3 = experiment_builder.build_view(name="test_single_exp", version=3)
+    exp1 = experiment_builder.load(name="test_single_exp", version=1)
+    exp2 = experiment_builder.load(name="test_single_exp", version=2)
+    exp3 = experiment_builder.load(name="test_single_exp", version=3)
     execute("db set -f test_single_exp status=broken status=interrupted")
     assert len(exp1.fetch_trials_by_status("broken")) > 0
     assert len(exp2.fetch_trials_by_status("broken")) > 0
@@ -147,9 +147,9 @@ def test_no_update_id_from_parent(
     clean_db, three_experiments_same_name_with_trials, capsys
 ):
     """Test trials of the parent experiment are not updated"""
-    exp1 = experiment_builder.build_view(name="test_single_exp", version=1)
-    exp2 = experiment_builder.build_view(name="test_single_exp", version=2)
-    exp3 = experiment_builder.build_view(name="test_single_exp", version=3)
+    exp1 = experiment_builder.load(name="test_single_exp", version=1)
+    exp2 = experiment_builder.load(name="test_single_exp", version=2)
+    exp3 = experiment_builder.load(name="test_single_exp", version=3)
     trial = exp1.fetch_trials_by_status("broken")[0]
     execute(f"db set -f test_single_exp id={trial.id} status=shouldnothappen")
     assert len(exp1.fetch_trials_by_status("shouldnothappen")) == 0

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -20,7 +20,6 @@ from orion.core.utils.exceptions import (
     UnsupportedOperation,
 )
 from orion.core.utils.singleton import SingletonNotInstantiatedError, update_singletons
-from orion.core.worker.experiment import ExperimentView
 from orion.storage.base import get_storage
 from orion.storage.legacy import Legacy
 from orion.testing import OrionState
@@ -520,7 +519,7 @@ class TestGetExperiment:
     @pytest.mark.usefixtures("mock_database")
     def test_experiment_exist(self):
         """
-        Tests that an instance of :class:`orion.core.worker.experiment.ExperimentView` is
+        Tests that an instance of :class:`orion.client.experiment.ExperimentClient` is
         returned representing the latest version when none is given.
         """
         experiment = create_experiment("a", space={"x": "uniform(0, 10)"})
@@ -528,7 +527,8 @@ class TestGetExperiment:
         experiment = get_experiment("a")
 
         assert experiment
-        assert isinstance(experiment, ExperimentView)
+        assert isinstance(experiment, ExperimentClient)
+        assert experiment.mode == "r"
 
     @pytest.mark.usefixtures("mock_database")
     def test_version_do_not_exist(self, caplog):

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -11,6 +11,7 @@ import orion.client
 import orion.client.cli as cli
 import orion.core
 from orion.client import get_experiment
+from orion.client.experiment import ExperimentClient
 from orion.core.io.database.ephemeraldb import EphemeralDB
 from orion.core.io.database.pickleddb import PickledDB
 from orion.core.utils.exceptions import (

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -6,7 +6,6 @@ import pytest
 
 from orion.core.evc.adapters import Adapter, CodeChange
 from orion.core.evc.experiment import ExperimentNode
-from orion.core.worker.experiment import ExperimentView
 
 # To avoid flake8 issues
 build_trimmed_tree = "dummy"

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -236,25 +236,25 @@ def test_fetch_config_from_db_hit(new_config):
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
-def test_build_view_from_args_no_hit(config_file):
+def test_get_from_args_no_hit(config_file):
     """Try building experiment view when not in db"""
     cmdargs = {"name": "supernaekei", "config": config_file}
 
     with OrionState(experiments=[], trials=[]):
         with pytest.raises(NoConfigurationError) as exc_info:
-            experiment_builder.build_view_from_args(cmdargs)
+            experiment_builder.get_from_args(cmdargs)
         assert "No experiment with given name 'supernaekei' and version '*'" in str(
             exc_info.value
         )
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
-def test_build_view_from_args_hit(config_file, random_dt, new_config):
+def test_get_from_args_hit(config_file, random_dt, new_config):
     """Try building experiment view when in db"""
     cmdargs = {"name": "supernaekei", "config": config_file}
 
     with OrionState(experiments=[new_config], trials=[]):
-        exp_view = experiment_builder.build_view_from_args(cmdargs)
+        exp_view = experiment_builder.get_from_args(cmdargs)
 
     assert exp_view._id == new_config["_id"]
     assert exp_view.name == new_config["name"]
@@ -267,7 +267,7 @@ def test_build_view_from_args_hit(config_file, random_dt, new_config):
 
 
 @pytest.mark.usefixtures("with_user_tsirif")
-def test_build_view_from_args_hit_no_conf_file(config_file, random_dt, new_config):
+def test_get_from_args_hit_no_conf_file(config_file, random_dt, new_config):
     """Try building experiment view when in db, and local config file of user script does
     not exist
     """
@@ -278,7 +278,7 @@ def test_build_view_from_args_hit_no_conf_file(config_file, random_dt, new_confi
     ]
 
     with OrionState(experiments=[new_config], trials=[]) as cfg:
-        exp_view = experiment_builder.build_view_from_args(cmdargs)
+        exp_view = experiment_builder.get_from_args(cmdargs)
 
     assert exp_view._id == new_config["_id"]
     assert exp_view.name == new_config["name"]
@@ -301,7 +301,7 @@ def test_build_from_args_no_hit(config_file, random_dt, script_path, new_config)
 
     with OrionState(experiments=[], trials=[]):
         with pytest.raises(NoConfigurationError) as exc_info:
-            experiment_builder.build_view_from_args(cmdargs)
+            experiment_builder.get_from_args(cmdargs)
         assert "No experiment with given name 'supernaekei' and version '*'" in str(
             exc_info.value
         )
@@ -337,7 +337,7 @@ def test_build_from_args_hit(old_config_file, script_path, new_config):
 
     with OrionState(experiments=[new_config], trials=[]):
         # Test that experiment already exists
-        experiment_builder.build_view_from_args(cmdargs)
+        experiment_builder.get_from_args(cmdargs)
 
         exp = experiment_builder.build_from_args(cmdargs)
 
@@ -394,13 +394,13 @@ def test_build_from_args_debug_mode(script_path):
 
 
 @pytest.mark.usefixtures("setup_pickleddb_database")
-def test_build_view_from_args_debug_mode(script_path):
+def test_get_from_args_debug_mode(script_path):
     """Try building experiment view in debug mode"""
     update_singletons()
 
     # Can't build view if none exist. It's fine we only want to test the storage creation.
     with pytest.raises(NoConfigurationError):
-        experiment_builder.build_view_from_args({"name": "whatever"})
+        experiment_builder.get_from_args({"name": "whatever"})
 
     storage = get_storage()
 
@@ -411,7 +411,7 @@ def test_build_view_from_args_debug_mode(script_path):
 
     # Can't build view if none exist. It's fine we only want to test the storage creation.
     with pytest.raises(NoConfigurationError):
-        experiment_builder.build_view_from_args({"name": "whatever", "debug": True})
+        experiment_builder.get_from_args({"name": "whatever", "debug": True})
 
     storage = get_storage()
 
@@ -519,7 +519,7 @@ def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
 
     with OrionState(experiments=[new_config], trials=[]):
         # Test that experiment already exists (this should fail otherwise)
-        experiment_builder.build_view_from_args(cmdargs)
+        experiment_builder.get_from_args(cmdargs)
 
         exp = experiment_builder.build_from_args(cmdargs)
 

--- a/tests/unittests/plotting/test_plotly_backend.py
+++ b/tests/unittests/plotting/test_plotly_backend.py
@@ -5,7 +5,7 @@ import pandas
 import plotly
 import pytest
 
-from orion.core.worker.experiment import Experiment, ExperimentView
+from orion.core.worker.experiment import Experiment
 from orion.plotting.base import lpi, parallel_coordinates, regret
 from orion.testing import create_experiment
 
@@ -165,19 +165,6 @@ class TestLPI:
 
         assert_lpi_plot(plot, dims=["x", "y"])
 
-    def test_experiment_view_as_parameter(self, monkeypatch):
-        """Tests that ``ExperimentView`` is a valid parameter"""
-        config = mock_space()
-        mock_experiment(monkeypatch)
-        with create_experiment(config, trial_config) as (
-            _,
-            experiment,
-            _,
-        ):
-            plot = lpi(ExperimentView(experiment), random_state=1)
-
-        assert_lpi_plot(plot, dims=["x", "y"])
-
     def test_ignore_uncompleted_statuses(self, monkeypatch):
         """Tests that uncompleted statuses are ignored"""
         config = mock_space()
@@ -286,17 +273,6 @@ class TestRegret:
 
         assert_regret_plot(plot)
 
-    def test_experiment_view_as_parameter(self):
-        """Tests that ``ExperimentView`` is a valid parameter"""
-        with create_experiment(config, trial_config, ["completed"]) as (
-            _,
-            experiment,
-            _,
-        ):
-            plot = regret(ExperimentView(experiment))
-
-        assert_regret_plot(plot)
-
     def test_ignore_uncompleted_statuses(self):
         """Tests that uncompleted statuses are ignored"""
         with create_experiment(config, trial_config) as (_, _, experiment):
@@ -362,17 +338,6 @@ class TestParallelCoordinates:
             _,
         ):
             plot = parallel_coordinates(experiment)
-
-        assert_parallel_coordinates_plot(plot, order=["x", "loss"])
-
-    def test_experiment_view_as_parameter(self):
-        """Tests that ``ExperimentView`` is a valid parameter"""
-        with create_experiment(config, trial_config, ["completed"]) as (
-            _,
-            experiment,
-            _,
-        ):
-            plot = parallel_coordinates(ExperimentView(experiment))
 
         assert_parallel_coordinates_plot(plot, order=["x", "loss"])
 


### PR DESCRIPTION
[Fixes #517, #519, #531]

### Why

The experiment view is useful to query the database and make plots, but
sometimes we want to add new trials or make modifications to trials
(like status) without executing the experiments. Making such edit should
not require building the experiment with checks for branching, as there
is no intention in executing trials. There should be
read/write/execution rights instead of just providing a view.

Read can:
Make any calls that only require reading the DB. No writes on DB

Read/Write can:
Make any calls that read or write the DB as long as it is not updating
trial results. Also the producer should not be accessible in Read/Write
mode, the algorithm should not be executed in an unchecked environment.

Read/Write/Exec can:
Do everything.

### How

Remove ExperimentView and add modes directly in Experiment. All methods
in Experiment now check it access rights of the experiment allows them
to execute.