### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/src/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+  system_packages: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ exclude *-requirements.txt
 exclude .pylintrc
 exclude codecov.yml
 exclude .mailmap
+exclude .readthedocs.yml
 prune conda/
 prune .github/
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import versioneer
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
 
-tests_require = ["pytest>=3.0.0" "scikit-learn"]
+tests_require = ["pytest>=3.0.0", "numpy", "scikit-learn"]
 
 
 packages = [  # Packages must be sorted alphabetically to ease maintenance and merges.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import versioneer
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
 
-tests_require = ["pytest>=3.0.0", "numpy", "scikit-learn"]
+tests_require = ["pytest>=3.0.0", "scikit-learn"]
 
 
 packages = [  # Packages must be sorted alphabetically to ease maintenance and merges.


### PR DESCRIPTION
Readthedocs is failing since release 0.24 of scikit-learn. This is due to a missing wheel for manylinux1 as explained [here](https://github.com/scikit-learn/scikit-learn/issues/19233).

Setting readthedocs configuration to run installation with pip instead of installing from source with `setup.py` solves the issue.