### PR TITLE
Add error bar to LPI

### DIFF
--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -19,7 +19,12 @@ from orion.core.worker.transformer import build_required_space
 
 
 def lpi(
-    experiment, model="RandomForestRegressor", model_kwargs=None, n_points=20, **kwargs
+    experiment,
+    model="RandomForestRegressor",
+    model_kwargs=None,
+    n_points=20,
+    n_runs=10,
+    **kwargs,
 ):
     """Plotly implementation of `orion.plotting.lpi`"""
     if not experiment:
@@ -31,10 +36,23 @@ def lpi(
     df = experiment.to_pandas()
     df = df.loc[df["status"] == "completed"]
     df = orion.analysis.lpi(
-        df, experiment.space, model=model, n_points=n_points, **model_kwargs
+        df,
+        experiment.space,
+        model=model,
+        n_points=n_points,
+        n_runs=n_runs,
+        **model_kwargs,
     )
 
-    fig = go.Figure(data=[go.Bar(x=df.index.tolist(), y=df["LPI"].tolist())])
+    fig = go.Figure(
+        data=[
+            go.Bar(
+                x=df.index.tolist(),
+                y=df["LPI"].tolist(),
+                error_y=dict(type="data", array=df["STD"].tolist()),
+            )
+        ]
+    )
 
     y_axis_label = "Local Parameter Importance (LPI)"
     fig.update_layout(

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -35,6 +35,10 @@ def lpi(
 
     df = experiment.to_pandas()
     df = df.loc[df["status"] == "completed"]
+
+    if df.empty:
+        return go.Figure()
+
     df = orion.analysis.lpi(
         df,
         experiment.space,

--- a/src/orion/plotting/base.py
+++ b/src/orion/plotting/base.py
@@ -6,7 +6,12 @@ import orion.plotting.backend_plotly as backend
 
 
 def lpi(
-    experiment, model="RandomForestRegressor", model_kwargs=None, n_points=20, **kwargs
+    experiment,
+    model="RandomForestRegressor",
+    model_kwargs=None,
+    n_points=20,
+    n_runs=10,
+    **kwargs,
 ):
     """
     Make a bar plot to visualize the local parameter importance metric.
@@ -50,7 +55,12 @@ def lpi(
 
     """
     return backend.lpi(
-        experiment, model=model, model_kwargs=model_kwargs, n_points=n_points, **kwargs
+        experiment,
+        model=model,
+        model_kwargs=model_kwargs,
+        n_points=n_points,
+        n_runs=n_runs,
+        **kwargs,
     )
 
 

--- a/src/orion/testing/plotting.py
+++ b/src/orion/testing/plotting.py
@@ -107,6 +107,7 @@ def assert_lpi_plot(plot, dims):
     trace = plot.data[0]
     assert trace["x"] == tuple(dims)
     assert trace["y"][0] > trace["y"][1]
+    assert len(trace["error_y"]["array"]) == len(dims)
 
 
 def assert_partial_dependencies_plot(

--- a/tests/unittests/plotting/test_plot_accessor.py
+++ b/tests/unittests/plotting/test_plot_accessor.py
@@ -90,3 +90,13 @@ def test_call_to(kind):
         plot = getattr(pa, kind)()
 
         check_plot(plot, kind)
+
+
+@pytest.mark.parametrize(
+    "kind", ("lpi", "regret", "parallel_coordinates", "partial_dependencies")
+)
+def test_emtpy(kind):
+    """Tests instance calls to `PlotAccessor.{kind}()`"""
+    with create_experiment(config, trial_config, []) as (_, _, experiment):
+        pa = PlotAccessor(experiment)
+        getattr(pa, kind)()


### PR DESCRIPTION
Why:

The LPI metric is not deterministic and depend on the initial state of
the regression model used. We make multiple runs with different
``random_state`` and compute the average LPI with its standard
deviation.