### PR TITLE
 Make plots use trials in EVC by default

### DIFF
--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -537,7 +537,7 @@ def regret(
     return fig
 
 
-def regrets(experiments, order_by="suggested", **kwargs):
+def regrets(experiments, with_evc_tree=True, order_by="suggested", **kwargs):
     """Plotly implementation of `orion.plotting.regrets`"""
 
     compute_average = bool(

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -20,6 +20,7 @@ from orion.core.worker.transformer import build_required_space
 
 def lpi(
     experiment,
+    with_evc_tree=True,
     model="RandomForestRegressor",
     model_kwargs=None,
     n_points=20,
@@ -33,7 +34,7 @@ def lpi(
     if model_kwargs is None:
         model_kwargs = {}
 
-    df = experiment.to_pandas()
+    df = experiment.to_pandas(with_evc_tree=with_evc_tree)
     df = df.loc[df["status"] == "completed"]
 
     if df.empty:
@@ -68,14 +69,16 @@ def lpi(
     return fig
 
 
-def parallel_coordinates(experiment, order=None, colorscale="YlOrRd", **kwargs):
+def parallel_coordinates(
+    experiment, with_evc_tree=True, order=None, colorscale="YlOrRd", **kwargs
+):
     """Plotly implementation of `orion.plotting.parallel_coordinates`"""
 
     def build_frame():
         """Builds the dataframe for the plot"""
         names = list(experiment.space.keys())
 
-        df = experiment.to_pandas()
+        df = experiment.to_pandas(with_evc_tree=with_evc_tree)
         df = df.loc[df["status"] == "completed"]
 
         if df.empty:
@@ -161,7 +164,7 @@ def parallel_coordinates(experiment, order=None, colorscale="YlOrRd", **kwargs):
     return fig
 
 
-def rankings(experiments, order_by, **kwargs):
+def rankings(experiments, with_evc_tree=True, order_by="suggested", **kwargs):
     """Plotly implementation of `orion.plotting.rankings`"""
 
     def reformat_competitions(experiments):
@@ -209,7 +212,7 @@ def rankings(experiments, order_by, **kwargs):
 
         frames = []
         for name, experiment in competition.items():
-            df = experiment.to_pandas()
+            df = experiment.to_pandas(with_evc_tree=with_evc_tree)
             df = df.loc[df["status"] == "completed"]
             df = df.sort_values(order_by)
             df = orion.analysis.regret(df)
@@ -286,6 +289,7 @@ def rankings(experiments, order_by, **kwargs):
 
 def partial_dependencies(
     experiment,
+    with_evc_tree=True,
     params=None,
     smoothing=0.85,
     n_grid_points=10,
@@ -298,7 +302,7 @@ def partial_dependencies(
 
     def build_data():
         """Builds the dataframe for the plot"""
-        df = experiment.to_pandas()
+        df = experiment.to_pandas(with_evc_tree=with_evc_tree)
 
         names = list(experiment.space.keys())
         df["params"] = df[names].apply(_format_hyperparameters, args=(names,), axis=1)
@@ -470,12 +474,14 @@ def partial_dependencies(
     return fig
 
 
-def regret(experiment, order_by, verbose_hover, **kwargs):
+def regret(
+    experiment, with_evc_tree=True, order_by="suggested", verbose_hover=True, **kwargs
+):
     """Plotly implementation of `orion.plotting.regret`"""
 
     def build_frame():
         """Builds the dataframe for the plot"""
-        df = experiment.to_pandas()
+        df = experiment.to_pandas(with_evc_tree=with_evc_tree)
 
         names = list(experiment.space.keys())
         df["params"] = df[names].apply(_format_hyperparameters, args=(names,), axis=1)
@@ -531,7 +537,7 @@ def regret(experiment, order_by, verbose_hover, **kwargs):
     return fig
 
 
-def regrets(experiments, order_by, **kwargs):
+def regrets(experiments, order_by="suggested", **kwargs):
     """Plotly implementation of `orion.plotting.regrets`"""
 
     compute_average = bool(
@@ -560,7 +566,7 @@ def regrets(experiments, order_by, **kwargs):
         """Builds the dataframe for the plot"""
         frames = []
         for i, experiment in enumerate(experiments):
-            df = experiment.to_pandas()
+            df = experiment.to_pandas(with_evc_tree=with_evc_tree)
             df = df.loc[df["status"] == "completed"]
             df = df.sort_values(order_by)
             df = orion.analysis.regret(df)

--- a/src/orion/plotting/base.py
+++ b/src/orion/plotting/base.py
@@ -7,6 +7,7 @@ import orion.plotting.backend_plotly as backend
 
 def lpi(
     experiment,
+    with_evc_tree=True,
     model="RandomForestRegressor",
     model_kwargs=None,
     n_points=20,
@@ -26,6 +27,10 @@ def lpi(
     ----------
     experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
+
+    with_evc_tree: bool, optional
+        Fetch all trials from the EVC tree.
+        Default: True
 
     model: str
         Name of the regression model to use. Can be one of
@@ -56,6 +61,7 @@ def lpi(
     """
     return backend.lpi(
         experiment,
+        with_evc_tree=with_evc_tree,
         model=model,
         model_kwargs=model_kwargs,
         n_points=n_points,
@@ -64,7 +70,7 @@ def lpi(
     )
 
 
-def parallel_coordinates(experiment, order=None, **kwargs):
+def parallel_coordinates(experiment, with_evc_tree=True, order=None, **kwargs):
     """
     Make a Parallel Coordinates Plot to visualize the effect of the hyperparameters
     on the objective.
@@ -73,6 +79,10 @@ def parallel_coordinates(experiment, order=None, **kwargs):
     ----------
     experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
+
+    with_evc_tree: bool, optional
+        Fetch all trials from the EVC tree.
+        Default: True
 
     order: list of str or None
         Indicates the order of columns in the parallel coordinate plot. By default
@@ -93,11 +103,14 @@ def parallel_coordinates(experiment, order=None, **kwargs):
         If no experiment is provided.
 
     """
-    return backend.parallel_coordinates(experiment, order=order, **kwargs)
+    return backend.parallel_coordinates(
+        experiment, with_evc_tree=with_evc_tree, order=order, **kwargs
+    )
 
 
 def partial_dependencies(
     experiment,
+    with_evc_tree=True,
     params=None,
     smoothing=0.85,
     n_grid_points=10,
@@ -113,6 +126,10 @@ def partial_dependencies(
     ----------
     experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
+
+    with_evc_tree: bool, optional
+        Fetch all trials from the EVC tree.
+        Default: True
 
     params: list of str, optional
         Indicates the parameters to include in the plots. All parameters are included by default.
@@ -155,6 +172,7 @@ def partial_dependencies(
 
     return backend.partial_dependencies(
         experiment,
+        with_evc_tree=with_evc_tree,
         params=params,
         smoothing=smoothing,
         n_grid_points=n_grid_points,
@@ -165,7 +183,7 @@ def partial_dependencies(
     )
 
 
-def rankings(experiments, order_by="suggested", **kwargs):
+def rankings(experiments, with_evc_tree=True, order_by="suggested", **kwargs):
     """
     Make a plot to visually compare the ranking of different hyper-optimization processes.
 
@@ -183,8 +201,12 @@ def rankings(experiments, order_by="suggested", **kwargs):
 
     Parameters
     ----------
-    experiment: list or dict
+    experiments: list or dict
         List or dictionary of experiments.
+
+    with_evc_tree: bool, optional
+        Fetch all trials from the EVC tree.
+        Default: True
 
     order_by: str
         Indicates how the trials should be ordered. Acceptable options are below.
@@ -208,10 +230,14 @@ def rankings(experiments, order_by="suggested", **kwargs):
         If no experiment is provided or order_by is invalid.
 
     """
-    return backend.rankings(experiments, order_by, **kwargs)
+    return backend.rankings(
+        experiments, with_evc_tree=with_evc_tree, order_by=order_by, **kwargs
+    )
 
 
-def regret(experiment, order_by="suggested", verbose_hover=True, **kwargs):
+def regret(
+    experiment, with_evc_tree=True, order_by="suggested", verbose_hover=True, **kwargs
+):
     """
     Make a plot to visualize the performance of the hyper-optimization process.
 
@@ -221,6 +247,10 @@ def regret(experiment, order_by="suggested", verbose_hover=True, **kwargs):
     ----------
     experiment: ExperimentClient or Experiment
         The orion object containing the experiment data
+
+    with_evc_tree: bool, optional
+        Fetch all trials from the EVC tree.
+        Default: True
 
     order_by: str
         Indicates how the trials should be ordered. Acceptable options are below.
@@ -247,10 +277,16 @@ def regret(experiment, order_by="suggested", verbose_hover=True, **kwargs):
         If no experiment is provided.
 
     """
-    return backend.regret(experiment, order_by, verbose_hover, **kwargs)
+    return backend.regret(
+        experiment,
+        with_evc_tree=with_evc_tree,
+        order_by=order_by,
+        verbose_hover=verbose_hover,
+        **kwargs,
+    )
 
 
-def regrets(experiments, order_by="suggested", **kwargs):
+def regrets(experiments, with_evc_tree=True, order_by="suggested", **kwargs):
     """
     Make a plot to visually compare the performance of different hyper-optimization processes.
 
@@ -266,8 +302,12 @@ def regrets(experiments, order_by="suggested", **kwargs):
 
     Parameters
     ----------
-    experiment: list or dict
+    experiments: list or dict
         List or dictionary of experiments.
+
+    with_evc_tree: bool, optional
+        Fetch all trials from the EVC tree.
+        Default: True
 
     order_by: str
         Indicates how the trials should be ordered. Acceptable options are below.
@@ -291,7 +331,9 @@ def regrets(experiments, order_by="suggested", **kwargs):
         If no experiment is provided or order_by is invalid.
 
     """
-    return backend.regrets(experiments, order_by, **kwargs)
+    return backend.regrets(
+        experiments, with_evc_tree=with_evc_tree, order_by=order_by, **kwargs
+    )
 
 
 PLOT_METHODS = {

--- a/tests/unittests/plotting/test_plot_accessor.py
+++ b/tests/unittests/plotting/test_plot_accessor.py
@@ -4,6 +4,14 @@ import pytest
 from orion.plotting.base import PlotAccessor
 from orion.testing import create_experiment
 
+
+SINGLE_EXPERIMENT_PLOTS = (
+    "lpi",
+    "regret",
+    "parallel_coordinates",
+    "partial_dependencies",
+)
+
 config = dict(
     name="experiment-name",
     space={"x": "uniform(0, 200)"},
@@ -72,7 +80,7 @@ def test_regret_is_default_plot():
         check_plot(plot, "regret")
 
 
-@pytest.mark.parametrize("kind", ("lpi", "regret", "parallel_coordinates"))
+@pytest.mark.parametrize("kind", SINGLE_EXPERIMENT_PLOTS)
 def test_kind(kind):
     """Tests that a plot can be created from specifying `kind` as a parameter."""
     with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):
@@ -82,7 +90,7 @@ def test_kind(kind):
         check_plot(plot, kind)
 
 
-@pytest.mark.parametrize("kind", ("lpi", "regret", "parallel_coordinates"))
+@pytest.mark.parametrize("kind", SINGLE_EXPERIMENT_PLOTS)
 def test_call_to(kind):
     """Tests instance calls to `PlotAccessor.{kind}()`"""
     with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):

--- a/tests/unittests/plotting/test_plot_accessor.py
+++ b/tests/unittests/plotting/test_plot_accessor.py
@@ -5,7 +5,6 @@ from orion.core.worker.experiment import Experiment
 from orion.plotting.base import PlotAccessor
 from orion.testing import create_experiment
 
-
 SINGLE_EXPERIMENT_PLOTS = (
     "lpi",
     "regret",

--- a/tests/unittests/plotting/test_plot_accessor.py
+++ b/tests/unittests/plotting/test_plot_accessor.py
@@ -1,6 +1,7 @@
 """Collection of tests for :mod:`orion.plotting.orion.plotting.PlotAccessor`."""
 import pytest
 
+from orion.core.worker.experiment import Experiment
 from orion.plotting.base import PlotAccessor
 from orion.testing import create_experiment
 
@@ -100,11 +101,37 @@ def test_call_to(kind):
         check_plot(plot, kind)
 
 
-@pytest.mark.parametrize(
-    "kind", ("lpi", "regret", "parallel_coordinates", "partial_dependencies")
-)
+@pytest.mark.parametrize("kind", SINGLE_EXPERIMENT_PLOTS)
 def test_emtpy(kind):
     """Tests instance calls to `PlotAccessor.{kind}()`"""
     with create_experiment(config, trial_config, []) as (_, _, experiment):
         pa = PlotAccessor(experiment)
         getattr(pa, kind)()
+
+
+@pytest.mark.parametrize("kind", SINGLE_EXPERIMENT_PLOTS)
+def test_with_evc_tree(monkeypatch, kind):
+    """Tests that the plotly backend returns a plotly object"""
+
+    WITH_EVC_TREE = True
+
+    original_to_pandas = Experiment.to_pandas
+
+    def mock_to_pandas(self, with_evc_tree):
+        assert with_evc_tree is WITH_EVC_TREE
+        return original_to_pandas(self, with_evc_tree)
+
+    monkeypatch.setattr(
+        "orion.core.worker.experiment.Experiment.to_pandas", mock_to_pandas
+    )
+
+    with create_experiment(config, trial_config, ["completed"]) as (_, _, experiment):
+        pa = PlotAccessor(experiment)
+
+        WITH_EVC_TREE = True
+        plot = getattr(pa, kind)(with_evc_tree=WITH_EVC_TREE)
+        check_plot(plot, kind)
+
+        WITH_EVC_TREE = False
+        plot = getattr(pa, kind)(with_evc_tree=WITH_EVC_TREE)
+        check_plot(plot, kind)


### PR DESCRIPTION
[Fixes #534]

The behavior is confusing when user wants to plot in some exp-{v>1}
and only part of the trials show up. Until now the plots would never
include trials from parent experiments. This commit makes it
configurable and True by default.