### PR TITLE
Fix for coverage issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ PLATFORM =
 
 [testenv]
 description = Run tests with coverage with pytest under current Python env
+usedevelop = true
 setenv = COVERAGE_FILE=.coverage.{envname}
 passenv = CI
 deps =
@@ -29,7 +30,7 @@ deps =
     coverage
 commands =
     pip install -U {toxinidir}/tests/functional/gradient_descent_algo
-    coverage run --parallel-mode -m pytest -vv --ignore tests/functional/backward_compatibility --ignore tests/stress --timeout=180 {posargs}
+    coverage run --source=src --parallel-mode -m pytest -vv --ignore tests/functional/backward_compatibility --ignore tests/stress --timeout=180 {posargs}
     coverage combine
     coverage report -m
     coverage xml


### PR DESCRIPTION
# Description
Fix #569.  Now codecov should report coverage on all files within src/ and not report anything about the tests.

There may be some lingering reports about `tests/functional/backward_compatibility/test_version.py`, because this was the file that had coverage previously, but those should disappear with time.

# Changes
tox now installs the package in development mode, to allow coverage to keep track of files.
