### PR TITLE
Add where parameter to Storage.fetch_trials

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -494,6 +494,6 @@ class Experiment:
         """Represent the object as a string."""
         return "Experiment(name=%s, metadata.user=%s, version=%s)" % (
             self.name,
-            self.metadata["user"],
+            self.metadata.get("user", "n/a"),
             self.version,
         )

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -200,7 +200,7 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         """
         raise NotImplementedError()
 
-    def fetch_trials(self, experiment=None, uid=None):
+    def fetch_trials(self, experiment=None, uid=None, where=None):
         """Fetch all the trials of an experiment in the database
 
         Parameters
@@ -210,6 +210,9 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
 
         uid: str, optional
             experiment id used to retrieve the trial object
+
+        where: Optional[dict]
+            constraint trials must respect
 
         Returns
         -------

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -158,8 +158,7 @@ class Legacy(BaseStorageProtocol):
         if where is None:
             where = dict()
 
-        if uid is not None:
-            where["experiment"] = uid
+        where["experiment"] = uid
 
         return self._fetch_trials(where)
 

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -151,11 +151,17 @@ class Legacy(BaseStorageProtocol):
         """See :func:`orion.storage.base.BaseStorageProtocol.fetch_experiments`"""
         return self._db.read("experiments", query, selection)
 
-    def fetch_trials(self, experiment=None, uid=None):
+    def fetch_trials(self, experiment=None, uid=None, where=None):
         """See :func:`orion.storage.base.BaseStorageProtocol.fetch_trials`"""
         uid = get_uid(experiment, uid)
 
-        return self._fetch_trials(dict(experiment=uid))
+        if where is None:
+            where = dict()
+
+        if uid is not None:
+            where["experiment"] = uid
+
+        return self._fetch_trials(where)
 
     def _fetch_trials(self, query, selection=None):
         """See :func:`orion.storage.base.BaseStorageProtocol.fetch_trials`"""

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -618,7 +618,13 @@ class Track(BaseStorageProtocol):  # noqa: F811
         """See :meth:`orion.storage.base.BaseStorageProtocol.fetch_trials`"""
         uid = get_uid(experiment, uid)
 
-        return self._fetch_trials(dict(group_id=uid))
+        if where is None:
+            where = dict()
+
+        if uid is not None:
+            where["group_id"] = uid
+
+        return self._fetch_trials(where)
 
     def get_trial(self, trial=None, uid=None):
         """See :meth:`orion.storage.base.BaseStorageProtocol.get_trial`"""

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -614,7 +614,7 @@ class Track(BaseStorageProtocol):  # noqa: F811
         trial.status = status
         return result_trial
 
-    def fetch_trials(self, experiment=None, uid=None):
+    def fetch_trials(self, experiment=None, uid=None, where=None):
         """See :meth:`orion.storage.base.BaseStorageProtocol.fetch_trials`"""
         uid = get_uid(experiment, uid)
 

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -621,8 +621,7 @@ class Track(BaseStorageProtocol):  # noqa: F811
         if where is None:
             where = dict()
 
-        if uid is not None:
-            where["group_id"] = uid
+        where["group_id"] = uid
 
         return self._fetch_trials(where)
 

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -452,6 +452,28 @@ class TestStorage:
             assert len(trials1) == len(cfg.trials), "trial count should match"
             assert len(trials2) == len(cfg.trials), "trial count should match"
 
+    def test_fetch_trials_with_query(self, storage):
+        """Test fetch experiment trials with queries"""
+        with OrionState(
+            experiments=[base_experiment],
+            trials=generate_trials(status=["completed", "reserved", "reserved"]),
+            storage=storage,
+        ) as cfg:
+            storage = cfg.storage()
+            experiment = cfg.get_experiment("default_name", version=None)
+
+            trials_all = storage.fetch_trials(experiment=experiment)
+            trials_completed = storage.fetch_trials(
+                experiment=experiment, where={"status": "completed"}
+            )
+            trials_reserved = storage.fetch_trials(
+                experiment=experiment, where={"status": "reserved"}
+            )
+
+            assert len(trials_all) == len(cfg.trials), "trial count should match"
+            assert len(trials_completed) == 1, "trial count should match"
+            assert len(trials_reserved) == 2, "trial count should match"
+
     def test_delete_all_trials(self, storage):
         """Test delete all trials of an experiment"""
         if storage and storage["type"] == "track":


### PR DESCRIPTION
# Description

This adds a `where` parameter to the `fetch_trials` method of all Storage interfaces (legacy and tracks). This is useful behavior that can be used to simplify some tests which currently use `_fetch_trials`, and it improves the consistency of the interface wrt the `update_trials` and `delete_trials` methods which already take a `where` parameter.

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)
