### PR TITLE
Make command `orion db setup` ask for right arguments based on storage backend.

### DIFF
--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -63,7 +63,7 @@ def main(*args):
     ).lower()
     # Get database arguments.
     db_class = Database.types[Database.typenames.index(_type)]
-    db_args = db_class.get_arguments()
+    db_args = db_class.get_defaults()
     arg_vals = {}
     for arg_name, default_value in sorted(db_args.items()):
         arg_vals[arg_name] = ask_question(

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -14,8 +14,8 @@ import os
 import yaml
 
 import orion.core
-from orion.core.utils.terminal import ask_question
 from orion.core.io.database import Database
+from orion.core.utils.terminal import ask_question
 
 log = logging.getLogger(__name__)
 SHORT_DESCRIPTION = "Starts the database configuration wizard"

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -55,25 +55,12 @@ def main(*args):
             return
 
     # Get database type.
-    while True:
-        _type = (
-            ask_question(
-                "Enter the database type (available: {}): ".format(
-                    ", ".join(Database.typenames)
-                ),
-                "mongodb",
-            )
-            .strip()
-            .lower()
-        )
-        if _type in Database.typenames:
-            break
-        print(
-            "Unknown database type: {}, expected: {}".format(
-                _type, ", ".join(Database.typenames)
-            )
-        )
-        print()
+    _type = ask_question(
+        "Enter the database",
+        choice=Database.typenames,
+        default="mongodb",
+        ignore_case=True,
+    ).lower()
     # Get database arguments.
     db_class = Database.types[Database.typenames.index(_type)]
     db_args = db_class.get_arguments()

--- a/src/orion/core/cli/db/setup.py
+++ b/src/orion/core/cli/db/setup.py
@@ -78,7 +78,7 @@ def main(*args):
     db_class = Database.types[Database.typenames.index(_type)]
     db_args = db_class.get_arguments()
     arg_vals = {}
-    for arg_name, default_value in db_args.items():
+    for arg_name, default_value in sorted(db_args.items()):
         arg_vals[arg_name] = ask_question(
             "Enter the database {}: ".format(arg_name), default_value
         )

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -268,7 +268,7 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 
     @classmethod
     @abstractmethod
-    def get_arguments(cls):
+    def get_defaults(cls):
         """Get database arguments needed to create a database instance.
 
         Returns

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -266,6 +266,20 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         """
         pass
 
+    @classmethod
+    @abstractmethod
+    def get_arguments(cls):
+        """Get database arguments needed to create a database instance.
+
+        Returns
+        -------
+        dict
+            A dictionary mapping an argument name to a default value.
+            If unexpected, default value can be None.
+
+        """
+        pass
+
 
 # pylint: disable=too-few-public-methods
 class ReadOnlyDB(object):

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -49,6 +49,10 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         **kwargs
     ):
         """Init method, see attributes of :class:`AbstractDB`."""
+        defaults = self.get_defaults()
+        host = defaults.get("host", None) if host is None or host == "" else host
+        name = defaults.get("name", None) if name is None or name == "" else name
+
         self.host = host
         self.name = name
         self.port = port

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -130,6 +130,16 @@ class EphemeralDB(AbstractDB):
 
         return dbcollection.delete_many(query=query)
 
+    @classmethod
+    def get_arguments(cls):
+        """Get database arguments needed to create a database instance.
+
+        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
+        for argument documentation.
+
+        """
+        return {}
+
 
 class EphemeralCollection(object):
     """Non permanent collection

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -131,10 +131,10 @@ class EphemeralDB(AbstractDB):
         return dbcollection.delete_many(query=query)
 
     @classmethod
-    def get_arguments(cls):
+    def get_defaults(cls):
         """Get database arguments needed to create a database instance.
 
-        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
+        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_defaults`
                      for argument documentation.
 
         """

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -135,7 +135,7 @@ class EphemeralDB(AbstractDB):
         """Get database arguments needed to create a database instance.
 
         .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
-        for argument documentation.
+                     for argument documentation.
 
         """
         return {}

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -339,4 +339,4 @@ class MongoDB(AbstractDB):
                      for argument documentation.
 
         """
-        return {"name": "test", "host": "localhost"}
+        return {"name": "orion", "host": "localhost"}

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -332,10 +332,10 @@ class MongoDB(AbstractDB):
             )
 
     @classmethod
-    def get_arguments(cls):
+    def get_defaults(cls):
         """Get database arguments needed to create a database instance.
 
-        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
+        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_defaults`
                      for argument documentation.
 
         """

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -336,7 +336,7 @@ class MongoDB(AbstractDB):
         """Get database arguments needed to create a database instance.
 
         .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
-        for argument documentation.
+                     for argument documentation.
 
         """
         return {"name": "test", "host": "localhost"}

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -330,3 +330,13 @@ class MongoDB(AbstractDB):
             self.options["authSource"] = settings["options"].get(
                 "authsource", self.name
             )
+
+    @classmethod
+    def get_arguments(cls):
+        """Get database arguments needed to create a database instance.
+
+        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
+        for argument documentation.
+
+        """
+        return {"name": "test", "host": "localhost"}

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -244,7 +244,7 @@ class PickledDB(AbstractDB):
         """Get database arguments needed to create a database instance.
 
         .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
-        for argument documentation.
+                     for argument documentation.
 
         """
         return {"host": DEFAULT_HOST}

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -239,6 +239,16 @@ class PickledDB(AbstractDB):
         except Timeout as e:
             raise DatabaseTimeout(TIMEOUT_ERROR_MESSAGE.format(self.timeout)) from e
 
+    @classmethod
+    def get_arguments(cls):
+        """Get database arguments needed to create a database instance.
+
+        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
+        for argument documentation.
+
+        """
+        return {"host": DEFAULT_HOST}
+
 
 local_file_systems = ["ext2", "ext3", "ext4", "ntfs"]
 

--- a/src/orion/core/io/database/pickleddb.py
+++ b/src/orion/core/io/database/pickleddb.py
@@ -240,10 +240,10 @@ class PickledDB(AbstractDB):
             raise DatabaseTimeout(TIMEOUT_ERROR_MESSAGE.format(self.timeout)) from e
 
     @classmethod
-    def get_arguments(cls):
+    def get_defaults(cls):
         """Get database arguments needed to create a database instance.
 
-        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_arguments`
+        .. seealso:: :meth:`orion.core.io.database.AbstractDB.get_defaults`
                      for argument documentation.
 
         """

--- a/src/orion/core/utils/terminal.py
+++ b/src/orion/core/utils/terminal.py
@@ -6,7 +6,7 @@ Helper functions for terminal i/o
 """
 
 
-def ask_question(question, default=None):
+def ask_question(question, default=None, choice=None, ignore_case=False):
     """Ask a question to the user and receive an answer.
 
     Parameters
@@ -15,6 +15,11 @@ def ask_question(question, default=None):
         The question to be asked.
     default: str
         The default value to use if the user enters nothing.
+    choice: list
+        List of expected values to check user answer
+    ignore_case: bool
+        Used only if choice is provided. If True, ignore case when checking
+        user answer against given choice.
 
     Returns
     -------
@@ -22,13 +27,24 @@ def ask_question(question, default=None):
         The answer provided by the user.
 
     """
+    if choice is not None:
+        if ignore_case:
+            choice = [value.lower() for value in choice]
+        question = question + " (choice: {})".format(", ".join(choice))
+
     if default is not None:
         question = question + " (default: {}) ".format(default)
 
-    answer = input(question)
-
-    if answer.strip() == "":
-        return default
+    while True:
+        answer = input(question)
+        if answer.strip() == "":
+            answer = default
+            break
+        if choice is None:
+            break
+        if answer in choice or (ignore_case and answer.lower() in choice):
+            break
+        print("Unexpected value {}\n".format(answer))
 
     return answer
 

--- a/src/orion/core/utils/terminal.py
+++ b/src/orion/core/utils/terminal.py
@@ -44,7 +44,11 @@ def ask_question(question, default=None, choice=None, ignore_case=False):
             break
         if answer in choice or (ignore_case and answer.lower() in choice):
             break
-        print("Unexpected value {}\n".format(answer))
+        print(
+            "Unexpected value: {}. Must be one of: {}\n".format(
+                answer, ", ".join(choice)
+            )
+        )
 
     return answer
 

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -83,6 +83,36 @@ def test_stop_creation_when_exists(monkeypatch, tmp_path):
     assert content == dump
 
 
+def test_invalid_database(monkeypatch, tmp_path):
+    """Test if command prompt loops when invalid database is typed."""
+    config_path = str(tmp_path) + "/tmp_config.yaml"
+    monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
+    monkeypatch.setattr(
+        builtins,
+        "input",
+        _mock_input(
+            [
+                "invalid database",
+                "invalid database again",
+                "2383ejdd",
+                "another invalid database",
+                "mongodb",
+                "the host",
+                "the name",
+            ]
+        ),
+    )
+
+    orion.core.cli.main(["db", "setup"])
+
+    with open(config_path, "r") as output:
+        content = yaml.safe_load(output)
+
+    assert content == {
+        "database": {"type": "mongodb", "name": "the name", "host": "the host"}
+    }
+
+
 def test_defaults(monkeypatch, tmp_path):
     """Test if the default values are used when nothing user enters nothing."""
     config_path = str(tmp_path) + "/tmp_config.yaml"

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -26,7 +26,7 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
     """Test if a configuration file is created when it does not exist."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(["mongodb", "name", "host"]))
+    monkeypatch.setattr(builtins, "input", _mock_input(["mongodb", "host", "name"]))
 
     try:
         os.remove(config_path)
@@ -48,7 +48,7 @@ def test_creation_when_exists(monkeypatch, tmp_path):
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
     monkeypatch.setattr(
-        builtins, "input", _mock_input(["y", "mongodb", "name", "host"])
+        builtins, "input", _mock_input(["y", "mongodb", "host", "name"])
     )
 
     dump = {"database": {"type": "allo2", "name": "allo2", "host": "allo2"}}

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -97,7 +97,14 @@ def test_invalid_database(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         builtins,
         "input",
-        _mock_input([*invalid_db_names, "mongodb", "the host", "the name",]),
+        _mock_input(
+            [
+                *invalid_db_names,
+                "mongodb",
+                "the host",
+                "the name",
+            ]
+        ),
     )
 
     orion.core.cli.main(["db", "setup"])

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -131,7 +131,7 @@ def test_defaults(monkeypatch, tmp_path):
         content = yaml.safe_load(output)
 
     assert content == {
-        "database": {"type": "mongodb", "name": "test", "host": "localhost"}
+        "database": {"type": "mongodb", "name": "orion", "host": "localhost"}
     }
 
 

--- a/tests/functional/commands/test_setup_command.py
+++ b/tests/functional/commands/test_setup_command.py
@@ -26,7 +26,7 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
     """Test if a configuration file is created when it does not exist."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(["type", "name", "host"]))
+    monkeypatch.setattr(builtins, "input", _mock_input(["mongodb", "name", "host"]))
 
     try:
         os.remove(config_path)
@@ -40,14 +40,16 @@ def test_creation_when_not_existing(monkeypatch, tmp_path):
     with open(config_path, "r") as output:
         content = yaml.safe_load(output)
 
-    assert content == {"database": {"type": "type", "name": "name", "host": "host"}}
+    assert content == {"database": {"type": "mongodb", "name": "name", "host": "host"}}
 
 
 def test_creation_when_exists(monkeypatch, tmp_path):
     """Test if the configuration file is overwritten when it exists."""
     config_path = str(tmp_path) + "/tmp_config.yaml"
     monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
-    monkeypatch.setattr(builtins, "input", _mock_input(["y", "type", "name", "host"]))
+    monkeypatch.setattr(
+        builtins, "input", _mock_input(["y", "mongodb", "name", "host"])
+    )
 
     dump = {"database": {"type": "allo2", "name": "allo2", "host": "allo2"}}
 
@@ -95,3 +97,33 @@ def test_defaults(monkeypatch, tmp_path):
     assert content == {
         "database": {"type": "mongodb", "name": "test", "host": "localhost"}
     }
+
+
+def test_ephemeraldb(monkeypatch, tmp_path):
+    """Test if config content is written for an ephemeraldb."""
+    config_path = str(tmp_path) + "/tmp_config.yaml"
+    monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
+    monkeypatch.setattr(builtins, "input", _mock_input(["ephemeraldb"]))
+
+    orion.core.cli.main(["db", "setup"])
+
+    with open(config_path, "r") as output:
+        content = yaml.safe_load(output)
+
+    assert content == {"database": {"type": "ephemeraldb"}}
+
+
+def test_pickleddb(monkeypatch, tmp_path):
+    """Test if config content is written for an pickleddb."""
+    host = "my_pickles.db"
+
+    config_path = str(tmp_path) + "/tmp_config.yaml"
+    monkeypatch.setattr(orion.core, "DEF_CONFIG_FILES_PATHS", [config_path])
+    monkeypatch.setattr(builtins, "input", _mock_input(["pickleddb", host]))
+
+    orion.core.cli.main(["db", "setup"])
+
+    with open(config_path, "r") as output:
+        content = yaml.safe_load(output)
+
+    assert content == {"database": {"type": "pickleddb", "host": host}}


### PR DESCRIPTION
# Description

Update command line `orion db setup` to ask for arguments depending of storage backend typed in first question.

To automate retrieval of storage backend arguments, a class method `get_arguments()` is added to base class `AbstractDB`.

Fixes #573 

# Checklist

## Tests
- [X] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Quality
- [X] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [X] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [X] My code follows the style guidelines (`$ tox -e lint`)
