### PR TITLE
[WIP] Add context-manager-enabled Trial subclass.

### DIFF
--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -533,10 +533,11 @@ class ExperimentClient:
 
             raise e
 
-        if trial is not None:
+        if trial is None:
+            return trial
+        else:
             self._maintain_reservation(trial)
-
-        return None if trial is None else TrialCM(self, trial)
+            return TrialCM(self, trial)
 
     def observe(self, trial, results):
         """Observe trial results

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -23,7 +23,7 @@ from orion.core.utils.exceptions import (
     WaitingForTrials,
 )
 from orion.core.utils.flatten import flatten, unflatten
-from orion.core.worker.trial import Trial
+from orion.core.worker.trial import Trial, TrialCM
 from orion.core.worker.trial_pacemaker import TrialPacemaker
 from orion.plotting.base import PlotAccessor
 from orion.storage.base import FailedUpdate
@@ -536,7 +536,7 @@ class ExperimentClient:
         if trial is not None:
             self._maintain_reservation(trial)
 
-        return trial
+        return None if trial is None else TrialCM(self, trial)
 
     def observe(self, trial, results):
         """Observe trial results

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -470,9 +470,11 @@ class TrialCM:
 
     def __exit__(self, exc_type, exc_value, traceback):
         try:
-            if exc_type is None:
-                self._cm_experiment.release(self._cm_trial)
-            else:
+            if exc_type is KeyboardInterrupt:
+                self._cm_experiment.release(self._cm_trial, "interrupted")
+            elif exc_type is not None:
                 self._cm_experiment.release(self._cm_trial, "broken")
+            else:
+                self._cm_experiment.release(self._cm_trial)
         except:
             pass

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -476,5 +476,5 @@ class TrialCM:
                 self._cm_experiment.release(self._cm_trial, "broken")
             else:
                 self._cm_experiment.release(self._cm_trial)
-        except:
-            pass
+        except RuntimeError as e:
+            log.warning(e)

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -496,10 +496,12 @@ class TestBroken:
     def test_broken_trial(self):
         """Test that broken trials are detected"""
         with create_experiment(config, base_trial) as (cfg, experiment, client):
-            trial = client.suggest()
-            assert trial.status == "reserved"
-
-            atexit._run_exitfuncs()
+            try:
+                with client.suggest() as trial:
+                    assert trial.status == "reserved"
+                    raise RuntimeError("Dummy failure!")
+            except:
+                pass
 
             assert client._pacemakers == {}
             assert client.get_trial(trial).status == "broken"

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -459,14 +459,11 @@ class TestClose:
     def test_close_with_reserved(self):
         """Test client cannot be closed if trials are reserved."""
         with create_experiment(config, base_trial) as (cfg, experiment, client):
-            trial = client.suggest()
+            with client.suggest() as trial:
+                with pytest.raises(RuntimeError) as exc:
+                    client.close()
 
-            with pytest.raises(RuntimeError) as exc:
-                client.close()
-
-            assert "There is still reserved trials" in str(exc.value)
-
-            client.release(trial)
+                assert "There is still reserved trials" in str(exc.value)
 
     def test_close_unregister_atexit(self, monkeypatch):
         """Test close properly unregister the atexit function"""
@@ -496,12 +493,10 @@ class TestBroken:
     def test_broken_trial(self):
         """Test that broken trials are detected"""
         with create_experiment(config, base_trial) as (cfg, experiment, client):
-            try:
+            with pytest.raises(RuntimeError):
                 with client.suggest() as trial:
                     assert trial.status == "reserved"
                     raise RuntimeError("Dummy failure!")
-            except:
-                pass
 
             assert client._pacemakers == {}
             assert client.get_trial(trial).status == "broken"
@@ -521,13 +516,11 @@ class TestBroken:
                 _,
                 client2,
             ):
-                trial1 = client1.suggest()
-                trial2 = client2.suggest()
-
-                assert trial1.status == "reserved"
-                assert trial2.status == "reserved"
-
-                atexit._run_exitfuncs()
+                with pytest.raises(RuntimeError):
+                    with client1.suggest() as trial1, client2.suggest() as trial2:
+                        assert trial1.status == "reserved"
+                        assert trial2.status == "reserved"
+                        raise RuntimeError("Dummy failure!")
 
                 assert client1._pacemakers == {}
                 assert client2._pacemakers == {}
@@ -581,13 +574,10 @@ class TestBroken:
     def test_interrupted_trial(self):
         """Test that interrupted trials are not set to broken"""
         with create_experiment(config, base_trial) as (cfg, experiment, client):
-            trial = client.suggest()
-            assert trial.status == "reserved"
-
-            try:
-                raise KeyboardInterrupt
-            except KeyboardInterrupt as e:
-                atexit._run_exitfuncs()
+            with pytest.raises(KeyboardInterrupt):
+                with client.suggest() as trial:
+                    assert trial.status == "reserved"
+                    raise KeyboardInterrupt
 
             assert client._pacemakers == {}
             assert client.get_trial(trial).status == "interrupted"


### PR DESCRIPTION
# Description
There are hangs in the tests when `release(trial)` is not invoked on a reserved trial (#583).

After discussion, it is agreed that the `atexit()` handling strategy should be abandoned in favour of turning `Trial` into a context manager, usable with the Python `with`-statement. We begin doing so here.

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)
