### PR TITLE
Handle cases when trial.status is not reserved anymore locally.

### DIFF
--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -455,6 +455,7 @@ class ExperimentClient:
         """
         self._check_if_writable()
 
+        current_status = trial.status
         raise_if_unreserved = True
         try:
             self._experiment.set_trial_status(trial, status, was="reserved")
@@ -463,7 +464,7 @@ class ExperimentClient:
                 raise ValueError(
                     "Trial {} does not exist in database.".format(trial.id)
                 ) from e
-            if trial.status != "reserved":
+            if current_status != "reserved":
                 raise_if_unreserved = False
                 raise RuntimeError(
                     "Trial {} was already released locally.".format(trial.id)

--- a/src/orion/storage/base.py
+++ b/src/orion/storage/base.py
@@ -327,8 +327,22 @@ class BaseStorageProtocol(metaclass=AbstractSingletonType):
         """Push the trial's results to the database"""
         raise NotImplementedError()
 
-    def set_trial_status(self, trial, status, heartbeat=None):
+    def set_trial_status(self, trial, status, heartbeat=None, was=None):
         """Update the trial status and the heartbeat
+
+        Parameters
+        ----------
+        trial: `Trial` object
+            Trial object to update in the database.
+        status: str
+            Status to be set to the trial
+        heartbeat: datetime, optional
+            New heartbeat to update simultaneously with status
+        was: str, optional
+            The status the trial should be set to in the database.
+            If None, current ``trial.status`` will be used.
+            This is used to ensure coherence in the database, protecting
+            against race conditions for instance.
 
         Raises
         ------

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -294,10 +294,8 @@ class Legacy(BaseStorageProtocol):
 
     def set_trial_status(self, trial, status, heartbeat=None, was=None):
         """See :func:`orion.storage.base.BaseStorageProtocol.set_trial_status`"""
-        if heartbeat is None:
-            heartbeat = datetime.datetime.utcnow()
-        if was is None:
-            was = trial.status
+        heartbeat = heartbeat or datetime.datetime.utcnow()
+        was = was or trial.status
 
         validate_status(status)
         validate_status(was)

--- a/src/orion/storage/legacy.py
+++ b/src/orion/storage/legacy.py
@@ -292,18 +292,19 @@ class Legacy(BaseStorageProtocol):
 
         return rc
 
-    def set_trial_status(self, trial, status, heartbeat=None):
+    def set_trial_status(self, trial, status, heartbeat=None, was=None):
         """See :func:`orion.storage.base.BaseStorageProtocol.set_trial_status`"""
         if heartbeat is None:
             heartbeat = datetime.datetime.utcnow()
+        if was is None:
+            was = trial.status
+
+        validate_status(status)
+        validate_status(was)
 
         update = dict(status=status, heartbeat=heartbeat, experiment=trial.experiment)
 
-        validate_status(status)
-
-        rc = self.update_trial(
-            trial, **update, where={"status": trial.status, "_id": trial.id}
-        )
+        rc = self.update_trial(trial, **update, where={"status": was, "_id": trial.id})
 
         if not rc:
             raise FailedUpdate()

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -600,8 +600,7 @@ class Track(BaseStorageProtocol):  # noqa: F811
             does not match the status in the database
 
         """
-        if was is None:
-            was = trial.status
+        was = was or trial.status
 
         validate_status(status)
         validate_status(was)

--- a/src/orion/storage/track.py
+++ b/src/orion/storage/track.py
@@ -590,7 +590,7 @@ class Track(BaseStorageProtocol):  # noqa: F811
 
         return self._fetch_trials(query)
 
-    def set_trial_status(self, trial, status, heartbeat=None):
+    def set_trial_status(self, trial, status, heartbeat=None, was=None):
         """Update the trial status and the heartbeat
 
         Raises
@@ -600,10 +600,14 @@ class Track(BaseStorageProtocol):  # noqa: F811
             does not match the status in the database
 
         """
+        if was is None:
+            was = trial.status
+
         validate_status(status)
+        validate_status(was)
         try:
             result_trial = self.backend.fetch_and_update_trial(
-                {"uid": trial.id, "status": get_track_status(trial.status)},
+                {"uid": trial.id, "status": get_track_status(was)},
                 "set_trial_status",
                 status=get_track_status(status),
             )


### PR DESCRIPTION
Why:

Some trial status updates require the trial to have a specific status
(like releasing the trial reservation). In such case, `set_trial_status`
should not verify that status in database in current trial.status, but
rather that the trial status should be a precise one.

How:

Add argument `was` which will override current trial status if given.