### PR TITLE
Test different type of categorical dims

### DIFF
--- a/src/orion/testing/algo.py
+++ b/src/orion/testing/algo.py
@@ -538,9 +538,9 @@ class BaseAlgoTests:
             num,
             attr,
             {  # Add 3 dims so that there exists many possible trials for the test
-                "x": "choices(['a', 'b', 'c', 'd'])",
-                "y": "choices(['a', 'b', 'c', 'd'])",
-                "z": "choices(['a', 'b', 'c', 'd'])",
+                "x": "choices(['a', 0.2, 1, None])",
+                "y": "choices(['a', 0.2, 1, None])",
+                "z": "choices(['a', 0.2, 1, None])",
             },
         )
 


### PR DESCRIPTION
Why:

Some algorithms may have issues with different type of values. For
instance TPE was failing to sample ``None`` values because it was
recognized as `GMM failed to sample` inside TPE.
