### PR TITLE
fix tpe space cardinality

### DIFF
--- a/src/orion/algo/tpe.py
+++ b/src/orion/algo/tpe.py
@@ -475,7 +475,7 @@ class TPE(BaseAlgorithm):
     def _sample_int_point(self, dimension, below_points, above_points):
         """Sample one value for integer dimension based on the observed good and bad points"""
         low, high = dimension.interval()
-        choices = range(low, high)
+        choices = range(low, high + 1)
 
         below_points = numpy.array(below_points).astype(int) - low
         above_points = numpy.array(above_points).astype(int) - low
@@ -589,7 +589,7 @@ class GMMSampler:
                         f"Failed to sample in interval ({self.low}, {self.high})"
                     )
                 pt = new_points.pop(0)
-                if self.low <= pt < self.high:
+                if self.low <= pt <= self.high:
                     point.append(pt)
                     break
 

--- a/tests/unittests/algo/test_tpe.py
+++ b/tests/unittests/algo/test_tpe.py
@@ -755,11 +755,6 @@ class TestTPE(BaseAlgoTests):
 
         assert exc.match(f"Failed to sample in interval \({low}, {high}\)")
 
-    def test_int_data(self, mocker, num, attr):
-        if num > 0:
-            pytest.skip("See https://github.com/Epistimio/orion/issues/600")
-        super(TestTPE, self).test_int_data(mocker, num, attr)
-
     def test_is_done_cardinality(self):
         # TODO: Support correctly loguniform(discrete=True)
         #       See https://github.com/Epistimio/orion/issues/566


### PR DESCRIPTION
# Description
fix issue https://github.com/Epistimio/orion/issues/600
Update tpe real and int sampler to be consistent with the default space dimension from cardinality.

# Changes

- real
uniform(0, 5) => before the fix, tpe samples from [0,5), after the fix, tpe samples [0,5]

- integer
uniform(0, 5, discrete=True) => before the fix, tpe samples from [0,5), after the fix, tpe samples [0,5] 



## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)
