### PR TITLE
fix benchmark ranking and regret visualization

### DIFF
--- a/src/orion/benchmark/__init__.py
+++ b/src/orion/benchmark/__init__.py
@@ -328,7 +328,7 @@ class Study:
 
         for _, experiment in self.experiments_info:
             # TODO: it is a blocking call
-            experiment.workon(self.task, max_trials, n_workers)
+            experiment.workon(self.task, n_workers=n_workers, max_trials=max_trials)
 
     def status(self):
         """Return status of the study"""

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -173,12 +173,11 @@ def rankings(experiments, with_evc_tree=True, order_by="suggested", **kwargs):
         ):
             competitions = []
             remaining = True
-            i = 0
             n_competitions = len(next(iter(experiments.values())))
             for ith_competition in range(n_competitions):
                 competition = {}
                 for name in experiments.keys():
-                    competition[name] = experiments[name][i]
+                    competition[name] = experiments[name][ith_competition]
                 competitions.append(competition)
         elif isinstance(experiments, dict):
             competitions = experiments
@@ -636,7 +635,7 @@ def regrets(experiments, with_evc_tree=True, order_by="suggested", **kwargs):
             name=name,
         )
         if "best_var" in exp_data:
-            dy = exp_data["best_var"]
+            dy = numpy.sqrt(exp_data["best_var"])
             fig.add_scatter(
                 x=list(x) + list(x)[::-1],
                 y=list(y - dy) + list(y + dy)[::-1],

--- a/tests/unittests/benchmark/test_benchmark.py
+++ b/tests/unittests/benchmark/test_benchmark.py
@@ -233,6 +233,8 @@ class TestStudy:
             name = "benchmark007_AverageResult_RosenBrock_0_0"
             experiment = experiment_builder.build(name)
 
+            assert len(experiment.fetch_trials()) == study.task.max_trials
+
             assert experiment is not None
 
     @pytest.mark.usefixtures("version_XYZ")


### PR DESCRIPTION
Fix:
1) banchmark experiment parallel execution parameter is inconsistent with `experimentclient.workon`
2) Rankings plot show wrong and different result compared with regrets

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

