### PR TITLE
Allow branching when parent script isn't available

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1318,7 +1318,7 @@ class CommandLineConflict(Conflict):
         log.debug("User script config: %s", user_script_config)
         log.debug("Non monitored arguments: %s", non_monitored_arguments)
 
-        parser = OrionCmdlineParser(user_script_config)
+        parser = OrionCmdlineParser(user_script_config, allow_non_existing_files=True)
         parser.set_state_dict(config["metadata"]["parser"])
         priors = parser.priors_to_normal()
         nameless_keys = set(parser.parser.arguments.keys()) - set(priors.keys())
@@ -1478,7 +1478,7 @@ class ScriptConfigConflict(Conflict):
         if user_script_config is None:
             user_script_config = orion.core.config.worker.user_script_config
 
-        parser = OrionCmdlineParser(user_script_config)
+        parser = OrionCmdlineParser(user_script_config, allow_non_existing_files=True)
         parser.set_state_dict(config["metadata"]["parser"])
 
         nameless_config = dict(

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -3,9 +3,9 @@
 """Perform a functional test for branching."""
 
 import os
-import yaml
 
 import pytest
+import yaml
 
 import orion.core.cli
 import orion.core.io.experiment_builder as experiment_builder


### PR DESCRIPTION
[Fixes #553]

Why:

Suppose we want to branch from a parent running from a different
computer, or for which we lost the execution script. The branching
should not fail because script is missing, we do not need it because we
wont execute trials from the parent anyway.

How:

Use allow_non_existing_files=True when building the cmdline parser to
compare cmdlines of experiments.