### PR TITLE
Add enable option for EVC, with default = false

### DIFF
--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -301,6 +301,14 @@ def define_evc_config(config):
     #       After this, the cmdline parser should be built based on config.
 
     evc_config.add_option(
+        "enable",
+        option_type=bool,
+        default=False,
+        env_var="ORION_EVC_ENABLE",
+        help="Enable the Experiment Version Control. Defaults to False.",
+    )
+
+    evc_config.add_option(
         "auto_resolution",
         option_type=bool,
         default=True,

--- a/src/orion/core/cli/evc.py
+++ b/src/orion/core/cli/evc.py
@@ -10,6 +10,15 @@ from orion.core.evc import adapters
 from orion.core.evc.conflicts import Resolution
 
 
+def _add_enable_argument(parser):
+    parser.add_argument(
+        "--enable-evc",
+        action="store_true",
+        default=None,
+        help="Enable the Experiment Version Control.",
+    )
+
+
 def _add_auto_resolution_argument(parser):
     parser.add_argument(
         "--auto-resolution",
@@ -106,6 +115,7 @@ def _add_branch_to_argument(parser, resolution_class):
 
 
 resolution_arguments = {
+    "enable": _add_enable_argument,
     "auto_resolution": _add_auto_resolution_argument,
     "manual_resolution": _add_manual_resolution_argument,
     "non_monitored_arguments": _add_non_monitored_arguments_argument,
@@ -133,6 +143,7 @@ def get_branching_args_group(parser):
         description="Arguments to automatically resolved branching events.",
     )
 
+    _add_enable_argument(branching_args_group)
     _add_manual_resolution_argument(branching_args_group)
     _add_non_monitored_arguments_argument(branching_args_group)
     _add_ignore_code_changes_argument(branching_args_group)

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -198,8 +198,10 @@ def main(args):
 
     signal.signal(signal.SIGTERM, _handler)
 
-    workon(
-        experiment,
-        ignore_code_changes=config["branching"].get("ignore_code_changes"),
-        **worker_config
-    )
+    # If EVC is not enabled, we force Consumer to ignore code changes.
+    if not config["branching"].get("enable", orion.core.config.evc.enable):
+        ignore_code_changes = True
+    else:
+        ignore_code_changes = config["branching"].get("ignore_code_changes")
+
+    workon(experiment, ignore_code_changes=ignore_code_changes, **worker_config)

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1169,9 +1169,15 @@ class CodeConflict(Conflict):
         old_hash_commit = old_config["metadata"].get("VCS", None)
         new_hash_commit = new_config["metadata"].get("VCS")
 
-        ignore_code_changes = branching_config is not None and branching_config.get(
-            "ignore_code_changes", False
-        )
+        # Will be overriden by global config if not set in branching_config
+        ignore_code_changes = None
+        # Try using user defined ignore_code_changes
+        if branching_config is not None:
+            ignore_code_changes = branching_config.get("ignore_code_changes", None)
+        # Otherwise use global conf's ignore_code_changes
+        if ignore_code_changes is None:
+            ignore_code_changes = orion.core.config.evc.ignore_code_changes
+
         if ignore_code_changes:
             log.debug("Ignoring code changes")
         if (

--- a/src/orion/core/io/experiment_branch_builder.py
+++ b/src/orion/core/io/experiment_branch_builder.py
@@ -54,7 +54,9 @@ class ExperimentBranchBuilder:
 
     """
 
-    def __init__(self, conflicts, manual_resolution=None, **branching_arguments):
+    def __init__(
+        self, conflicts, enabled=True, manual_resolution=None, **branching_arguments
+    ):
         # TODO: handle all other arguments
         if manual_resolution is None:
             manual_resolution = orion.core.config.evc.manual_resolution
@@ -69,7 +71,8 @@ class ExperimentBranchBuilder:
         self.branching_arguments = branching_arguments
 
         self.conflicting_config.update(branching_arguments)
-        self.resolve_conflicts()
+        if enabled:
+            self.resolve_conflicts()
 
     @property
     def experiment_config(self):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -100,13 +100,9 @@ def fetch_config_from_cmdargs(cmdargs):
         cmdargs_config["worker.max_trials"] = cmdargs.pop("worker_trials")
 
     mappings = dict(
-        experiment=dict(exp_max_broken="max_broken", exp_max_trials="max_trials"),
-        worker=dict(worker_max_broken="max_broken", worker_max_trials="max_trials"),
-    )
-
-    mappings = dict(
         experiment=dict(max_broken="exp_max_broken", max_trials="exp_max_trials"),
         worker=dict(max_broken="worker_max_broken", max_trials="worker_max_trials"),
+        evc=dict(enable="enable_evc"),
     )
 
     global_config = orion.core.config.to_dict()

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -217,7 +217,7 @@ def test_with_evc(algorithm):
             space=space_with_fidelity,
             algorithms=algorithm,
             max_trials=30,
-            branching={"branch_from": "exp"},
+            branching={"branch_from": "exp", "enable": True},
         )
 
         assert exp.version == 2

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -277,7 +277,7 @@ def test_parallel_workers(algorithm):
             name=name,
             space=space_with_fidelity,
             algorithms=algorithm,
-            branching={"branch_from": name},
+            branching={"branch_from": name, "enable": True},
         )
 
         assert exp.version == 2

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -42,6 +42,7 @@ def init_full_x_full_y(init_full_x):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box_with_y.py "
             "-x~uniform(-10,10) "
             "-y~+uniform(-10,10,default_value=1)"
@@ -70,7 +71,9 @@ def init_half_x_full_y(init_full_x_full_y):
     branch = "half_x_full_y"
     orion.core.cli.main(
         (
-            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "hunt --init-only -n {branch} --branch-from {name} "
+            "--enable-evc "
+            "./black_box_with_y.py "
             "-x~+uniform(0,10) "
             "-y~uniform(-10,10,default_value=1)"
         )
@@ -92,7 +95,9 @@ def init_full_x_half_y(init_full_x_full_y):
     branch = "full_x_half_y"
     orion.core.cli.main(
         (
-            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "hunt --init-only -n {branch} --branch-from {name} "
+            "--enable-evc "
+            "./black_box_with_y.py "
             "-x~uniform(-10,10) "
             "-y~+uniform(0,10,default_value=1)"
         )
@@ -115,6 +120,7 @@ def init_full_x_rename_y_z(init_full_x_full_y):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box_with_z.py -x~uniform(-10,10) -y~>z -z~uniform(-10,10,default_value=1)"
         )
         .format(name=name, branch=branch)
@@ -142,6 +148,7 @@ def init_full_x_rename_half_y_half_z(init_full_x_half_y):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box_with_z.py -x~uniform(-10,10) -y~>z -z~uniform(0,10,default_value=1)"
         )
         .format(name=name, branch=branch)
@@ -163,6 +170,7 @@ def init_full_x_rename_half_y_full_z(init_full_x_half_y):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box_with_z.py "
             "-x~uniform(-10,10) -y~>z "
             "-z~+uniform(-10,10,default_value=1)"
@@ -192,6 +200,7 @@ def init_full_x_remove_y(init_full_x_full_y):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box.py "
             "-x~uniform(-10,10) -y~-"
         )
@@ -214,6 +223,7 @@ def init_full_x_full_y_add_z_remove_y(init_full_x_full_y):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box.py -x~uniform(-10,10) "
             "-z~uniform(-20,10,default_value=0)"
         )
@@ -236,6 +246,7 @@ def init_full_x_remove_z(init_full_x_rename_y_z):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box.py "
             "-x~uniform(-10,10) -z~-"
         )
@@ -258,6 +269,7 @@ def init_full_x_remove_z_default_4(init_full_x_rename_y_z):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box.py "
             "-x~uniform(-10,10) -z~-4"
         )
@@ -281,6 +293,7 @@ def init_full_x_new_algo(init_full_x):
         (
             "hunt --init-only -n {branch} --branch-from {name} "
             "--algorithm-change --config new_algo_config.yaml "
+            "--enable-evc "
             "./black_box.py -x~uniform(-10,10)"
         )
         .format(name=name, branch=branch)
@@ -302,6 +315,7 @@ def init_full_x_new_cli(init_full_x):
     orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --cli-change-type noeffect "
+            "--enable-evc "
             "./black_box_new.py -x~uniform(-10,10) --a-new argument"
         )
         .format(name=name, branch=branch)
@@ -321,7 +335,9 @@ def init_full_x_ignore_cli(init_full_x):
     name = "full_x_with_new_opt"
     orion.core.cli.main(
         (
-            "hunt --init-only -n {name} --config orion_config.yaml ./black_box_new.py "
+            "hunt --init-only -n {name} --config orion_config.yaml "
+            "--enable-evc "
+            "./black_box_new.py "
             "-x~uniform(-10,10)"
         )
         .format(name=name)
@@ -332,7 +348,9 @@ def init_full_x_ignore_cli(init_full_x):
     orion.core.cli.main(
         (
             "hunt --init-only -n {name} --non-monitored-arguments a-new "
-            "--config orion_config.yaml ./black_box_new.py "
+            "--config orion_config.yaml "
+            "--enable-evc "
+            "./black_box_new.py "
             "-x~uniform(-10,10) --a-new argument"
         )
         .format(name=name)
@@ -813,7 +831,9 @@ def test_new_algo_not_resolved(init_full_x, capsys):
     error_code = orion.core.cli.main(
         (
             "hunt --init-only -n {branch} --branch-from {name} --config new_algo_config.yaml "
-            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+            "--manual-resolution "
+            "--enable-evc "
+            "./black_box.py -x~uniform(-10,10)"
         )
         .format(name=name, branch=branch)
         .split(" ")
@@ -832,7 +852,9 @@ def test_ignore_cli(init_full_x_ignore_cli):
     orion.core.cli.main(
         (
             "hunt --init-only -n {name} --non-monitored-arguments a-new "
-            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+            "--manual-resolution "
+            "--enable-evc "
+            "./black_box.py -x~uniform(-10,10)"
         )
         .format(name=name)
         .split(" ")
@@ -846,7 +868,9 @@ def test_new_code_triggers_code_conflict(capsys):
     error_code = orion.core.cli.main(
         (
             "hunt --init-only -n {name} "
-            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+            "--manual-resolution "
+            "--enable-evc "
+            "./black_box.py -x~uniform(-10,10)"
         )
         .format(name=name)
         .split(" ")
@@ -864,7 +888,7 @@ def test_new_code_triggers_code_conflict_with_name_only(capsys):
     """Test that a different git hash is generating a child, even if cmdline is not passed"""
     name = "full_x"
     error_code = orion.core.cli.main(
-        ("hunt --init-only -n {name} " "--manual-resolution")
+        ("hunt --init-only -n {name} --manual-resolution --enable-evc")
         .format(name=name)
         .split(" ")
     )
@@ -884,7 +908,9 @@ def test_new_code_ignores_code_conflict():
     error_code = orion.core.cli.main(
         (
             "hunt --worker-max-trials 2 -n {name} --ignore-code-changes "
-            "--manual-resolution ./black_box.py -x~uniform(-10,10)"
+            "--manual-resolution "
+            "--enable-evc "
+            "./black_box.py -x~uniform(-10,10)"
         )
         .format(name=name)
         .split(" ")
@@ -897,7 +923,9 @@ def test_new_orion_version_triggers_conflict(capsys):
     """Test that a different git hash is generating a child"""
     name = "full_x"
     error_code = orion.core.cli.main(
-        ("hunt --init-only -n {name} --manual-resolution").format(name=name).split(" ")
+        ("hunt --init-only -n {name} --manual-resolution --enable-evc")
+        .format(name=name)
+        .split(" ")
     )
     assert error_code == 1
 
@@ -931,7 +959,7 @@ def test_no_cli_no_branching():
     """Test that no branching occurs when using same code and not passing cmdline"""
     name = "full_x"
     error_code = orion.core.cli.main(
-        ("hunt --init-only -n {name} " "--manual-resolution")
+        ("hunt --init-only -n {name} --manual-resolution --enable-evc")
         .format(name=name)
         .split(" ")
     )
@@ -1082,7 +1110,9 @@ def test_auto_resolution_does_resolve(init_full_x_full_y, monkeypatch):
     # experiment
     orion.core.cli.main(
         (
-            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "hunt --init-only -n {branch} --branch-from {name} "
+            "--enable-evc "
+            "./black_box_with_y.py "
             "-x~uniform(0,10) "
             "-w~choices(['a','b'])"
         )
@@ -1121,7 +1151,9 @@ def test_auto_resolution_with_fidelity(init_full_x_full_y, monkeypatch):
     # experiment
     orion.core.cli.main(
         (
-            "hunt --init-only -n {branch} --branch-from {name} ./black_box_with_y.py "
+            "hunt --init-only -n {branch} --branch-from {name} "
+            "--enable-evc "
+            "./black_box_with_y.py "
             "-x~uniform(0,10) "
             "-w~fidelity(1,10)"
         )
@@ -1156,14 +1188,18 @@ def test_init_w_version_from_parent_w_children(
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     execute(
         "hunt --init-only -n experiment --config orion_config.yaml "
+        "--enable-evc "
         "./black_box.py -x~normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+        "hunt --init-only -n experiment "
+        "--enable-evc "
+        "./black_box.py -x~normal(0,1) -y~+normal(0,1)"
     )
 
     execute(
         "hunt --init-only -n experiment -v 1 "
+        "--enable-evc "
         "./black_box.py -x~normal(0,1) -y~+normal(0,1) -z~normal(0,1)",
         assert_code=1,
     )
@@ -1179,13 +1215,18 @@ def test_init_w_version_from_exp_wout_child(setup_pickleddb_database, monkeypatc
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     execute(
         "hunt --init-only -n experiment --config orion_config.yaml "
+        "--enable-evc "
         "./black_box.py -x~normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+        "hunt --init-only -n experiment "
+        "--enable-evc "
+        "./black_box.py -x~normal(0,1) -y~+normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment -v 2 ./black_box.py "
+        "hunt --init-only -n experiment -v 2 "
+        "--enable-evc "
+        "./black_box.py "
         "-x~normal(0,1) -y~+normal(0,1) -z~+normal(0,1)"
     )
 
@@ -1198,13 +1239,18 @@ def test_init_w_version_gt_max(setup_pickleddb_database, monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     execute(
         "hunt --init-only -n experiment --config orion_config.yaml "
+        "--enable-evc "
         "./black_box.py -x~normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+        "hunt --init-only -n experiment "
+        "--enable-evc "
+        "./black_box.py -x~normal(0,1) -y~+normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment -v 2000 ./black_box.py "
+        "hunt --init-only -n experiment -v 2000 "
+        "--enable-evc "
+        "./black_box.py "
         "-x~normal(0,1) -y~+normal(0,1) -z~+normal(0,1)"
     )
 
@@ -1217,14 +1263,18 @@ def test_init_check_increment_w_children(setup_pickleddb_database, monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     execute(
         "hunt --init-only -n experiment --config orion_config.yaml "
+        "--enable-evc "
         "./black_box.py -x~normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment --branch-to experiment_2 ./black_box.py "
+        "hunt --init-only -n experiment --branch-to experiment_2 "
+        "--enable-evc "
+        "./black_box.py "
         "-x~normal(0,1) -y~+normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -z~+normal(0,1)"
+        "hunt --init-only -n experiment --enable-evc "
+        "./black_box.py -x~normal(0,1) -z~+normal(0,1)"
     )
 
     exp = get_storage().fetch_experiments({"name": "experiment", "version": 2})
@@ -1236,13 +1286,18 @@ def test_branch_from_selected_version(setup_pickleddb_database, monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     execute(
         "hunt --init-only -n experiment --config orion_config.yaml "
+        "--enable-evc "
         "./black_box.py -x~normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment ./black_box.py -x~normal(0,1) -y~+normal(0,1)"
+        "hunt --init-only -n experiment "
+        "--enable-evc "
+        "./black_box.py -x~normal(0,1) -y~+normal(0,1)"
     )
     execute(
-        "hunt --init-only -n experiment --version 1 -b experiment_2 ./black_box.py "
+        "hunt --init-only -n experiment --version 1 -b experiment_2 "
+        "--enable-evc "
+        "./black_box.py "
         "-x~normal(0,1) -z~+normal(0,1)"
     )
 

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -405,7 +405,7 @@ def init_full_x_new_config(init_full_x, tmp_path):
 
     orion.core.cli.main(
         (
-            "hunt --init-only -n {branch} --branch-from {name} "
+            "hunt --enable-evc --init-only -n {branch} --branch-from {name} "
             "--cli-change-type noeffect "
             "--config-change-type unsure "
             "./black_box_new.py -x~uniform(-10,10) --config {config_file}"
@@ -1033,7 +1033,7 @@ def test_new_script(init_full_x, monkeypatch):
 
     orion.core.cli.main(
         (
-            "hunt --init-only -n {name} --config orion_config.yaml ./black_box.py "
+            "hunt --enable-evc --init-only -n {name} --config orion_config.yaml ./black_box.py "
             "-x~uniform(-10,10) --some-new args"
         )
         .format(name=name)
@@ -1081,7 +1081,7 @@ def test_missing_config(init_full_x_new_config, monkeypatch):
 
     orion.core.cli.main(
         (
-            "hunt --init-only -n {name} "
+            "hunt --enable-evc --init-only -n {name} "
             "--cli-change-type noeffect "
             "--config-change-type unsure "
             "./black_box_new.py -x~uniform(-10,10) --config {config_file}"
@@ -1127,7 +1127,7 @@ def test_missing_and_new_config(init_full_x_new_config, monkeypatch):
 
     orion.core.cli.main(
         (
-            "hunt --init-only -n {name} "
+            "hunt --enable-evc --init-only -n {name} "
             "--cli-change-type noeffect "
             "--config-change-type unsure "
             "./black_box_new.py -x~uniform(-10,10) --config {config_file}"

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -179,6 +179,7 @@ def two_experiments(monkeypatch, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_double_exp",
             "--branch-to",
@@ -239,6 +240,7 @@ def three_experiments_family(two_experiments, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_double_exp",
             "--branch-to",
@@ -274,6 +276,7 @@ def three_experiments_family_branch(two_experiments, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_double_exp_child",
             "--branch-to",
@@ -317,6 +320,7 @@ def two_experiments_same_name(one_experiment, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_single_exp",
             "./black_box.py",
@@ -336,6 +340,7 @@ def three_experiments_family_same_name(two_experiments_same_name, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_single_exp",
             "-v",
@@ -359,6 +364,7 @@ def three_experiments_branch_same_name(two_experiments_same_name, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_single_exp",
             "-b",
@@ -379,6 +385,7 @@ def three_experiments_same_name(two_experiments_same_name, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_single_exp",
             "./black_box.py",
@@ -397,6 +404,7 @@ def three_experiments_same_name_with_trials(two_experiments_same_name, storage):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "test_single_exp",
             "./black_box.py",

--- a/tests/functional/commands/test_insert_command.py
+++ b/tests/functional/commands/test_insert_command.py
@@ -222,6 +222,7 @@ def test_insert_with_version(storage, monkeypatch, script_path):
         [
             "hunt",
             "--init-only",
+            "--enable-evc",
             "-n",
             "experiment",
             "-c",

--- a/tests/functional/serving/test_trials_resource.py
+++ b/tests/functional/serving/test_trials_resource.py
@@ -55,7 +55,8 @@ def add_experiment(**kwargs):
     """Adds experiment to the dummy orion instance"""
     base_experiment.update(copy.deepcopy(kwargs))
     experiment_builder.build(
-        branching=dict(branch_from=base_experiment["name"]), **base_experiment
+        branching=dict(branch_from=base_experiment["name"], enable=True),
+        **base_experiment
     )
 
 

--- a/tests/unittests/client/test_client.py
+++ b/tests/unittests/client/test_client.py
@@ -266,7 +266,9 @@ class TestCreateExperiment:
         """Test creating a differing experiment that cause branching."""
         with OrionState(experiments=[config]):
             experiment = create_experiment(
-                config["name"], space={"y": "uniform(0, 10)"}
+                config["name"],
+                space={"y": "uniform(0, 10)"},
+                branching={"enable": True},
             )
 
             assert experiment.name == config["name"]
@@ -289,7 +291,11 @@ class TestCreateExperiment:
         """
         with OrionState(experiments=[config]):
             parent = create_experiment(config["name"])
-            child = create_experiment(config["name"], space={"y": "uniform(0, 10)"})
+            child = create_experiment(
+                config["name"],
+                space={"y": "uniform(0, 10)"},
+                branching={"enable": True},
+            )
 
             def insert_race_condition(self, query):
                 is_auto_version_query = query == {
@@ -315,7 +321,9 @@ class TestCreateExperiment:
             )
 
             experiment = create_experiment(
-                config["name"], space={"y": "uniform(0, 10)"}
+                config["name"],
+                space={"y": "uniform(0, 10)"},
+                branching={"enable": True},
             )
 
             assert insert_race_condition.count == 1
@@ -326,7 +334,11 @@ class TestCreateExperiment:
         """Test that two or more race condition leads to raise"""
         with OrionState(experiments=[config]):
             parent = create_experiment(config["name"])
-            child = create_experiment(config["name"], space={"y": "uniform(0, 10)"})
+            child = create_experiment(
+                config["name"],
+                space={"y": "uniform(0, 10)"},
+                branching={"enable": True},
+            )
 
             def insert_race_condition(self, query):
                 is_auto_version_query = query == {
@@ -350,7 +362,11 @@ class TestCreateExperiment:
             )
 
             with pytest.raises(RaceCondition) as exc:
-                create_experiment(config["name"], space={"y": "uniform(0, 10)"})
+                create_experiment(
+                    config["name"],
+                    space={"y": "uniform(0, 10)"},
+                    branching={"enable": True},
+                )
 
             assert insert_race_condition.count == 2
             assert "There was a race condition during branching and new version" in str(
@@ -361,10 +377,17 @@ class TestCreateExperiment:
         """Test creating a differing experiment that cause branching."""
         new_space = {"y": "uniform(0, 10)"}
         with OrionState(experiments=[config]):
-            create_experiment(config["name"], space=new_space)
+            create_experiment(
+                config["name"], space=new_space, branching={"enable": True}
+            )
 
             with pytest.raises(BranchingEvent) as exc:
-                create_experiment(config["name"], version=1, space=new_space)
+                create_experiment(
+                    config["name"],
+                    version=1,
+                    space=new_space,
+                    branching={"enable": True},
+                )
 
             assert "Configuration is different and generates" in str(exc.value)
 

--- a/tests/unittests/core/io/interactive_commands/test_branching_prompt.py
+++ b/tests/unittests/core/io/interactive_commands/test_branching_prompt.py
@@ -81,7 +81,7 @@ def conflicts(
 @pytest.fixture
 def branch_builder(conflicts):
     """Generate the experiment branch builder"""
-    return ExperimentBranchBuilder(conflicts, {"manual_resolution": True})
+    return ExperimentBranchBuilder(conflicts, manual_resolution=True)
 
 
 @pytest.fixture

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -571,7 +571,9 @@ class TestExperimentVersioning(object):
         parent_version_config.pop("version")
         with OrionState(experiments=[parent_version_config]):
             exp = experiment_builder.build(
-                name=parent_version_config["name"], space={"y": "uniform(0, 10)"}
+                name=parent_version_config["name"],
+                space={"y": "uniform(0, 10)"},
+                branching={"enable": True},
             )
 
         assert exp.version == 2
@@ -854,7 +856,7 @@ class TestBuild(object):
             child_name = "child"
 
             child = experiment_builder.build(
-                name=name, branching={"branch_to": child_name}
+                name=name, branching={"branch_to": child_name, "enable": True}
             )
 
             assert child.name == child_name
@@ -864,7 +866,7 @@ class TestBuild(object):
             child_name = "child2"
 
             child = experiment_builder.build(
-                name=child_name, branching={"branch_from": name}
+                name=child_name, branching={"branch_from": name, "enable": True}
             )
 
             assert child.name == child_name
@@ -878,14 +880,19 @@ class TestBuild(object):
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name=name, space=space)
-            child = experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+            child = experiment_builder.build(
+                name=name, space={"x": "loguniform(1,10)"}, branching={"enable": True}
+            )
             assert child.name == parent.name
             assert parent.version == 1
             assert child.version == 2
 
             with pytest.raises(BranchingEvent) as exc_info:
                 experiment_builder.build(
-                    name=name, version=1, space={"x": "loguniform(1,10)"}
+                    name=name,
+                    version=1,
+                    space={"x": "loguniform(1,10)"},
+                    branching={"enable": True},
                 )
             assert "Configuration is different and generates a branching" in str(
                 exc_info.value
@@ -900,7 +907,9 @@ class TestBuild(object):
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name, space=space)
-            child = experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+            child = experiment_builder.build(
+                name=name, space={"x": "loguniform(1,10)"}, branching={"enable": True}
+            )
             assert child.name == parent.name
             assert parent.version == 1
             assert child.version == 2
@@ -939,7 +948,11 @@ class TestBuild(object):
             )
 
             with pytest.raises(RaceCondition) as exc_info:
-                experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+                experiment_builder.build(
+                    name=name,
+                    space={"x": "loguniform(1,10)"},
+                    branching={"enable": True},
+                )
             assert "There was likely a race condition during version" in str(
                 exc_info.value
             )
@@ -968,7 +981,11 @@ class TestBuild(object):
             )
 
             with pytest.raises(RaceCondition) as exc_info:
-                experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+                experiment_builder.build(
+                    name=name,
+                    space={"x": "loguniform(1,10)"},
+                    branching={"enable": True},
+                )
             assert "There was a race condition during branching." in str(exc_info.value)
 
     def test_race_condition_w_version(self, monkeypatch):
@@ -985,7 +1002,9 @@ class TestBuild(object):
 
         with OrionState(experiments=[], trials=[]):
             parent = experiment_builder.build(name, space=space)
-            child = experiment_builder.build(name=name, space={"x": "loguniform(1,10)"})
+            child = experiment_builder.build(
+                name=name, space={"x": "loguniform(1,10)"}, branching={"enable": True}
+            )
             assert child.name == parent.name
             assert parent.version == 1
             assert child.version == 2
@@ -1025,7 +1044,10 @@ class TestBuild(object):
 
             with pytest.raises(BranchingEvent) as exc_info:
                 experiment_builder.build(
-                    name=name, version=1, space={"x": "loguniform(1,10)"}
+                    name=name,
+                    version=1,
+                    space={"x": "loguniform(1,10)"},
+                    branching={"enable": True},
                 )
             assert "Configuration is different and generates" in str(exc_info.value)
 
@@ -1054,7 +1076,10 @@ class TestBuild(object):
 
             with pytest.raises(RaceCondition) as exc_info:
                 experiment_builder.build(
-                    name=name, version=1, space={"x": "loguniform(1,10)"}
+                    name=name,
+                    version=1,
+                    space={"x": "loguniform(1,10)"},
+                    branching={"enable": True},
                 )
             assert "There was a race condition during branching." in str(exc_info.value)
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -289,6 +289,7 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
 
     # Test evc subconfig
     evc_config = config.pop("evc")
+    assert evc_config.pop("enable") is orion.core.config.evc.enable
     assert evc_config.pop("auto_resolution") == orion.core.config.evc.auto_resolution
     assert (
         evc_config.pop("manual_resolution") == orion.core.config.evc.manual_resolution

--- a/tests/unittests/core/worker/test_consumer.py
+++ b/tests/unittests/core/worker/test_consumer.py
@@ -101,7 +101,7 @@ def test_code_changed_evc_disabled(config, monkeypatch, caplog):
     con, trial = setup_code_change_mock(config, monkeypatch, ignore_code_changes=True)
 
     with caplog.at_level(logging.WARNING):
-        con.consume(trial)
+        con(trial)
         assert "Code changed between execution of 2 trials" in caplog.text
 
 

--- a/tests/unittests/core/worker/test_producer.py
+++ b/tests/unittests/core/worker/test_producer.py
@@ -625,7 +625,9 @@ def test_original_seeding(producer):
 def test_evc(monkeypatch, producer):
     """Verify that producer is using available trials from EVC"""
     experiment = producer.experiment
-    new_experiment = build(experiment.name, algorithms="random")
+    new_experiment = build(
+        experiment.name, algorithms="random", branching={"enable": True}
+    )
 
     # Replace parent with hacked exp, otherwise parent ID does not match trials in DB
     # and fetch_trials() won't return anything.
@@ -652,7 +654,9 @@ def test_evc(monkeypatch, producer):
 def test_evc_duplicates(monkeypatch, producer):
     """Verify that producer wont register samples that are available in parent experiment"""
     experiment = producer.experiment
-    new_experiment = build(experiment.name, algorithms="random")
+    new_experiment = build(
+        experiment.name, algorithms="random", branching={"enable": True}
+    )
 
     # Replace parent with hacked exp, otherwise parent ID does not match trials in DB
     # and fetch_trials() won't return anything.

--- a/tests/unittests/plotting/test_plotly_backend.py
+++ b/tests/unittests/plotting/test_plotly_backend.py
@@ -755,7 +755,7 @@ class TestRankings:
             experiment,
         ):
             child = orion.client.create_experiment(
-                experiment.name, branching={"branch_to": "child"}
+                experiment.name, branching={"branch_to": "child", "enable": True}
             )
 
             plot = rankings([experiment, child])
@@ -774,7 +774,8 @@ class TestRankings:
             experiment,
         ):
             child = orion.client.create_experiment(
-                experiment.name, branching={"branch_to": experiment.name}
+                experiment.name,
+                branching={"branch_to": experiment.name, "enable": True},
             )
             assert child.name == experiment.name
             assert child.version == experiment.version + 1
@@ -962,7 +963,7 @@ class TestRegrets:
             experiment,
         ):
             child = orion.client.create_experiment(
-                experiment.name, branching={"branch_to": "child"}
+                experiment.name, branching={"branch_to": "child", "enable": True}
             )
 
             plot = regrets([experiment, child])
@@ -981,7 +982,8 @@ class TestRegrets:
             experiment,
         ):
             child = orion.client.create_experiment(
-                experiment.name, branching={"branch_to": experiment.name}
+                experiment.name,
+                branching={"branch_to": experiment.name, "enable": True},
             )
             assert child.name == experiment.name
             assert child.version == experiment.version + 1


### PR DESCRIPTION
[Fixes #547]

The EVC is a constant source of confusion for users. It should be
disabled by default with warning messages when different versions of
experiments are used. Users who wants using advanced features of the EVC
would still be able to use it by enabling it.

Making it false by default is a breaking change and may cause issues to
user currently using the EVC. Based on discussion with users there does
not seem to have much usage of the EVC so far so this breaking change
should be relatively harmless. Avoiding further confusion by making it
disabled by default is worth the breaking change.