### PR TITLE
Remove space upgrade from DB upgrade

### DIFF
--- a/src/orion/core/cli/db/upgrade.py
+++ b/src/orion/core/cli/db/upgrade.py
@@ -12,7 +12,6 @@ import logging
 import sys
 
 import orion.core.io.experiment_builder as experiment_builder
-import orion.core.utils.backward as backward
 from orion.core.io.database.ephemeraldb import EphemeralCollection
 from orion.core.io.database.mongodb import MongoDB
 from orion.core.io.database.pickleddb import PickledDB

--- a/src/orion/core/cli/db/upgrade.py
+++ b/src/orion/core/cli/db/upgrade.py
@@ -126,18 +126,12 @@ def upgrade_documents(storage):
     """Upgrade scheme of the documents"""
     for experiment in storage.fetch_experiments({}):
         add_version(experiment)
-        add_space(experiment)
         storage.update_experiment(uid=experiment.pop("_id"), **experiment)
 
 
 def add_version(experiment):
     """Add version 1 if not present"""
     experiment.setdefault("version", 1)
-
-
-def add_space(experiment):
-    """Add space to metadata if not present"""
-    backward.populate_space(experiment)
 
 
 def update_indexes(database):

--- a/tests/functional/backward_compatibility/test_versions.py
+++ b/tests/functional/backward_compatibility/test_versions.py
@@ -244,7 +244,6 @@ class TestBackwardCompatibility:
 
         experiments = storage.fetch_experiments({})
         assert "version" in experiments[0]
-        assert "priors" in experiments[0]["metadata"]
 
     def test_db_test(self):
         """Verify db test command"""


### PR DESCRIPTION
[Fixes #554]

Why:

The space upgrade relies on local files if the experiment's search space
is defined in a configuration file. Parsing these file during the DB
upgrade can break the DB because all experiments may not be executed on
the same file system and thus some configuration files may not be
present. The space should only be upgraded when the user attempts
running an experiment, in which case the configuration file is available.

The space does not need to be upgraded during DB upgrade anyway, because
experiment built is backward compatible with experiments lacking an
explicit space definition in DB (relying on cmdargs and config file to
define space at run-time).

How:

Remove space upgrade from db upgrade script.