### PR TITLE
Feature/filter duplicate in evc

### DIFF
--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -33,6 +33,7 @@ Adapters can be build using the factory class `Adapter(**kwargs)` or using
 import copy
 from abc import ABCMeta, abstractmethod
 
+from orion.algo.space import Dimension
 from orion.core.io.space_builder import DimensionBuilder
 from orion.core.utils import Factory
 from orion.core.worker.trial import Trial
@@ -278,6 +279,9 @@ class DimensionAddition(BaseAdapter):
 
             :meth:`orion.core.evc.adapters.BaseAdapter.forward`
         """
+        if self.param.value is Dimension.NO_DEFAULT_VALUE:
+            return []
+
         adapted_trials = []
 
         for trial in trials:

--- a/tests/functional/commands/conftest.py
+++ b/tests/functional/commands/conftest.py
@@ -204,7 +204,7 @@ def family_with_trials(two_experiments):
         x["value"] = x_value
         y["value"] = x_value
         trial = Trial(experiment=exp.id, params=[x], status=status)
-        x["value"] = x_value
+        x["value"] = x_value + 0.5  # To avoid duplicates
         trial2 = Trial(experiment=exp2.id, params=[x, y], status=status)
         x_value += 1
         Database().write("trials", trial.to_dict())
@@ -260,7 +260,7 @@ def three_family_with_trials(three_experiments_family, family_with_trials):
 
     x_value = 0
     for status in Trial.allowed_stati:
-        x["value"] = x_value
+        x["value"] = x_value + 0.75  # To avoid duplicates
         z["value"] = x_value * 100
         trial = Trial(experiment=exp.id, params=[x, z], status=status)
         x_value += 1
@@ -302,7 +302,7 @@ def three_family_branch_with_trials(
 
     x_value = 0
     for status in Trial.allowed_stati:
-        x["value"] = x_value
+        x["value"] = x_value + 0.25  # To avoid duplicates
         y["value"] = x_value * 10
         z["value"] = x_value * 100
         trial = Trial(experiment=exp.id, params=[x, y, z], status=status)
@@ -416,7 +416,7 @@ def three_experiments_same_name_with_trials(two_experiments_same_name, storage):
     z = {"name": "/z", "type": "real"}
     x_value = 0
     for status in Trial.allowed_stati:
-        x["value"] = x_value
+        x["value"] = x_value + 0.1  # To avoid duplicates
         y["value"] = x_value * 10
         z["value"] = x_value * 100
         trial = Trial(experiment=exp.id, params=[x], status=status)

--- a/tests/functional/commands/test_status_command.py
+++ b/tests/functional/commands/test_status_command.py
@@ -501,12 +501,12 @@ adbe6c400cd1e667696e28fbecd000a0  reserved
   ========================
   id                                status
   --------------------------------  -----------
-  890b4f07685ed020f5d9e28cac9316e1  broken
-  ff81ff46da5ffe6bd623fb38a06df993  completed
-  78a3e60699eee1d0b9bc51a049168fce  interrupted
-  13cd454155748351790525e3079fb620  new
-  d1b7ecbd3621de9195a42c76defb6603  reserved
-  33d6208ef03cb236a8f3b567665c357d  suspended
+  2b08bdbad673e60fef739b7f162d4120  broken
+  af45e26f349f9b186e5c05a91d854fb5  completed
+  b334ea9e2c86873ddb18b206cf72cc27  interrupted
+  16b024079173ca3903eb956c478afa3d  new
+  17ce012a15a7398d3e7703d0c13e21c2  reserved
+  d4721fe7f50df1fe3ba60424df6dec67  suspended
 
 
 """
@@ -537,12 +537,12 @@ adbe6c400cd1e667696e28fbecd000a0  reserved
   ========================
   id                                status
   --------------------------------  -----------
-  890b4f07685ed020f5d9e28cac9316e1  broken
-  ff81ff46da5ffe6bd623fb38a06df993  completed
-  78a3e60699eee1d0b9bc51a049168fce  interrupted
-  13cd454155748351790525e3079fb620  new
-  d1b7ecbd3621de9195a42c76defb6603  reserved
-  33d6208ef03cb236a8f3b567665c357d  suspended
+  2b08bdbad673e60fef739b7f162d4120  broken
+  af45e26f349f9b186e5c05a91d854fb5  completed
+  b334ea9e2c86873ddb18b206cf72cc27  interrupted
+  16b024079173ca3903eb956c478afa3d  new
+  17ce012a15a7398d3e7703d0c13e21c2  reserved
+  d4721fe7f50df1fe3ba60424df6dec67  suspended
 
 
 test_single_exp-v1
@@ -585,24 +585,24 @@ adbe6c400cd1e667696e28fbecd000a0  reserved
   ========================
   id                                status
   --------------------------------  -----------
-  890b4f07685ed020f5d9e28cac9316e1  broken
-  ff81ff46da5ffe6bd623fb38a06df993  completed
-  78a3e60699eee1d0b9bc51a049168fce  interrupted
-  13cd454155748351790525e3079fb620  new
-  d1b7ecbd3621de9195a42c76defb6603  reserved
-  33d6208ef03cb236a8f3b567665c357d  suspended
+  2b08bdbad673e60fef739b7f162d4120  broken
+  af45e26f349f9b186e5c05a91d854fb5  completed
+  b334ea9e2c86873ddb18b206cf72cc27  interrupted
+  16b024079173ca3903eb956c478afa3d  new
+  17ce012a15a7398d3e7703d0c13e21c2  reserved
+  d4721fe7f50df1fe3ba60424df6dec67  suspended
 
 
   test_double_exp_child2-v1
   =========================
   id                                status
   --------------------------------  -----------
-  1c238040d6b6d8423d99a08551fe0998  broken
-  2c13424a9212ab92ea592bdaeb1c13e9  completed
-  a2680fbda1faa9dfb94946cf25536f44  interrupted
-  abbda454d0577ded5b8e784a9d6d5abb  new
-  df58aa8fd875f129f7faa84eb15ca453  reserved
-  71657e86bad0f2e8b06098a64cb883b6  suspended
+  f736224f9687f86c493a004696abd95b  broken
+  2def838a2eb199820f283e1948e7c37a  completed
+  75752e1ba3c9007e42616249087a7fef  interrupted
+  5f5e1c8d886ef0b0c0666d6db7bf1723  new
+  2623a01bd2483a5e18fac9bc3dfbdee2  reserved
+  2eecad70c53bb52c99efad36f2d9502f  suspended
 
 
 """
@@ -633,24 +633,24 @@ adbe6c400cd1e667696e28fbecd000a0  reserved
   ========================
   id                                status
   --------------------------------  -----------
-  890b4f07685ed020f5d9e28cac9316e1  broken
-  ff81ff46da5ffe6bd623fb38a06df993  completed
-  78a3e60699eee1d0b9bc51a049168fce  interrupted
-  13cd454155748351790525e3079fb620  new
-  d1b7ecbd3621de9195a42c76defb6603  reserved
-  33d6208ef03cb236a8f3b567665c357d  suspended
+  2b08bdbad673e60fef739b7f162d4120  broken
+  af45e26f349f9b186e5c05a91d854fb5  completed
+  b334ea9e2c86873ddb18b206cf72cc27  interrupted
+  16b024079173ca3903eb956c478afa3d  new
+  17ce012a15a7398d3e7703d0c13e21c2  reserved
+  d4721fe7f50df1fe3ba60424df6dec67  suspended
 
 
     test_double_exp_grand_child-v1
     ==============================
     id                                status
     --------------------------------  -----------
-    e374d8f802aed52c07763545f46228a7  broken
-    f9ee14ff9ef0b95ed7a24860731c85a9  completed
-    3f7dff101490727d5fa0efeb36ca6366  interrupted
-    40838d46dbf7778a3cb51b7a09118391  new
-    b7860a18b2700cce4e8009cde543975c  reserved
-    cd406126bc350ad82ac77c75174cc8a2  suspended
+    e1c929d9c4d48eca4dcd463690e4096d  broken
+    e8eec526a7f7fdea5e4a30d969ec69ae  completed
+    e88f1d26158efb393ae1278c6ef115fe  interrupted
+    4510dc7d16a692c7415dd2898faced9f  new
+    523881db96da0de9dd972ef8f3545f81  reserved
+    f967423d15c50ddf88c242f511997ff7  suspended
 
 
 """
@@ -853,7 +853,7 @@ id                                status
 cbb766d729294f77f0ca86ff2bf72707  completed
 ca6576848f17201852225d816fb71fcc  interrupted
 28097ba31dbdffc0aa265c6bc5c98b0f  new
-4c409da13bdc93c54f6997797c296356  new
+cd16dd40955335aae3bd40371e636b71  new
 adbe6c400cd1e667696e28fbecd000a0  reserved
 5679af6c6bb54aa8042043008ab2bc1f  suspended
 
@@ -878,7 +878,7 @@ id                                status
 cbb766d729294f77f0ca86ff2bf72707  completed
 ca6576848f17201852225d816fb71fcc  interrupted
 28097ba31dbdffc0aa265c6bc5c98b0f  new
-4c409da13bdc93c54f6997797c296356  new
+cd16dd40955335aae3bd40371e636b71  new
 adbe6c400cd1e667696e28fbecd000a0  reserved
 5679af6c6bb54aa8042043008ab2bc1f  suspended
 
@@ -915,8 +915,8 @@ id                                status
 cbb766d729294f77f0ca86ff2bf72707  completed
 ca6576848f17201852225d816fb71fcc  interrupted
 28097ba31dbdffc0aa265c6bc5c98b0f  new
-4c409da13bdc93c54f6997797c296356  new
-b97518f91e006cd4a2805657c596b11c  new
+cd16dd40955335aae3bd40371e636b71  new
+8d5652cba225224d6702107e97a53cd9  new
 adbe6c400cd1e667696e28fbecd000a0  reserved
 5679af6c6bb54aa8042043008ab2bc1f  suspended
 
@@ -941,8 +941,8 @@ id                                status
 cbb766d729294f77f0ca86ff2bf72707  completed
 ca6576848f17201852225d816fb71fcc  interrupted
 28097ba31dbdffc0aa265c6bc5c98b0f  new
-4c409da13bdc93c54f6997797c296356  new
-5183ee9c28601cc78c0a148a386df9f9  new
+cd16dd40955335aae3bd40371e636b71  new
+17fab2503ac14ae55e207c7cca1b8f1f  new
 adbe6c400cd1e667696e28fbecd000a0  reserved
 5679af6c6bb54aa8042043008ab2bc1f  suspended
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -355,7 +355,7 @@ def test_workon():
         assert len(params) == 1
         px = params["/x"]
         assert isinstance(px, float)
-        assert (px - 34.56789) < 5
+        assert (px - 34.56789) < 10
 
 
 def test_stress_unique_folder_creation(storage, monkeypatch, tmpdir, capfd):

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -355,7 +355,7 @@ def test_workon():
         assert len(params) == 1
         px = params["/x"]
         assert isinstance(px, float)
-        assert (px - 34.56789) < 10
+        assert (px - 34.56789) < 20
 
 
 def test_stress_unique_folder_creation(storage, monkeypatch, tmpdir, capfd):

--- a/tests/functional/serving/test_trials_resource.py
+++ b/tests/functional/serving/test_trials_resource.py
@@ -59,7 +59,7 @@ def add_experiment(**kwargs):
     )
 
 
-def add_trial(experiment: int, status: str = None, **kwargs):
+def add_trial(experiment: int, status: str = None, value=10, **kwargs):
     """
     Add trials to the dummy orion instance
 
@@ -79,6 +79,7 @@ def add_trial(experiment: int, status: str = None, **kwargs):
     kwargs["status"] = status
 
     base_trial.update(copy.deepcopy(kwargs))
+    base_trial["params"][0]["value"] = value
     get_storage().register_trial(Trial(**base_trial))
 
 
@@ -180,9 +181,10 @@ class TestTrialCollection:
         add_experiment(name="a", version=2, _id=2)
         add_experiment(name="a", version=3, _id=3)
 
-        add_trial(experiment=1, id_override="00")
-        add_trial(experiment=2, id_override="01")
-        add_trial(experiment=3, id_override="02")
+        # Specify values to avoid duplicates
+        add_trial(experiment=1, id_override="00", value=1)
+        add_trial(experiment=2, id_override="01", value=2)
+        add_trial(experiment=3, id_override="02", value=3)
 
         # Happy case default
         response = client.simulate_get("/trials/a?ancestors=true")
@@ -255,10 +257,10 @@ class TestTrialCollection:
         add_experiment(name="a", version=2, _id=3)
         add_experiment(name="a", version=3, _id=4)
 
-        add_trial(experiment=1, id_override="00", status="completed")
-        add_trial(experiment=3, id_override="01", status="broken")
-        add_trial(experiment=3, id_override="02", status="completed")
-        add_trial(experiment=2, id_override="03", status="completed")
+        add_trial(experiment=1, id_override="00", value=1, status="completed")
+        add_trial(experiment=3, id_override="01", value=2, status="broken")
+        add_trial(experiment=3, id_override="02", value=3, status="completed")
+        add_trial(experiment=2, id_override="03", value=4, status="completed")
 
         response = client.simulate_get(
             "/trials/a?ancestors=true&version=2&status=completed"

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.evc.experiment`."""
+
+import pytest
+
+from orion.client import build_experiment, get_experiment
+from orion.core.evc.adapters import Adapter, CodeChange
+from orion.core.evc.experiment import ExperimentNode
+
+
+def generate_trials(exp, params):
+    """Generate trials for each item in params.
+
+    Items of params can be either dictionary of valid hyperparameters based on exp.space or `None`.
+    For items that are `None`, trials are suggested with exp.suggest().
+    """
+    for trial_params in params:
+        if trial_params is None:
+            with exp.suggest() as trial:
+                # Releases suggested trial when leaving with-clause.
+                pass
+        else:
+            exp.insert(params=trial_params)
+
+
+def build_root_experiment(space=None, trials=None):
+    """Build a root experiment and generate trials."""
+    if space is None:
+        space = {"x": "uniform(0, 100)", "y": "uniform(0, 100)", "z": "uniform(0, 100)"}
+    if trials is None:
+        trials = [{"x": i, "y": i * 2, "z": i ** 2} for i in range(4)]
+
+    root = build_experiment(name="root", max_trials=len(trials), space=space)
+
+    generate_trials(root, trials)
+
+
+def build_child_experiment(space=None, trials=None, name="child", parent="root"):
+    """Build a child experiment by branching from `parent` and generate trials."""
+    if trials is None:
+        trials = [None for i in range(6)]
+
+    max_trials = get_experiment(parent).max_trials + len(trials)
+
+    child = build_experiment(
+        name=name,
+        space=space,
+        max_trials=max_trials,
+        branching={"branch_from": parent, "enable": True},
+    )
+    assert child.name == name
+    assert child.version == 1
+
+    generate_trials(child, trials)
+
+
+def build_grand_child_experiment(space=None, trials=None):
+    """Build a grand-child experiment by branching from `child` and generate trials."""
+    if trials is None:
+        trials = [None for i in range(5)]
+
+    build_child_experiment(
+        space=space, trials=trials, name="grand-child", parent="child"
+    )
+
+
+ROOT_SPACE_WITH_DEFAULTS = {
+    "x": "uniform(0, 100, default_value=0)",
+    "y": "uniform(0, 100,  default_value=2)",
+    "z": "uniform(0, 100, default_value=4)",
+}
+
+CHILD_SPACE_WITH_DEFAULTS = {
+    "x": "uniform(0, 100, default_value=0)",
+    "y": "uniform(0, 100,  default_value=2)",
+}
+
+GRAND_CHILD_SPACE_WITH_DEFAULTS = {
+    "x": "uniform(0, 100, default_value=0)",
+}
+
+
+CHILD_SPACE_DELETION = {
+    "x": "uniform(0, 100)",
+    "y": "uniform(0, 100)",
+}
+
+GRAND_CHILD_SPACE_DELETION = {
+    "x": "uniform(0, 100)",
+}
+
+
+CHILD_SPACE_PRIOR_CHANGE = {
+    "x": "uniform(0, 8)",
+    "y": "uniform(0, 8)",
+    "z": "uniform(0, 8)",
+}
+
+GRAND_CHILD_SPACE_PRIOR_CHANGE = {
+    "x": "uniform(0, 3)",
+    "y": "uniform(0, 3)",
+    "z": "uniform(0, 3)",
+}
+
+
+CHILD_TRIALS_DUPLICATES = [{"x": i, "y": i * 2, "z": i ** 2} for i in range(2, 8)]
+
+GRAND_CHILD_TRIALS_DUPLICATES = [
+    {"x": i, "y": i * 2, "z": i ** 2} for i in list(range(1, 4)) + list(range(8, 10))
+]
+
+
+CHILD_TRIALS_DELETION = [{"x": i, "y": i * 2} for i in range(4, 10)]
+
+GRAND_CHILD_TRIALS_DELETION = [{"x": i} for i in range(10, 15)]
+
+
+CHILD_TRIALS_PRIOR_CHANGE = [{"x": i, "y": i / 2, "z": i / 4} for i in range(1, 8)]
+
+GRAND_CHILD_TRIALS_PRIOR_CHANGE = [
+    {"x": i * 2 / 10, "y": i / 10, "z": i / 20} for i in range(1, 10)
+]
+
+
+def generic_tree_test(
+    experiment_name,
+    parent_name=None,
+    grand_parent_name=None,
+    children_names=tuple(),
+    grand_children_names=tuple(),
+    node_trials=0,
+    parent_trials=0,
+    grand_parent_trials=0,
+    children_trials=tuple(),
+    grand_children_trials=tuple(),
+    total_trials=0,
+):
+    """Test fetching of trials from experiments in the EVC tree.
+
+    Parameters
+    ----------
+    experiment_name: str
+        The name of the experiment that will be the main node for the tests.
+    parent_name: str or None
+        The name of the parent experiment, this will be used to fetch the trials from the parent
+        experiment directly (not in EVC) for comparison.
+    grand_parent_name: str or None
+        The name of the grand parent experiment, this will be used to fetch the trials from the
+        grand parent experiment directly (not in EVC) for comparison.
+    children_names: list or str
+        The names of the children experiments, this will be used to fetch the trials from the
+        children experiments directly (not in EVC) for comparison.
+    grand_children_names: list or str
+        The names of the grand children experiments, this will be used to fetch the trials from the
+        grand children experiments directly (not in EVC) for comparison. All grand children names
+        may be included in the list even though they are associated to different children.
+    node_trials: int,
+        The number of trials that should be fetched from current node experiment.
+    parent_trials: int,
+        The number of trials that should be fetched from parent experiment (not using EVC tree).
+    grand_parent_trials: int,
+        The number of trials that should be fetched from grand parent experiment (not using EVC tree).
+    children_trials: list of int,
+        The number of trials that should be fetched from each children experiment (not using EVC tree).
+    grand_children_trials: list of int,
+        The number of trials that should be fetched from each grand children experiment (not using EVC tree).
+    total_trials: int,
+        The number of trials that should be fetched from current node experiment when fetching
+        recursively from the EVC tree. This may not be equal to the sum of all trials in parent and
+        children experiments depending on the adapters.
+
+    """
+
+    experiment = get_experiment(experiment_name)
+    exp_node = experiment.node
+
+    assert exp_node.item.name == experiment_name
+
+    num_nodes = 1
+
+    if parent_name:
+        assert exp_node.parent.item.name == parent_name
+        num_nodes += 1
+    if grand_parent_name:
+        assert exp_node.parent.parent.item.name == grand_parent_name
+        num_nodes += 1
+
+    assert len(exp_node.children) == len(children_names)
+    if children_names:
+        assert [child.item.name for child in exp_node.children] == children_names
+        num_nodes += len(children_names)
+
+    if grand_children_names:
+        grand_children = sum([child.children for child in exp_node.children], [])
+        assert [child.item.name for child in grand_children] == grand_children_names
+        num_nodes += len(grand_children_names)
+
+    assert len(list(exp_node.root)) == num_nodes
+
+    assert len(experiment.fetch_trials()) == node_trials
+    if parent_name:
+        assert len(exp_node.parent.item.fetch_trials()) == parent_trials
+    if grand_parent_name:
+        assert len(exp_node.parent.parent.item.fetch_trials()) == grand_parent_trials
+
+    if children_names:
+        assert [
+            len(child.item.fetch_trials()) for child in exp_node.children
+        ] == children_trials
+
+    if grand_children_names:
+        grand_children = sum([child.children for child in exp_node.children], [])
+        assert [
+            len(child.item.fetch_trials()) for child in grand_children
+        ] == grand_children_trials
+
+    for trial in experiment.fetch_trials(with_evc_tree=True):
+        print(
+            trial,
+            trial.compute_trial_hash(trial, ignore_lie=True, ignore_experiment=True),
+        )
+
+    assert len(experiment.fetch_trials(with_evc_tree=True)) == total_trials
+
+    all_ids = [trial.id for trial in experiment.fetch_trials(with_evc_tree=True)]
+    exp_ids = [trial.id for trial in experiment.fetch_trials(with_evc_tree=False)]
+
+    # Ensure all trials of experiment are fetched when fetching from all EVC
+    # It could happen that some trials are missing if duplicates are incorrectly filtered out
+    # from current node instead of from parent or child.
+    assert set(exp_ids) - set(all_ids) == set()
+
+
+parametrization = {
+    "no-adapter-parent": (
+        {},
+        {},
+        None,
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            node_trials=6,
+            parent_trials=4,
+            total_trials=10,
+        ),
+    ),
+    "no-adapter-children": (
+        {},
+        {},
+        None,
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            node_trials=4,
+            children_trials=[6],
+            total_trials=10,
+        ),
+    ),
+    "no-adapter-parent-children": (
+        {},
+        {},
+        {},
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            children_names=["grand-child"],
+            node_trials=6,
+            parent_trials=4,
+            children_trials=[5],
+            total_trials=15,
+        ),
+    ),
+    "no-adapter-parent-parent": (
+        {},
+        {},
+        {},
+        dict(
+            experiment_name="grand-child",
+            parent_name="child",
+            grand_parent_name="root",
+            node_trials=5,
+            parent_trials=6,
+            grand_parent_trials=4,
+            total_trials=15,
+        ),
+    ),
+    "no-adapter-children-children": (
+        {},
+        {},
+        {},
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            grand_children_names=["grand-child"],
+            node_trials=4,
+            children_trials=[6],
+            grand_children_trials=[5],
+            total_trials=15,
+        ),
+    ),
+    "duplicates-parent": (
+        {},
+        dict(trials=CHILD_TRIALS_DUPLICATES),
+        None,
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            node_trials=6,
+            parent_trials=4,
+            total_trials=8,
+        ),
+    ),
+    "duplicates-children": (
+        {},
+        dict(trials=CHILD_TRIALS_DUPLICATES),
+        None,
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            node_trials=4,
+            children_trials=[6],
+            total_trials=8,
+        ),
+    ),
+    "duplicates-parent-children": (
+        {},
+        dict(trials=CHILD_TRIALS_DUPLICATES),
+        dict(trials=GRAND_CHILD_TRIALS_DUPLICATES),
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            children_names=["grand-child"],
+            node_trials=6,
+            parent_trials=4,
+            children_trials=[5],
+            total_trials=6
+            + 1  # Only 1 trial from root
+            + 1  # 1 trial from grand_child with i=1
+            + 2,  # 2 trials from grand_child with i>=8,
+        ),
+    ),
+    "duplicates-parent-parent": (
+        {},
+        dict(trials=CHILD_TRIALS_DUPLICATES),
+        dict(trials=GRAND_CHILD_TRIALS_DUPLICATES),
+        dict(
+            experiment_name="grand-child",
+            parent_name="child",
+            grand_parent_name="root",
+            node_trials=5,
+            parent_trials=6,
+            grand_parent_trials=4,
+            total_trials=5
+            + 4  # 4 trials from `child` experiment (parent)
+            + 1,  # 1 trial from `root` experiment (grand-parent)
+        ),
+    ),
+    "duplicates-children-children": (
+        {},
+        dict(trials=CHILD_TRIALS_DUPLICATES),
+        dict(trials=GRAND_CHILD_TRIALS_DUPLICATES),
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            grand_children_names=["grand-child"],
+            node_trials=4,
+            children_trials=[6],
+            grand_children_trials=[5],
+            total_trials=4
+            + 4  # 4 trials from `child` experiment
+            + 2,  # 2 trials from  `grand-child` experiment
+        ),
+    ),
+    "deletion-with-default-forward": (
+        dict(space=ROOT_SPACE_WITH_DEFAULTS),
+        dict(space=CHILD_SPACE_WITH_DEFAULTS),
+        None,
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            node_trials=9,
+            parent_trials=4,
+            total_trials=10,
+        ),
+    ),
+    "deletion-with-default-backward": (
+        dict(space=ROOT_SPACE_WITH_DEFAULTS),
+        dict(space=CHILD_SPACE_WITH_DEFAULTS),
+        None,
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            node_trials=4,
+            children_trials=[9],
+            total_trials=13,
+        ),
+    ),
+    "deletion-without-default-forward": (
+        dict(),
+        dict(space=CHILD_SPACE_DELETION),
+        None,
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            node_trials=10,
+            parent_trials=4,
+            total_trials=10,
+        ),
+    ),
+    "deletion-without-default-backward": (
+        dict(),
+        dict(space=CHILD_SPACE_DELETION),
+        None,
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            node_trials=4,
+            children_trials=[10],
+            total_trials=4,
+        ),
+    ),
+    "deletion-with-default-forward-forward": (
+        dict(space=ROOT_SPACE_WITH_DEFAULTS),
+        dict(space=CHILD_SPACE_WITH_DEFAULTS, trials=CHILD_TRIALS_DELETION),
+        dict(space=GRAND_CHILD_SPACE_WITH_DEFAULTS),
+        dict(
+            experiment_name="grand-child",
+            parent_name="child",
+            grand_parent_name="root",
+            node_trials=15,
+            parent_trials=6,
+            grand_parent_trials=4,
+            total_trials=15,
+        ),
+    ),
+    "deletion-with-default-forward-backward": (
+        dict(space=ROOT_SPACE_WITH_DEFAULTS),
+        dict(space=CHILD_SPACE_WITH_DEFAULTS, trials=CHILD_TRIALS_DELETION),
+        dict(space=GRAND_CHILD_SPACE_WITH_DEFAULTS),
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            children_names=["grand-child"],
+            node_trials=6,
+            parent_trials=4,
+            children_trials=[15],
+            total_trials=6 + 1 + 15,
+        ),
+    ),
+    "deletion-with-default-backward-backward": (
+        dict(space=ROOT_SPACE_WITH_DEFAULTS),
+        dict(space=CHILD_SPACE_WITH_DEFAULTS, trials=CHILD_TRIALS_DELETION),
+        dict(space=GRAND_CHILD_SPACE_WITH_DEFAULTS),
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            grand_children_names=["grand-child"],
+            node_trials=4,
+            children_trials=[6],
+            grand_children_trials=[15],
+            total_trials=4 + 6 + 15,
+        ),
+    ),
+    "deletion-without-default-forward-forward": (
+        dict(),
+        dict(space=CHILD_SPACE_DELETION, trials=CHILD_TRIALS_DELETION),
+        dict(space=GRAND_CHILD_SPACE_DELETION),
+        dict(
+            experiment_name="grand-child",
+            parent_name="child",
+            grand_parent_name="root",
+            node_trials=15,
+            parent_trials=6,
+            grand_parent_trials=4,
+            total_trials=15,
+        ),
+    ),
+    "deletion-without-default-forward-backward": (
+        dict(),
+        dict(space=CHILD_SPACE_DELETION, trials=CHILD_TRIALS_DELETION),
+        dict(space=GRAND_CHILD_SPACE_DELETION),
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            children_names=["grand-child"],
+            node_trials=6,
+            parent_trials=4,
+            children_trials=[15],
+            total_trials=6,
+        ),
+    ),
+    "deletion-without-default-backward-backward": (
+        dict(),
+        dict(space=CHILD_SPACE_DELETION, trials=CHILD_TRIALS_DELETION),
+        dict(space=GRAND_CHILD_SPACE_DELETION),
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            grand_children_names=["grand-child"],
+            node_trials=4,
+            children_trials=[6],
+            grand_children_trials=[15],
+            total_trials=4,
+        ),
+    ),
+    "prior-change-forward": (
+        dict(),
+        dict(space=CHILD_SPACE_PRIOR_CHANGE, trials=CHILD_TRIALS_PRIOR_CHANGE),
+        None,
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            node_trials=len(CHILD_TRIALS_PRIOR_CHANGE),
+            parent_trials=4,
+            total_trials=len(CHILD_TRIALS_PRIOR_CHANGE) + 4 - 1,  # One is out of bound
+        ),
+    ),
+    "prior-change-backward": (
+        dict(),
+        dict(space=CHILD_SPACE_PRIOR_CHANGE, trials=CHILD_TRIALS_PRIOR_CHANGE),
+        None,
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            node_trials=4,
+            children_trials=[len(CHILD_TRIALS_PRIOR_CHANGE)],
+            total_trials=len(CHILD_TRIALS_PRIOR_CHANGE) + 4,  # They are all included
+        ),
+    ),
+    "prior-change-forward-forward": (
+        dict(),
+        dict(space=CHILD_SPACE_PRIOR_CHANGE, trials=CHILD_TRIALS_PRIOR_CHANGE),
+        dict(
+            space=GRAND_CHILD_SPACE_PRIOR_CHANGE, trials=GRAND_CHILD_TRIALS_PRIOR_CHANGE
+        ),
+        dict(
+            experiment_name="grand-child",
+            parent_name="child",
+            grand_parent_name="root",
+            node_trials=len(GRAND_CHILD_TRIALS_PRIOR_CHANGE),
+            parent_trials=len(CHILD_TRIALS_PRIOR_CHANGE),
+            grand_parent_trials=4,
+            total_trials=len(GRAND_CHILD_TRIALS_PRIOR_CHANGE)
+            + sum(trial["x"] <= 3 for trial in CHILD_TRIALS_PRIOR_CHANGE)
+            + 2,  # Only 2 of root trials are compatible with grand-child space
+        ),
+    ),
+    "prior-change-backward-forward": (
+        dict(),
+        dict(space=CHILD_SPACE_PRIOR_CHANGE, trials=CHILD_TRIALS_PRIOR_CHANGE),
+        dict(
+            space=GRAND_CHILD_SPACE_PRIOR_CHANGE, trials=GRAND_CHILD_TRIALS_PRIOR_CHANGE
+        ),
+        dict(
+            experiment_name="child",
+            parent_name="root",
+            children_names=["grand-child"],
+            node_trials=len(CHILD_TRIALS_PRIOR_CHANGE),
+            parent_trials=4,
+            children_trials=[len(GRAND_CHILD_TRIALS_PRIOR_CHANGE)],
+            total_trials=len(GRAND_CHILD_TRIALS_PRIOR_CHANGE)
+            + len(CHILD_TRIALS_PRIOR_CHANGE)  # All trials are compatible
+            + 3,  # Only 3 of root trials are compatible with grand-child space
+        ),
+    ),
+    "prior-change-backward-backward": (
+        dict(),
+        dict(space=CHILD_SPACE_PRIOR_CHANGE, trials=CHILD_TRIALS_PRIOR_CHANGE),
+        dict(
+            space=GRAND_CHILD_SPACE_PRIOR_CHANGE, trials=GRAND_CHILD_TRIALS_PRIOR_CHANGE
+        ),
+        dict(
+            experiment_name="root",
+            children_names=["child"],
+            grand_children_names=["grand-child"],
+            node_trials=4,
+            children_trials=[len(CHILD_TRIALS_PRIOR_CHANGE)],
+            grand_children_trials=[len(GRAND_CHILD_TRIALS_PRIOR_CHANGE)],
+            total_trials=len(GRAND_CHILD_TRIALS_PRIOR_CHANGE)
+            + len(CHILD_TRIALS_PRIOR_CHANGE)
+            + 4,  # All trials are compatible
+        ),
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "root, child, grand_child, test_kwargs",
+    list(parametrization.values()),
+    ids=list(parametrization.keys()),
+)
+def test_evc_fetch_adapters(storage, root, child, grand_child, test_kwargs):
+    """Test the recursive fetch of trials in the EVC tree."""
+    build_root_experiment(**root)
+    build_child_experiment(**child)
+    if grand_child is not None:
+        build_grand_child_experiment(**grand_child)
+    generic_tree_test(**test_kwargs)


### PR DESCRIPTION
[Fixes #628]

Why:

During execution of the experiment the producer verifies that suggested
trials do not already exist in parent or children, but race conditions
can lead to duplicates. Also, in attempt to solve #576, we will need to
duplicate trials that are not completed in parents into executed
experiments to allow reserving and executing the trials. This will lead
to more potential duplicated trials and raise the important of handling
duplicate properly.

When fetching from the EVC, we should ignore duplicates from parent or
children if the trials are available in current experiment. This will
recursively solve the issue during recursive fetch from EVC. This will
also simplify the handling of potential duplicates during
{naive-}algorithm updates, as there will simply be no duplicates.

How:

During the call to adaptors, a set of hash is generated from trials of
current nodes based on hyperparameter values (ignores experiment id).
Any trials from the parents or child that has a hash found in this set
of hash will be filtered out. When there is a duplicate, only the trial
of the current node is kept. This also applies recursively to call from
children experiments to grand-children.