### PR TITLE
Compute cardinality for loguniform with precision 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup_args = dict(
             "legacy = orion.storage.legacy:Legacy",
         ],
         "Executor": [
+            "singleexecutor = orion.executor.single_backend:SingleExecutor",
             "joblib = orion.executor.joblib_backend:Joblib",
             "dask = orion.executor.dask_backend:Dask",
         ],

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -35,7 +35,6 @@ import numbers
 import numpy
 from scipy.stats import distributions
 
-
 from orion.core.utils import float_to_digits_list
 from orion.core.utils.points import flatten_dims, regroup_dims
 

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -335,7 +335,8 @@ def workon(
         producer = Producer(experiment)
 
         experiment_client = ExperimentClient(experiment, producer)
-        experiment_client.workon(function, n_workers=1, max_trials=max_trials)
+        with experiment_client.tmp_executor("singleexecutor", n_workers=1):
+            experiment_client.workon(function, n_workers=1, max_trials=max_trials)
 
     finally:
         # Restore singletons

--- a/src/orion/core/utils/__init__.py
+++ b/src/orion/core/utils/__init__.py
@@ -25,6 +25,25 @@ def nesteddict():
     return defaultdict(nesteddict)
 
 
+def float_to_digits_list(number):
+    """Convert a float into a list of digits, without conserving exponant"""
+    # Get rid of scientific-format exponant
+    str_number = str(number)
+    str_number = str_number.split("e")[0]
+
+    res = [int(ele) for ele in str_number if ele.isdigit()]
+
+    # Remove trailing 0s in front
+    while len(res) > 1 and res[0] == 0:
+        res.pop(0)
+
+    # Remove training 0s at end
+    while len(res) > 1 and res[-1] == 0:
+        res.pop(-1)
+
+    return res
+
+
 def get_all_subclasses(parent):
     """Get set of subclasses recursively"""
     subclasses = set()

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -690,16 +690,12 @@ class TransformedDimension(object):
     @property
     def cardinality(self):
         """Wrap original :class:`orion.algo.space.Dimension` capacity"""
-        if self.type == "real":
-            return Real.get_cardinality(self.shape, self.interval())
-        elif self.type == "integer":
+        # May be a discretized real, must reduce cardinality
+        if self.type == "integer":
             return Integer.get_cardinality(self.shape, self.interval())
-        elif self.type == "categorical":
-            return Categorical.get_cardinality(self.shape, self.interval())
-        elif self.type == "fidelity":
-            return Fidelity.get_cardinality(self.shape, self.interval())
-        else:
-            raise RuntimeError(f"No cardinality can be computed for type `{self.type}`")
+
+        # Else we don't care what transformation is.
+        return self.original_dimension.cardinality
 
 
 class ReshapedDimension(TransformedDimension):

--- a/src/orion/executor/single_backend.py
+++ b/src/orion/executor/single_backend.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+Executor without parallelism for debugging
+==========================================
+
+"""
+import functools
+
+from orion.executor.base import BaseExecutor
+
+
+class SingleExecutor(BaseExecutor):
+    """Single thread executor
+
+    Simple executor for debugging. No parameters.
+
+    The submitted functions are wrapped with ``functools.partial``
+    which are then executed in ``wait()``.
+
+    """
+
+    def __init__(self, n_workers=1, **config):
+        super(SingleExecutor, self).__init__(n_workers=1)
+
+    def wait(self, futures):
+        return [future() for future in futures]
+
+    def submit(self, function, *args, **kwargs):
+        return functools.partial(function, *args, **kwargs)

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -132,6 +132,14 @@ def test_cardinality_stop(algorithm):
     assert len(trials) == 16
     assert trials[-1].status == "completed"
 
+    discrete_space["x"] = "loguniform(0.1, 1, precision=1)"
+    exp = workon(rosenbrock, discrete_space, algorithms=algorithm, max_trials=30)
+    print(exp.space.cardinality)
+
+    trials = exp.fetch_trials()
+    assert len(trials) == 10
+    assert trials[-1].status == "completed"
+
 
 @pytest.mark.parametrize(
     "algorithm", algorithm_configs.values(), ids=list(algorithm_configs.keys())

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -1095,11 +1095,15 @@ class TestReshapedSpace(object):
     def test_cardinality(self, dim2):
         """Check cardinality of reshaped space"""
         space = Space()
-        space.register(Real("yolo0", "uniform", 0, 2, shape=(2, 2)))
+        space.register(Real("yolo0", "reciprocal", 0.1, 1, precision=1, shape=(2, 2)))
         space.register(dim2)
 
         rspace = build_required_space(space, shape_requirement="flattened")
-        assert rspace.cardinality == numpy.inf
+        assert rspace.cardinality == (10 ** (2 * 2)) * 4
+
+        space = Space()
+        space.register(Real("yolo0", "uniform", 0, 2, shape=(2, 2)))
+        space.register(dim2)
 
         rspace = build_required_space(
             space, type_requirement="integer", shape_requirement="flattened"

--- a/tests/unittests/core/utils/test_utils.py
+++ b/tests/unittests/core/utils/test_utils.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from orion.core.utils import Factory
+from orion.core.utils import Factory, float_to_digits_list
 
 
 def test_factory_subclasses_detection():
@@ -55,3 +55,21 @@ def test_factory_subclasses_detection():
         pass
 
     assert type(MyFactory(of_type="random")) is Random
+
+
+@pytest.mark.parametrize(
+    "number,digits_list",
+    [
+        (float("inf"), []),
+        (0.0, [0]),
+        (0.00001, [1]),
+        (12.0, [1, 2]),
+        (123000.0, [1, 2, 3]),
+        (10.0001, [1, 0, 0, 0, 0, 1]),
+        (1e-50, [1]),
+        (5.32156e-3, [5, 3, 2, 1, 5, 6]),
+    ],
+)
+def test_float_to_digits_list(number, digits_list):
+    """Test that floats are correctly converted to list of digits"""
+    assert float_to_digits_list(number) == digits_list


### PR DESCRIPTION
[Fixes #633]

Why:

With loguniform the number of possible values is limited if precision is
used. Cardinality computation should account for this otherwise
algorithms may get stuck in suggest(). It happened to a user with a
prior loguniform(1e-4, 1e-2, precision=2). This gives only 181 possible
values.

How:

If real dimension has precision and prior loguniform, then compute
cardinality.

There is a problem with transformed space however. A linearized
dimension for instance would attempt to compute the cardinality with the
linearized bounds. What matters is the smallest cardinality between the
transformed space and the original space. The only case where
cardinality is smaller in transformed space is when real values are
discretized. Therefore, we only compute cardinality of transformed
dimensions if transformation lead to integer, otherwise we use the
cardinality of the original dimension.

### Also: Add single executor for debugging

We cannot use python debugger (or pytest.set_trace()) during the
execution of the workers with joblib backend. We should have a simple
executor backend that is not using multithreading or multi-processing to
enable simple debugging. Also, since client's `workon()` helper function
does not support parallelism, it should use this simple executor.

How:

Use functools.partial to wrap submitted functions for future execution.