### PR TITLE
Warn only if diffs exists during exp build

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -203,7 +203,7 @@ def build(name, version=None, branching=None, **config):
 
     if must_branch and branching.get("enable", orion.core.config.evc.enable):
         return _attempt_branching(conflicts, experiment, version, branching)
-    else:
+    elif must_branch:
         log.warning(
             "Running experiment in a different state:\n%s",
             _get_branching_status_string(conflicts, branching),

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -547,7 +547,9 @@ def test_build_from_args_without_cmd(old_config_file, script_path, new_config):
     assert exp.algorithms.configuration == new_config["algorithms"]
 
 
-@pytest.mark.usefixtures("with_user_tsirif", "version_XYZ")
+@pytest.mark.usefixtures(
+    "with_user_tsirif", "version_XYZ", "mock_infer_versioning_metadata"
+)
 class TestExperimentVersioning(object):
     """Create new Experiment with auto-versioning."""
 
@@ -572,7 +574,11 @@ class TestExperimentVersioning(object):
         parent_version_config.pop("version")
         with OrionState(experiments=[parent_version_config]):
 
-            exp = experiment_builder.load(name=parent_version_config["name"])
+            with caplog.at_level(logging.WARNING):
+
+                exp = experiment_builder.build(name=parent_version_config["name"])
+                assert "Running experiment in a different state" not in caplog.text
+
             assert exp.version == 1
             assert exp.configuration["algorithms"] == {"random": {"seed": None}}
 


### PR DESCRIPTION
A warning about conflicts was always printed when building an
experiment. There should be no warning if there are no difference.