### PR TITLE
Handle properly all types in config during branch

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -83,10 +83,13 @@ def _build_extended_user_args(config):
     parser = OrionCmdlineParser()
     parser.set_state_dict(config["metadata"]["parser"])
 
-    return user_args + [
-        standard_param_name(key) + value
-        for key, value in parser.config_file_data.items()
-    ]
+    for key, value in parser.config_file_data.items():
+        if not isinstance(value, str) or "~" not in value:
+            continue
+
+        user_args.append(standard_param_name(key) + value)
+
+    return user_args
 
 
 def _build_space(config):

--- a/src/orion/testing/evc.py
+++ b/src/orion/testing/evc.py
@@ -2,6 +2,7 @@ import contextlib
 import copy
 
 from orion.client import build_experiment, get_experiment
+from orion.core.io.space_builder import DimensionBuilder
 
 
 @contextlib.contextmanager
@@ -84,3 +85,15 @@ def build_grand_child_experiment(space=None, trials=None):
     build_child_experiment(
         space=space, trials=trials, name="grand-child", parent="child"
     )
+
+
+def add_default_config_for_missing(conflict, value):
+    """Create a missing dimension conflict with a default value for the prior"""
+    conflict_with_default = copy.deepcopy(conflict)
+    conflict_with_default.prior = (
+        conflict_with_default.prior[:-1] + f", default_value={value})"
+    )
+    conflict_with_default.dimension = DimensionBuilder().build(
+        conflict_with_default.dimension.name, conflict_with_default.prior
+    )
+    return conflict_with_default

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -5,6 +5,7 @@ import copy
 import datetime
 import getpass
 import os
+import yaml
 
 import pytest
 
@@ -331,6 +332,34 @@ def new_config():
 
 
 @pytest.fixture
+def old_config_with_script_conf(old_config, tmp_path):
+    """Generate a old experiment configuration with a config file"""
+
+    config_path = tmp_path / "old_config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump({"config-hp": "uniform(0, 10)", "dropped": "uniform(-1, 5)"}, f)
+    old_config["metadata"]["user_args"] += ["--config", str(config_path)]
+
+    backward.populate_space(old_config, force_update=True)
+
+    return old_config
+
+
+@pytest.fixture
+def new_config_with_script_conf(new_config, tmp_path):
+    """Generate a new experiment configuration with a different config file"""
+
+    config_path = tmp_path / "new_config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump({"config-hp": "uniform(0, 5)", "dropped": {"hp": "value"}}, f)
+    new_config["metadata"]["user_args"] += ["--config", str(config_path)]
+
+    backward.populate_space(new_config, force_update=True)
+
+    return new_config
+
+
+@pytest.fixture
 def old_config(storage):
     """Generate an old experiment configuration"""
     user_script = "tests/functional/demo/black_box.py"
@@ -412,6 +441,19 @@ def missing_dimension_conflict(old_config, new_config):
 
 
 @pytest.fixture
+def missing_dimension_from_config_conflict(
+    old_config_with_script_conf, new_config_with_script_conf
+):
+    """Generate a missing dimension conflict in the config file"""
+    name = "dropped"
+    prior = "uniform(-1, 5)"
+    dimension = DimensionBuilder().build(name, prior)
+    return conflicts.MissingDimensionConflict(
+        old_config_with_script_conf, new_config_with_script_conf, dimension, prior
+    )
+
+
+@pytest.fixture
 def missing_dimension_with_default_conflict(old_config, new_config):
     """Generate a missing dimension conflict with a default value"""
     name = "missing"
@@ -444,14 +486,16 @@ def cli_conflict(old_config, new_config):
     new_config = copy.deepcopy(new_config)
     new_config["metadata"]["user_args"].append("--some-new=args")
     new_config["metadata"]["user_args"].append("--bool-arg")
-    backward.populate_space(new_config)
+    backward.populate_space(new_config, force_update=True)
     return conflicts.CommandLineConflict(old_config, new_config)
 
 
 @pytest.fixture
-def config_conflict(old_config, new_config):
+def config_conflict(old_config_with_script_conf, new_config_with_script_conf):
     """Generate a script config conflict"""
-    return conflicts.ScriptConfigConflict(old_config, new_config)
+    return conflicts.ScriptConfigConflict(
+        old_config_with_script_conf, new_config_with_script_conf
+    )
 
 
 @pytest.fixture

--- a/tests/unittests/core/evc/test_resolutions.py
+++ b/tests/unittests/core/evc/test_resolutions.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Collection of tests resolutions in :mod:`orion.core.evc.conflicts`."""
-
 import pytest
 
 from orion.algo.space import Dimension
 from orion.core.evc import adapters, conflicts
+from orion.testing.evc import add_default_config_for_missing
 
 
 @pytest.fixture
@@ -19,14 +19,6 @@ def change_dimension_resolution(changed_dimension_conflict):
     """Create a resolution for a changed prior"""
     return changed_dimension_conflict.ChangeDimensionResolution(
         changed_dimension_conflict
-    )
-
-
-@pytest.fixture
-def remove_dimension_resolution(missing_dimension_conflict):
-    """Create a resolution to remove a missing dimension"""
-    return missing_dimension_conflict.RemoveDimensionResolution(
-        missing_dimension_conflict, default_value=0
     )
 
 
@@ -224,51 +216,65 @@ class TestChangeDimensionResolution(object):
         assert changed_dimension_conflict.resolution is None
 
 
+@pytest.mark.parametrize(
+    "dimension_conflict",
+    [
+        pytest.lazy_fixture("missing_dimension_conflict"),
+        pytest.lazy_fixture("missing_dimension_from_config_conflict"),
+    ],
+)
 class TestRemoveDimensionResolution(object):
     """Test methods for resolution of missing dimensions"""
 
-    def test_prefix(self, missing_dimension_conflict):
+    def test_prefix(self, dimension_conflict):
         """Verify prefix of resolution with corresponding marker"""
-        resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict
-        )
-        assert resolution.prefix == "missing~-"
+        resolution = dimension_conflict.RemoveDimensionResolution(dimension_conflict)
+        assert resolution.prefix == f"{dimension_conflict.dimension.name}~-"
 
-    def test_repr_no_default(self, missing_dimension_conflict):
+    def test_repr_no_default(self, dimension_conflict):
         """Verify resolution representation for user interface, without default value"""
-        resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict
-        )
-        assert repr(resolution) == "missing~-"
+        resolution = dimension_conflict.RemoveDimensionResolution(dimension_conflict)
+        assert repr(resolution) == f"{dimension_conflict.dimension.name}~-"
 
-    def test_repr_default_from_dim(self, missing_dimension_with_default_conflict):
+    def test_repr_default_from_dim(self, dimension_conflict):
         """Verify resolution representation for user interface, with default value from dimension"""
+        missing_dimension_with_default_conflict = add_default_config_for_missing(
+            dimension_conflict, 0.0
+        )
+
         resolution = missing_dimension_with_default_conflict.RemoveDimensionResolution(
             missing_dimension_with_default_conflict
         )
-        assert repr(resolution) == "missing~-0.0"
+        assert repr(resolution) == f"{dimension_conflict.dimension.name}~-0.0"
 
-    def test_repr_default(
-        self, missing_dimension_conflict, missing_dimension_with_default_conflict
-    ):
+    def test_repr_default(self, dimension_conflict):
         """Verify resolution representation for user interface, with default provided by user"""
+        missing_dimension_with_default_conflict = add_default_config_for_missing(
+            dimension_conflict, 0.0
+        )
         default_value = 1.2
-        resolution = missing_dimension_conflict.RemoveDimensionResolution(
+        resolution = dimension_conflict.RemoveDimensionResolution(
             missing_dimension_with_default_conflict, default_value=default_value
         )
-        assert repr(resolution) == "missing~-{}".format(default_value)
-
-        resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict, default_value=default_value
+        assert (
+            repr(resolution) == f"{dimension_conflict.dimension.name}~-{default_value}"
         )
-        assert repr(resolution) == "missing~-{}".format(default_value)
 
-    def test_adapters_without_default(self, missing_dimension_conflict):
+        resolution = dimension_conflict.RemoveDimensionResolution(
+            dimension_conflict, default_value=default_value
+        )
+        assert (
+            repr(resolution) == f"{dimension_conflict.dimension.name}~-{default_value}"
+        )
+
+    def test_adapters_without_default(self, dimension_conflict):
         """Verify adapters without default value"""
-        param = {"name": "missing", "type": "real", "value": Dimension.NO_DEFAULT_VALUE}
-        resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict
-        )
+        param = {
+            "name": dimension_conflict.dimension.name,
+            "type": "real",
+            "value": Dimension.NO_DEFAULT_VALUE,
+        }
+        resolution = dimension_conflict.RemoveDimensionResolution(dimension_conflict)
         resolution_adapters = resolution.get_adapters()
         assert len(resolution_adapters) == 1
         assert (
@@ -276,11 +282,15 @@ class TestRemoveDimensionResolution(object):
             == adapters.DimensionDeletion(param).configuration
         )
 
-    def test_adapters_with_default(self, missing_dimension_conflict):
+    def test_adapters_with_default(self, dimension_conflict):
         """Verify adapters with default value"""
-        param = {"name": "missing", "type": "real", "value": 1.2}
-        resolution = missing_dimension_conflict.RemoveDimensionResolution(
-            missing_dimension_conflict, default_value=1.2
+        param = {
+            "name": dimension_conflict.dimension.name,
+            "type": "real",
+            "value": 1.2,
+        }
+        resolution = dimension_conflict.RemoveDimensionResolution(
+            dimension_conflict, default_value=1.2
         )
         resolution_adapters = resolution.get_adapters()
         assert len(resolution_adapters) == 1
@@ -289,12 +299,15 @@ class TestRemoveDimensionResolution(object):
             == adapters.DimensionDeletion(param).configuration
         )
 
-    def test_revert(self, missing_dimension_conflict, remove_dimension_resolution):
+    def test_revert(self, dimension_conflict):
         """Verify reverting resolution set conflict to unresolved"""
-        assert missing_dimension_conflict.is_resolved
+        remove_dimension_resolution = dimension_conflict.RemoveDimensionResolution(
+            dimension_conflict, default_value=0
+        )
+        assert dimension_conflict.is_resolved
         assert remove_dimension_resolution.revert() == []
-        assert not missing_dimension_conflict.is_resolved
-        assert missing_dimension_conflict.resolution is None
+        assert not dimension_conflict.is_resolved
+        assert dimension_conflict.resolution is None
 
 
 class TestRenameDimensionResolution(object):


### PR DESCRIPTION
Why:

During resolution of conflicts, the user's script configuration file is
parsed for any marked resolution. This parsing is not handling properly
values that may not be string and causes Oríon to crash.

How:

The values should only be handled if they are string and contain the
value '~' as this is the only way to mark a resolution. They can be
safely ignored otherwise.
