### PR TITLE
List EVC tree once only when querying with name

### DIFF
--- a/src/orion/core/cli/list.py
+++ b/src/orion/core/cli/list.py
@@ -43,6 +43,7 @@ def main(args):
 
     if args["name"]:
         query["name"] = args["name"]
+        query["version"] = args.get("version", None) or 1
 
     experiments = get_storage().fetch_experiments(query)
 

--- a/tests/functional/commands/test_list_command.py
+++ b/tests/functional/commands/test_list_command.py
@@ -192,3 +192,46 @@ def test_exp_family_branch_same_name(
                                       └test_single_exp_child-v1
 """
     )
+
+
+def test_exp_family_branch_same_name_with_name_query(
+    three_experiments_branch_same_name, monkeypatch, capsys
+):
+    """Test that two experiments with the same name and different versions are correctly printed
+    when name is queried
+    """
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    orion.core.cli.main(["list", "--name", "test_single_exp"])
+
+    captured = capsys.readouterr().out
+
+    assert (
+        captured
+        == """\
+ test_single_exp-v1┐
+                   └test_single_exp-v2┐
+                                      └test_single_exp_child-v1
+"""
+    )
+
+
+def test_exp_family_branch_same_name_with_name_version_query(
+    three_experiments_branch_same_name, monkeypatch, capsys
+):
+    """Test that two experiments with the same name and different versions are correctly printed
+    when name and version is queried
+    """
+    monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    orion.core.cli.main(["list", "--name", "test_single_exp", "--version", "2"])
+
+    captured = capsys.readouterr().out
+
+    assert (
+        captured
+        == """\
+ test_single_exp-v2┐
+                   └test_single_exp_child-v1
+"""
+    )


### PR DESCRIPTION
[Fixes #596]

Why:

The children should not be listed multiple times. If they appear in the
EVC tree of some parent experiment then they should not be listed as a
root as well.

How:

Problem was that all experiments matching the name would be fetched and
printed with their tree. When name is specified, version queried should
be 1 by default unless specified by the user.