### PR TITLE
Handle repo with invalid HEAD state

### DIFF
--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -411,6 +411,13 @@ def infer_versioning_metadata(user_script):
     git_repo = fetch_user_repo(user_script)
     if not git_repo:
         return {}
+    if not git_repo.head.is_valid():
+        logging.warning(
+            f"Repository at {git_repo.git.rev_parse('--show-toplevel')} has an invalid HEAD. "
+            "No commits maybe?"
+        )
+        return {}
+
     vcs = {}
     vcs["type"] = "git"
     vcs["is_dirty"] = git_repo.is_dirty()

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -617,6 +617,31 @@ def repo():
     os.chdir("orion")
 
 
+@pytest.fixture
+def invalid_repo():
+    """Create a dummy invalid repo for the tests."""
+    os.chdir("../")
+    os.makedirs("dummy_orion")
+    os.chdir("dummy_orion")
+    repo = git.Repo.init(".")
+    with open("README.md", "w+") as f:
+        f.write("dummy content")
+    # No commit, no branch, blank...
+    yield repo
+    os.chdir("../")
+    shutil.rmtree("dummy_orion")
+    os.chdir("orion")
+
+
+def test_infer_version_on_invalid_head(invalid_repo, caplog):
+    """Test that repo is ignored if repo has an invalid HEAD state."""
+
+    with caplog.at_level(logging.WARNING):
+        assert resolve_config.infer_versioning_metadata(".git") == {}
+
+    assert "dummy_orion has an invalid HEAD." in caplog.text
+
+
 def test_infer_versioning_metadata_on_clean_repo(repo):
     """
     Test how `infer_versioning_metadata` fills its different fields


### PR DESCRIPTION
[Fixes #543]

Why:

If the HEAD of the repo is in an invalid state (no branch, no commit),
gitpython will crash when attempting to fetch the information required
for the EVC.

How:

First check if HEAD state is valid, if not raise warning and ignore
repo.
