### PR TITLE
Fix TPE sampling in narrow spaces

### DIFF
--- a/src/orion/algo/tpe.py
+++ b/src/orion/algo/tpe.py
@@ -617,7 +617,7 @@ class GMMSampler:
 
                 if any(valid_points):
                     index = numpy.argmax(valid_points)
-                    point.append(new_points[index])
+                    point.append(float(new_points[index]))
                     break
 
                 index = None
@@ -629,7 +629,7 @@ class GMMSampler:
                 )
             elif index is None:
                 point.append(
-                    self.sample(num=1, attempts=attempts * self.attempts_factor)
+                    self.sample(num=1, attempts=attempts * self.attempts_factor)[0]
                 )
 
         return point

--- a/tests/unittests/algo/test_tpe.py
+++ b/tests/unittests/algo/test_tpe.py
@@ -764,12 +764,14 @@ class TestTPE(BaseAlgoTests):
         original_sample = GMMSampler.sample
 
         low = 0.5
-        high = 0.50001
+        high = 0.5000001
 
-        def sample(self, num):
+        def sample(self, num, attempts=None):
+            self.attempts_factor = 1
+            self.max_attempts = 10
             self.low = low
             self.high = high
-            return original_sample(self, num)
+            return original_sample(self, num, attempts=attempts)
 
         monkeypatch.setattr(GMMSampler, "sample", sample)
         with pytest.raises(RuntimeError) as exc:


### PR DESCRIPTION
[Solves #647]

Why:

The GMM for real values could not sample efficiently in narrow spaces.
It would often lead to RuntimeError because the number of attempts
allowed would be exhausted. We could increase the default number of
attempts allowed but that would increase the computational cost for any
space, even those easy to sample.

How:

Use numpy array to avoid playing with a list. It is more efficient.
Also, increase the number of attempts as needed until it reaches a max
value of attempts. This way easy samples do not take more time while
difficult ones are allowed more.