### PR TITLE
Clear error message for dup branching error

### DIFF
--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -612,7 +612,12 @@ def _attempt_branching(conflicts, experiment, version, branching):
             "during branching. Now rolling back and re-attempting building "
             "the branched experiment."
         )
-        raise RaceCondition("There was a race condition during branching.") from e
+        raise RaceCondition(
+            "There was a race condition during branching. This error can "
+            "also occur if you try branching from a specific version that already "
+            "has a child experiment with the same name. Change the name of the new "
+            "experiment and use `branch-from` to specify the parent experiment."
+        ) from e
 
     return branched_experiment
 


### PR DESCRIPTION
[Fixes #533]

Why:

When trying to branch from an experiment that already has a child with
the same name, Oríon will crash with a RaceCondition error. The problem
is that this issue and a real race-condition are indiscernible as they
lead to the same state. The only thing we can do is clarify the error
message and warn that this error can also be caused by branching from a
parent experiment that already has a child with the same name.

Note:

This issue only arises if the user specifies the version of the parent
experiment, otherwise the EVC will use the child or branch from the
child without any issue.
