### PR TITLE
Fix shape argument in categorical dims

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -787,6 +787,8 @@ class Categorical(Dimension):
 
         args = [prior]
 
+        if self._shape is not None:
+            args += ["shape={}".format(self._shape)]
         if self.default_value is not self.NO_DEFAULT_VALUE:
             args += ["default_value={}".format(repr(self.default_value))]
 

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -31,12 +31,16 @@ Adapters can be build using the factory class `Adapter(**kwargs)` or using
 
 """
 import copy
+import logging
 from abc import ABCMeta, abstractmethod
 
 from orion.algo.space import Dimension
 from orion.core.io.space_builder import DimensionBuilder
 from orion.core.utils import Factory
 from orion.core.worker.trial import Trial
+
+
+log = logging.getLogger(__name__)
 
 
 class BaseAdapter(object, metaclass=ABCMeta):
@@ -447,8 +451,9 @@ class DimensionPriorChange(BaseAdapter):
         self.new_dimension = DimensionBuilder().build("new", new_prior)
 
         if self.old_dimension.shape != self.new_dimension.shape:
-            raise NotImplementedError(
-                "Oríon does not support yet adaptations on prior " "shape changes."
+            log.warning(
+                "Oríon does not support yet adaptations on prior shape changes. All trials "
+                "of different shapes will be ignored."
             )
 
     def forward(self, trials):

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -39,7 +39,6 @@ from orion.core.io.space_builder import DimensionBuilder
 from orion.core.utils import Factory
 from orion.core.worker.trial import Trial
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/unittests/algo/test_space.py
+++ b/tests/unittests/algo/test_space.py
@@ -629,6 +629,30 @@ class TestCategorical(object):
             dim.cast(sample)
         assert "Invalid category: asdfa" in str(exc.value)
 
+    def test_get_prior_string_list(self):
+        """Test that prior string can be rebuilt with list of choices."""
+        categories = list(range(10))
+        categories[0] = "asdfa"
+        categories[2] = "lalala"
+        dim = Categorical(
+            "yolo", categories, shape=2, default_value=["asdfa", "lalala"]
+        )
+        assert dim.get_prior_string() == (
+            "choices(['asdfa', 1, 'lalala', 3, 4, 5, 6, 7, 8, 9], "
+            "shape=2, default_value=['asdfa', 'lalala'])"
+        )
+
+    def test_get_prior_string_dict(self):
+        """Test that prior string can be rebuilt with dict of choices."""
+        categories = {"asdfa": 0.1, 2: 0.2, 3: 0.3, "lalala": 0.4}
+        dim = Categorical(
+            "yolo", categories, shape=2, default_value=["asdfa", "lalala"]
+        )
+        assert dim.get_prior_string() == (
+            "choices({'asdfa': 0.10, 2: 0.20, 3: 0.30, 'lalala': 0.40}, "
+            "shape=2, default_value=['asdfa', 'lalala'])"
+        )
+
 
 class TestFidelity(object):
     """Test methods of a Fidelity object."""

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -437,6 +437,18 @@ def changed_dimension_conflict(old_config, new_config):
 
 
 @pytest.fixture
+def changed_dimension_shape_conflict(old_config, new_config):
+    """Generate a changed shape dimension conflict"""
+    name = "changed_shape"
+    old_prior = "uniform(-10, 10)"
+    new_prior = "uniform(-10, 10, shape=2)"
+    dimension = DimensionBuilder().build(name, old_prior)
+    return conflicts.ChangedDimensionConflict(
+        old_config, new_config, dimension, old_prior, new_prior
+    )
+
+
+@pytest.fixture
 def missing_dimension_conflict(old_config, new_config):
     """Generate a missing dimension conflict"""
     name = "missing"

--- a/tests/unittests/core/evc/test_resolutions.py
+++ b/tests/unittests/core/evc/test_resolutions.py
@@ -25,7 +25,7 @@ def change_dimension_resolution(changed_dimension_conflict):
 @pytest.fixture
 def change_dimension_shape_resolution(changed_dimension_shape_conflict):
     """Create a resolution for a changed shape prior"""
-    return changed_dimension_conflict.ChangeDimensionResolution(
+    return changed_dimension_shape_conflict.ChangeDimensionResolution(
         changed_dimension_shape_conflict
     )
 
@@ -210,7 +210,6 @@ class TestChangeDimensionResolution(object):
         old_prior = "uniform(-10, 10)"
         new_prior = "normal(0, 2)"
         resolution_adapters = change_dimension_resolution.get_adapters()
-        print(resolution_adapters[0].configuration)
         assert len(resolution_adapters) == 1
         assert (
             resolution_adapters[0].configuration
@@ -219,10 +218,10 @@ class TestChangeDimensionResolution(object):
 
     def test_adapters_shape(self, change_dimension_shape_resolution):
         """Verify adapters with old and new priors of different shapes"""
-        name = "changed"
-        old_prior = "uniform(-10, 10, shape=2)"
-        new_prior = "normal(0, 2, shape=3)"
-        resolution_adapters = change_dimension_resolution.get_adapters()
+        name = "changed_shape"
+        old_prior = "uniform(-10, 10)"
+        new_prior = "uniform(-10, 10, shape=2)"
+        resolution_adapters = change_dimension_shape_resolution.get_adapters()
         assert len(resolution_adapters) == 1
         assert (
             resolution_adapters[0].configuration

--- a/tests/unittests/core/evc/test_resolutions.py
+++ b/tests/unittests/core/evc/test_resolutions.py
@@ -23,6 +23,14 @@ def change_dimension_resolution(changed_dimension_conflict):
 
 
 @pytest.fixture
+def change_dimension_shape_resolution(changed_dimension_shape_conflict):
+    """Create a resolution for a changed shape prior"""
+    return changed_dimension_conflict.ChangeDimensionResolution(
+        changed_dimension_shape_conflict
+    )
+
+
+@pytest.fixture
 def rename_dimension_resolution(missing_dimension_conflict, new_dimension_conflict):
     """Create a resolution to rename a missing dimension to a new dimension"""
     return missing_dimension_conflict.RenameDimensionResolution(
@@ -201,6 +209,19 @@ class TestChangeDimensionResolution(object):
         name = "changed"
         old_prior = "uniform(-10, 10)"
         new_prior = "normal(0, 2)"
+        resolution_adapters = change_dimension_resolution.get_adapters()
+        print(resolution_adapters[0].configuration)
+        assert len(resolution_adapters) == 1
+        assert (
+            resolution_adapters[0].configuration
+            == adapters.DimensionPriorChange(name, old_prior, new_prior).configuration
+        )
+
+    def test_adapters_shape(self, change_dimension_shape_resolution):
+        """Verify adapters with old and new priors of different shapes"""
+        name = "changed"
+        old_prior = "uniform(-10, 10, shape=2)"
+        new_prior = "normal(0, 2, shape=3)"
         resolution_adapters = change_dimension_resolution.get_adapters()
         assert len(resolution_adapters) == 1
         assert (


### PR DESCRIPTION
[Fixes #535]

Why:

The shape of categorical dimensions was not included in
`get_prior_string`, causing the lost of the shape during branching.

How:

Add the shape to `get_prior_string` of Categorical dimensions and add
tests to catch this issue.

Also add tests for Conflict and Resolutions of priors with different
shape.

The adaptor for a change of prior does not raise an issue anymore when
shapes are different and rather logs a warning. The trials are all
ignored is this case.
