### PR TITLE
Use user_script_config from parser in EVC

### DIFF
--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1486,7 +1486,7 @@ class ScriptConfigConflict(Conflict):
         if "parser" not in config["metadata"]:
             return ""
 
-        user_script_config =(
+        user_script_config = (
             config.get("metadata", {}).get("parser", {}).get("config_prefix")
         )
         if not user_script_config:

--- a/src/orion/core/evc/conflicts.py
+++ b/src/orion/core/evc/conflicts.py
@@ -1311,16 +1311,18 @@ class CommandLineConflict(Conflict):
 
     # pylint: disable=unused-argument
     @classmethod
-    def get_nameless_args(
-        cls, config, user_script_config=None, non_monitored_arguments=None, **kwargs
-    ):
+    def get_nameless_args(cls, config, non_monitored_arguments=None, **kwargs):
         """Get user's commandline arguments which are not dimension definitions"""
         # Used python API
         if "parser" not in config["metadata"]:
             return ""
 
-        if user_script_config is None:
+        user_script_config = (
+            config.get("metadata", {}).get("parser", {}).get("config_prefix")
+        )
+        if not user_script_config:
             user_script_config = orion.core.config.worker.user_script_config
+
         if non_monitored_arguments is None:
             non_monitored_arguments = orion.core.config.evc.non_monitored_arguments
 
@@ -1478,14 +1480,19 @@ class ScriptConfigConflict(Conflict):
 
     # pylint:disable=unused-argument
     @classmethod
-    def get_nameless_config(cls, config, user_script_config=None, **branching_kwargs):
+    def get_nameless_config(cls, config, **branching_kwargs):
         """Get configuration dict of user's script without dimension definitions"""
         # Used python API
         if "parser" not in config["metadata"]:
             return ""
 
-        if user_script_config is None:
+        user_script_config =(
+            config.get("metadata", {}).get("parser", {}).get("config_prefix")
+        )
+        if not user_script_config:
             user_script_config = orion.core.config.worker.user_script_config
+
+        log.debug("User script config: %s", user_script_config)
 
         parser = OrionCmdlineParser(user_script_config, allow_non_existing_files=True)
         parser.set_state_dict(config["metadata"]["parser"])


### PR DESCRIPTION
[Fixes #636]

Why:

The option `user_script_config` is part of the worker configuration, not
the EVC. As such, this option is not part of `branching` group of option
and does not find its way to the Conflict objects of the EVC. The value
of user_script_config is already available anyway inside the
experiment configuration, so there is no need to pass it. Furthermore, it may
differ from past experiments to the new one, and both experiments should be handled
based on their respective `user_script_config`, not the new one. For
these reasons, it is better to use the information available in the
experiment configurations.
