### PR TITLE
Support linearize log integer properly

### DIFF
--- a/src/orion/algo/tpe.py
+++ b/src/orion/algo/tpe.py
@@ -412,7 +412,7 @@ class TPE(BaseAlgorithm):
 
     def _sample_real_dimension(self, dimension, shape_size, below_points, above_points):
         """Sample values for real dimension"""
-        if dimension.prior_name in ["uniform", "reciprocal"]:
+        if any(map(dimension.prior_name.endswith, ["uniform", "reciprocal"])):
             return self.sample_one_dimension(
                 dimension,
                 shape_size,
@@ -421,7 +421,9 @@ class TPE(BaseAlgorithm):
                 self._sample_real_point,
             )
         else:
-            raise NotImplementedError()
+            raise NotImplementedError(
+                f"Prior {dimension.prior_name} is not supported for real values"
+            )
 
     def _sample_loguniform_real_point(self, dimension, below_points, above_points):
         """Sample one value for real dimension in a loguniform way"""

--- a/tests/unittests/core/test_transformer.py
+++ b/tests/unittests/core/test_transformer.py
@@ -96,9 +96,10 @@ class TestReverse(object):
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
         t = Reverse(Quantize())
-        assert t.reverse(8.6) == 8
+        assert t.reverse(8.6) == 9
+        assert t.reverse(8.4) == 8
         assert t.reverse(5.3) == 5
-        assert numpy.all(t.reverse([8.6, 5.3]) == numpy.array([8, 5], dtype=int))
+        assert numpy.all(t.reverse([8.6, 5.3]) == numpy.array([9, 5], dtype=int))
 
     def test_infer_target_shape(self):
         """Check if it infers the shape of a transformed `Dimension`."""
@@ -302,9 +303,10 @@ class TestQuantize(object):
     def test_transform(self):
         """Check if it transforms properly."""
         t = Quantize()
-        assert t.transform(8.6) == 8
+        assert t.transform(8.6) == 9
+        assert t.transform(8.4) == 8
         assert t.transform(5.3) == 5
-        assert numpy.all(t.transform([8.6, 5.3]) == numpy.array([8, 5], dtype=int))
+        assert numpy.all(t.transform([8.6, 5.3]) == numpy.array([9, 5], dtype=int))
 
     def test_reverse(self):
         """Check if it reverses `transform` properly, if possible."""
@@ -706,9 +708,9 @@ class TestTransformedDimension(object):
 
     def test_transform(self, tdim):
         """Check method `transform`."""
-        assert tdim.transform(8.6) == 8
+        assert tdim.transform(8.4) == 8
         assert tdim.transform(5.3) == 5
-        assert numpy.all(tdim.transform([8.6, 5.3]) == numpy.array([8, 5], dtype=int))
+        assert numpy.all(tdim.transform([8.6, 5.3]) == numpy.array([9, 5], dtype=int))
 
     def test_reverse(self, tdim):
         """Check method `reverse`."""
@@ -1224,7 +1226,7 @@ Space([Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), def
         assert tspace[1].type == "categorical"
         assert tspace[2].type == "integer"
         assert tspace[3].type == "real"
-        assert tspace[4].type == "integer"
+        assert tspace[4].type == "real"
         assert (
             str(tspace)
             == """\
@@ -1232,7 +1234,7 @@ Space([Precision(4, Real(name=yolo0, prior={norm: (0.9,), {}}, shape=(3, 2), def
        Categorical(name=yolo2, prior={asdfa: 0.10, 2: 0.20, 3: 0.30, 4: 0.40}, shape=(), default value=None),
        Integer(name=yolo3, prior={uniform: (3, 7), {}}, shape=(), default value=None),
        Linearize(Precision(4, Real(name=yolo4, prior={reciprocal: (1.0, 10.0), {}}, shape=(3, 2), default value=None))),
-       Quantize(Linearize(ReverseQuantize(Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None))))])\
+       Linearize(ReverseQuantize(Integer(name=yolo5, prior={reciprocal: (1, 10), {}}, shape=(3, 2), default value=None)))])\
 """
         )  # noqa
 
@@ -1311,10 +1313,13 @@ def test_quantization_does_not_violate_bounds():
     assert 10 in dim
     # but be careful, because upper bound is inclusive
     assert 11.5 not in tdim
-    assert 10.6 in tdim
+    # rounded to 11
+    assert 10.6 not in tdim
+    # rounded to 10
+    assert 10.4 in tdim
     assert tdim.reverse(9.6) in dim
-    # solution is to quantize with 'floor' instead of 'round'
-    assert tdim.reverse(9.6) == 9
+    assert tdim.reverse(9.6) == 10
+    assert tdim.reverse(9.4) == 9
 
 
 def test_precision_with_linear(space, logdim, logintdim):


### PR DESCRIPTION
[Fixes #552]

Why:

A log integer dimension would be casted to real, linearized, then casted
back to integer. This reduces dramatically the number of possible values
that can be sampled as many exp(int(log(x))) will result in the same
integer for many different values of x. An algorithm that needs
linearization should be able to handle real space or otherwise state a
requirement for integers. This should be handled separately and
quantization of linearized log integer should not be applied by default.

Note:

Due to the use of floor instead of rounding in Quantize, the values of
int(exp(log(x))) would still clash for close values of x. Using rounding
instead solves the issue. Rounding may be problematic however for
algorithms that require integer type, as the rounding may cast real
integers to values that are out-of-bound. For now there are no
foreseeable algorithms that may require integer type so I avoid fixing
the issue and leave it for later if the need even arises (which I highly
doubt).
