### PR TITLE
Avoid inf-loop in TPE.suggest

### DIFF
--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -31,6 +31,7 @@ algorithm_configs = {
             "equal_weight": False,
             "prior_weight": 1.0,
             "full_weight_num": 25,
+            "max_retry": 100,
         }
     },
     "asha": {"asha": {"seed": 1, "num_rungs": 4, "num_brackets": 1, "repetitions": 2}},

--- a/tests/unittests/algo/test_tpe.py
+++ b/tests/unittests/algo/test_tpe.py
@@ -718,6 +718,7 @@ class TestTPE(BaseAlgoTests):
         "equal_weight": True,
         "prior_weight": 0.8,
         "full_weight_num": 10,
+        "max_retry": 100,
     }
 
     def test_suggest_init(self, mocker):

--- a/tests/unittests/algo/test_tpe.py
+++ b/tests/unittests/algo/test_tpe.py
@@ -18,7 +18,7 @@ from orion.algo.tpe import (
     ramp_up_weights,
 )
 from orion.core.worker.transformer import build_required_space
-from orion.testing.algo import BaseAlgoTests
+from orion.testing.algo import BaseAlgoTests, phase
 
 
 @pytest.fixture()
@@ -825,6 +825,30 @@ class TestTPE(BaseAlgoTests):
         self.force_observe(RANGE, algo)
         assert algo.n_observed == RANGE
         assert algo.n_suggested == RANGE
+
+    @phase
+    def test_stuck_exploiting(self, mocker, num, attr):
+        """Test that algo drops out when exploiting an already explored region."""
+        algo = self.create_algo()
+        spy = self.spy_phase(mocker, 0, algo, "space.sample")
+
+        points = algo.space.sample(1)
+
+        # Mock sampling so that always returns the same point
+        def sample(self, n_samples=1, seed=None):
+            return points
+
+        def _suggest_random(self, num):
+            return self._suggest(num, sample)
+
+        mocker.patch("orion.algo.tpe.TPE._suggest_random", _suggest_random)
+        mocker.patch("orion.algo.tpe.TPE._suggest_bo", _suggest_random)
+
+        with pytest.raises(RuntimeError):
+            self.force_observe(2, algo)
+
+        assert algo.n_observed == 1
+        assert algo.n_suggested == 1
 
 
 TestTPE.set_phases([("random", 0, "space.sample"), ("bo", N_INIT + 1, "_suggest_bo")])


### PR DESCRIPTION
[Fixes #679]

If TPE keep sampling points already suggested, the suggest loop will run
infinitely. This adds a `max_retry` to limit the number of iterations on
the loop.
