### PR TITLE
Support batched promotions in ASHA 

### DIFF
--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -192,7 +192,7 @@ class ASHA(Hyperband):
         return samples
 
     def suggest(self, num):
-        return super(ASHA, self).suggest(1)
+        return super(ASHA, self).suggest(num)
 
     def create_bracket(self, i, budgets, iteration):
         return ASHABracket(self, budgets, iteration)

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -155,6 +155,8 @@ class ASHA(Hyperband):
 
         self.brackets = self.create_brackets()
 
+        self.seed_rng(seed)
+
     def compute_bracket_idx(self, num):
         def assign_resources(n, remainings, totals):
             if n == 0 or remainings.sum() == 0:

--- a/src/orion/algo/asha.py
+++ b/src/orion/algo/asha.py
@@ -299,7 +299,8 @@ class ASHABracket(HyperbandBracket):
                     },
                 )
 
-                candidates.append(candidate)
+                if not self.hyperband.has_suggested(candidate):
+                    candidates.append(candidate)
 
                 if len(candidates) >= num:
                     return candidates

--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -259,7 +259,7 @@ class BaseAlgorithm:
 
         """
         self._trials_info[self.get_id(trial)] = (
-            trial,
+            copy.deepcopy(trial),
             format_trials.get_trial_results(trial) if trial.objective else None,
         )
 

--- a/src/orion/algo/evolution_es.py
+++ b/src/orion/algo/evolution_es.py
@@ -184,7 +184,7 @@ class EvolutionES(Hyperband):
 
     def _get_bracket(self, trial):
         """Get the bracket of a trial during observe"""
-        return self.brackets[0]
+        return self.brackets[-1]
 
 
 class BracketEVES(HyperbandBracket):

--- a/src/orion/algo/hyperband.py
+++ b/src/orion/algo/hyperband.py
@@ -170,11 +170,12 @@ class Hyperband(BaseAlgorithm):
         if self.reduction_factor >= 2:
             self.budgets = compute_budgets(self.max_resources, self.reduction_factor)
             self.brackets = self.create_brackets()
-            self.seed_rng(seed)
         else:
             self.budgets = None
             self.brackets = None
             logger.warning("Reduction factor for Hyperband needs to be at least 2")
+
+        self.seed_rng(seed)
 
     def create_bracket(self, i, budgets, iteration):
         return HyperbandBracket(self, budgets, iteration)

--- a/src/orion/algo/hyperband.py
+++ b/src/orion/algo/hyperband.py
@@ -456,10 +456,14 @@ class HyperbandBracket:
 
     @property
     def state_dict(self):
-        return {"rungs": copy.deepcopy(self.rungs)}
+        return {
+            "rungs": copy.deepcopy(self.rungs),
+            "samples": copy.deepcopy(self._samples),
+        }
 
     def set_state(self, state_dict):
         self.rungs = state_dict["rungs"]
+        self._samples = state_dict["samples"]
 
     @property
     def is_filled(self):

--- a/src/orion/algo/hyperband.py
+++ b/src/orion/algo/hyperband.py
@@ -508,7 +508,7 @@ class HyperbandBracket:
         """Register a trial in the corresponding rung"""
         self._get_results(trial)[self.hyperband.get_id(trial, ignore_fidelity=True)] = (
             trial.objective.value if trial.objective else None,
-            trial,
+            copy.deepcopy(trial),
         )
 
     def _get_results(self, trial):

--- a/src/orion/testing/algo.py
+++ b/src/orion/testing/algo.py
@@ -409,6 +409,25 @@ class BaseAlgoTests:
         self.assert_callbacks(spy, num, new_algo)
 
     @phase
+    def test_seed_rng_init(self, mocker, num, attr):
+        """Test that the seeding gives reproducibile results."""
+        algo = self.create_algo(seed=1)
+
+        spy = self.spy_phase(mocker, num, algo, attr)
+        trials = algo.suggest(1)
+        algo.suggest(1)[0].id != trials[0].id
+
+        new_algo = self.create_algo(seed=2)
+        self.force_observe(algo.n_observed, new_algo)
+        assert new_algo.suggest(1)[0].id != trials[0].id
+
+        new_algo = self.create_algo(seed=1)
+        self.force_observe(algo.n_observed, new_algo)
+        assert new_algo.suggest(1)[0].id == trials[0].id
+
+        self.assert_callbacks(spy, num, new_algo)
+
+    @phase
     def test_state_dict(self, mocker, num, attr):
         """Verify that resetting state makes sampling deterministic"""
         algo = self.create_algo()

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -163,7 +163,8 @@ class TestASHABracket:
 
         assert len(bracket.rungs[0])
         assert trial_id in bracket.rungs[0]["results"]
-        assert (trial.objective.value, trial) == bracket.rungs[0]["results"][trial_id]
+        assert bracket.rungs[0]["results"][trial_id][0] == trial.objective.value
+        assert bracket.rungs[0]["results"][trial_id][1].to_dict() == trial.to_dict()
 
     def test_bad_register(self, asha, bracket):
         """Check that a non-valid point is not registered."""

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -389,10 +389,10 @@ class TestASHA:
         fidelity = 2
         trial = create_trial_for_hb((fidelity, value))
 
-        with pytest.raises(ValueError) as ex:
-            force_observe(asha, trial)
+        asha.observe([trial])
 
-        assert "No bracket found for trial" in str(ex.value)
+        assert not asha.has_suggested(trial)
+        assert not asha.has_observed(trial)
 
     def test_register_not_sampled(self, space, b_config, caplog):
         """Check that a point cannot registered if not sampled."""
@@ -457,7 +457,7 @@ class TestASHA:
             resources=1,
             results={duplicate_id_wo_fidelity: (0.0, duplicate_trial)},
         )
-        asha.trial_to_brackets[duplicate_id_wo_fidelity] = bracket
+        asha.trial_to_brackets[duplicate_id_wo_fidelity] = 0
 
         asha.register(duplicate_trial)
 
@@ -479,7 +479,7 @@ class TestASHA:
 
         fidelity = 1
         zhe_trial = create_trial_for_hb((fidelity, 0.0))
-        asha.trial_to_brackets[asha.get_id(zhe_trial, ignore_fidelity=True)] = bracket
+        asha.trial_to_brackets[asha.get_id(zhe_trial, ignore_fidelity=True)] = 0
 
         def sample(num=1, seed=None):
             return [zhe_trial]

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -529,9 +529,7 @@ class TestASHA:
 
         assert trials[0].params == {"epoch": 3, "lr": 0.0}
 
-    def test_suggest_promote_many(
-        self, asha, bracket, big_rung_0, big_rung_1
-    ):
+    def test_suggest_promote_many(self, asha, bracket, big_rung_0, big_rung_1):
         """Test that correct points are promoted and returned."""
         asha.brackets = [bracket]
         bracket.asha = asha

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -588,7 +588,12 @@ class TestGenericASHA(BaseAlgoTests):
         algo = self.create_algo()
         spy = self.spy_phase(mocker, num, algo, attr)
         trials = algo.suggest(5)
-        assert len(trials) == 1
+
+        if num == BUDGETS[-1]:
+            # Rung 2 has 2 trials for bracket 1, 1 trial for bracket 2
+            assert len(trials) == 2 + 1
+        else:
+            assert len(trials) == 5
 
     @pytest.mark.skip(reason="See https://github.com/Epistimio/orion/issues/598")
     def test_is_done_cardinality(self):
@@ -681,9 +686,9 @@ class TestGenericASHA(BaseAlgoTests):
 
 
 BUDGETS = [
-    4 + 2,  # rung 0
-    (8 + 4 + 2 + 4),  # rung 1 (first bracket 8 4 2, second bracket 4)
-    (16 + 8 + 4 + 2 + 1 + 8 + 4 + 2),  #  rung 2
+    16 + 8,  # rung 0
+    (16 + 8 + 8 + 4),  # rung 1 (first bracket 8 4 2, second bracket 4)
+    (16 + 8 + 4 + 8 + 4 + 2),  #  rung 2
 ]
 
 TestGenericASHA.set_phases(

--- a/tests/unittests/algo/test_gridsearch.py
+++ b/tests/unittests/algo/test_gridsearch.py
@@ -169,6 +169,19 @@ class TestGridSearch(BaseAlgoTests):
     config = {"n_values": 10}
 
     @phase
+    def test_seed_rng_init(self, mocker, num, attr):
+        """The algo should return the same trials irrespective of the seed"""
+        algo = self.create_algo(seed=1)
+
+        spy = self.spy_phase(mocker, num, algo, attr)
+        trials = algo.suggest(1)
+        algo.suggest(1)[0].id != trials[0].id
+
+        new_algo = self.create_algo(seed=2)
+        self.force_observe(algo.n_observed, new_algo)
+        assert new_algo.suggest(1)[0].id == trials[0].id
+
+    @phase
     def test_suggest_lots(self, mocker, num, attr):
         """Test that gridsearch returns the whole grid when requesting more points"""
         algo = self.create_algo()

--- a/tests/unittests/algo/test_hyperband.py
+++ b/tests/unittests/algo/test_hyperband.py
@@ -10,9 +10,9 @@ import pytest
 
 from orion.algo.hyperband import Hyperband, HyperbandBracket, compute_budgets
 from orion.algo.space import Fidelity, Integer, Real, Space
+from orion.core.utils.flatten import flatten
 from orion.testing.algo import BaseAlgoTests, phase
 from orion.testing.trial import compare_trials, create_trial
-from orion.core.utils.flatten import flatten
 
 
 def create_trial_for_hb(point, objective=None):

--- a/tests/unittests/algo/test_hyperband.py
+++ b/tests/unittests/algo/test_hyperband.py
@@ -156,7 +156,8 @@ class TestHyperbandBracket:
 
         assert len(bracket.rungs[0])
         assert trial_id in bracket.rungs[0]["results"]
-        assert (trial.objective.value, trial) == bracket.rungs[0]["results"][trial_id]
+        assert bracket.rungs[0]["results"][trial_id][0] == trial.objective.value
+        assert bracket.rungs[0]["results"][trial_id][1].to_dict() == trial.to_dict()
 
     def test_bad_register(self, hyperband, bracket):
         """Check that a non-valid point is not registered."""

--- a/tests/unittests/algo/test_hyperband.py
+++ b/tests/unittests/algo/test_hyperband.py
@@ -12,6 +12,7 @@ from orion.algo.hyperband import Hyperband, HyperbandBracket, compute_budgets
 from orion.algo.space import Fidelity, Integer, Real, Space
 from orion.testing.algo import BaseAlgoTests, phase
 from orion.testing.trial import compare_trials, create_trial
+from orion.core.utils.flatten import flatten
 
 
 def create_trial_for_hb(point, objective=None):
@@ -113,9 +114,19 @@ def force_observe(hyperband, trial):
 
     hyperband.register(trial)
 
-    bracket = hyperband._get_bracket(trial)
     id_wo_fidelity = hyperband.get_id(trial, ignore_fidelity=True)
-    hyperband.trial_to_brackets[id_wo_fidelity] = bracket
+
+    bracket_index = hyperband.trial_to_brackets.get(id_wo_fidelity, None)
+
+    if bracket_index is None:
+        fidelity = flatten(trial.params)[hyperband.fidelity_index]
+        bracket_index = [
+            i
+            for i, bracket in enumerate(hyperband.brackets)
+            if bracket.rungs[0]["resources"] == fidelity
+        ][0]
+
+    hyperband.trial_to_brackets[id_wo_fidelity] = bracket_index
 
     hyperband.observe([trial])
 
@@ -348,10 +359,10 @@ class TestHyperband:
         fidelity = 2
         trial = create_trial_for_hb((fidelity, value))
 
-        with pytest.raises(ValueError) as ex:
-            force_observe(hyperband, trial)
+        hyperband.observe([trial])
 
-        assert "No bracket found for trial" in str(ex.value)
+        assert not hyperband.has_suggested(trial)
+        assert not hyperband.has_observed(trial)
 
     def test_register_not_sampled(self, space, caplog):
         """Check that a point cannot registered if not sampled."""
@@ -414,7 +425,7 @@ class TestHyperband:
         duplicate_id = hyperband.get_id(duplicate_trial, ignore_fidelity=True)
         bracket.rungs[0]["results"] = {duplicate_id: (0.0, duplicate_trial)}
 
-        hyperband.trial_to_brackets[duplicate_id] = bracket
+        hyperband.trial_to_brackets[duplicate_id] = 0
 
         trials = [duplicate_trial, new_trial]
 
@@ -462,10 +473,10 @@ class TestHyperband:
         )
         hyperband.trial_to_brackets[
             hyperband.get_id(create_trial_for_hb((1, 0.0)), ignore_fidelity=True)
-        ] = bracket
+        ] = 0
         hyperband.trial_to_brackets[
             hyperband.get_id(create_trial_for_hb((1, 0.0)), ignore_fidelity=True)
-        ] = bracket
+        ] = 0
         zhe_samples = hyperband.suggest(100)
         assert zhe_samples[0].params["lr"] == 5.0
         assert zhe_samples[1].params["lr"] == 4.0
@@ -489,13 +500,39 @@ class TestHyperband:
 
         assert not hyperband.is_done
 
-        zhe_point = list(map(create_trial_for_hb, [(9, 0), (9, 1), (9, 2)]))
+        # lr:7 and lr:8 are already sampled in first repetition, they should not be present
+        # in second repetition. Samples with lr:7 and lr:8 will be ignored.
+
+        # (9, 0) already exists
+        candidates_for_epoch_9_bracket = [(9, 0), (9, 2), (9, 3), (9, 10)]
+        # (9, 1) -> (3, 1) already promoted in last repetition
+        # (9, 3) sampled for previous bracket
+        candidates_for_epoch_3_bracket = [(9, 1), (9, 3), (9, 4), (9, 5), (9, 11)]
+        # (9, 0) -> (1, 0) already sampled in last repetition
+        # (9, 8) -> (1, 8) already sampled in last repetition
+        candidates_for_epoch_1_bracket = [(9, 0), (9, 8), (9, 12), (9, 13)]
+
+        zhe_point = list(
+            map(
+                create_trial_for_hb,
+                candidates_for_epoch_9_bracket
+                + candidates_for_epoch_3_bracket
+                + candidates_for_epoch_1_bracket,
+            )
+        )
 
         hyperband._refresh_brackets()
-        mock_samples(hyperband, zhe_point * 2)
+        mock_samples(hyperband, zhe_point)
         zhe_samples = hyperband.suggest(100)
-        assert zhe_samples[0].params == {"epoch": 9, "lr": 1}
-        assert zhe_samples[1].params == {"epoch": 9, "lr": 2}
+        assert len(zhe_samples) == 8
+        assert zhe_samples[0].params == {"epoch": 9, "lr": 2}
+        assert zhe_samples[1].params == {"epoch": 9, "lr": 3}
+        assert zhe_samples[2].params == {"epoch": 9, "lr": 10}
+        assert zhe_samples[3].params == {"epoch": 3, "lr": 4}
+        assert zhe_samples[4].params == {"epoch": 3, "lr": 5}
+        assert zhe_samples[5].params == {"epoch": 3, "lr": 11}
+        assert zhe_samples[6].params == {"epoch": 1, "lr": 12}
+        assert zhe_samples[7].params == {"epoch": 1, "lr": 13}
 
     def test_suggest_inf_duplicates(
         self, monkeypatch, hyperband, bracket, rung_0, rung_1, rung_2
@@ -507,7 +544,7 @@ class TestHyperband:
         zhe_trial = create_trial_for_hb(("fidelity", 0.0))
         hyperband.trial_to_brackets[
             hyperband.get_id(zhe_trial, ignore_fidelity=True)
-        ] = bracket
+        ] = 0
 
         mock_samples(hyperband, [zhe_trial] * 2)
 
@@ -683,9 +720,7 @@ class TestHyperband:
         # Fill all brackets' first rung
 
         trials = hyperband.suggest(100)
-        from orion.algo.hyperband import tabulate_status
 
-        print(tabulate_status(hyperband.brackets))
         compare_trials(trials[:3], [create_trial_for_hb((9, i)) for i in range(3)])
         compare_trials(trials[3:6], [create_trial_for_hb((3, i)) for i in range(3, 6)])
         compare_trials(trials[6:], [create_trial_for_hb((1, i)) for i in range(6, 15)])
@@ -781,12 +816,15 @@ class TestHyperband:
         monkeypatch.setattr(hyperband, "repetitions", 2)
         # monkeypatch.setattr(hyperband.brackets[0], "repetition_id", 0)
         # hyperband.observe([(9, 12)], [{"objective": 3 - i}])
+        assert len(hyperband.brackets) == 3
         hyperband._refresh_brackets()
-        mock_samples(hyperband, copy.deepcopy(sample_trials))
+        assert len(hyperband.brackets) == 6
+        mock_samples(hyperband, copy.deepcopy(sample_trials[:3] + sample_trials))
         trials = hyperband.suggest(100)
         assert not hyperband.is_done
-        assert not hyperband.brackets[0].is_ready(2)
-        assert not hyperband.brackets[0].is_done
+        assert not hyperband.brackets[3].is_ready(2)
+        assert not hyperband.brackets[3].is_done
+
         compare_trials(trials[:3], map(create_trial_for_hb, [(9, 3), (9, 4), (9, 6)]))
         compare_trials(trials[3:6], map(create_trial_for_hb, [(3, 7), (3, 8), (3, 9)]))
         compare_trials(trials[6:], [create_trial_for_hb((1, i)) for i in range(15, 24)])


### PR DESCRIPTION
Why:

Currently only one promotion can be done for each suggest. This means
with pool-size greater than 1 ASHA would always end up suggesting many
new trials and only do 1 promotion at a time.