### PR TITLE
Improve resiliency of trial reservation

### DIFF
--- a/docs/src/user/config.rst
+++ b/docs/src/user/config.rst
@@ -110,7 +110,7 @@ Full Example of Global Configuration
         heartbeat: 120
         interrupt_signal_code: 130
         max_broken: 10
-        max_idle_time: 60
+        reservation_timeout: 60
         max_trials: 1000000000
         user_script_config: config
 
@@ -365,7 +365,7 @@ Worker
         heartbeat: 120
         interrupt_signal_code: 130
         max_broken: 10
-        max_idle_time: 60
+        reservation_timeout: 60
         max_trials: 1000000000
         user_script_config: config
 
@@ -464,21 +464,37 @@ max_broken
     Maximum number of broken trials before worker stops.
 
 
+.. _config_worker_reservation_timeout:
+
+reservation_timeout
+~~~~~~~~~~~~~~~~~~~
+
+:Type: int
+:Default: 60
+:Env var: ORION_RESERVATION_TIMEOUT
+:Description:
+    Maximum time the experiment can spend trying to reserve a new suggestion. Such timeout are
+    generally caused by slow database, large number of concurrent workers leading to many race
+    conditions or small search spaces with integer/categorical dimensions that may be fully
+    explored.
+
 
 .. _config_worker_max_idle_time:
 
 max_idle_time
 ~~~~~~~~~~~~~
 
+.. warning::
+
+   **DEPRECATED.** This argument will be removed in v0.3.
+   Use :ref:`config_worker_reservation_timeout` instead.
+
 :Type: int
 :Default: 60
 :Env var: ORION_MAX_IDLE_TIME
 :Description:
-    Maximum time the producer can spend trying to generate a new suggestion.Such timeout are
-    generally caused by slow database, large number of concurrent workers leading to many race
-    conditions or small search spaces with integer/categorical dimensions that may be fully
-    explored.
-
+    (DEPRECATED) This argument will be removed in v0.3. Use :ref:`config_worker_reservation_timeout`
+    instead.
 
 
 .. _config_worker_interrupt_signal_code:

--- a/src/orion/algo/hyperband.py
+++ b/src/orion/algo/hyperband.py
@@ -89,7 +89,7 @@ def tabulate_status(brackets):
             row.append(r_i)
         data.append(row)
     table = tabulate(data, header, tablefmt="github")
-    logger.debug(table)
+    logger.info(table)
 
 
 def display_budgets(budgets_tab, max_resources, reduction_factor):
@@ -116,7 +116,7 @@ def display_budgets(budgets_tab, max_resources, reduction_factor):
     table_str += "max resource={}, eta={}, trials number of one execution={}\n".format(
         max_resources, reduction_factor, total_trials
     )
-    logger.debug(table_str)
+    logger.info(table_str)
 
 
 class Hyperband(BaseAlgorithm):
@@ -360,7 +360,7 @@ class Hyperband(BaseAlgorithm):
     def _refresh_brackets(self):
         """Refresh bracket if one hyperband execution is done"""
         if all(bracket.is_done for bracket in self.brackets):
-            logger.debug(
+            logger.info(
                 "Hyperband execution %i is done, required to execute %s times",
                 self.executed_times,
                 str(self.repetitions),
@@ -399,7 +399,7 @@ class Hyperband(BaseAlgorithm):
         for trial in trials:
 
             if not self.has_suggested(trial):
-                logger.info(
+                logger.debug(
                     "Ignoring trial %s because it was not sampled by current algo.",
                     trial,
                 )

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -6,6 +6,8 @@ Python API
 Provides functions for communicating with `orion.core`.
 
 """
+import logging
+
 import orion.core.io.experiment_builder as experiment_builder
 from orion.client.cli import (
     interrupt_trial,
@@ -29,6 +31,8 @@ __all__ = [
     "get_experiment",
     "workon",
 ]
+
+log = logging.getLogger(__name__)
 
 
 def create_experiment(name, **config):
@@ -136,11 +140,8 @@ def build_experiment(
         Working directory created for the experiment inside which a unique folder will be created
         for each trial. Defaults to a temporary directory that is deleted at end of execution.
     max_idle_time: int, optional
-        Maximum time the producer can spend trying to generate a new suggestion.
-        Such timeout are generally caused by slow database, large number of
-        concurrent workers leading to many race conditions or small search spaces
-        with integer/categorical dimensions that may be fully explored.
-        Defaults to ``orion.core.config.worker.max_idle_time``.
+        Deprecated and will be removed in v0.3.0.
+        Use experiment.workon(reservation_timeout) instead.
     heartbeat: int, optional
         Frequency (seconds) at which the heartbeat of the trial is updated.
         If the heartbeat of a `reserved` trial is larger than twice the configured
@@ -202,6 +203,11 @@ def build_experiment(
         If the algorithm, storage or strategy specified is not properly installed.
 
     """
+    if max_idle_time:
+        log.warning(
+            "max_idle_time is deprecated. Use experiment.workon(reservation_timeout) instead."
+        )
+
     setup_storage(storage=storage, debug=debug)
 
     try:
@@ -241,7 +247,7 @@ def build_experiment(
                 "repository."
             ) from e
 
-    producer = Producer(experiment, max_idle_time)
+    producer = Producer(experiment)
 
     return ExperimentClient(experiment, producer, executor, heartbeat)
 

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -8,6 +8,7 @@ Wraps the core Experiment object to provide further functionalities for the user
 """
 import inspect
 import logging
+import time
 import traceback
 from contextlib import contextmanager
 
@@ -18,7 +19,7 @@ from orion.core.utils.exceptions import (
     BrokenExperiment,
     CompletedExperiment,
     InvalidResult,
-    SampleTimeout,
+    ReservationTimeout,
     UnsupportedOperation,
     WaitingForTrials,
 )
@@ -32,28 +33,51 @@ from orion.storage.base import FailedUpdate
 log = logging.getLogger(__name__)
 
 
-def reserve_trial(experiment, producer, pool_size, _depth=1):
+def reserve_trial(experiment, producer, pool_size, timeout):
     """Reserve a new trial, or produce and reserve a trial if none are available."""
     log.debug("Trying to reserve a new trial to evaluate.")
-    trial = experiment.reserve_trial()
 
-    if trial is None and not producer.is_done:
+    trial = None
+    start = time.time()
+    failure_count = 0
 
-        if _depth > 10:
-            raise WaitingForTrials(
-                "No trials are available at the moment "
-                "wait for current trials to finish"
-            )
+    n_trials_at_start = len(experiment.fetch_trials())
 
-        log.debug("#### Failed to pull a new trial from database.")
+    while (
+        trial is None
+        and not (experiment.is_done or experiment.is_broken)
+        and time.time() - start < timeout
+    ):
+        trial = experiment.reserve_trial()
 
-        log.debug("#### Fetch most recent completed trials and update algorithm.")
-        producer.update()
+        if trial is not None:
+            break
 
-        log.debug("#### Produce new trials.")
-        producer.produce(pool_size)
+        failure_count += 1
 
-        return reserve_trial(experiment, producer, pool_size, _depth=_depth + 1)
+        # TODO: Add backoff
+        log.debug(
+            "#### Failed %s time to pull a new trial from database.",
+            failure_count,
+        )
+
+        if not (experiment.is_done or experiment.is_broken):
+            log.debug("#### Fetch most recent completed trials and update algorithm.")
+            producer.update()
+
+            log.debug("#### Produce new trials.")
+            produced = producer.produce(pool_size)
+            log.debug("#### %s trials produced.", produced)
+
+    if trial is None and time.time() - start > timeout:
+        new_trials_meanwhile = len(experiment.fetch_trials()) - n_trials_at_start
+        raise ReservationTimeout(
+            f"Unable to reserve a trial in less than {timeout} seconds. "
+            f"Failed to reserve {failure_count} times. "
+            f"{new_trials_meanwhile} new trials were generated meanwhile and reserved "
+            "by other workers. Consider increasing worker.pool_size if you have many workers "
+            "or increasing worker.reservation_timeout if only a few trials were generated."
+        )
 
     return trial
 
@@ -500,7 +524,7 @@ class ExperimentClient:
         finally:
             self._release_reservation(trial, raise_if_unreserved=raise_if_unreserved)
 
-    def suggest(self, pool_size=0):
+    def suggest(self, pool_size=0, timeout=None):
         """Suggest a trial to execute.
 
         Experiment must be in executable ('x') mode.
@@ -518,6 +542,12 @@ class ExperimentClient:
             trials but may return less. Note: The method will still return only 1 trial even though
             if the pool size is larger than 1. This is because atomic reservation of trials
             can only be done one at a time.
+        timeout: int, optional
+            Maximum time allowed to try reserving a trial. ReservationTimeout will be raised if
+            timeout is reached.  Such timeout are generally caused by slow database, large number
+            of concurrent workers leading to many race conditions or small search spaces with
+            integer/categorical dimensions that may be fully explored.
+            Defaults to ``orion.core.config.worker.reservation_timeout``.
 
         Returns
         -------
@@ -534,8 +564,8 @@ class ExperimentClient:
             if too many trials failed to run and the experiment cannot continue.
             This is determined by ``max_broken`` in the configuration of the experiment.
 
-        :class:`orion.core.utils.exceptions.SampleTimeout`
-            if the algorithm of the experiment could not sample new unique trials.
+        :class:`orion.core.utils.exceptions.ReservationTimeout`
+            If a trial could not be reserved in less than ``timeout`` seconds.
 
         :class:`orion.core.utils.exceptions.CompletedExperiment`
             if the experiment was completed and algorithm could not sample new trials.
@@ -549,6 +579,8 @@ class ExperimentClient:
             pool_size = orion.core.config.worker.pool_size
         if not pool_size:
             pool_size = 1
+        if not timeout:
+            timeout = orion.core.config.worker.reservation_timeout
 
         if self.is_broken:
             raise BrokenExperiment("Trials failed too many times")
@@ -557,17 +589,19 @@ class ExperimentClient:
             raise CompletedExperiment("Experiment is done, cannot sample more trials.")
 
         try:
-            trial = reserve_trial(self._experiment, self._producer, pool_size)
+            trial = reserve_trial(self._experiment, self._producer, pool_size, timeout)
 
-        except (WaitingForTrials, SampleTimeout) as e:
+        except (WaitingForTrials, ReservationTimeout) as e:
             if self.is_broken:
                 raise BrokenExperiment("Trials failed too many times") from e
 
             raise e
 
         # This is to handle cases where experiment was completed during call to `reserve_trial`
-        if trial is None:
+        if trial is None and self.is_done:
             raise CompletedExperiment("Producer is done, cannot sample more trials.")
+        elif trial is None and self.is_broken:
+            raise BrokenExperiment("Trials failed too many times")
 
         self._maintain_reservation(trial)
         return TrialCM(self, trial)
@@ -649,6 +683,7 @@ class ExperimentClient:
         fct,
         n_workers=None,
         pool_size=0,
+        reservation_timeout=None,
         max_trials=None,
         max_trials_per_worker=None,
         max_broken=None,
@@ -673,6 +708,12 @@ class ExperimentClient:
             config if defined.  Increase it to improve the sampling speed if workers spend too much
             time waiting for algorithms to sample points. An algorithm will try sampling
             `pool_size` trials but may return less.
+        reservation_timeout: int, optional
+            Maximum time allowed to try reserving a trial. ReservationTimeout will be raised if
+            timeout is reached.  Such timeout are generally caused by slow database, large number
+            of concurrent workers leading to many race conditions or small search spaces with
+            integer/categorical dimensions that may be fully explored.
+            Defaults to ``orion.core.config.worker.reservation_timeout``.
         max_trials: int, optional
             Maximum number of trials to execute within ``workon``. If the experiment or algorithm
             reach status is_done before, the execution of ``workon`` terminates.
@@ -714,7 +755,7 @@ class ExperimentClient:
             if too many trials failed to run and the experiment cannot continue.
             This is determined by ``max_broken`` in the configuration of the experiment.
 
-        :class:`orion.core.utils.exceptions.SampleTimeout`
+        :class:`orion.core.utils.exceptions.ReservationTimeout`
             if the algorithm of the experiment could not sample new unique points.
 
         :class:`orion.core.utils.exceptions.UnsupportedOperation`
@@ -738,6 +779,9 @@ class ExperimentClient:
         if not pool_size:
             pool_size = n_workers
 
+        if not reservation_timeout:
+            reservation_timeout = orion.core.config.worker.reservation_timeout
+
         if max_trials is None:
             max_trials = self.max_trials
 
@@ -758,6 +802,7 @@ class ExperimentClient:
                 self._optimize,
                 fct,
                 pool_size,
+                reservation_timeout,
                 max_trials_per_worker,
                 max_broken,
                 trial_arg,
@@ -770,7 +815,15 @@ class ExperimentClient:
         return sum(trials)
 
     def _optimize(
-        self, fct, pool_size, max_trials, max_broken, trial_arg, on_error, **kwargs
+        self,
+        fct,
+        pool_size,
+        reservation_timeout,
+        max_trials,
+        max_broken,
+        trial_arg,
+        on_error,
+        **kwargs,
     ):
         worker_broken_trials = 0
         trials = 0
@@ -778,7 +831,9 @@ class ExperimentClient:
         max_trials = min(max_trials, self.max_trials)
         while not self.is_done and trials - worker_broken_trials < max_trials:
             try:
-                with self.suggest(pool_size=pool_size) as trial:
+                with self.suggest(
+                    pool_size=pool_size, timeout=reservation_timeout
+                ) as trial:
 
                     kwargs.update(flatten(trial.params))
 

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -271,8 +271,23 @@ def define_worker_config(config):
         option_type=int,
         default=60,
         env_var="ORION_MAX_IDLE_TIME",
+        deprecate=dict(
+            version="v0.3",
+            alternative="worker.reservation_timeout",
+            name="worker.max_idle_time",
+        ),
         help=(
-            "Maximum time the producer can spend trying to generate a new suggestion."
+            "This argument will be removed in v0.3.0. Use reservation_timeout instead."
+        ),
+    )
+
+    worker_config.add_option(
+        "reservation_timeout",
+        option_type=int,
+        default=60,
+        env_var="ORION_RESERVATION_TIMEOUT",
+        help=(
+            "Maximum time the experiment can spend trying to reserve a new suggestion."
             "Such timeout are generally caused by slow database, large number of "
             "concurrent workers leading to many race conditions or small search spaces "
             "with integer/categorical dimensions that may be fully explored."

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -134,6 +134,7 @@ def workon(
     max_trials=None,
     max_broken=None,
     max_idle_time=None,
+    reservation_timeout=None,
     heartbeat=None,
     user_script_config=None,
     interrupt_signal_code=None,
@@ -142,7 +143,12 @@ def workon(
     executor_configuration=None,
 ):
     """Try to find solution to the search problem defined in `experiment`."""
-    producer = Producer(experiment, max_idle_time)
+
+    # NOTE: Remove in v0.3.0
+    if max_idle_time is not None and reservation_timeout is None:
+        reservation_timeout = max_idle_time
+
+    producer = Producer(experiment)
     consumer = Consumer(
         experiment,
         user_script_config,
@@ -165,6 +171,7 @@ def workon(
                 consumer,
                 n_workers=n_workers,
                 pool_size=pool_size,
+                reservation_timeout=reservation_timeout,
                 max_trials_per_worker=max_trials,
                 max_broken=max_broken,
                 trial_arg="trial",

--- a/src/orion/core/utils/exceptions.py
+++ b/src/orion/core/utils/exceptions.py
@@ -94,8 +94,8 @@ class BranchingEvent(Exception):
         super().__init__(message.format(status))
 
 
-class SampleTimeout(Exception):
-    """Raised when the algorithm is not able to sample new unique points in time"""
+class ReservationTimeout(Exception):
+    """Raised when the experiment client is not able to reserve a trial in time"""
 
     pass
 

--- a/tests/functional/configuration/test_all_options.py
+++ b/tests/functional/configuration/test_all_options.py
@@ -568,6 +568,7 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "heartbeat": 30,
             "max_trials": 10,
             "max_broken": 5,
+            "reservation_timeout": 16,
             "max_idle_time": 15,
             "interrupt_signal_code": 131,
             "user_script_config": "cfg",
@@ -581,6 +582,7 @@ class TestWorkerConfig(ConfigurationTestSuite):
         "ORION_HEARTBEAT": 40,
         "ORION_WORKER_MAX_TRIALS": 20,
         "ORION_WORKER_MAX_BROKEN": 6,
+        "ORION_RESERVATION_TIMEOUT": 17,
         "ORION_MAX_IDLE_TIME": 16,
         "ORION_INTERRUPT_CODE": 132,
         "ORION_USER_SCRIPT_CONFIG": "envcfg",
@@ -595,7 +597,8 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "heartbeat": 50,
             "max_trials": 30,
             "max_broken": 7,
-            "max_idle_time": 17,
+            "reservation_timeout": 17,
+            "max_idle_time": 16,
             "interrupt_signal_code": 133,
             "user_script_config": "lclcfg",
         }
@@ -608,7 +611,8 @@ class TestWorkerConfig(ConfigurationTestSuite):
         "heartbeat": 70,
         "worker-max-trials": 1,
         "worker-max-broken": 8,
-        "max-idle-time": 18,
+        "reservation-timeout": 18,
+        "max-idle-time": 17,
         "interrupt-signal-code": 134,
         "user-script-config": "cmdcfg",
     }
@@ -667,7 +671,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
     def _check_mocks(self, config):
         self._check_exp_client(config)
         self._check_consumer(config)
-        self._check_producer(config)
         self._check_workon(config)
 
     def _check_exp_client(self, config):
@@ -679,15 +682,16 @@ class TestWorkerConfig(ConfigurationTestSuite):
         )
         assert self.consumer.interrupt_signal_code == config["interrupt_signal_code"]
 
-    def _check_producer(self, config):
-        assert self.producer.max_idle_time == config["max_idle_time"]
-
     def _check_workon(self, config):
         assert self.workon_kwargs["n_workers"] == config["n_workers"]
         assert self.workon_kwargs["executor"] == config["executor"]
         assert (
             self.workon_kwargs["executor_configuration"]
             == config["executor_configuration"]
+        )
+        assert self.workon_kwargs["pool_size"] == config["pool_size"]
+        assert (
+            self.workon_kwargs["reservation_timeout"] == config["reservation_timeout"]
         )
         assert self.workon_kwargs["max_trials"] == config["max_trials"]
         assert self.workon_kwargs["max_broken"] == config["max_broken"]
@@ -713,6 +717,7 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "heartbeat": self.env_vars["ORION_HEARTBEAT"],
             "max_trials": self.env_vars["ORION_WORKER_MAX_TRIALS"],
             "max_broken": self.env_vars["ORION_WORKER_MAX_BROKEN"],
+            "reservation_timeout": self.env_vars["ORION_RESERVATION_TIMEOUT"],
             "max_idle_time": self.env_vars["ORION_MAX_IDLE_TIME"],
             "interrupt_signal_code": self.env_vars["ORION_INTERRUPT_CODE"],
             "user_script_config": self.env_vars["ORION_USER_SCRIPT_CONFIG"],
@@ -753,10 +758,11 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "n_workers": self.cmdargs["n-workers"],
             "executor": self.cmdargs["executor"],
             "executor_configuration": {"threads_per_worker": 2},
+            "pool_size": self.cmdargs["pool-size"],
+            "reservation_timeout": self.cmdargs["reservation-timeout"],
             "heartbeat": self.cmdargs["heartbeat"],
             "max_trials": self.cmdargs["worker-max-trials"],
             "max_broken": self.cmdargs["worker-max-broken"],
-            "max_idle_time": self.cmdargs["max-idle-time"],
             "interrupt_signal_code": self.cmdargs["interrupt-signal-code"],
             "user_script_config": self.cmdargs["user-script-config"],
         }

--- a/tests/unittests/algo/test_asha.py
+++ b/tests/unittests/algo/test_asha.py
@@ -403,7 +403,7 @@ class TestASHA:
         fidelity = 2
         trial = create_trial_for_hb((fidelity, value))
 
-        with caplog.at_level(logging.INFO, logger="orion.algo.hyperband"):
+        with caplog.at_level(logging.DEBUG, logger="orion.algo.hyperband"):
             asha.observe([trial])
 
         assert len(caplog.records) == 1

--- a/tests/unittests/algo/test_hyperband.py
+++ b/tests/unittests/algo/test_hyperband.py
@@ -373,7 +373,7 @@ class TestHyperband:
         fidelity = 2
         trial = create_trial_for_hb((fidelity, value))
 
-        with caplog.at_level(logging.INFO, logger="orion.algo.hyperband"):
+        with caplog.at_level(logging.DEBUG, logger="orion.algo.hyperband"):
             hyperband.observe([trial])
 
         assert len(caplog.records) == 1

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -4,18 +4,20 @@
 import copy
 import datetime
 import logging
+import time
 
 import joblib
 import pandas.testing
 import pytest
 
 import orion.core
+from orion.client.experiment import reserve_trial
 from orion.core.io.database import DuplicateKeyError
 from orion.core.utils import format_trials
 from orion.core.utils.exceptions import (
     BrokenExperiment,
     CompletedExperiment,
-    SampleTimeout,
+    ReservationTimeout,
 )
 from orion.core.worker.trial import Trial
 from orion.executor.joblib_backend import Joblib
@@ -122,6 +124,95 @@ def test_experiment_to_pandas():
     """Test compliance of client and experiment `to_pandas()`"""
     with create_experiment(config, base_trial) as (cfg, experiment, client):
         pandas.testing.assert_frame_equal(experiment.to_pandas(), client.to_pandas())
+
+
+class TestReservationFct:
+    def test_exceed_timeout(self, monkeypatch):
+        """Test that ReservationTimeout is raised when exp unable to reserve trials."""
+
+        with create_experiment(config, base_trial, ["reserved"]) as (
+            cfg,
+            experiment,
+            client,
+        ):
+
+            N_TRIALS = 5
+
+            def do_nothing(pool_size):
+                # Another worker generates a trial meanwhile
+                n_trials_so_far = len(client.fetch_trials())
+                if n_trials_so_far < N_TRIALS:
+                    client.insert(
+                        dict(x=n_trials_so_far),
+                        results=[
+                            {"name": "objective", "type": "objective", "value": 1}
+                        ],
+                    )
+                return 0
+
+            monkeypatch.setattr(client._producer, "produce", do_nothing)
+
+            # to limit run-time, default would work as well.
+            timeout = 3
+
+            start = time.time()
+
+            with pytest.raises(ReservationTimeout) as exc:
+                reserve_trial(
+                    experiment, client._producer, pool_size=1, timeout=timeout
+                )
+
+            assert timeout <= time.time() - start < timeout + 1
+
+            assert f". {N_TRIALS - 1} new trials were generated" in str(exc.value)
+
+    def test_stops_if_exp_done(self, monkeypatch):
+        """Test that reservation attempt is stopped when experiment is done."""
+
+        with create_experiment(config, base_trial, ["reserved"]) as (
+            cfg,
+            experiment,
+            client,
+        ):
+
+            timeout = 3
+
+            # Make sure first it produces properly
+            n_trials_before_reserve = len(client.fetch_trials())
+            assert not client.is_done
+
+            reserve_trial(experiment, client._producer, pool_size=1, timeout=timeout)
+
+            assert not client.is_done
+            assert len(client.fetch_trials()) == n_trials_before_reserve + 1
+
+            # Then make sure the producer raises properly
+            def cant_produce(pool_size):
+                raise RuntimeError("I should not be called")
+
+            monkeypatch.setattr(client._producer, "produce", cant_produce)
+
+            with pytest.raises(RuntimeError, match="I should not be called"):
+                reserve_trial(
+                    experiment, client._producer, pool_size=1, timeout=timeout
+                )
+
+            # Now make sure the producer is not called and no additional trials are generated
+            def make_exp_is_done(reserve):
+                # Another worker generates a trial meanwhile
+                monkeypatch.setattr(experiment, "max_trials", 0)
+                assert experiment.is_done
+                return None
+
+            monkeypatch.setattr(type(experiment), "reserve_trial", make_exp_is_done)
+
+            n_trials_before_reserve = len(client.fetch_trials())
+            assert not client.is_done
+
+            reserve_trial(experiment, client._producer, pool_size=1, timeout=timeout)
+
+            assert client.is_done
+            assert len(client.fetch_trials()) == n_trials_before_reserve
 
 
 @pytest.mark.usefixtures("version_XYZ")
@@ -601,7 +692,7 @@ class TestSuggest:
             """Never suggest a new trial"""
             return None
 
-        monkeypatch.setattr(orion.core.config.worker, "max_idle_time", -1)
+        monkeypatch.setattr(orion.core.config.worker, "reservation_timeout", -1)
 
         with create_experiment(config, base_trial, statuses=["completed"]) as (
             cfg,
@@ -613,7 +704,7 @@ class TestSuggest:
 
             assert len(experiment.fetch_trials()) == 1
 
-            with pytest.raises(SampleTimeout):
+            with pytest.raises(ReservationTimeout):
                 client.suggest()
 
     def test_suggest_is_done(self):
@@ -709,12 +800,15 @@ class TestSuggest:
 
             monkeypatch.setattr(client._producer, "produce", set_is_broken)
 
+            start_time = time.time()
+
             assert len(experiment.fetch_trials()) == 1
             assert not client.is_broken
 
             with pytest.raises(BrokenExperiment):
-                client.suggest()
+                client.suggest(timeout=5)
 
+            assert time.time() - start_time < 3
             assert len(experiment.fetch_trials()) == 1
             assert client.is_broken
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -118,6 +118,7 @@ def test_fetch_config_from_cmdargs():
         "worker_max_trials": "worker_max_trials",
         "worker_max_broken": "worker_max_broken",
         "max_idle_time": "max_idle_time",
+        "reservation_timeout": "reservation_timeout",
         "interrupt_signal_code": "interrupt_signal_code",
         "user_script_config": "user_script_config",
         "manual_resolution": "manual_resolution",
@@ -151,6 +152,7 @@ def test_fetch_config_from_cmdargs():
     assert worker_config.pop("max_trials") == "worker_max_trials"
     assert worker_config.pop("max_broken") == "worker_max_broken"
     assert worker_config.pop("max_idle_time") == "max_idle_time"
+    assert worker_config.pop("reservation_timeout") == "reservation_timeout"
     assert worker_config.pop("interrupt_signal_code") == "interrupt_signal_code"
     assert worker_config.pop("user_script_config") == "user_script_config"
 
@@ -273,6 +275,10 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
     assert worker_config.pop("max_trials") == orion.core.config.worker.max_trials
     assert worker_config.pop("max_broken") == orion.core.config.worker.max_broken
     assert worker_config.pop("max_idle_time") == orion.core.config.worker.max_idle_time
+    assert (
+        worker_config.pop("reservation_timeout")
+        == orion.core.config.worker.reservation_timeout
+    )
     assert (
         worker_config.pop("interrupt_signal_code")
         == orion.core.config.worker.interrupt_signal_code


### PR DESCRIPTION
Why:

We had two levels of patience when reserving a trial. There was the
customizable `max_idle_time` used in producer.produce() to limit the
time spend trying to generate new trials, and there was `_max_depth` in
`reserve_trial` limiting the number of times a reservation would be
attempted and producer.produce would be called. This lead to misleading
error messages. For instance, with many workers it happened that a
worker would always be unable to reserve a trial because each time it
executed producer.produce() all other workers would reserve the trials
before the current worker had time to reserve one. In such scenario the
error message would be that the algorithm was unable to sample new point
and is waiting for trials to complete. It is not true. We should state
the number of trials that were generated during these reservation
attempts and recommend increasing the pool-size and timeout.

How:

Producer.produce only attempts producing `pool-size` once (calling
algo.suggest only once) and returns the number of successfully
produced trials. The whole patience is moved to `reserve_trial` where
it attempts reserving and producing until it reaches the timeout, in
which case a helpful error message is raised.