### PR TITLE
Fix Track requirement URL for github

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,5 +3,5 @@ pytest-xdist
 pytest-timeout
 pytest-mock
 pytest-lazy-fixture
-git+git://github.com/Delaunay/track
+git+https://github.com/Delaunay/track
 dask[complete]


### PR DESCRIPTION
Due to git protocol modifications for security, the `git:` urls are not
supported anymore when running from github. We need to use https
instead.