### PR TITLE
Print version on debug verbosity level

### DIFF
--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -74,7 +74,7 @@ class OrionArgsParser:
             format="%(asctime)-15s::%(levelname)s::%(name)s::%(message)s",
             level=levels.get(verbose, logging.DEBUG),
         )
-        logger.debug("Orion version : %s",orion.core.__version__)
+        logger.debug("Orion version : %s", orion.core.__version__)
 
         if args["command"] is None:
             self.parser.parse_args(["--help"])

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -9,6 +9,7 @@ import sys
 import textwrap
 
 import orion
+import orion.core
 from orion.core.io.database import DatabaseError
 from orion.core.utils.exceptions import (
     BranchingEvent,
@@ -71,6 +72,8 @@ class OrionArgsParser:
             format="%(asctime)-15s::%(levelname)s::%(name)s::%(message)s",
             level=levels.get(verbose, logging.DEBUG),
         )
+        if verbose >= 2:
+            print("Orion version : " + orion.core.__version__)
 
         if args["command"] is None:
             self.parser.parse_args(["--help"])

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -19,6 +19,8 @@ from orion.core.utils.exceptions import (
     NoNameError,
 )
 
+logger = logging.getLogger(__name__)
+
 CLI_DOC_HEADER = "Oríon CLI for asynchronous distributed optimization"
 
 
@@ -72,8 +74,7 @@ class OrionArgsParser:
             format="%(asctime)-15s::%(levelname)s::%(name)s::%(message)s",
             level=levels.get(verbose, logging.DEBUG),
         )
-        if verbose >= 2:
-            print("Orion version : " + orion.core.__version__)
+        logger.debug("Orion version : " + orion.core.__version__)
 
         if args["command"] is None:
             self.parser.parse_args(["--help"])

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -74,7 +74,7 @@ class OrionArgsParser:
             format="%(asctime)-15s::%(levelname)s::%(name)s::%(message)s",
             level=levels.get(verbose, logging.DEBUG),
         )
-        logger.debug("Orion version : " + orion.core.__version__)
+        logger.debug("Orion version : %s",orion.core.__version__)
 
         if args["command"] is None:
             self.parser.parse_args(["--help"])

--- a/tests/functional/commands/test_verbose_messages.py
+++ b/tests/functional/commands/test_verbose_messages.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Perform a functional test of the debug verbosity level."""
+import pytest
+import logging
+
+import orion.core.cli
+
+def test_version_print_debug_verbosity(caplog):
+    """Tests that Orion version is printed in debug verbosity level"""
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(SystemExit):
+        orion.core.cli.main(["-vv"])
+    assert "Orion version : " not in caplog.text
+
+    caplog.clear()    
+    caplog.set_level(logging.DEBUG)
+    with pytest.raises(SystemExit):
+        orion.core.cli.main([""])
+    assert "Orion version : " not in caplog.text
+
+    caplog.clear()    
+    caplog.set_level(logging.DEBUG)
+    with pytest.raises(SystemExit):
+        orion.core.cli.main(["-vv"])
+    assert "Orion version : " in caplog.text
+   

--- a/tests/functional/commands/test_verbose_messages.py
+++ b/tests/functional/commands/test_verbose_messages.py
@@ -11,19 +11,17 @@ import orion.core.cli
 def test_version_print_debug_verbosity(caplog):
     """Tests that Orion version is printed in debug verbosity level"""
 
-    caplog.set_level(logging.INFO)
-    with pytest.raises(SystemExit):
-        orion.core.cli.main(["-vv"])
-    assert "Orion version : " not in caplog.text
-
-    caplog.clear()
     caplog.set_level(logging.DEBUG)
+
     with pytest.raises(SystemExit):
         orion.core.cli.main([""])
     assert "Orion version : " not in caplog.text
 
     caplog.clear()
-    caplog.set_level(logging.DEBUG)
     with pytest.raises(SystemExit):
         orion.core.cli.main(["-vv"])
+    for (loggername, loggerlevel, text) in caplog.record_tuples:
+        assert not (
+            text.startswith("Orion version : ") and (loggerlevel != logging.DEBUG)
+        )
     assert "Orion version : " in caplog.text

--- a/tests/functional/commands/test_verbose_messages.py
+++ b/tests/functional/commands/test_verbose_messages.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Perform a functional test of the debug verbosity level."""
-import pytest
 import logging
 
+import pytest
+
 import orion.core.cli
+
 
 def test_version_print_debug_verbosity(caplog):
     """Tests that Orion version is printed in debug verbosity level"""
@@ -14,15 +16,14 @@ def test_version_print_debug_verbosity(caplog):
         orion.core.cli.main(["-vv"])
     assert "Orion version : " not in caplog.text
 
-    caplog.clear()    
+    caplog.clear()
     caplog.set_level(logging.DEBUG)
     with pytest.raises(SystemExit):
         orion.core.cli.main([""])
     assert "Orion version : " not in caplog.text
 
-    caplog.clear()    
+    caplog.clear()
     caplog.set_level(logging.DEBUG)
     with pytest.raises(SystemExit):
         orion.core.cli.main(["-vv"])
     assert "Orion version : " in caplog.text
-   


### PR DESCRIPTION
# Description
Prints Orion version if verbose level is debug.
```
% orion -vv
```

Implements changes requested in issue #735.

# Changes
Quite straitforward. 

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
n/a