### PR TITLE
Replace exp's stat dict by a dataclass

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - pytest-runner
     - appdirs
   run:
+    - dataclasses
     - python
     - numpy
     - scipy

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup_args = dict(
         ],
     },
     install_requires=[
+        "dataclasses",
         "PyYAML",
         "pymongo>=3",
         "numpy",

--- a/src/orion/benchmark/__init__.py
+++ b/src/orion/benchmark/__init__.py
@@ -139,7 +139,7 @@ class Benchmark:
                 ]
                 exp_column["Experiment Name"] = exp.name
                 exp_column["Number Trial"] = len(exp.fetch_trials())
-                exp_column["Best Evaluation"] = stats["best_evaluation"]
+                exp_column["Best Evaluation"] = stats.best_evaluation
                 experiment_table.append(exp_column)
 
         if not silent:

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -187,11 +187,8 @@ class ExperimentClient:
 
     @property
     def stats(self):
-        """Calculate stats for this particular experiment.
-
-        Returns
-        -------
-        stats : :py:class:`orion.core.worker.experiment.ExperimentStats`
+        """Calculate :py:class:`orion.core.worker.experiment.ExperimentStats` for this particular
+        experiment.
         """
         return self._experiment.stats
 

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -187,28 +187,11 @@ class ExperimentClient:
 
     @property
     def stats(self):
-        """Calculate a stats dictionary for this particular experiment.
+        """Calculate stats for this particular experiment.
 
         Returns
         -------
-        stats : dict
-
-        Stats
-        -----
-        trials_completed : int
-           Number of completed trials
-        best_trials_id : int
-           Unique identifier of the :class:`orion.core.worker.trial.Trial` object in the database
-           which achieved the best known objective result.
-        best_evaluation : float
-           Evaluation score of the best trial
-        start_time : `datetime.datetime`
-           When Experiment was first dispatched and started running.
-        finish_time : `datetime.datetime`
-           When Experiment reached terminating condition and stopped running.
-        duration : `datetime.timedelta`
-           Elapsed time.
-
+        stats : :py:class:`orion.core.worker.experiment.ExperimentStats`
         """
         return self._experiment.stats
 

--- a/src/orion/core/utils/format_terminal.py
+++ b/src/orion/core/utils/format_terminal.py
@@ -362,15 +362,15 @@ def format_refers(experiment):
 STATS_TEMPLATE = """\
 {title}
 completed: {is_done}
-trials completed: {stats[trials_completed]}
+trials completed: {stats.trials_completed}
 best trial:
-  id: {stats[best_trials_id]}
-  evaluation: {stats[best_evaluation]}
+  id: {stats.best_trials_id}
+  evaluation: {stats.best_evaluation}
   params:
 {best_params}
-start time: {stats[start_time]}
-finish time: {stats[finish_time]}
-duration: {stats[duration]}
+start time: {stats.start_time}
+finish time: {stats.finish_time}
+duration: {stats.duration}
 """
 
 
@@ -395,7 +395,7 @@ def format_stats(experiment):
     if not stats:
         return NO_STATS_TEMPLATE.format(title=format_title("Stats"))
 
-    best_params = get_trial_params(stats["best_trials_id"], experiment)
+    best_params = get_trial_params(stats.best_trials_id, experiment)
 
     stats_string = STATS_TEMPLATE.format(
         title=format_title("Stats"),

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -49,9 +49,9 @@ class ExperimentStats:
     trials_completed: int
     best_trials_id: int
     best_evaluation: float
-    start_time: field(default_factory=datetime.datetime)
-    finish_time: field(default_factory=datetime.datetime)
-    duration: field(default_factory=datetime.timedelta)
+    start_time: datetime.datetime = field(default_factory=datetime.datetime)
+    finish_time: datetime.datetime = field(default_factory=datetime.datetime)
+    duration: datetime.timedelta = field(default_factory=datetime.timedelta)
 
 
 # pylint: disable=too-many-public-methods

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -522,11 +522,8 @@ class Experiment:
 
     @property
     def stats(self):
-        """Calculate a stats dictionary for this particular experiment.
-
-        Returns
-        -------
-        stats : :py:class:`orion.core.worker.experiment.ExperimentStats`
+        """Calculate :py:class:`orion.core.worker.experiment.ExperimentStats` for this particular
+        experiment.
         """
         completed_trials = self.fetch_trials_by_status("completed")
 

--- a/src/orion/serving/experiments_resource.py
+++ b/src/orion/serving/experiments_resource.py
@@ -91,4 +91,4 @@ def _retrieve_best_trial(experiment: Experiment) -> Optional[Trial]:
     if not experiment.stats:
         return None
 
-    return experiment.get_trial(uid=experiment.stats["best_trials_id"])
+    return experiment.get_trial(uid=experiment.stats.best_trials_id)

--- a/src/orion/serving/responses.py
+++ b/src/orion/serving/responses.py
@@ -63,15 +63,14 @@ def build_experiment_response(
     -------
     A JSON-serializable experiment response object representing the given experiment.
     """
-    return {
+
+    data = {
         "name": experiment.name,
         "version": experiment.version,
         "status": status,
-        "trialsCompleted": experiment.stats["trials_completed"]
-        if experiment.stats
-        else 0,
-        "startTime": str(experiment.stats["start_time"]) if experiment.stats else None,
-        "endTime": str(experiment.stats["finish_time"]) if experiment.stats else None,
+        "trialsCompleted": 0,
+        "startTime": None,
+        "endTime": None,
         "user": experiment.metadata["user"],
         "orionVersion": experiment.metadata["orion_version"],
         "config": {
@@ -82,6 +81,14 @@ def build_experiment_response(
         },
         "bestTrial": build_trial_response(best_trial) if best_trial else {},
     }
+
+    stats = experiment.stats
+    if stats:
+        data["trialsCompleted"] = stats.trials_completed
+        data["startTime"] = str(stats.start_time)
+        data["endTime"] = str(stats.finish_time)
+
+    return data
 
 
 def build_experiments_response(experiments: dict):

--- a/tests/functional/example/test_scikit_learn.py
+++ b/tests/functional/example/test_scikit_learn.py
@@ -62,5 +62,5 @@ def test_result_reproducibility(monkeypatch):
     )
 
     experiment = create_experiment(name="scikit-iris-tutorial")
-    assert "best_evaluation" in experiment.stats
-    assert experiment.stats["best_evaluation"] == 0.6666666666666667
+    assert experiment.stats is not None
+    assert experiment.stats.best_evaluation == 0.6666666666666667

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -21,6 +21,7 @@ from orion.core.utils.format_terminal import (
     format_title,
     get_trial_params,
 )
+from orion.core.worker.experiment import ExperimentStats
 from orion.core.worker.trial import Trial
 
 
@@ -564,7 +565,7 @@ def test_get_trial_params(dummy_trial):
 def test_format_stats(dummy_trial):
     """Test stats section formatting"""
     experiment = DummyExperiment()
-    experiment.stats = dict(
+    experiment.stats = ExperimentStats(
         best_trials_id="dummy",
         trials_completed=10,
         best_evaluation=0.1,
@@ -647,7 +648,7 @@ def test_format_info(algorithm_dict, dummy_trial):
     adapter.configuration = dict(adummy="dict", foran="adapter")
 
     experiment.refers = dict(adapter=adapter)
-    experiment.stats = dict(
+    experiment.stats = ExperimentStats(
         best_trials_id="dummy",
         trials_completed=10,
         best_evaluation=0.1,

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -553,13 +553,12 @@ def test_experiment_stats():
         exp._id = cfg.trials[0]["experiment"]
         exp.metadata = {"datetime": datetime.datetime.utcnow()}
         stats = exp.stats
-        assert stats["trials_completed"] == NUM_COMPLETED
-        assert stats["best_trials_id"] == cfg.trials[3]["_id"]
-        assert stats["best_evaluation"] == 0
-        assert stats["start_time"] == exp.metadata["datetime"]
-        assert stats["finish_time"] == cfg.trials[0]["end_time"]
-        assert stats["duration"] == stats["finish_time"] - stats["start_time"]
-        assert len(stats) == 6
+        assert stats.trials_completed == NUM_COMPLETED
+        assert stats.best_trials_id == cfg.trials[3]["_id"]
+        assert stats.best_evaluation == 0
+        assert stats.start_time == exp.metadata["datetime"]
+        assert stats.finish_time == cfg.trials[0]["end_time"]
+        assert stats.duration == stats.finish_time - stats.start_time
 
 
 def test_experiment_pickleable():


### PR DESCRIPTION
The custom section of the docstring was causing issues when compiling
the documentation. Also returning a generic dict was not ideal, creating
a dataclass instead provides better documentation and interface for the
users.