### PR TITLE
Fix parsing of hps with "." in name from commandline

### DIFF
--- a/src/orion/core/io/cmdline_parser.py
+++ b/src/orion/core/io/cmdline_parser.py
@@ -91,7 +91,6 @@ class CmdlineParser(object):
         # Arguments with spaces are broken if we use ' '.join(template).format().split(' ').
         # Hence we iterate over the list as-is and format on each item separately.
         formatted = []
-        item: str
         for item in self.template:
             if item.startswith("-"):
                 formatted.append(item)

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -24,6 +24,7 @@ from collections import OrderedDict, defaultdict
 
 from orion.core.io.cmdline_parser import CmdlineParser
 from orion.core.io.convert import infer_converter_from_file_type
+from orion.core.utils.flatten import flatten
 
 log = logging.getLogger(__name__)
 
@@ -507,7 +508,7 @@ class OrionCmdlineParser:
     def _build_configuration(self, trial):
         configuration = copy.deepcopy(self.parser.arguments)
 
-        for name, value in trial.params.items():
+        for name, value in flatten(trial.params).items():
             name = name.lstrip("/")
             configuration[name] = value
 

--- a/tests/unittests/core/io/test_cmdline_parser.py
+++ b/tests/unittests/core/io/test_cmdline_parser.py
@@ -50,7 +50,7 @@ def basic_keys():
 @pytest.fixture
 def to_format():
     """Return a commandline to format"""
-    return "python 1 --arg value --args value1 value2 --boolean"
+    return "python 1 --arg value --args value1 value2 --boolean --a.b 123 --some:weird-arg_name 123"
 
 
 def test_key_to_arg():

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -212,6 +212,8 @@ def test_format_commandline_only(parser, commandline):
         "choices({'sgd': 0.2, 'adam': 0.8})",
         "--prior",
         "sgd",
+        "--a.b",
+        "0.5",
     ]
 
 

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -2,10 +2,14 @@
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.core.io.orion_cmdliner_parser`."""
 import os
+from pathlib import Path
+from typing import Any, List, NamedTuple, Optional, Tuple
 
 import pytest
+from orion.core.io.convert import JSONConverter
 
 from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
+from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial
 
 
@@ -27,31 +31,65 @@ def parser_diff_prefix():
     return OrionCmdlineParser(config_prefix="config2", allow_non_existing_files=True)
 
 
+class WeirdArgument(NamedTuple):
+    """NamedTuple that contains the fields used to construct a weird argument used in tests.
+
+    This is nicer than having the `weird_argument` fixture return a length-4 unnamed tuple.
+    """
+
+    name: str
+    prior_str: str
+    prior_type: str
+    value: Any
+
+
 @pytest.fixture(
-    params=[("some/weird:arg_value", "choices({{'a': 0.5, 'b': 0.5}})", "a")]
+    params=[
+        ("choices({{'a': 0.5, 'b': 0.5}})", "categorical", "a"),
+        ("uniform(0, 10, discrete=True)", "integer", "2"),
+        ("uniform(0, 10)", "real", "2.3"),
+    ]
 )
-def weird_argument_name_prior_and_value(request):
+def prior_and_prior_type_and_value(request):
+    """ Fixture that gives a prior str, the prior type, and a value. """
+    prior_str, prior_type, value = request.param
+    return prior_str, prior_type, value
+
+
+@pytest.fixture(
+    params=[
+        "name:with:colons",
+        "name.with.dots",
+        "name$with$dollars",
+        "name/with/slashes",
+        "name^with^weird",
+        "name^with_weird?!^%^&*()_+_)(*&^%$%^&*()_chars",
+    ]
+)
+def weird_argument(request, prior_and_prior_type_and_value: Tuple[str, str, str]):
     """ Fixture that provides a weird name, along with a prior and value. """
-    weird_param_name, prior, value = request.param
-    yield weird_param_name, prior, value
+    weird_param_name = request.param
+    prior_str, prior_type, value = prior_and_prior_type_and_value
+    return WeirdArgument(
+        name=weird_param_name, prior_str=prior_str, prior_type=prior_type, value=value
+    )
 
 
 @pytest.fixture
-def commandline(weird_argument_name_prior_and_value):
+def commandline(weird_argument: WeirdArgument):
     """Return a simple commandline list."""
-    weird_name, prior, _ = weird_argument_name_prior_and_value
     return [
         "--seed=555",
         "--lr~uniform(-3, 1)",
         "--non-prior=choices({{'sgd': 0.2, 'adam': 0.8}})",
         "--prior~choices({'sgd': 0.2, 'adam': 0.8})",
         "--a.b~uniform(0,1)",
-        f"--{weird_name}~{prior}",
+        f"--{weird_argument.name}~{weird_argument.prior_str}",
     ]
 
 
 @pytest.fixture
-def commandline_fluff(commandline):
+def commandline_fluff(commandline: List[str]):
     """Add extra useless info to commandline."""
     cmd_args = commandline.copy()
     cmd_args.extend(
@@ -61,7 +99,7 @@ def commandline_fluff(commandline):
 
 
 @pytest.fixture
-def cmd_with_properties(commandline):
+def cmd_with_properties(commandline: List[str]):
     """Add extra arguments that use `trial` and `exp` properties"""
     cmd_args = commandline.copy()
     cmd_args.extend(["--trial-name", "{trial.hash_name}", "--exp-name", "{exp.name}"])
@@ -69,7 +107,7 @@ def cmd_with_properties(commandline):
     return cmd_args
 
 
-def test_parse_from_yaml_config(parser, yaml_config):
+def test_parse_from_yaml_config(parser: OrionCmdlineParser, yaml_config: List[str]):
     """Parse from a yaml config only."""
     parser.parse(yaml_config)
     config = parser.priors
@@ -83,7 +121,7 @@ def test_parse_from_yaml_config(parser, yaml_config):
     assert "/something-same" in config
 
 
-def test_parse_from_json_config(parser, json_config):
+def test_parse_from_json_config(parser: OrionCmdlineParser, json_config: List[str]):
     """Parse from a json config only."""
     parser.parse(json_config)
     config = parser.priors
@@ -97,7 +135,9 @@ def test_parse_from_json_config(parser, json_config):
     assert "/something-same" in config
 
 
-def test_parse_from_unknown_config(parser, some_sample_config):
+def test_parse_from_unknown_config(
+    parser: OrionCmdlineParser, some_sample_config: List[str]
+):
     """Parse from a unknown config type only."""
     parser.parse(some_sample_config)
     config = parser.priors
@@ -111,7 +151,7 @@ def test_parse_from_unknown_config(parser, some_sample_config):
     assert "/something-same" in config
 
 
-def test_parse_equivalency(yaml_config, json_config):
+def test_parse_equivalency(yaml_config: List[str], json_config: List[str]):
     """Templates found from json and yaml are the same."""
     parser_yaml = OrionCmdlineParser(allow_non_existing_files=True)
     parser_yaml.parse(yaml_config)
@@ -124,7 +164,9 @@ def test_parse_equivalency(yaml_config, json_config):
 
 
 def test_parse_from_args_only(
-    parser, commandline_fluff, weird_argument_name_prior_and_value
+    parser: OrionCmdlineParser,
+    commandline_fluff: List[str],
+    weird_argument: WeirdArgument,
 ):
     """Parse a commandline."""
     cmd_args = commandline_fluff
@@ -136,8 +178,7 @@ def test_parse_from_args_only(
     assert "/lr" in parser.cmd_priors
     assert "/prior" in parser.cmd_priors
     assert "/a.b" in parser.cmd_priors
-    weird_name, _, _ = weird_argument_name_prior_and_value
-    assert f"/{weird_name}" in parser.cmd_priors
+    assert f"/{weird_argument.name}" in parser.cmd_priors
 
     assert parser.parser.template == [
         "--seed",
@@ -150,8 +191,8 @@ def test_parse_from_args_only(
         "{prior}",
         "--a.b",
         "{a.b}",
-        f"--{weird_name}",
-        f"{{{weird_name}}}",
+        f"--{weird_argument.name}",
+        f"{{{weird_argument.name}}}",
         "--some-path",
         "{some-path}",
         "--home-path",
@@ -161,7 +202,10 @@ def test_parse_from_args_only(
 
 
 def test_parse_from_args_and_config_yaml(
-    parser, commandline, yaml_config, weird_argument_name_prior_and_value
+    parser: OrionCmdlineParser,
+    commandline: List[str],
+    yaml_config: List[str],
+    weird_argument: WeirdArgument,
 ):
     """Parse both from commandline and config file."""
     cmd_args = yaml_config
@@ -181,8 +225,7 @@ def test_parse_from_args_and_config_yaml(
     assert "/something-same" in config
     assert "/a.b" in config
 
-    weird_name, _, _ = weird_argument_name_prior_and_value
-    assert f"/{weird_name}" in config
+    assert f"/{weird_argument.name}" in config
 
     template = parser.parser.template
     assert template == [
@@ -198,12 +241,14 @@ def test_parse_from_args_and_config_yaml(
         "{prior}",
         "--a.b",
         "{a.b}",
-        f"--{weird_name}",
-        f"{{{weird_name}}}",
+        f"--{weird_argument.name}",
+        f"{{{weird_argument.name}}}",
     ]
 
 
-def test_parse_finds_conflict(parser, commandline, yaml_config):
+def test_parse_finds_conflict(
+    parser: OrionCmdlineParser, commandline: List[str], yaml_config: List[str]
+):
     """Parse find conflicting declaration in commandline and config file."""
     cmd_args = yaml_config
     cmd_args.extend(commandline)
@@ -216,18 +261,21 @@ def test_parse_finds_conflict(parser, commandline, yaml_config):
 
 
 def test_format_commandline_only(
-    parser, commandline, weird_argument_name_prior_and_value
+    parser: OrionCmdlineParser, commandline: List[str], weird_argument: WeirdArgument
 ):
     """Format the commandline using only args."""
     parser.parse(commandline)
 
-    weird_name, prior, value = weird_argument_name_prior_and_value
     trial = Trial(
         params=[
             {"name": "/lr", "type": "real", "value": -2.4},
             {"name": "/prior", "type": "categorical", "value": "sgd"},
             {"name": "/a.b", "type": "real", "value": 0.5},
-            {"name": f"/{weird_name}", "type": "categorical", "value": value},
+            {
+                "name": f"/{weird_argument.name}",
+                "type": weird_argument.prior_type,
+                "value": weird_argument.value,
+            },
         ]
     )
 
@@ -243,25 +291,24 @@ def test_format_commandline_only(
         "sgd",
         "--a.b",
         "0.5",
-        f"--{weird_name}",
-        f"{value}",
+        f"--{weird_argument.name}",
+        f"{weird_argument.value}",
     ]
 
 
 def test_format_commandline_and_config(
-    parser,
-    commandline,
-    json_config,
-    tmpdir,
+    parser: OrionCmdlineParser,
+    commandline: List[str],
+    json_config: List[str],
+    tmp_path: Path,
     json_converter,
-    weird_argument_name_prior_and_value,
+    weird_argument: WeirdArgument,
 ):
     """Format the commandline and a configuration file."""
     cmd_args = json_config
     cmd_args.extend(commandline)
 
     parser.parse(cmd_args)
-    weird_name, prior, value = weird_argument_name_prior_and_value
     trial = Trial(
         params=[
             {"name": "/lr", "type": "real", "value": -2.4},
@@ -273,11 +320,15 @@ def test_format_commandline_and_config(
             {"name": "/training/mbs", "type": "integer", "value": 64},
             {"name": "/something-same", "type": "categorical", "value": "3"},
             {"name": "/a.b", "type": "real", "value": 0.3},
-            {"name": f"/{weird_name}", "type": "categorical", "value": value},
+            {
+                "name": f"/{weird_argument.name}",
+                "type": f"{weird_argument.prior_type}",
+                "value": weird_argument.value,
+            },
         ]
     )
 
-    output_file = str(tmpdir.join("output.json"))
+    output_file = str(tmp_path / "output.json")
 
     cmd_inst = parser.format(output_file, trial)
 
@@ -294,8 +345,8 @@ def test_format_commandline_and_config(
         "sgd",
         "--a.b",
         "0.3",
-        f"--{weird_name}",
-        f"{value}",
+        f"--{weird_argument.name}",
+        f"{weird_argument.value}",
     ]
 
     output_data = json_converter.parse(output_file)
@@ -312,20 +363,18 @@ def test_format_commandline_and_config(
 
 
 def test_format_without_config_path(
-    parser,
-    commandline,
-    json_config,
-    tmpdir,
-    json_converter,
-    weird_argument_name_prior_and_value,
+    parser: OrionCmdlineParser,
+    commandline: List[str],
+    json_config: List[str],
+    tmp_path: Path,
+    json_converter: JSONConverter,
+    weird_argument: WeirdArgument,
 ):
     """Verify that parser.format() raises ValueError when config path not passed."""
     cmd_args = json_config
     cmd_args.extend(commandline)
 
     parser.parse(cmd_args)
-
-    weird_name, prior, value = weird_argument_name_prior_and_value
 
     trial = Trial(
         params=[
@@ -337,7 +386,11 @@ def test_format_without_config_path(
             {"name": "/training/lr0", "type": "real", "value": 0.032},
             {"name": "/training/mbs", "type": "integer", "value": 64},
             {"name": "/something-same", "type": "categorical", "value": "3"},
-            {"name": f"/{weird_name}", "type": "categorical", "value": value},
+            {
+                "name": f"/{weird_argument.name}",
+                "type": "categorical",
+                "value": weird_argument.value,
+            },
         ]
     )
 
@@ -348,20 +401,26 @@ def test_format_without_config_path(
 
 
 def test_format_with_properties(
-    parser, cmd_with_properties, hacked_exp, weird_argument_name_prior_and_value
+    parser: OrionCmdlineParser,
+    cmd_with_properties: List[str],
+    hacked_exp: Experiment,
+    weird_argument: WeirdArgument,
 ):
     """Test if format correctly puts the value of `trial` and `exp` when used as properties"""
     parser.parse(cmd_with_properties)
     # NOTE: Also using a weird argument here, to make sure the parser is able to distinguish
     # property look-up vs weird argument names.
-    weird_name, prior, value = weird_argument_name_prior_and_value
 
     trial = Trial(
         experiment="trial_test",
         params=[
             {"name": "/lr", "type": "real", "value": -2.4},
             {"name": "/prior", "type": "categorical", "value": "sgd"},
-            {"name": f"/{weird_name}", "type": "categorical", "value": value},
+            {
+                "name": f"/{weird_argument.name}",
+                "type": weird_argument.prior_type,
+                "value": weird_argument.value,
+            },
         ],
     )
 
@@ -371,7 +430,9 @@ def test_format_with_properties(
     assert "supernaedo2-dendi" in cmd_line
 
 
-def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
+def test_configurable_config_arg(
+    parser_diff_prefix: OrionCmdlineParser, yaml_sample_path: str
+):
     """Parse from a yaml config only."""
     parser_diff_prefix.parse(["--config2", yaml_sample_path])
     config = parser_diff_prefix.priors
@@ -385,14 +446,14 @@ def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
     assert "/something-same" in config
 
 
-def test_infer_user_script(script_path):
+def test_infer_user_script(script_path: str):
     """Test that user script is infered correctly"""
     parser = OrionCmdlineParser()
     parser.parse(f"{script_path} and some args".split(" "))
     assert parser.user_script == script_path
 
 
-def test_infer_user_script_python(script_path):
+def test_infer_user_script_python(script_path: str):
     """Test that user script is infered correctly when using python"""
     parser = OrionCmdlineParser()
     parser.parse(f"python {script_path} and some args".split(" "))
@@ -412,7 +473,7 @@ def test_infer_user_script_when_missing():
     assert parser.user_script == "script.py"
 
 
-def test_configurable_config_arg_do_not_exist(script_path):
+def test_configurable_config_arg_do_not_exist(script_path: str):
     """Test that parser can handle command if config file does not exist"""
     parser = OrionCmdlineParser()
     command = f"python {script_path} --config idontexist.yaml".split(" ")
@@ -424,7 +485,9 @@ def test_configurable_config_arg_do_not_exist(script_path):
     parser.parse(command)
 
 
-def test_get_state_dict_before_parse(parser, commandline):
+def test_get_state_dict_before_parse(
+    parser: OrionCmdlineParser, commandline: List[str]
+):
     """Test getting state dict."""
     assert parser.get_state_dict() == {
         "parser": {"keys": [], "arguments": [], "template": []},
@@ -437,7 +500,9 @@ def test_get_state_dict_before_parse(parser, commandline):
     }
 
 
-def test_get_state_dict_after_parse_no_config_file(parser, commandline):
+def test_get_state_dict_after_parse_no_config_file(
+    parser: OrionCmdlineParser, commandline: List[str]
+):
     """Test getting state dict."""
     parser.parse(commandline)
 
@@ -452,7 +517,9 @@ def test_get_state_dict_after_parse_no_config_file(parser, commandline):
     }
 
 
-def test_get_state_dict_after_parse_with_config_file(parser, yaml_config, commandline):
+def test_get_state_dict_after_parse_with_config_file(
+    parser: OrionCmdlineParser, yaml_config: List[str], commandline: List[str]
+):
     """Test getting state dict."""
     cmd_args = yaml_config
     cmd_args.extend(commandline)
@@ -471,25 +538,25 @@ def test_get_state_dict_after_parse_with_config_file(parser, yaml_config, comman
 
 
 def test_set_state_dict(
-    parser,
-    commandline,
-    json_config,
-    tmpdir,
+    parser: OrionCmdlineParser,
+    commandline: List[str],
+    json_config: List[str],
+    tmp_path: Path,
     json_converter,
-    weird_argument_name_prior_and_value,
+    weird_argument: WeirdArgument,
 ):
     """Test that set_state_dict sets state properly to generate new config."""
     cmd_args = json_config
     cmd_args.extend(commandline)
 
-    parser.parse(cmd_args)
+    temp_parser: Optional[OrionCmdlineParser] = parser
+    assert temp_parser is not None
+    temp_parser.parse(cmd_args)
 
-    state = parser.get_state_dict()
-    parser = None
+    state = temp_parser.get_state_dict()
+    temp_parser = None
 
     blank_parser = OrionCmdlineParser(allow_non_existing_files=True)
-    weird_name, prior, value = weird_argument_name_prior_and_value
-
     blank_parser.set_state_dict(state)
 
     trial = Trial(
@@ -503,11 +570,15 @@ def test_set_state_dict(
             {"name": "/training/mbs", "type": "integer", "value": 64},
             {"name": "/something-same", "type": "categorical", "value": "3"},
             {"name": "/a.b", "type": "real", "value": 0.2},
-            {"name": f"/{weird_name}", "type": "categorical", "value": value},
+            {
+                "name": f"/{weird_argument.name}",
+                "type": weird_argument.prior_type,
+                "value": weird_argument.value,
+            },
         ]
     )
 
-    output_file = str(tmpdir.join("output.json"))
+    output_file = str(tmp_path / "output.json")
 
     cmd_inst = blank_parser.format(output_file, trial)
 
@@ -524,8 +595,8 @@ def test_set_state_dict(
         "sgd",
         "--a.b",
         "0.2",
-        f"--{weird_name}",
-        f"{value}",
+        f"--{weird_argument.name}",
+        f"{weird_argument.value}",
     ]
 
     output_data = json_converter.parse(output_file)

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Tuple
 
 import pytest
-from orion.core.io.convert import JSONConverter
 
+from orion.core.io.convert import JSONConverter
 from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.worker.experiment import Experiment
 from orion.core.worker.trial import Trial

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -2,11 +2,8 @@
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.core.io.orion_cmdliner_parser`."""
 import os
-import textwrap
-from typing import List
 
 import pytest
-from orion.core.cli.base import OrionArgsParser
 
 from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.worker.trial import Trial


### PR DESCRIPTION
Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>
# Description
Fixes #769 

# Checklist

## Tests
- [X] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
~~- [ ] I have updated the relevant documentation related to my changes~~

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [X] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)
