### PR TITLE
added test_user_script_crash test (#709)

### DIFF
--- a/tests/functional/commands/black_box_fail.py
+++ b/tests/functional/commands/black_box_fail.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""User script that exits with code given in argument."""
+import argparse
+import sys
+from xmlrpc.client import boolean
+
+
+def execute():
+    """Execute a simple pipeline as an example."""
+    # 1. Get the wanted exit code
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--exitcode", "-e", type=int, default=0, help="wanted exit code"
+    )
+    parser.add_argument(
+        "--crash", "-c", action="store_true", help="make a crash happen"
+    )
+    parser.add_argument("-x", type=float, required=True)
+    inputs = parser.parse_args()
+
+    # 2. if needed, crash !
+    if inputs.crash:
+        print("%b" % False)  # black_box_fail.py : this line should crash
+
+    # 3. exit with the wanted code
+    sys.exit(inputs.exitcode)
+
+
+if __name__ == "__main__":
+    execute()

--- a/tests/functional/commands/test_hunt_command.py
+++ b/tests/functional/commands/test_hunt_command.py
@@ -35,3 +35,26 @@ def test_no_name(capsys):
     captured = capsys.readouterr().err
 
     assert captured == "Error: No name provided for the experiment.\n"
+
+
+def test_user_script_crash(capfd):
+    """Checks that the Traceback of a crashing user script is output to stderr"""
+
+    orion.core.cli.main(
+        [
+            "--debug",
+            "hunt",
+            "-n",
+            "test",
+            "--exp-max-trials",
+            "1",
+            "./black_box_fail.py",
+            "-c",
+            "-x~uniform(-5,5)",
+        ]
+    )
+
+    out, err = capfd.readouterr()
+
+    assert "Traceback" in err
+    assert "# black_box_fail.py : this line should crash" in err


### PR DESCRIPTION

# Description
Detects if a by-design crashing black-box script Traceback is visible in the stderr output of orion.

The test succeeds, which indicates that the stacktrace is indeed visible by the user on his terminal output.

Is meant to implement issue #709 

# Changes
Just a test, since the behaviour is already good.
Added a "black box" utility script that can return a code passed by argument, and/or crash if -c argument is specified.

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
n/a