### PR TITLE
Add falcon-cors requirement to make orion server accept CORS requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup_args = dict(
         "pandas",
         "gunicorn",
         "falcon",
+        "falcon-cors",
         "scikit-learn",
         "psutil",
         "joblib",

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -9,6 +9,7 @@ Exposes a WSGI REST server application instance by subclassing ``falcon.API``.
 """
 
 import falcon
+from falcon_cors import CORS
 
 from orion.serving.experiments_resource import ExperimentsResource
 from orion.serving.plots_resources import PlotsResource
@@ -24,7 +25,17 @@ class WebApi(falcon.API):
     """
 
     def __init__(self, config=None):
-        super(WebApi, self).__init__()
+        # By default, server will reject requests coming from a server
+        # with different origin. E.g., if server is hosted at
+        # http://myorionserver.com, it won't accept an API call
+        # coming from a server not hosted at same address
+        # (e.g. a local installation at http://localhost)
+        # This is a Cross-Origin Resource Sharing (CORS) security:
+        # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
+        # To make server accept CORS requests, we need to use
+        # falcon-cors package: https://github.com/lwcolton/falcon-cors
+        cors = CORS(allow_all_origins=True)
+        super(WebApi, self).__init__(middleware=[cors.middleware])
         self.config = config
 
         setup_storage(config.get("storage"))

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -34,7 +34,7 @@ class WebApi(falcon.API):
         # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
         # To make server accept CORS requests, we need to use
         # falcon-cors package: https://github.com/lwcolton/falcon-cors
-        cors = CORS(allow_all_origins=True)
+        cors = CORS(allow_origins_list=["http://localhost:3000"])
         super(WebApi, self).__init__(middleware=[cors.middleware])
         self.config = config
 


### PR DESCRIPTION
# Description

Hi, @bouthilx ! I suggest this pull request to make orion server support CORS (cross-origin resource sharing) requests.

Currently, Orion will reject any API call made from a server located in a different address than himself. For example, if orion server is at `http://myorionserver.com`, and I make an API call from a local server (`http://localhost`), then API call won't work because servers addresses are different.

# Changes

This PR adds and uses Python package `falcon-cors`. I guess an orion server should be public, so `falcon-cors` currently makes server accepts requests from any other server. But, if necessary, we could later restrict allowed requests to a specific list of addresses.

I need this PR to make `orion-dashbord` API calls work correctly.

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [X] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [X] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [X] My code follows the style guidelines (`$ tox -e lint`)
