### PR TITLE
Add configuration `frontends` to list allowed frontends for Orion server

### DIFF
--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -55,6 +55,7 @@ def define_config():
     define_experiment_config(config)
     define_worker_config(config)
     define_evc_config(config)
+    define_frontends_config(config)
 
     config.add_option(
         "user_script_config",
@@ -71,6 +72,17 @@ def define_config():
     )
 
     return config
+
+
+def define_frontends_config(config):
+    """Create and define the field of frontends configuration."""
+    config.add_option(
+        "frontends",
+        option_type=list,
+        default=[],
+        env_var=None,
+        help="List of frontends addresses allowed to send requests to Orion server.",
+    )
 
 
 def define_storage_config(config):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -213,8 +213,9 @@ def fetch_config(args):
 
         local_config = unflatten(local_config)
 
+        backawrd_keys = ["storage", "experiment", "worker", "evc"]
         # For backward compatibility
-        for key in ["storage", "experiment", "worker", "evc"]:
+        for key in backawrd_keys:
             subkeys = list(global_config[key].keys())
 
             # Arguments that are only supported locally
@@ -240,6 +241,11 @@ def fetch_config(args):
                 if value is not None:
                     local_config.setdefault(key, {})
                     local_config[key][subkey] = value
+
+        # Keep other keys parsed from config file
+        for key in tmp_config.keys():
+            if key not in backawrd_keys:
+                local_config[key] = tmp_config[key]
 
     return local_config
 

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -34,7 +34,9 @@ class WebApi(falcon.API):
         # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
         # To make server accept CORS requests, we need to use
         # falcon-cors package: https://github.com/lwcolton/falcon-cors
-        cors = CORS(allow_origins_list=["http://localhost:3000"])
+        cors = CORS(
+            allow_origins_list=config.get("frontends", ["http://localhost:3000"])
+        )
         super(WebApi, self).__init__(middleware=[cors.middleware])
         self.config = config
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -319,6 +319,10 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
 
     assert evc_config == {}
 
+    # Test remaining config
+    assert config.pop("debug") is False
+    assert config.pop("frontends") == []
+
     # Confirm that all fields were tested.
     assert config == {}
 


### PR DESCRIPTION
# Description

Hi @bouthilx ! This PR should fix #779 . It allows to specify a list of accepted frontend addresses in YAML config file.

Currently, a unique allowed frontend is hardcoded (`http://localhost:3000`). But we will need to dynamically set frontends that can send requests to orion server, for e.g. if orion server and frontend are deployed at different addresses or unexpected ports.

# Changes

Code adds configuration entry `frontends` to YAML orion config file. `frontends` accepts a list of addresses.

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)
