### PR TITLE
(re) Fix parsing of hps with "." in name from commandline

### DIFF
--- a/src/orion/core/io/cmdline_parser.py
+++ b/src/orion/core/io/cmdline_parser.py
@@ -94,6 +94,18 @@ class CmdlineParser(object):
         for item in self.template:
             if item.startswith("-"):
                 formatted.append(item)
+            elif (
+                item.startswith("{")
+                and item.endswith("}")
+                and any(item == f"{{{key}}}" for key in configuration)
+            ):
+                # The argument has an entry with exactly matching name in the configuration.
+                # Extract it from the configuration, rather than try to use `str.format`.
+                # This solves bugs that arise from using strings that are invalid python expressions
+                # (e.g. names with ".", "/", or ":").
+                key = [key for key in configuration if item == f"{{{key}}}"][0]
+                value = configuration[key]
+                formatted.append(str(value))
             else:
                 formatted.append(item.format(**configuration))
 

--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -24,6 +24,7 @@ from collections import OrderedDict, defaultdict
 
 from orion.core.io.cmdline_parser import CmdlineParser
 from orion.core.io.convert import infer_converter_from_file_type
+from orion.core.utils.flatten import flatten
 
 log = logging.getLogger(__name__)
 
@@ -507,7 +508,7 @@ class OrionCmdlineParser:
     def _build_configuration(self, trial):
         configuration = copy.deepcopy(self.parser.arguments)
 
-        for name, value in trial.params.items():
+        for name, value in flatten(trial.params).items():
             name = name.lstrip("/")
             configuration[name] = value
 

--- a/tests/unittests/core/io/test_cmdline_parser.py
+++ b/tests/unittests/core/io/test_cmdline_parser.py
@@ -50,7 +50,7 @@ def basic_keys():
 @pytest.fixture
 def to_format():
     """Return a commandline to format"""
-    return "python 1 --arg value --args value1 value2 --boolean"
+    return "python 1 --arg value --args value1 value2 --boolean --a.b 123 --some:weird-arg_name 123"
 
 
 def test_key_to_arg():


### PR DESCRIPTION
New / improved  of #775 

- Fix parsing of arguments with "." in their name.
- Improve tests for OrionCmdlineParser