### PR TITLE
Check for lost processes and threads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,34 +13,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  pretest:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toxenv: [black, isort, pylint, doc8, docs]
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox -e ${{ matrix.toxenv }}
   test:
-    needs: pretest
     runs-on: ${{ matrix.platform }}
     strategy:
-      max-parallel: 4
+      fail-fast: false
+      max-parallel: 12
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7]
+        module_to_test: ['functional/algos', 'functional/benchmark', 'functional/branching', 'functional/client', 'functional/commands', 'functional/configuration', 'functional/core', 'functional/demo', 'functional/example', 'functional/parsing', 'functional/serving', 'unittests/algo', 'unittests/analysis', 'unittests/benchmark', 'unittests/client', 'unittests/core', 'unittests/executor', 'unittests/plotting', 'unittests/storage']
     env:
       PLATFORM: ${{ matrix.platform }}
+      MODULE_TO_TEST: ${{ matrix.module_to_test }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -62,7 +46,6 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
   mongodb:
-    needs: pretest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -91,9 +74,9 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
   backward-compatibility:
-    needs: pretest
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 2
       matrix:
         orion_db_type: [mongodb, pickleddb]
@@ -125,49 +108,3 @@ jobs:
         env_vars: PLATFORM,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: false
-  pypi:
-    needs: [test, backward-compatibility]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
-    - name: Test packaging
-      run: tox -e packaging
-    - name: Build
-      run: tox -e build
-    - name: Publish distribution 📦 to Test PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
-  conda:
-    needs: [test, backward-compatibility]
-    runs-on: ubuntu-latest
-    env:
-        ANACONDA_TOKEN: ${{ secrets.anaconda_token }}
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Build conda
-      run: ./conda/ci_build.sh
-    - name: Publish distribution 📦 to Conda
-      if: startsWith(github.ref, 'refs/tags')
-      run: ./conda/upload.sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,3 +393,45 @@ def random_dt(monkeypatch):
     """Make ``datetime.datetime.utcnow()`` return an arbitrary date."""
     with mocked_datetime(monkeypatch) as datetime:
         yield datetime.utcnow()
+
+
+@pytest.fixture(autouse=True)
+def ensure_no_lost_process(monkeypatch):
+    """Detect if a test did not close properly its sub-processes"""
+    from multiprocessing import Process
+
+    original_init = Process.__init__
+
+    processes = []
+
+    def mocked_init(self, *args, **kwargs):
+        processes.append(self)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(Process, "__init__", mocked_init)
+
+    yield
+
+    for process in processes:
+        assert not process.is_alive()
+
+
+@pytest.fixture(autouse=True)
+def ensure_no_lost_thread(monkeypatch):
+    """Detect if a test did not close properly its threads"""
+    from threading import Thread
+
+    original_init = Thread.__init__
+
+    threads = []
+
+    def mocked_init(self, *args, **kwargs):
+        threads.append(self)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(Thread, "__init__", mocked_init)
+
+    yield
+
+    for thread in threads:
+        assert not thread.is_alive()

--- a/tox.ini
+++ b/tox.ini
@@ -23,14 +23,14 @@ PLATFORM =
 description = Run tests with coverage with pytest under current Python env
 usedevelop = true
 setenv = COVERAGE_FILE=.coverage.{envname}
-passenv = CI
+passenv = CI MODULE_TO_TEST
 deps =
     -rtests/requirements.txt
     -rexamples/scikitlearn-iris/requirements.txt
     coverage
 commands =
     pip install -U {toxinidir}/tests/functional/gradient_descent_algo
-    coverage run --source=src --parallel-mode -m pytest --durations=50 --durations-min 1 -vv --ignore tests/functional/backward_compatibility --ignore tests/stress --timeout=180 {posargs}
+    coverage run --source=src --parallel-mode -m pytest --durations=50 --durations-min 1 -vv tests/{env:MODULE_TO_TEST:} --timeout=180 {posargs}
     coverage combine
     coverage report -m
     coverage xml


### PR DESCRIPTION
Many tests leave running processes or threads in the backgrounds. There
are both cause of tests randomly hanging and side-effects during other
tests latter on. We should verify at end of each tests that no processes
or threads are left running.

# NOTE

Commit for github-actions and tox.ini should be removed before merge. This is just to focus the CI on the faulty tests while I am still debugging. 