### PR TITLE
Revert "Add falcon-cors requirement to make orion server accept CORS requests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup_args = dict(
         "pandas",
         "gunicorn",
         "falcon",
-        "falcon-cors",
         "scikit-learn",
         "psutil",
         "joblib",

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -9,7 +9,6 @@ Exposes a WSGI REST server application instance by subclassing ``falcon.API``.
 """
 
 import falcon
-from falcon_cors import CORS
 
 from orion.serving.experiments_resource import ExperimentsResource
 from orion.serving.plots_resources import PlotsResource
@@ -25,17 +24,7 @@ class WebApi(falcon.API):
     """
 
     def __init__(self, config=None):
-        # By default, server will reject requests coming from a server
-        # with different origin. E.g., if server is hosted at
-        # http://myorionserver.com, it won't accept an API call
-        # coming from a server not hosted at same address
-        # (e.g. a local installation at http://localhost)
-        # This is a Cross-Origin Resource Sharing (CORS) security:
-        # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
-        # To make server accept CORS requests, we need to use
-        # falcon-cors package: https://github.com/lwcolton/falcon-cors
-        cors = CORS(allow_origins_list=["http://localhost:3000"])
-        super(WebApi, self).__init__(middleware=[cors.middleware])
+        super(WebApi, self).__init__()
         self.config = config
 
         setup_storage(config.get("storage"))


### PR DESCRIPTION
Reverts Epistimio/orion#778

This is to solve conda packaging for release v0.2.2.