### PR TITLE
Add config option `frontends_uri` to specify allowed frontend addresses for Orion Web API

### DIFF
--- a/conda/ci_build.sh
+++ b/conda/ci_build.sh
@@ -6,7 +6,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
-conda config --add channels notoraptor
+conda config --add channels mila-iqia
 conda config --set channel_priority strict
 
 pip uninstall -y setuptools

--- a/conda/ci_build.sh
+++ b/conda/ci_build.sh
@@ -6,6 +6,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
+conda config --add channels notoraptor
 conda config --set channel_priority strict
 
 pip uninstall -y setuptools

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - requests
     - pandas
     - falcon
+    - falcon-cors
     - gunicorn
     - scikit-learn
     - psutil

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup_args = dict(
         "pandas",
         "gunicorn",
         "falcon",
+        "falcon-cors",
         "scikit-learn",
         "psutil",
         "joblib",

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -32,10 +32,10 @@ del get_versions
 __descr__ = "Asynchronous [black-box] Optimization"
 __version__ = VERSIONS["version"]
 __license__ = "BSD-3-Clause"
-__author__ = u"Epistímio"
-__author_short__ = u"Epistímio"
+__author__ = "Epistímio"
+__author_short__ = "Epistímio"
 __author_email__ = "xavier.bouthillier@umontreal.ca"
-__copyright__ = u"2017-2022, Epistímio"
+__copyright__ = "2017-2022, Epistímio"
 __url__ = "https://github.com/epistimio/orion"
 
 DIRS = AppDirs(__name__, __author_short__)

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -55,6 +55,7 @@ def define_config():
     define_experiment_config(config)
     define_worker_config(config)
     define_evc_config(config)
+    define_frontends_uri_config(config)
 
     config.add_option(
         "user_script_config",
@@ -71,6 +72,31 @@ def define_config():
     )
 
     return config
+
+
+def define_frontends_uri_config(config):
+    """Create and define the field of frontends URI configuration."""
+
+    def parse_frontends_uri(data):
+        # Expect either a list of strings (URLs),
+        # or a string as comma-separated list of URLs
+        if isinstance(data, list):
+            return data
+        elif isinstance(data, str):
+            return [piece.strip() for piece in data.split(",")]
+        else:
+            raise RuntimeError(
+                f"frontends_uri: expected either a list of strings (URLs), "
+                f"or a string as comma-separated list of URLs, got {data}"
+            )
+
+    config.add_option(
+        "frontends_uri",
+        option_type=parse_frontends_uri,
+        default=[],
+        env_var="ORION_WEBAPI_FRONTENDS_URI",
+        help="List of frontends addresses allowed to send requests to Orion server.",
+    )
 
 
 def define_storage_config(config):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -213,8 +213,9 @@ def fetch_config(args):
 
         local_config = unflatten(local_config)
 
+        backward_keys = ["storage", "experiment", "worker", "evc"]
         # For backward compatibility
-        for key in ["storage", "experiment", "worker", "evc"]:
+        for key in backward_keys:
             subkeys = list(global_config[key].keys())
 
             # Arguments that are only supported locally
@@ -240,6 +241,11 @@ def fetch_config(args):
                 if value is not None:
                     local_config.setdefault(key, {})
                     local_config[key][subkey] = value
+
+        # Keep other keys parsed from config file
+        for key in tmp_config.keys():
+            if key not in backward_keys:
+                local_config[key] = tmp_config[key]
 
     return local_config
 

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -34,7 +34,10 @@ class WebApi(falcon.API):
         # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
         # To make server accept CORS requests, we need to use
         # falcon-cors package: https://github.com/lwcolton/falcon-cors
-        cors = CORS(allow_origins_list=["http://localhost:3000"])
+        frontends_uri = config["frontends_uri"] if "frontends_uri" in config else ["http://localhost:3000"]
+        cors = CORS(
+            allow_origins_list=frontends_uri
+        )
         super(WebApi, self).__init__(middleware=[cors.middleware])
         self.config = config
 

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -8,8 +8,9 @@ Exposes a WSGI REST server application instance by subclassing ``falcon.API``.
 
 """
 
-import falcon
 import logging
+
+import falcon
 from falcon_cors import CORS, CORSMiddleware
 
 from orion.serving.experiments_resource import ExperimentsResource
@@ -17,7 +18,6 @@ from orion.serving.plots_resources import PlotsResource
 from orion.serving.runtime import RuntimeResource
 from orion.serving.trials_resource import TrialsResource
 from orion.storage.base import setup_storage
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -43,10 +43,15 @@ class MyCORSMiddleware(CORSMiddleware):
     - https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
     - https://fr.wikipedia.org/wiki/Cross-origin_resource_sharing
     """
+
     def process_resource(self, req, resp, resource, *args):
         """Generate a 403 Forbidden response if response is not allowed."""
 
-        cors_resp_headers_before = [header for header in resp.headers if header.lower().startswith("access-control-")]
+        cors_resp_headers_before = [
+            header
+            for header in resp.headers
+            if header.lower().startswith("access-control-")
+        ]
         assert not cors_resp_headers_before, cors_resp_headers_before
 
         super().process_resource(req, resp, resource, *args)
@@ -55,13 +60,18 @@ class MyCORSMiddleware(CORSMiddleware):
         # If not, reponse is not allowed.
         # Special case: if request did not have an origin, it was certainly sent from
         # a browser (ie. not another server), so CORS is not relevant.
-        cors_resp_headers_after = [header for header in resp.headers if header.lower().startswith("access-control-")]
+        cors_resp_headers_after = [
+            header
+            for header in resp.headers
+            if header.lower().startswith("access-control-")
+        ]
         if not cors_resp_headers_after and req.get_header("origin"):
             raise falcon.HTTPForbidden()
 
 
 class MyCORS(CORS):
     """Subclass of falcon-cors CORS class to return a custom middleware."""
+
     @property
     def middleware(self):
         return MyCORSMiddleware(self)
@@ -83,11 +93,17 @@ class WebApi(falcon.API):
         # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
         # To make server accept CORS requests, we need to use
         # falcon-cors package: https://github.com/lwcolton/falcon-cors
-        frontends_uri = config["frontends_uri"] if "frontends_uri" in config else ["http://localhost:3000"]
-        logger.info("allowed frontends: {}".format(", ".join(frontends_uri) if frontends_uri else "(none)"))
-        cors = MyCORS(
-            allow_origins_list=frontends_uri
+        frontends_uri = (
+            config["frontends_uri"]
+            if "frontends_uri" in config
+            else ["http://localhost:3000"]
         )
+        logger.info(
+            "allowed frontends: {}".format(
+                ", ".join(frontends_uri) if frontends_uri else "(none)"
+            )
+        )
+        cors = MyCORS(allow_origins_list=frontends_uri)
         super(WebApi, self).__init__(middleware=[cors.middleware])
         self.config = config
 

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -9,6 +9,7 @@ Exposes a WSGI REST server application instance by subclassing ``falcon.API``.
 """
 
 import falcon
+from falcon_cors import CORS
 
 from orion.serving.experiments_resource import ExperimentsResource
 from orion.serving.plots_resources import PlotsResource
@@ -24,7 +25,17 @@ class WebApi(falcon.API):
     """
 
     def __init__(self, config=None):
-        super(WebApi, self).__init__()
+        # By default, server will reject requests coming from a server
+        # with different origin. E.g., if server is hosted at
+        # http://myorionserver.com, it won't accept an API call
+        # coming from a server not hosted at same address
+        # (e.g. a local installation at http://localhost)
+        # This is a Cross-Origin Resource Sharing (CORS) security:
+        # https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
+        # To make server accept CORS requests, we need to use
+        # falcon-cors package: https://github.com/lwcolton/falcon-cors
+        cors = CORS(allow_origins_list=["http://localhost:3000"])
+        super(WebApi, self).__init__(middleware=[cors.middleware])
         self.config = config
 
         setup_storage(config.get("storage"))

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -9,13 +9,62 @@ Exposes a WSGI REST server application instance by subclassing ``falcon.API``.
 """
 
 import falcon
-from falcon_cors import CORS
+import logging
+from falcon_cors import CORS, CORSMiddleware
 
 from orion.serving.experiments_resource import ExperimentsResource
 from orion.serving.plots_resources import PlotsResource
 from orion.serving.runtime import RuntimeResource
 from orion.serving.trials_resource import TrialsResource
 from orion.storage.base import setup_storage
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class MyCORSMiddleware(CORSMiddleware):
+    """Subclass of falcon-cors CORSMiddleware class.
+
+    Generate a HTTP 403 Forbidden response if request sender is not allowed
+    to access requested content.
+
+    Default middleware just prints a message in server side
+    (e.g. "Aborting response due to origin not allowed"), but still
+    sends content, so, a client ignoring headers might still access
+    data even if not allowed.
+
+    CORS middleware role is to add necessary "access-control-" headers to
+    response to mark it as allowed. So, a response lacking expected headers
+    after call to parent method `process_ressource()` can be considered
+    to not be delivered to request sender.
+
+    More info about CORS:
+    - https://developer.mozilla.org/fr/docs/Web/HTTP/CORS
+    - https://fr.wikipedia.org/wiki/Cross-origin_resource_sharing
+    """
+    def process_resource(self, req, resp, resource, *args):
+        """Generate a 403 Forbidden response if response is not allowed."""
+
+        cors_resp_headers_before = [header for header in resp.headers if header.lower().startswith("access-control-")]
+        assert not cors_resp_headers_before, cors_resp_headers_before
+
+        super().process_resource(req, resp, resource, *args)
+
+        # We then verify if some access control headers were added to response.
+        # If not, reponse is not allowed.
+        # Special case: if request did not have an origin, it was certainly sent from
+        # a browser (ie. not another server), so CORS is not relevant.
+        cors_resp_headers_after = [header for header in resp.headers if header.lower().startswith("access-control-")]
+        if not cors_resp_headers_after and req.get_header("origin"):
+            raise falcon.HTTPForbidden()
+
+
+class MyCORS(CORS):
+    """Subclass of falcon-cors CORS class to return a custom middleware."""
+    @property
+    def middleware(self):
+        return MyCORSMiddleware(self)
 
 
 class WebApi(falcon.API):
@@ -35,7 +84,8 @@ class WebApi(falcon.API):
         # To make server accept CORS requests, we need to use
         # falcon-cors package: https://github.com/lwcolton/falcon-cors
         frontends_uri = config["frontends_uri"] if "frontends_uri" in config else ["http://localhost:3000"]
-        cors = CORS(
+        logger.info("allowed frontends: {}".format(", ".join(frontends_uri) if frontends_uri else "(none)"))
+        cors = MyCORS(
             allow_origins_list=frontends_uri
         )
         super(WebApi, self).__init__(middleware=[cors.middleware])

--- a/tests/functional/serving/conftest.py
+++ b/tests/functional/serving/conftest.py
@@ -21,4 +21,11 @@ def client_with_frontends_uri():
     """Mock the falcon.API instance for testing with custom frontend_uri"""
     storage = {"type": "legacy", "database": {"type": "EphemeralDB"}}
     with OrionState(storage=storage):
-        yield testing.TestClient(WebApi({"storage": storage, "frontends_uri": ["http://123.456", "http://example.com"]}))
+        yield testing.TestClient(
+            WebApi(
+                {
+                    "storage": storage,
+                    "frontends_uri": ["http://123.456", "http://example.com"],
+                }
+            )
+        )

--- a/tests/functional/serving/conftest.py
+++ b/tests/functional/serving/conftest.py
@@ -14,3 +14,11 @@ def client():
     storage = {"type": "legacy", "database": {"type": "EphemeralDB"}}
     with OrionState(storage=storage):
         yield testing.TestClient(WebApi({"storage": storage}))
+
+
+@pytest.fixture()
+def client_with_frontends_uri():
+    """Mock the falcon.API instance for testing with custom frontend_uri"""
+    storage = {"type": "legacy", "database": {"type": "EphemeralDB"}}
+    with OrionState(storage=storage):
+        yield testing.TestClient(WebApi({"storage": storage, "frontends_uri": ["http://123.456", "http://example.com"]}))

--- a/tests/functional/serving/test_root.py
+++ b/tests/functional/serving/test_root.py
@@ -10,3 +10,52 @@ def test_runtime_summary(client):
     assert response.json["server"] == "gunicorn"
     assert response.json["database"] == "EphemeralDB"
     assert response.status == "200 OK"
+
+
+def test_cors_with_default_frontends_uri(client):
+    """Tests CORS with default frontends_uri"""
+
+    # No origin (e.g. from a browser), should pass
+    response = client.simulate_get("/")
+    assert response.status == "200 OK"
+
+    # Default origin, should pass
+    response = client.simulate_get("/", headers={"Origin": "http://localhost:3000"})
+    assert response.status == "200 OK"
+
+    # Any other origin should fail (even with same host but different port)
+
+    response = client.simulate_get("/", headers={"Origin": "http://localhost:4000"})
+    assert response.status == "403 Forbidden"
+
+    response = client.simulate_get("/", headers={"Origin": "http://localhost"})
+    assert response.status == "403 Forbidden"
+
+    response = client.simulate_get("/", headers={"Origin": "http://google.com"})
+    assert response.status == "403 Forbidden"
+
+
+def test_cors_with_custom_frontends_uri(client_with_frontends_uri):
+    """Tests CORS with custom frontends_uri"""
+
+    # No origin (e.g. from a browser), should pass
+    response = client_with_frontends_uri.simulate_get("/")
+    assert response.status == "200 OK"
+
+    # Allowed address, should pass
+    response = client_with_frontends_uri.simulate_get("/", headers={
+        "Origin": "http://123.456"})
+    assert response.status == "200 OK"
+
+    # Another allowed address, should pass
+    response = client_with_frontends_uri.simulate_get("/", headers={
+        "Origin": "http://example.com"})
+    assert response.status == "200 OK"
+
+    # Any other origin should fail
+
+    response = client_with_frontends_uri.simulate_get("/", headers={"Origin": "http://localhost"})
+    assert response.status == "403 Forbidden"
+
+    response = client_with_frontends_uri.simulate_get("/", headers={"Origin": "http://google.com"})
+    assert response.status == "403 Forbidden"

--- a/tests/functional/serving/test_root.py
+++ b/tests/functional/serving/test_root.py
@@ -43,19 +43,25 @@ def test_cors_with_custom_frontends_uri(client_with_frontends_uri):
     assert response.status == "200 OK"
 
     # Allowed address, should pass
-    response = client_with_frontends_uri.simulate_get("/", headers={
-        "Origin": "http://123.456"})
+    response = client_with_frontends_uri.simulate_get(
+        "/", headers={"Origin": "http://123.456"}
+    )
     assert response.status == "200 OK"
 
     # Another allowed address, should pass
-    response = client_with_frontends_uri.simulate_get("/", headers={
-        "Origin": "http://example.com"})
+    response = client_with_frontends_uri.simulate_get(
+        "/", headers={"Origin": "http://example.com"}
+    )
     assert response.status == "200 OK"
 
     # Any other origin should fail
 
-    response = client_with_frontends_uri.simulate_get("/", headers={"Origin": "http://localhost"})
+    response = client_with_frontends_uri.simulate_get(
+        "/", headers={"Origin": "http://localhost"}
+    )
     assert response.status == "403 Forbidden"
 
-    response = client_with_frontends_uri.simulate_get("/", headers={"Origin": "http://google.com"})
+    response = client_with_frontends_uri.simulate_get(
+        "/", headers={"Origin": "http://google.com"}
+    )
     assert response.status == "403 Forbidden"

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -321,7 +321,7 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
 
     # Test remaining config
     assert config.pop("debug") is False
-    assert config.pop("frontends") == []
+    assert config.pop("frontends_uri") == []
 
     # Confirm that all fields were tested.
     assert config == {}

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -319,6 +319,10 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
 
     assert evc_config == {}
 
+    # Test remaining config
+    assert config.pop("debug") is False
+    assert config.pop("frontends") == []
+
     # Confirm that all fields were tested.
     assert config == {}
 


### PR DESCRIPTION
# Description
Hi @bouthilx ! This is a pull request to wrap all changes related to CORS handling for Orion Web API. I will close other related pull requests so that we can focus only on this one.

This PR adds option `frontends_uri` to list allowed frontend addresses and add `falcon-cors` dependencies for PYPI (using original package) and conda (using conda package I built from PYPI package and uploaded on my anaconda repo)

# Changes

- Re-add changes reverted from https://github.com/Epistimio/orion/pull/792
- Add changes from https://github.com/bouthilx/orion/pull/4
  - Changes should fix https://github.com/Epistimio/orion/issues/793
  - Changes should resolve issue from https://github.com/Epistimio/orion/pull/780
- Add changes from https://github.com/Epistimio/orion/pull/782
  - Changes should fix https://github.com/Epistimio/orion/issues/779

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
_Please include any additional information or comment that you feel will be helpful to the review of this pull request._
