### PR TITLE
Simplify setting test phases in Test Classes

### DIFF
--- a/src/orion/testing/algo.py
+++ b/src/orion/testing/algo.py
@@ -8,7 +8,7 @@ import inspect
 import itertools
 import logging
 from collections import defaultdict
-from typing import Type, TypeVar
+from typing import ClassVar, NamedTuple, Type, TypeVar
 
 import numpy
 import pytest
@@ -112,6 +112,19 @@ def customized_mutate_example(search_space, rng, old_value, **kwargs):
     return new_value
 
 
+class TestPhase(NamedTuple):
+    name: str
+    """ Name of the test phase."""
+
+    n_trials: int
+    """ Number of trials after which the phase should begin."""
+
+    method_to_spy: str
+    """ Name of the algorithm's attribute to use to spy.
+    NOTE: need to clarify what exactly this is used for.
+    """
+
+
 class BaseAlgoTests:
     """Generic Test-suite for HPO algorithms.
 
@@ -134,6 +147,12 @@ class BaseAlgoTests:
     config = {}
     max_trials = 200
     space = {"x": "uniform(0, 1)", "y": "uniform(0, 1)"}
+
+    phases: ClassVar[list[TestPhase]]
+
+    def __init_subclass__(cls) -> None:
+        if hasattr(cls, "phases"):
+            cls.set_phases(cls.phases)
 
     @classmethod
     def set_phases(cls, phases):

--- a/tests/unittests/algo/pbt/test_pbt.py
+++ b/tests/unittests/algo/pbt/test_pbt.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.algo.random`."""
+from __future__ import annotations
+
+from typing import ClassVar
 
 import pytest
 from base import (
@@ -16,7 +19,7 @@ from orion.algo.pbt.pbt import PBT, compute_fidelities
 from orion.algo.space import Space
 from orion.core.worker.primary_algo import SpaceTransformAlgoWrapper
 from orion.core.worker.trial import Trial
-from orion.testing.algo import BaseAlgoTests, create_algo
+from orion.testing.algo import BaseAlgoTests, TestPhase, create_algo
 
 
 class TestComputeFidelities:
@@ -601,6 +604,12 @@ class TestGenericPBT(BaseAlgoTests):
     }
     space = {"x": "uniform(0, 1)", "y": "uniform(0, 1)", "f": "fidelity(1, 10, base=1)"}
 
+    phases: ClassVar[list[TestPhase]] = [
+        TestPhase("random", 5, "space.sample"),
+        TestPhase("generation_2", 2 * population_size, "_generate_offspring"),
+        TestPhase("generation_3", 3 * population_size, "_generate_offspring"),
+    ]
+
     def test_no_fidelity(self):
         space = self.create_space({"x": "uniform(0, 1)", "y": "uniform(0, 1)"})
 
@@ -660,12 +669,3 @@ class TestGenericPBT(BaseAlgoTests):
             check_population_size(gen_population_size, depth, expected_population_size)
 
             remaining_num = max(remaining_num - expected_population_size, 0)
-
-
-TestGenericPBT.set_phases(
-    [
-        ("random", 5, "space.sample"),
-        ("generation_2", 2 * population_size, "_generate_offspring"),
-        ("generation_3", 3 * population_size, "_generate_offspring"),
-    ]
-)

--- a/tests/unittests/algo/test_gridsearch.py
+++ b/tests/unittests/algo/test_gridsearch.py
@@ -1,6 +1,9 @@
 """Example usage and tests for :mod:`orion.algo.gridsearch`."""
+from __future__ import annotations
+
 import copy
 import logging
+from typing import ClassVar
 
 import numpy.testing
 import pytest
@@ -13,7 +16,7 @@ from orion.algo.gridsearch import (
     real_grid,
 )
 from orion.algo.space import Categorical, Integer, Real, Space
-from orion.testing.algo import BaseAlgoTests, phase
+from orion.testing.algo import BaseAlgoTests, TestPhase, phase
 
 
 def test_categorical_grid():
@@ -167,6 +170,7 @@ def test_build_grid_cannot_limit_size(caplog):
 class TestGridSearch(BaseAlgoTests):
     algo_name = "gridsearch"
     config = {"n_values": 10}
+    phases: ClassVar[list[TestPhase]] = [TestPhase("grid", 0, "suggest")]
 
     @phase
     def test_seed_rng_init(self, mocker, num, attr):
@@ -192,6 +196,3 @@ class TestGridSearch(BaseAlgoTests):
     @pytest.mark.skip(reason="Deterministic algorithm")
     def test_seed_rng(self, mocker, num, attr):
         pass
-
-
-TestGridSearch.set_phases([("grid", 0, "suggest")])

--- a/tests/unittests/algo/test_random.py
+++ b/tests/unittests/algo/test_random.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Example usage and tests for :mod:`orion.algo.random`."""
+from __future__ import annotations
+
+from typing import ClassVar
+
 import numpy
 import pytest
 
 from orion.algo.random import Random
 from orion.algo.space import Integer, Real, Space
-from orion.testing.algo import BaseAlgoTests
+from orion.testing.algo import BaseAlgoTests, TestPhase
 
 
 class TestRandomSearch(BaseAlgoTests):
     algo_name = "random"
     config = {"seed": 123456}
-
-
-TestRandomSearch.set_phases([("random", 0, "space.sample")])
+    phases: ClassVar[list[TestPhase]] = [TestPhase("random", 0, "space.sample")]

--- a/tests/unittests/algo/test_tpe.py
+++ b/tests/unittests/algo/test_tpe.py
@@ -26,7 +26,7 @@ from orion.core.utils import backward, format_trials
 from orion.core.worker.primary_algo import SpaceTransformAlgoWrapper, create_algo
 from orion.core.worker.transformer import build_required_space
 from orion.core.worker.trial import Trial
-from orion.testing.algo import BaseAlgoTests, phase
+from orion.testing.algo import BaseAlgoTests, TestPhase, phase
 
 
 @pytest.fixture()
@@ -775,6 +775,11 @@ class TestTPE(BaseAlgoTests):
         },
     }
 
+    phases: ClassVar[list[TestPhase]] = [
+        TestPhase("random", 0, "space.sample"),
+        TestPhase("bo", N_INIT + 1, "_suggest_bo"),
+    ]
+
     def test_suggest_init(self, mocker):
         algo = self.create_algo()
         spy = self.spy_phase(mocker, 0, algo, "space.sample")
@@ -933,6 +938,3 @@ class TestTPE(BaseAlgoTests):
 
         assert algo.n_observed == 1
         assert algo.n_suggested == 1
-
-
-TestTPE.set_phases([("random", 0, "space.sample"), ("bo", N_INIT + 1, "_suggest_bo")])


### PR DESCRIPTION
- Test phases can be directly set using the `phases` class attribute instead of having to call `TestMyAlgo.set_phases`.
- Also adds a `TestPhase` NamedTuple that gives a better description of each item, since the "raw" tuples are a little bit unintuitive IMO. 