### PR TITLE
Improve prior build error message

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -880,13 +880,13 @@ class Fidelity(Dimension):
     # pylint:disable=super-init-not-called
     def __init__(self, name, low, high, base=2):
         if low <= 0:
-            raise AttributeError("Minimum resources must be a positive number.")
+            raise ValueError("Minimum resources must be a positive number.")
         elif low > high:
-            raise AttributeError(
+            raise ValueError(
                 "Minimum resources must be smaller than maximum resources."
             )
         if base < 1:
-            raise AttributeError("Base should be greater than or equal to 1")
+            raise ValueError("Base should be greater than or equal to 1")
         self.name = name
         self.low = int(low)
         self.high = int(high)

--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -193,6 +193,16 @@ class DimensionBuilder(object):
         klass = _real_or_int(kwargs)
         return klass(name, "reciprocal", *args, **kwargs)
 
+    def _build_custom(self, expression, globals_, locals_):
+        name = expression.split("(")[0]
+        if not hasattr(self, name):
+            return None
+        try:
+            dimension = eval("self." + expression, globals_, {"self": self})
+            return dimension
+        except AttributeError as error:
+            raise AttributeError(f"Parameter '{name}': {error}") from error
+
     def _build(self, name, expression):
         """Build a `Dimension` object using a string as its `name` and another
         string, `expression`, from configuration as a "function" to create it.
@@ -205,12 +215,10 @@ class DimensionBuilder(object):
         import numpy as np
 
         globals_["np"] = np
-        try:
-            dimension = eval("self." + expression, globals_, {"self": self})
-
+        locals_ = {"self": self}
+        dimension = self._build_custom(expression, globals_, locals_)
+        if dimension is not None:
             return dimension
-        except AttributeError:
-            pass
 
         # If not found in the methods of `DimensionBuilder`.
         # try to see if it is legit scipy stuff and call a `Dimension`

--- a/tests/unittests/core/io/test_space_builder.py
+++ b/tests/unittests/core/io/test_space_builder.py
@@ -127,6 +127,17 @@ class TestDimensionBuilder(object):
         assert "Parameter" in str(exc.value)
         assert "size" in str(exc.value.__cause__)
 
+    def test_build_fails_because_of_invalid_arguments_for_custom_prior(
+        self, dimbuilder
+    ):
+        """Build fails because ValueError happens on init of builtin prior."""
+        with pytest.raises(ValueError) as exc:
+            dimbuilder.build("yolo2", "fidelity(0, 10, base=1)")
+        assert "Parameter" in str(exc.value)
+        assert "Minimum resources must be a positive number." in str(
+            exc.value.__cause__
+        )
+
     def test_build_gaussian(self, dimbuilder):
         """Check that gaussian/normal/norm is built into reciprocal correctly."""
         dim = dimbuilder.build("yolo", "gaussian(3, 5)")


### PR DESCRIPTION
If there is an error during the attempt of building a builtin prior
(methods implemented in SpaceBuilder), the builder assumes the
expression is not a builtin prior and then tries to create a scipy.stat
prior which also fails. The error message is then that the name of the
expression is not a valid prior. We should instead explicitly verify if
the name of the prior is one that is builtin and then try to build it
without silencing error messages. This way we get the correct error
message for the prior.