### PR TITLE
Add .pre-commit-config.yaml for local setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,10 +29,15 @@ repos:
     rev: v2.31.0
     hooks:
       - id: pyupgrade
-        # TODO: remove `--keep-runtime-typing` option
-        args: ["--py37-plus", "--keep-runtime-typing"]
+        args: ["--py37-plus"]
   - repo: https://github.com/PyCQA/autoflake
     rev: v1.4
     hooks:
       - id: autoflake
         args: ["--in-place", "--expand-star-imports", "--remove-all-unused-imports", "--ignore-init-module-imports"]
+
+  - repo: https://github.com/PyCQA/doc8
+    rev: 0.8.1
+    hooks:
+      - id: doc8
+        args: ["--max-line-length=100", "--file-encoding=utf-8"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+---
+repos:
+  - repo: https://github.com/python/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=nd,reacher,thist,ths,hist
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        args:
+          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503,E302,E704
+          - --max-complexity=30
+          - --max-line-length=456
+          - --show-source
+          - --statistics
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+      - id: pyupgrade
+        # TODO: remove `--keep-runtime-typing` option
+        args: ["--py37-plus", "--keep-runtime-typing"]
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: ["--in-place --expand-star-imports --remove-all-unused-imports --ignore-init-module-imports"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
     rev: v1.4
     hooks:
       - id: autoflake
-        args: ["--in-place --expand-star-imports --remove-all-unused-imports --ignore-init-module-imports"]
+        args: ["--in-place", "--expand-star-imports", "--remove-all-unused-imports", "--ignore-init-module-imports"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,6 +29,7 @@ recursive-include src *.py
 recursive-include tests *.py *.yaml *.json *.txt *.yml *.in LICENSE
 include tests/requirements.txt
 include .pre-commit-config.yaml
+include CITATION.bib
 
 # Include examples
 recursive-include examples *.md *.py *.pkl *.yaml *.ipynb */requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -28,6 +28,7 @@ prune docs/src/reference
 recursive-include src *.py
 recursive-include tests *.py *.yaml *.json *.txt *.yml *.in LICENSE
 include tests/requirements.txt
+include .pre-commit-config.yaml
 
 # Include examples
 recursive-include examples *.md *.py *.pkl *.yaml *.ipynb */requirements.txt

--- a/docs/src/developer/ci.rst
+++ b/docs/src/developer/ci.rst
@@ -33,6 +33,23 @@ If a step fails at any point in any environment, the build will be immediately s
 failed and reported to the pull request and repository. In such case, the maintainers and
 relevant contributors will be alerted.
 
+
+.. tip::
+
+   We recommend using `pre-commit`_ to validate your changes locally before they get committed.
+
+   This greatly reduces the turnaround time when working on a pull request by avoiding builds
+   failing due to the initial filters of the CI loop (black, isort, pylint, doc8, etc). It also
+   helps you to write modern python code by avoiding older syntax.
+
+   To get started with pre-commit, simply install and enable it like so:
+
+   .. code-block:: sh
+
+      $ pip install pre-commit
+      $ pre-commit install
+
+
 The workflow described above is also executed daily to detect any break due to change in
 dependencies. When releases are made, the workflow is also executed and additionally
 publish the release to PyPi_ and Conda_.
@@ -42,3 +59,4 @@ publish the release to PyPi_ and Conda_.
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _PyPI: https://pypi.org/project/orion/
 .. _Conda: https://anaconda.org/epistimio/orion
+.. _pre-commit: https://pre-commit.com/

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,7 @@ description = Use isort to check import orders
 basepython = python3
 skip_install = true
 deps =
-    isort == 5.6.*
+    isort == 5.10.1
 commands =
     isort --profile black -c src/orion/ tests/
 


### PR DESCRIPTION
Devs can optionally turn on pre-commit locally using:
```console
$ pip install pre-commit
$ pre-commit install
```

Then, the following actions are performed on the diff before it is committed locally:
- black: Reformat the code using black
- codespell: Check for spelling mistakes
- flake8: check for various code quality issues
- isort: sort imports
- pyupgrade: Remove outdated python syntax stuff from the code (e.g. super(thing, self), etc)
- autoflake: Remove unused imports

If any of the above hooks fail, the commit is interrupted, the differences get added as modifications, and the user can add them before the commit goes through.

It's really simple and convenient.

The only thing that I'm not 100% sure about is codespell, which I think might generate a bunch of false positives. Even then, it's always possible to just add words to the ignored words list, as needed.