### PR TITLE
Add CITATION.bib to make it easier to cite Orion

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,32 @@
+@software{xavier_bouthillier_2022_0_2_3,
+  author    = {Xavier Bouthillier and
+               Christos Tsirigotis and
+               François Corneau-Tremblay and
+               Thomas Schweizer and
+               Lin Dong and
+               Pierre Delaunay and
+               Fabrice Normandin and
+               Mirko Bronzi and
+               Dendi Suhubdy and
+               Reyhane Askari and
+               Michael Noukhovitch and
+               Chao Xue and
+               Satya Ortiz-Gagné and
+               Olivier Breuleux and
+               Arnaud Bergeron and
+               Olexa Bilaniuk and
+               Steven Bocco and
+               Hadrien Bertrand and
+               Guillaume Alain and
+               Dmitriy Serdyuk and
+               Peter Henderson and
+               Pascal Lamblin and
+               Christopher Beckham},
+  title     = {{Epistimio/orion: Asynchronous Distributed Hyperparameter Optimization}},
+  month     = mar,
+  year      = 2022,
+  publisher = {Zenodo},
+  version   = {v0.2.3},
+  doi       = {10.5281/zenodo.3478592},
+  url       = {https://doi.org/10.5281/zenodo.3478592}
+}


### PR DESCRIPTION
Based on the docs here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

This should generate a "Cite this repository" tab on the right of the GitHub page of Orion: [Like this](https://docs.github.com/assets/cb-230711/images/help/repository/citation-link.png)