### PR TITLE
Fix IndexError for freshly branched exp

### DIFF
--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -124,8 +124,9 @@ def parallel_coordinates(
     if df.empty:
         return go.Figure()
 
-    trial = experiment.fetch_trials_by_status(
-        "completed", with_evc_tree=with_evc_tree)[0]
+    trial = experiment.fetch_trials_by_status("completed", with_evc_tree=with_evc_tree)[
+        0
+    ]
 
     flattened_space = build_required_space(
         experiment.space, shape_requirement="flattened"
@@ -519,8 +520,9 @@ def regret(
     if df.empty:
         return fig
 
-    trial = experiment.fetch_trials_by_status(
-        "completed", with_evc_tree=with_evc_tree)[0]
+    trial = experiment.fetch_trials_by_status("completed", with_evc_tree=with_evc_tree)[
+        0
+    ]
 
     fig.add_scatter(
         y=df["objective"],

--- a/src/orion/plotting/backend_plotly.py
+++ b/src/orion/plotting/backend_plotly.py
@@ -124,7 +124,8 @@ def parallel_coordinates(
     if df.empty:
         return go.Figure()
 
-    trial = experiment.fetch_trials_by_status("completed")[0]
+    trial = experiment.fetch_trials_by_status(
+        "completed", with_evc_tree=with_evc_tree)[0]
 
     flattened_space = build_required_space(
         experiment.space, shape_requirement="flattened"
@@ -518,7 +519,8 @@ def regret(
     if df.empty:
         return fig
 
-    trial = experiment.fetch_trials_by_status("completed")[0]
+    trial = experiment.fetch_trials_by_status(
+        "completed", with_evc_tree=with_evc_tree)[0]
 
     fig.add_scatter(
         y=df["objective"],


### PR DESCRIPTION
# Description
The plotting backend functions fetch a trial of the experiment to infer the objective. For a freshly branched experiment that doesn't have trials yet, the trial list is empty. This results in an IndexError when the functions try to access the first element of the `fetch_trials_by_status()` calls [here](https://github.com/Epistimio/orion/blob/e13326d6453ed15c98e3f2ff7989c5ad1a4b7ccd/src/orion/plotting/backend_plotly.py#L127) and [here](https://github.com/Epistimio/orion/blob/e13326d6453ed15c98e3f2ff7989c5ad1a4b7ccd/src/orion/plotting/backend_plotly.py#L521). 

# Changes
This PR changes the `fetch_trials_by_status` calls to copy the plotting functions' `with_evc_tree` arguments to (optionally) fetch trials from prior versions of the experiment if the `with_evc_tree` flag is set to `True`.

# Checklist
Optional:
* [ ] Maybe add an error message if `not with_evc_tree` and the current experiment does not have trials yet that is shown instead of the IndexError.

## Tests
Didn't have time to run tests, sorry :/

## Documentation
N/A

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)