### PR TITLE
Hotfix for nevergrad tests

### DIFF
--- a/src/orion/testing/algo.py
+++ b/src/orion/testing/algo.py
@@ -6,7 +6,7 @@ import inspect
 import itertools
 import logging
 from dataclasses import dataclass, field
-from typing import ClassVar, Generic, Sequence, TypeVar
+from typing import ClassVar, Sequence, TypeVar
 
 import numpy
 import pytest
@@ -97,7 +97,11 @@ def last_phase_only(test):
     return pytest.mark.usefixtures("last_phase")(test)
 
 
-class BaseAlgoTests(Generic[AlgoType]):
+# NOTE: Can't make the test class generic in python 3.7, because it adds a __new__ constructor to
+# the type, which prevents it being collected.
+
+
+class BaseAlgoTests:
     """Generic Test-suite for HPO algorithms.
 
     This test-suite covers all typical cases for HPO algorithms. To use it for a new algorithm,

--- a/tests/unittests/algo/long/nevergrad/integration_test.py
+++ b/tests/unittests/algo/long/nevergrad/integration_test.py
@@ -1,4 +1,6 @@
 """Perform integration tests for `orion.algo.nevergrad`."""
+from __future__ import annotations
+
 from typing import Any, ClassVar
 
 import nevergrad as ng

--- a/tests/unittests/algo/pbt/test_pbt.py
+++ b/tests/unittests/algo/pbt/test_pbt.py
@@ -562,7 +562,7 @@ generations = 5
 
 
 @pytest.mark.usefixtures("no_shutil_copytree")
-class TestGenericPBT(BaseAlgoTests[PBT]):
+class TestGenericPBT(BaseAlgoTests):
     algo_name = "pbt"
     algo_type = PBT
     max_trials = population_size * generations

--- a/tests/unittests/algo/test_random.py
+++ b/tests/unittests/algo/test_random.py
@@ -9,7 +9,7 @@ from orion.algo.random import Random
 from orion.testing.algo import BaseAlgoTests
 
 
-class TestRandomSearch(BaseAlgoTests[Random]):
+class TestRandomSearch(BaseAlgoTests):
     """Tests for the Random algorithm."""
 
     algo_type: ClassVar[type[Random]] = Random


### PR DESCRIPTION
- Missing `from __future__ import annotations` at the top of `integration_test.py`
- Remove the Generic base for the test class, which prevented tests from being  collected in python 3.7
