### PR TITLE
[dashboard] Increase Axios timeout

### DIFF
--- a/dashboard/src/src/utils/queryServer.js
+++ b/dashboard/src/src/utils/queryServer.js
@@ -17,7 +17,7 @@ function makeRESTCall(path, parameters, resolve, reject) {
     responseType: 'json',
     responseEncoding: 'utf8',
     adapter: adapter,
-    timeout: 60000
+    timeout: 60000,
   };
   if (Object.keys(parameters).length) config.params = parameters;
   axios(config)

--- a/dashboard/src/src/utils/queryServer.js
+++ b/dashboard/src/src/utils/queryServer.js
@@ -17,6 +17,7 @@ function makeRESTCall(path, parameters, resolve, reject) {
     responseType: 'json',
     responseEncoding: 'utf8',
     adapter: adapter,
+    timeout: 60000
   };
   if (Object.keys(parameters).length) config.params = parameters;
   axios(config)


### PR DESCRIPTION
# Description

Hi @bouthilx . This is a fix to make Dashboard tests pass. I hope it will work.

# Changes

Increase timeout for axios to make API calls.

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)