### PR TITLE
[dashboard] Display trials for selected experiment in Database page

### DIFF
--- a/dashboard/src/src/__tests__/benchmark.test.js
+++ b/dashboard/src/src/__tests__/benchmark.test.js
@@ -280,6 +280,7 @@ test('Test sleep', async () => {
   await sleep(1000);
   let end = performance.now();
   let diff = end - start;
+  diff = Math.round(diff);
   console.log(diff);
   expect(diff).toBeGreaterThanOrEqual(1000);
   expect(diff).toBeLessThan(2000);
@@ -288,6 +289,8 @@ test('Test sleep', async () => {
   await sleep(2000);
   end = performance.now();
   diff = end - start;
+  // NB: got 1999.5901880000001 on a run.
+  diff = Math.round(diff);
   console.log(diff);
   expect(diff).toBeGreaterThanOrEqual(2000);
   expect(diff).toBeLessThan(3000);
@@ -296,6 +299,7 @@ test('Test sleep', async () => {
   await sleep(20000);
   end = performance.now();
   diff = end - start;
+  diff = Math.round(diff);
   console.log(diff);
   expect(diff).toBeGreaterThanOrEqual(20000);
   expect(diff).toBeLessThan(21000);

--- a/dashboard/src/src/__tests__/experiments.databasePage.test.js
+++ b/dashboard/src/src/__tests__/experiments.databasePage.test.js
@@ -88,7 +88,7 @@ test('Test if experiment trials are loaded', async () => {
     screen.queryByText(/0915da146c84975df9bdf4c3ee9376dc/)
   ).toBeInTheDocument();
 
-  // Select another experiment and check if plots are loaded
+  // Select another experiment and check if trials are loaded
   const anotherExperiment = await screen.findByText(/tpe-rosenbrock/);
   expect(anotherExperiment).toBeInTheDocument();
   fireEvent.click(anotherExperiment);

--- a/dashboard/src/src/__tests__/experiments.databasePage.test.js
+++ b/dashboard/src/src/__tests__/experiments.databasePage.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import App from '../App';
+import { render, fireEvent, screen } from '@testing-library/react';
+/* Use MemoryRouter to isolate history for each test */
+import { MemoryRouter } from 'react-router-dom';
+
+// Since I updated dependencies in package.json, this seems necessary.
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // deprecated
+      removeListener: jest.fn(), // deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+test('Test if experiment trials are loaded', async () => {
+  // Load page
+  render(<App />, { wrapper: MemoryRouter });
+  const experiment = await screen.findByText(
+    /2-dim-shape-exp/,
+    {},
+    { interval: 1000, timeout: 120000 }
+  );
+  expect(experiment).toBeInTheDocument();
+
+  // Switch to database page
+  const menu = screen.queryByTitle(/Go to experiments database/);
+  fireEvent.click(menu);
+  expect(
+    await screen.findByText(
+      /No trials to display, please select an experiment\./
+    )
+  ).toBeInTheDocument();
+
+  // Select an experiment
+  expect(experiment).toBeInTheDocument();
+  fireEvent.click(experiment);
+
+  // Check if trials are loaded
+  expect(
+    await screen.findByText(
+      /Experiment Trials for "2-dim-shape-exp"/,
+      {},
+      { interval: 1000, timeout: 120000 }
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(/0915da146c84975df9bdf4c3ee9376dc/)
+  ).toBeInTheDocument();
+
+  // Unselect experiment
+  const span = screen.queryByTitle(/unselect experiment '2-dim-shape-exp'/);
+  expect(span).toBeInTheDocument();
+  expect(span.tagName.toLowerCase()).toBe('span');
+  fireEvent.click(span);
+  expect(
+    await screen.findByText(
+      /No trials to display, please select an experiment\./
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      /Experiment Trials for "2-dim-shape-exp"/,
+      {},
+      { interval: 1000, timeout: 120000 }
+    )
+  ).toBeNull();
+  expect(screen.queryByText(/0915da146c84975df9bdf4c3ee9376dc/)).toBeNull();
+
+  // re-select experiment and check if trials are loaded
+  fireEvent.click(experiment);
+  expect(
+    await screen.findByText(
+      /Experiment Trials for "2-dim-shape-exp"/,
+      {},
+      { interval: 1000, timeout: 120000 }
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(/0915da146c84975df9bdf4c3ee9376dc/)
+  ).toBeInTheDocument();
+
+  // Select another experiment and check if plots are loaded
+  const anotherExperiment = await screen.findByText(/tpe-rosenbrock/);
+  expect(anotherExperiment).toBeInTheDocument();
+  fireEvent.click(anotherExperiment);
+  expect(
+    await screen.findByText(
+      /Experiment Trials for "tpe-rosenbrock"/,
+      {},
+      { interval: 1000, timeout: 120000 }
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(/20 trial\(s\) for experiment "tpe-rosenbrock"/)
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(/081134e84076d4c4aba210e88d0dce81/)
+  ).toBeInTheDocument();
+});

--- a/dashboard/src/src/experiments/content/DatabasePage/DatabasePage.js
+++ b/dashboard/src/src/experiments/content/DatabasePage/DatabasePage.js
@@ -1,6 +1,76 @@
 import React from 'react';
-
+import { Backend, DEFAULT_BACKEND } from '../../../utils/queryServer';
 import TrialTable from './TrialTable';
+import { BackendContext } from '../../BackendContext';
+import { Grid, Row, Column } from 'carbon-components-react';
+
+/**
+ * Component to pretty display an object (JSON dictionary) into data table.
+ * Used to render trial parameters and statistics.
+ */
+class ObjectToGrid extends React.Component {
+  render() {
+    const object = this.props.object;
+    const keys = Object.keys(object);
+    if (!keys.length) return '';
+    keys.sort();
+    return (
+      <Grid condensed fullWidth className="object-to-grid">
+        {keys.map(key => (
+          <Row key={key}>
+            <Column className="object-to-grid-key">
+              <strong>
+                <em>{key}</em>
+              </strong>
+            </Column>
+            <Column>
+              {Array.isArray(object[key])
+                ? object[key].map((value, i) => (
+                    <div key={i}>{value.toString()}</div>
+                  ))
+                : object[key].toString()}
+            </Column>
+          </Row>
+        ))}
+      </Grid>
+    );
+  }
+}
+
+/**
+ * Utility class to provide and cache experiment trials.
+ */
+class TrialsProvider {
+  constructor(address) {
+    this.backend = new Backend(address);
+    this.trials = {};
+  }
+  async get(experiment) {
+    if (!this.trials.hasOwnProperty(experiment)) {
+      const queryTrials = await this.backend.query(`trials/${experiment}`);
+      const trialIndices = queryTrials.map(trial => trial.id);
+      trialIndices.sort();
+      const trials = [];
+      for (let trialID of trialIndices) {
+        const trial = await this.backend.query(
+          `trials/${experiment}/${trialID}`
+        );
+        // Save parameters and statistics as already rendered components.
+        trial.parameters = <ObjectToGrid object={trial.parameters} />;
+        trial.statistics = <ObjectToGrid object={trial.statistics} />;
+        trials.push(trial);
+      }
+      this.trials[experiment] = trials;
+    }
+    return this.trials[experiment];
+  }
+}
+
+/**
+ * Singleton to provide experiment trials.
+ * @type {TrialsProvider}
+ */
+const TRIALS_PROVIDER = new TrialsProvider(DEFAULT_BACKEND);
 
 const headers = [
   {
@@ -8,78 +78,97 @@ const headers = [
     header: 'ID',
   },
   {
-    key: 'experiment',
-    header: 'Experiment',
+    key: 'submitTime',
+    header: 'Submit time',
   },
   {
-    key: 'status',
-    header: 'Status',
+    key: 'startTime',
+    header: 'Start time',
   },
   {
-    key: 'created_on',
-    header: 'Created',
+    key: 'endTime',
+    header: 'End time',
   },
   {
-    key: 'params',
+    key: 'parameters',
     header: 'Parameters',
   },
   {
     key: 'objective',
     header: 'Objective',
   },
-];
-
-const rows = [
   {
-    id: '1',
-    experiment: '1',
-    status: 'Completed',
-    created_on: '2020-12-01 05:05:05',
-    updatedAt: 'Date',
-    params: [],
-    results: [{ type: 'objective', name: 'loss', value: 1 }],
-  },
-  {
-    id: '2',
-    name: 'Repo 2',
-    createdAt: 'Date',
-    updatedAt: 'Date',
-    issueCount: '123',
-    stars: '456',
-    links: 'Links',
-  },
-  {
-    id: '3',
-    name: 'Repo 3',
-    createdAt: 'Date',
-    updatedAt: 'Date',
-    issueCount: '123',
-    stars: '456',
-    links: 'Links',
+    key: 'statistics',
+    header: 'Statistics',
   },
 ];
 
-const getRowItems = rows =>
-  rows.map(row => ({
-    ...row,
-    id: row.id,
-    experiment: row.experiment,
-    status: row.status,
-    created_on: new Date(row.created_on).toLocaleDateString(),
-    params: 'dunno',
-    objective: 'bad',
-  }));
-
-const DatabasePage = () => {
-  return (
-    <div className="bx--grid bx--grid--full-width bx--grid--no-gutter database-page">
-      <div className="bx--row database-page__r1">
-        <div className="bx--col-lg-16">
-          <TrialTable headers={headers} rows={getRowItems(rows)} />
+class DatabasePage extends React.Component {
+  // Control variable to avoid setting state if component was unmounted before an asynchronous API call finished.
+  _isMounted = false;
+  static contextType = BackendContext;
+  constructor(props) {
+    super(props);
+    this.state = { experiment: null, trials: null };
+  }
+  render() {
+    if (this.state.experiment === null)
+      return 'No trials to display, please select an experiment.';
+    if (this.state.trials === null)
+      return `Loading trials for experiment "${this.state.experiment}" ...`;
+    if (this.state.trials === false)
+      return `Unable to load trials for experiment "${this.state.experiment}".`;
+    return (
+      <div className="bx--grid bx--grid--full-width bx--grid--no-gutter database-page">
+        <div className="bx--row database-page__r1">
+          <div className="bx--col-lg-16">
+            <TrialTable
+              headers={headers}
+              rows={this.state.trials}
+              experiment={this.state.experiment}
+            />
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+  componentDidMount() {
+    this._isMounted = true;
+    const experiment = this.context.experiment;
+    if (experiment !== null) {
+      this.loadTrials(experiment);
+    }
+  }
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    // We must check if selected experiment changed
+    const experiment = this.context.experiment;
+    if (this.state.experiment !== experiment) {
+      if (experiment === null) {
+        this.setState({ experiment, trials: null });
+      } else {
+        this.loadTrials(experiment);
+      }
+    }
+  }
+  loadTrials(experiment) {
+    this.setState({ experiment, trials: null }, () => {
+      TRIALS_PROVIDER.get(experiment)
+        .then(trials => {
+          if (this._isMounted) {
+            this.setState({ trials });
+          }
+        })
+        .catch(error => {
+          console.error(error);
+          if (this._isMounted) {
+            this.setState({ trials: false });
+          }
+        });
+    });
+  }
+}
 
 export default DatabasePage;

--- a/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
+++ b/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
@@ -5,15 +5,12 @@ import {
   Table,
   TableHead,
   TableRow,
-  TableExpandHeader,
   TableHeader,
   TableBody,
-  TableExpandRow,
   TableCell,
-  TableExpandedRow,
 } from 'carbon-components-react';
 
-const TrialTable = ({ rows, headers }) => {
+const TrialTable = ({ rows, headers, experiment }) => {
   return (
     <DataTable
       rows={rows}
@@ -26,12 +23,11 @@ const TrialTable = ({ rows, headers }) => {
         getTableProps,
       }) => (
         <TableContainer
-          title="Experiment Trials"
-          description="Trials of selected experiments.">
+          title={`Experiment Trials for "${experiment}"`}
+          description={`${rows.length} trial(s) for experiment "${experiment}"`}>
           <Table {...getTableProps()}>
             <TableHead>
               <TableRow>
-                <TableExpandHeader />
                 {headers.map(header => (
                   <TableHeader {...getHeaderProps({ header })}>
                     {header.header}
@@ -41,16 +37,11 @@ const TrialTable = ({ rows, headers }) => {
             </TableHead>
             <TableBody>
               {rows.map(row => (
-                <React.Fragment key={row.id}>
-                  <TableExpandRow {...getRowProps({ row })}>
-                    {row.cells.map(cell => (
-                      <TableCell key={cell.id}>{cell.value}</TableCell>
-                    ))}
-                  </TableExpandRow>
-                  <TableExpandedRow colSpan={headers.length + 1}>
-                    <p>TODO: Trial detailed configuration</p>
-                  </TableExpandedRow>
-                </React.Fragment>
+                <TableRow key={row.id} {...getRowProps({ row })}>
+                  {row.cells.map(cell => (
+                    <TableCell key={cell.id}>{cell.value}</TableCell>
+                  ))}
+                </TableRow>
               ))}
             </TableBody>
           </Table>

--- a/dashboard/src/src/style.css
+++ b/dashboard/src/src/style.css
@@ -22,3 +22,10 @@ a.bx--header__menu-item.bx--header__menu-title[aria-label='experiments (selected
 a.bx--header__menu-item.bx--header__menu-title[aria-label='benchmarks (selected)'] {
   font-weight: bold;
 }
+.bx--grid.object-to-grid {
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+.bx--grid.object-to-grid .bx--col.object-to-grid-key {
+  padding-right: 0.5rem;
+}


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a PR to display experiment trials in database page.

# Changes

- Display trials for selected experiment in database page.
- Trials are displayed in a table.
- Trial parameters and statistics are displayed as a small table inside the trials table.
- A unit test is added and succeeds on my computer, tough there is not currently CI testing for dashboard.

# Checklist

## Tests
- [X] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)