### PR TITLE
Fix some documentation formatting

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -357,27 +357,27 @@ class Real(Dimension):
 
     Parameters
     ----------
-    name : str
-    prior : str
+    name: str
+    prior: str
        See Parameters of `Dimension.__init__()`.
-    args : list
-    kwargs : dict
+    args: list
+    kwargs: dict
        See Parameters of `Dimension.__init__()` for general.
 
     Notes
     -----
     Real kwargs (extra)
 
-    low : float
+    low: float
        Lower bound (inclusive), optional; default ``-numpy.inf``.
-    high : float:
+    high: float:
        Upper bound (inclusive), optional; default ``numpy.inf``.
        The upper bound must be inclusive because of rounding errors
        during optimization which may cause values to round exactly
        to the upper bound.
-    precision : int
+    precision: int
         Precision, optional; default ``4``.
-    shape : tuple
+    shape: tuple
        Defines how many dimensions are packed in this `Dimension`.
        Describes the shape of the corresponding tensor.
 
@@ -592,24 +592,24 @@ class Integer(Real, _Discrete):
 
     Parameters
     ----------
-    name : str
-    prior : str
+    name: str
+    prior: str
        See Parameters of `Dimension.__init__()`.
-    args : list
-    kwargs : dict
+    args: list
+    kwargs: dict
        See Parameters of `Dimension.__init__()` for general.
 
     Notes
     -----
     Real kwargs (extra)
 
-    low : float
+    low: float
        Lower bound (inclusive), optional; default ``-numpy.inf``.
-    high : float:
+    high: float:
        Upper bound (inclusive), optional; default ``numpy.inf``.
-    precision : int
+    precision: int
         Precision, optional; default ``4``.
-    shape : tuple
+    shape: tuple
        Defines how many dimensions are packed in this `Dimension`.
        Describes the shape of the corresponding tensor.
 

--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -364,8 +364,10 @@ class Real(Dimension):
     kwargs : dict
        See Parameters of `Dimension.__init__()` for general.
 
+    Notes
+    -----
     Real kwargs (extra)
-    -------------------
+
     low : float
        Lower bound (inclusive), optional; default ``-numpy.inf``.
     high : float:
@@ -597,8 +599,10 @@ class Integer(Real, _Discrete):
     kwargs : dict
        See Parameters of `Dimension.__init__()` for general.
 
+    Notes
+    -----
     Real kwargs (extra)
-    -------------------
+
     low : float
        Lower bound (inclusive), optional; default ``-numpy.inf``.
     high : float:

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -113,7 +113,7 @@ class Database(object):
     def index_information(self, collection_name):
         """Return dict of names and sorting order of indexes
 
-        Paramaters
+        Parameters
         ----------
         collection_name : str
            A collection inside database, a table.
@@ -131,7 +131,7 @@ class Database(object):
     def drop_index(self, collection_name, name):
         """Remove index from the database
 
-        Paramaters
+        Parameters
         ----------
         collection_name : str
            A collection inside database, a table.

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -22,17 +22,17 @@ class Database(object):
 
     Attributes
     ----------
-    host : str
+    host: str
        It can be either:
           1. Known hostname or IP address in which database server resides.
           2. URI: A database framework specific connection string.
-    name : str
+    name: str
        Name of database containing experiments.
-    port : int
+    port: int
        Port that database server listens to for requests.
-    username : str
+    username: str
         Name of user with write/read permissions to database with name `name`.
-    password : str
+    password: str
         Secret phrase of user, `username`.
 
     """
@@ -115,7 +115,7 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
 
         Returns
@@ -133,7 +133,7 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
         name: str
             Index name in the format {name}_{order}
@@ -147,11 +147,11 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
-        data : dict or list of dicts
+        data: dict or list of dicts
            New data that will **be inserted** or that will **update** entries.
-        query : dict, optional
+        query: dict, optional
            Assumes an update operation: filter entries in collection to be updated.
 
         Returns
@@ -183,11 +183,11 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
-        query : dict, optional
+        query: dict, optional
            Filter entries in collection.
-        selection : dict, optional
+        selection: dict, optional
            Elements of matched entries to return, the projection.
 
         Returns
@@ -208,13 +208,13 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
-        query : dict
+        query: dict
            Filter entries in collection.
-        data : dict or list of dicts
+        data: dict or list of dicts
            New data that will **update** the entry.
-        selection : dict, optional
+        selection: dict, optional
            Elements of matched entries to return, the projection.
 
         Returns
@@ -238,9 +238,9 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
-        query : dict
+        query: dict
            Filter entries in collection.
 
         """
@@ -252,9 +252,9 @@ class Database(object):
 
         Parameters
         ----------
-        collection_name : str
+        collection_name: str
            A collection inside database, a table.
-        query : dict
+        query: dict
            Filter entries in collection.
 
         Returns

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -91,8 +91,11 @@ class Experiment:
        Complete specification of the optimization and dynamical procedures taking
        place in this `Experiment`.
 
-    Metadata
-    --------
+    Notes
+    -----
+
+    The following list represents possible entries in the metadata dict.
+
     user : str
        System user currently owning this running process, the one who invoked **Oríon**.
     datetime : `datetime.datetime`

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -32,18 +32,18 @@ class ExperimentStats:
     """
     Parameters
     ----------
-    trials_completed : int
+    trials_completed: int
        Number of completed trials
-    best_trials_id : int
+    best_trials_id: int
        Unique identifier of the :class:`orion.core.worker.trial.Trial` object in the database
        which achieved the best known objective result.
-    best_evaluation : float
+    best_evaluation: float
        Evaluation score of the best trial
-    start_time : `datetime.datetime`
+    start_time: `datetime.datetime`
        When Experiment was first dispatched and started running.
-    finish_time : `datetime.datetime`
+    finish_time: `datetime.datetime`
        When Experiment reached terminating condition and stopped running.
-    duration : `datetime.timedelta`
+    duration: `datetime.timedelta`
        Elapsed time.
     """
 
@@ -61,21 +61,21 @@ class Experiment:
 
     Attributes
     ----------
-    name : str
+    name: str
        Unique identifier for this experiment per ``user``.
     id: object
        id of the experiment in the database if experiment is configured. Value is ``None``
        if the experiment is not configured.
-    refers : dict or list of `Experiment` objects, after initialization is done.
+    refers: dict or list of `Experiment` objects, after initialization is done.
        A dictionary pointing to a past `Experiment` id, ``refers[parent_id]``, whose
        trials we want to add in the history of completed trials we want to re-use.
        For convenience and database effiency purpose, all experiments of a common tree shares
        ``refers[root_id]``, with the root experiment refering to itself.
     version: int
         Current version of this experiment.
-    metadata : dict
+    metadata: dict
        Contains managerial information about this `Experiment`.
-    max_trials : int
+    max_trials: int
        How many trials must be evaluated, before considering this `Experiment` done.
        This attribute can be updated if the rest of the experiment configuration
        is the same. In that case, if trying to set to an already set experiment,
@@ -87,7 +87,7 @@ class Experiment:
        it will overwrite the previous one.
     space: Space
        Object representing the optimization space.
-    algorithms : `BaseAlgorithm` object or a wrapper.
+    algorithms: `BaseAlgorithm` object or a wrapper.
        Complete specification of the optimization and dynamical procedures taking
        place in this `Experiment`.
 
@@ -96,23 +96,23 @@ class Experiment:
 
     The following list represents possible entries in the metadata dict.
 
-    user : str
+    user: str
        System user currently owning this running process, the one who invoked **Oríon**.
-    datetime : `datetime.datetime`
+    datetime: `datetime.datetime`
        When was this particular configuration submitted to the database.
-    orion_version : str
+    orion_version: str
        Version of **Oríon** which suggested this experiment. `user`'s current
        **Oríon** version.
-    user_script : str
+    user_script: str
        Full absolute path to `user`'s executable.
-    user_args : list of str
+    user_args: list of str
        Contains separate arguments to be passed when invoking `user_script`,
        possibly templated for **Oríon**.
-    user_vcs : str, optional
+    user_vcs: str, optional
        User's version control system for this executable's code repository.
-    user_version : str, optional
+    user_version: str, optional
        Current user's repository version.
-    user_commit_hash : str, optional
+    user_commit_hash: str, optional
        Current `Experiment`'s commit hash for **Oríon**'s invocation.
 
     """

--- a/src/orion/core/worker/transformer.py
+++ b/src/orion/core/worker/transformer.py
@@ -772,8 +772,8 @@ class ReshapedDimension(TransformedDimension):
 class TransformedSpace(Space):
     """Wrap the :class:`orion.algo.space.Space` to support transformation methods.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     space: `orion.algo.space.Space`
        Original problem's definition of parameter space.
 
@@ -817,8 +817,8 @@ class TransformedSpace(Space):
 class ReshapedSpace(Space):
     """Wrap the `TransformedSpace` to support reshape methods.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     space: `orion.core.worker.TransformedSpace`
        Transformed version of the orinigal problem's definition of parameter space.
 

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -40,15 +40,15 @@ class Trial:
 
     Attributes
     ----------
-    experiment : str
+    experiment: str
        Unique identifier for the experiment that produced this trial.
        Same as an `Experiment._id`.
     id_override: str
         Trial id returned by the database. It should be unique for a given
         set of parameters
-    heartbeat : datetime.datetime
+    heartbeat: datetime.datetime
         Last time trial was identified as being alive.
-    status : str
+    status: str
        Indicates how this trial is currently being used. Can take the following
        values:
 
@@ -65,19 +65,19 @@ class Trial:
           of the worker process).
        * 'broken' : Indicates a trial that was not successfully evaluated for not
           expected reason.
-    worker : str
+    worker: str
        Corresponds to worker's unique id that handled this trial.
-    submit_time : `datetime.datetime`
+    submit_time: `datetime.datetime`
        When was this trial suggested?
-    start_time : `datetime.datetime`
+    start_time: `datetime.datetime`
        When was this trial first reserved?
-    end_time : `datetime.datetime`
+    end_time: `datetime.datetime`
        When was this trial evaluated successfully?
-    results : list of `Trial.Result`
+    results: list of `Trial.Result`
        List of evaluated metrics for this particular set of params. One and only
        one of them is necessarily an *objective* function value. The other are
        *constraints*, the value of an expression desired to be larger/equal to 0.
-    params : dict of params
+    params: dict of params
        Dict of suggested values for the `Experiment` parameter space.
        Consists a sample to be evaluated.
 
@@ -102,12 +102,12 @@ class Trial:
 
         Attributes
         ----------
-        name : str
+        name: str
            A possible named for the quality that this is quantifying.
-        type : str
+        type: str
            An identifier with semantic importance for **Oríon**. See
            `Param.type` and `Result.type`.
-        value : str or numerical
+        value: str or numerical
            value suggested for this dimension of the parameter space.
 
         """


### PR DESCRIPTION
# Description
Fix some formatting in the docs to avoid missing sections and weirdly formatted arguments list.

# Changes
1. Using custom section is bad because sphinx skips them and doesn't show anything in the rendered docs.
2. Typos in the section names are bad for the same reason.
3. `arg : type` renders as `argtype`
 `arg: type` renders as `arg: type`

# Checklist

## Tests
- [x] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x] I have updated the relevant documentation related to my changes

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
As a general comment, the docstrings seems to use at least two different markup standards (I have seen numpydoc and reST) often in the same file.

It would be good to standardize on one style and try to enforce it and it may help with odd formatting that may be caused by the doc parser getting confused by the different styles.