### PR TITLE
Fix bug with algo param_names

### DIFF
--- a/src/orion/algo/base.py
+++ b/src/orion/algo/base.py
@@ -115,11 +115,12 @@ class BaseAlgorithm:
         if kwargs:
             param_names = list(kwargs)
         else:
-            init_signature = inspect.signature(type(self))
+            init_signature = inspect.signature(type(self).__init__)
             param_names = [
                 name
                 for name, param in init_signature.parameters.items()
-                if name != "space" and param.kind != param.VAR_KEYWORD
+                if name not in ["self", "space"]
+                and param.kind not in [param.VAR_KEYWORD, param.VAR_POSITIONAL]
             ]
         self._param_names = param_names
         # Instantiate tunable parameters of an algorithm


### PR DESCRIPTION
Fixes a bug when inferring the param names (configuration keys) for algorithms that inherit from `typing.Generic`, in python 3.7.

In python 3.7, the Generic class has a metaclass (GenericMeta or something similar), and inspect.signature(type(self)) would give
the signature of the metaclass's `__call__` method, instead of the signature of the __init__ of the class.

Also fixed a bug whereby it would include "self" and "args" from *args into the param names.
This wasn't causing issues because we check if `self` has an attribute with the given name before including it in the configuration.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>
