### PR TITLE
[dashboard/DB page] Display only 7 first characters of trial ID in ID column.

### DIFF
--- a/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
+++ b/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
@@ -38,8 +38,12 @@ const TrialTable = ({ rows, headers, experiment }) => {
             <TableBody>
               {rows.map(row => (
                 <TableRow key={row.id} {...getRowProps({ row })}>
-                  {row.cells.map(cell => (
-                    <TableCell key={cell.id}>{cell.value}</TableCell>
+                  {row.cells.map((cell, cellIndex) => (
+                    <TableCell key={cell.id}>
+                      {cellIndex === 0 && cell.value.length > 7 ? (
+                        <span title={cell.value}>{cell.value.substr(0,7)}...</span>
+                      ) : cell.value}
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}

--- a/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
+++ b/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
@@ -41,8 +41,12 @@ const TrialTable = ({ rows, headers, experiment }) => {
                   {row.cells.map((cell, cellIndex) => (
                     <TableCell key={cell.id}>
                       {cellIndex === 0 && cell.value.length > 7 ? (
-                        <span title={cell.value}>{cell.value.substr(0,7)}...</span>
-                      ) : cell.value}
+                        <span title={cell.value}>
+                          {cell.value.substr(0, 7)}...
+                        </span>
+                      ) : (
+                        cell.value
+                      )}
                     </TableCell>
                   ))}
                 </TableRow>


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a PR to display only first characters of trial ID in trials table.

# Changes
- Display first 7 characters of a trail ID then 3 points
- Display full trial ID in a tooltip on mouseover

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)

# Further comments

Since I am still unable to fix timeout issue for dashboarc tests, I have not added unit tests for these changes here.