### PR TITLE
[dashboard/db page] DIsplay parameters in separated flattened columns after ID column

### DIFF
--- a/dashboard/src/src/__tests__/flattenObject.test.js
+++ b/dashboard/src/src/__tests__/flattenObject.test.js
@@ -1,0 +1,44 @@
+import { flattenObject } from '../utils/flattenObject';
+
+test('test flatten object', () => {
+  const input = {
+    a: 1,
+    b: {
+      ba: 'world',
+      bb: 1.5,
+      bc: {
+        bd: {
+          'a key': 333,
+          'another key': {
+            x: -1,
+            y: true,
+          },
+        },
+      },
+      bd: {
+        bff: 'abcdefgh',
+        orion: 'benchmarks',
+      },
+      be: 100,
+      bf: 'bf',
+    },
+    c: [10, '2a'],
+    d: 'hello',
+  };
+  const output = flattenObject(input);
+  console.log(output);
+  const keys = Object.keys(output);
+  expect(keys.length).toBe(12);
+  expect(output.hasOwnProperty('a')).toBeTruthy();
+  expect(output.hasOwnProperty('b.ba')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bb')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bc.bd.a key')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bc.bd.another key.x')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bc.bd.another key.y')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bd.bff')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bd.orion')).toBeTruthy();
+  expect(output.hasOwnProperty('b.be')).toBeTruthy();
+  expect(output.hasOwnProperty('b.bf')).toBeTruthy();
+  expect(output.hasOwnProperty('c')).toBeTruthy();
+  expect(output.hasOwnProperty('d')).toBeTruthy();
+});

--- a/dashboard/src/src/utils/flattenObject.js
+++ b/dashboard/src/src/utils/flattenObject.js
@@ -1,0 +1,19 @@
+function _flattenObject(inObj, outObj, prefix = '') {
+  if (prefix.length) {
+    prefix += '.';
+  }
+  for (let key of Object.keys(inObj)) {
+    const value = inObj[key];
+    if (value.constructor === Object) {
+      _flattenObject(value, outObj, prefix + key);
+    } else {
+      outObj[prefix + key] = value;
+    }
+  }
+}
+
+export function flattenObject(obj, prefix = '') {
+  const output = {};
+  _flattenObject(obj, output, prefix);
+  return output;
+}


### PR DESCRIPTION
# Description

Hi @bouthilx , this is a PR to display parameters in separated columns with flattened parameter names.

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)

# Further comments

Still don't know what to do with testing. I added a preliminary test for flatten function, but not for changes in trials table.