### PR TITLE
[dashboard/experiments/database] make columns sortable, except non-singleton array columns

### DIFF
--- a/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
+++ b/dashboard/src/src/experiments/content/DatabasePage/TrialTable.js
@@ -10,7 +10,7 @@ import {
   TableCell,
 } from 'carbon-components-react';
 
-const TrialTable = ({ rows, headers, experiment }) => {
+const TrialTable = ({ rows, headers, sortable, experiment }) => {
   return (
     <DataTable
       rows={rows}
@@ -28,8 +28,12 @@ const TrialTable = ({ rows, headers, experiment }) => {
           <Table {...getTableProps()}>
             <TableHead>
               <TableRow>
-                {headers.map(header => (
-                  <TableHeader {...getHeaderProps({ header })}>
+                {headers.map((header, indexHeader) => (
+                  <TableHeader
+                    {...getHeaderProps({
+                      header,
+                      isSortable: sortable[indexHeader],
+                    })}>
                     {header.header}
                   </TableHeader>
                 ))}


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a PR that allows to sort columns in experiment trials table.

# Changes

- Allow to sort by clicking on column header
- A parameter column can be sorted either if parameter is not an array, or is an array with only 1 element in all trials.

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)
