### PR TITLE
Downgrade pandas temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup_args = dict(
         "plotly",
         "kaleido",
         "requests",
-        "pandas",
+        "pandas<=1.4.4",
         "gunicorn",
         "falcon",
         "falcon-cors",


### PR DESCRIPTION
Latest pandas version (1.5.0) has a compatibility issue with ax. Downgrading to 1.4.4 until it is fixed in ax.