### PR TITLE
(WIP) Add command lines `orion db dump` and `orion db load`

### DIFF
--- a/src/orion/core/cli/db/dump.py
+++ b/src/orion/core/cli/db/dump.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# pylint: disable=too-few-public-methods
+"""
+Storage export tool
+===================
+
+Export database content into a file.
+
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+DESCRIPTION = "Export storage"
+
+
+def add_subparser(parser):
+    """Add the subparser that needs to be used for this command"""
+    serve_parser = parser.add_parser("dump", help=DESCRIPTION, description=DESCRIPTION)
+
+    serve_parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default=None,
+        help="Orion config file, used to open database",
+    )
+
+    serve_parser.add_argument(
+        "-e",
+        "--exp",
+        type=str,
+        default=None,
+        help="Experiment to dump (default: all experiments are exported)",
+    )
+
+    serve_parser.set_defaults(func=main)
+
+    return serve_parser
+
+
+def main(args):
+    """Starts an application server to serve http requests"""
+    print("Current args")
+    print(args)

--- a/src/orion/core/cli/db/dump.py
+++ b/src/orion/core/cli/db/dump.py
@@ -7,12 +7,77 @@ Storage export tool
 Export database content into a file.
 
 """
+import argparse
 import logging
+import os
+
+from orion.core.io import experiment_builder
+from orion.core.io.database.mongodb import MongoDB
+from orion.core.io.database.pickleddb import PickledDB
+from orion.storage.base import setup_storage
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 DESCRIPTION = "Export storage"
+
+
+def _dump_pickledb(orig_db, db, experiment=None):
+    """Dump data from a PickledDB orig_db to db"""
+    with orig_db.locked_database(write=False) as database:
+        collection_names = set(database._db.keys())
+        _dump(database, db, collection_names, experiment)
+
+
+def _dump_other_db(orig_db, db, experiment=None):
+    """Dump data from a non-PickledDB orig_db to db"""
+    if isinstance(orig_db, MongoDB):
+        collection_names = (data["name"] for data in orig_db._db.list_collections())
+    else:
+        collection_names = orig_db._db.keys()
+    _dump(orig_db, db, set(collection_names), experiment)
+
+
+def _dump(src_db, dst_db, collection_names, experiment=None):
+    """
+    Dump data from database to db.
+    :param src_db: input database
+    :param dst_db: output database
+    :param collection_names: set of collection names to dump
+    :param experiment: (optional) if provided, dump only
+        data related to experiment with this name
+    """
+    # Get collection names in a set
+    if experiment is None:
+        # Nothing to filter, dump everything
+        for collection_name in collection_names:
+            logger.info(f"Dumping collection {collection_name}")
+            data = src_db.read(collection_name)
+            dst_db.write(collection_name, data)
+    else:
+        # Get experiments with given name
+        assert "experiments" in collection_names
+        experiments = [d for d in src_db.read("experiments") if d["name"] == experiment]
+        logger.info(f"Found {len(experiments)} experiment(s) named {experiment}")
+        # Dump selected experiments
+        logger.info(f"Dumping experiment {experiment}")
+        dst_db.write("experiments", experiments)
+        # Do not dump other experiments
+        collection_names.remove("experiments")
+        # Dump data related to selected experiments
+        exp_indices = {exp["_id"] for exp in experiments}
+        for collection_name in sorted(collection_names):
+            logger.info(f"Dumping collection {collection_name}")
+            filtered_data = [
+                element
+                for element in src_db.read(collection_name)
+                if element.get("experiment", None) in exp_indices
+            ]
+            dst_db.write(collection_name, filtered_data)
+            logger.info(
+                f"Written {len(filtered_data)} filtered data "
+                f"for collection {collection_name}"
+            )
 
 
 def add_subparser(parser):
@@ -22,8 +87,8 @@ def add_subparser(parser):
     serve_parser.add_argument(
         "-c",
         "--config",
-        type=str,
-        default=None,
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
         help="Orion config file, used to open database",
     )
 
@@ -35,12 +100,32 @@ def add_subparser(parser):
         help="Experiment to dump (default: all experiments are exported)",
     )
 
+    serve_parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="dump.pkl",
+        help="Output file path (default: dump.pkl)",
+    )
+
     serve_parser.set_defaults(func=main)
 
     return serve_parser
 
 
 def main(args):
-    """Starts an application server to serve http requests"""
-    print("Current args")
-    print(args)
+    """Script to dump storage"""
+    dump_host = os.path.abspath(args["output"])
+    storage = setup_storage(experiment_builder.get_cmd_config(args).get("storage"))
+    orig_db = storage._db
+    logger.info(f"Loaded {orig_db}")
+    if isinstance(orig_db, PickledDB):
+        orig_host = os.path.abspath(orig_db.host)
+        if dump_host != orig_host:
+            logger.info(f"Dump to {dump_host}")
+            db = PickledDB(host=dump_host)
+            _dump_pickledb(orig_db, db, experiment=args["exp"])
+    else:
+        logger.info(f"Dump to {dump_host}")
+        db = PickledDB(host=dump_host)
+        _dump_other_db(orig_db, db, experiment=args["exp"])

--- a/src/orion/core/cli/db/load.py
+++ b/src/orion/core/cli/db/load.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# pylint: disable=too-few-public-methods
+"""
+Storage import tool
+===================
+
+Import database content from a file.
+
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+DESCRIPTION = "Import storage"
+
+
+def add_subparser(parser):
+    """Add the subparser that needs to be used for this command"""
+    serve_parser = parser.add_parser("load", help=DESCRIPTION, description=DESCRIPTION)
+
+    serve_parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default=None,
+        help="Orion config file, used to open database",
+    )
+
+    serve_parser.add_argument(
+        "-e",
+        "--exp",
+        type=str,
+        default=None,
+        help="Experiment to import (default: all experiments are imported)",
+    )
+
+    serve_parser.add_argument(
+        "file",
+        type=str,
+        help="File to import",
+    )
+
+    serve_parser.add_argument(
+        "-r",
+        "--resolve",
+        type=str,
+        choices=("ignore", "overwrite", "bump"),
+        required=True,
+        help="Strategy to resolve conflicts: "
+        "'ignore', 'overwrite' or 'bump' "
+        "(bump version of imported experiment). "
+        "When overwriting, prior trials will be deleted.",
+    )
+
+    serve_parser.set_defaults(func=main)
+
+    return serve_parser
+
+
+def main(args):
+    """Starts an application server to serve http requests"""
+    print("Current args")
+    print(args)

--- a/src/orion/core/cli/db/load.py
+++ b/src/orion/core/cli/db/load.py
@@ -7,7 +7,15 @@ Storage import tool
 Import database content from a file.
 
 """
+import argparse
 import logging
+import os
+import pprint
+
+from orion.core.io import experiment_builder
+from orion.core.io.database.mongodb import MongoDB
+from orion.core.io.database.pickleddb import PickledDB
+from orion.storage.base import setup_storage
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -22,8 +30,8 @@ def add_subparser(parser):
     serve_parser.add_argument(
         "-c",
         "--config",
-        type=str,
-        default=None,
+        type=argparse.FileType("r"),
+        metavar="path-to-config",
         help="Orion config file, used to open database",
     )
 
@@ -59,6 +67,119 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Starts an application server to serve http requests"""
-    print("Current args")
-    print(args)
+    """Script to import storage"""
+    experiment = args["exp"]
+    resolve = args["resolve"]
+    storage = setup_storage(experiment_builder.get_cmd_config(args).get("storage"))
+    dst_db = storage._db
+    logger.info(f"Loaded dst {dst_db}")
+    src_db = PickledDB(host=os.path.abspath(args["file"]))
+    logger.info(f"Loaded src {src_db}")
+    with src_db.locked_database(write=False) as src_database:
+        src_collection_names = set(src_database._db.keys())
+        if experiment is None:
+            # TODO How to manage collisions
+            for collection_name in src_database._db.keys():
+                data = src_database.read(collection_name)
+                logger.info(
+                    f"Importing collection {collection_name} " f"({len(data)} entries)"
+                )
+                dst_db.write(collection_name, data)
+        else:
+            logger.info(f"Filter experiment {experiment}")
+            # Get experiments with given name
+            assert "experiments" in src_collection_names
+            src_experiments = {
+                d["_id"]: d
+                for d in src_database.read("experiments")
+                if d["name"] == experiment
+            }
+            if not src_experiments:
+                logger.info(f"Experiment not found in src: {experiment}")
+                return
+
+            all_dst_experiments = dst_db.read("experiments")
+            dst_experiments = {
+                d["_id"]: d for d in all_dst_experiments if d["name"] == experiment
+            }
+            if resolve == "ignore" and dst_experiments:
+                # Found experiment name in src and dst.
+                # Ignore experiment.
+                logger.info(f"Experiment already in dst, ignored: {experiment}")
+                return
+
+            logger.info(
+                f"Found {len(src_experiments)} experiment(s) named {experiment}"
+            )
+            # Get data related to experiment
+            src_related_data = {
+                collection_name: [
+                    element
+                    for element in src_database.read(collection_name)
+                    if element.get("experiment", None) in src_experiments
+                ]
+                for collection_name in sorted(src_collection_names - {"experiments"})
+            }
+            if resolve == "overwrite":
+                if dst_experiments:
+                    logger.info(
+                        f"Overwrite {len(dst_experiments)} experiment(s) "
+                        f"named {experiment} in dst"
+                    )
+                    # We must remove experiment data in dst
+                    if isinstance(dst_db, MongoDB):
+                        dst_coll_names = {
+                            data["name"] for data in dst_db._db.list_collections()
+                        }
+                    elif isinstance(dst_db, PickledDB):
+                        with dst_db.locked_database(write=False) as dst_database:
+                            dst_coll_names = set(dst_database._db.keys())
+                    else:
+                        dst_coll_names = set(dst_db._db.keys())
+                    dst_related_data = {
+                        collection_name: [
+                            element
+                            for element in dst_db.read(collection_name)
+                            if element.get("experiment", None) in dst_experiments
+                        ]
+                        for collection_name in (dst_coll_names - {"experiments"})
+                    }
+                    dst_related_data["experiments"] = list(dst_experiments.values())
+                    for collection_name, collection_data in dst_related_data.items():
+                        for data in collection_data:
+                            dst_db.remove(collection_name, query={"_id": data["_id"]})
+            else:
+                logger.info(
+                    f"Bump {len(src_experiments)} experiment(s) "
+                    f"named {experiment} from src"
+                )
+                # resolve == "bump"
+                # Bump version and update experiment indices
+                next_id = (
+                    max((data["_id"] for data in all_dst_experiments), default=0) + 1
+                )
+                old_to_new_id = {}
+                for src_exp in src_experiments.values():
+                    old_to_new_id[src_exp["_id"]] = next_id
+                    next_id += 1
+                    src_exp["version"] += 1
+                    src_exp["_id"] = old_to_new_id[src_exp["_id"]]
+                for src_col_data in src_related_data.values():
+                    for element in src_col_data:
+                        if "experiment" in element:
+                            element["experiment"] = old_to_new_id[element["experiment"]]
+            # Then we can insert experiment data from src into dst
+            # Remove "_id" fields from data to insert
+            for coll_data in src_related_data.values():
+                for data in coll_data:
+                    del data["_id"]
+            # Add experiment to data to insert
+            # Keep "_id" as it is already updated
+            src_related_data["experiments"] = list(src_experiments.values())
+            pprint.pprint(src_related_data)
+            for collection_name, collection_data in src_related_data.items():
+                logger.info(
+                    f"Load {len(collection_data)} data "
+                    f"from collection {collection_name} to dst"
+                )
+                dst_db.write(collection_name, collection_data)


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a PR to fix #953 . Commands `orion db dump` and `orion db load` are added.

- `orion db dump` show already fully work
- `orion db load` should work with parameter `--exp`, and for full import if there is no ID collision.

TODO
- Make `orion db load` work when there is ID collision on full import.
- Add testing

# Changes

Add commands `orion db dump` and `orion db load`

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)
