### PR TITLE
Remove pandas version cap

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - plotly
     - python-kaleido
     - requests
-    - pandas <=1.4.4
+    - pandas
     - falcon
     - falcon-cors
     - gunicorn

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup_args = dict(
         "plotly",
         "kaleido",
         "requests",
-        "pandas<=1.4.4",
+        "pandas",
         "gunicorn",
         "falcon",
         "falcon-cors",


### PR DESCRIPTION
This was necessary because of an issue with Ax: https://github.com/Epistimio/orion/issues/999

But it is now fixed: https://github.com/facebook/Ax/releases/tag/0.2.8