### PR TITLE
reservation_timeout removed

### DIFF
--- a/docs/src/user/config.rst
+++ b/docs/src/user/config.rst
@@ -108,7 +108,7 @@ Full Example of Global Configuration
         heartbeat: 120
         interrupt_signal_code: 130
         max_broken: 10
-        reservation_timeout: 60
+        idle_timeout: 60
         max_trials: 1000000000
         user_script_config: config
 
@@ -365,7 +365,7 @@ Worker
         heartbeat: 120
         interrupt_signal_code: 130
         max_broken: 10
-        reservation_timeout: 60
+        idle_timeout: 60
         max_trials: 1000000000
         user_script_config: config
 
@@ -464,14 +464,14 @@ max_broken
     Maximum number of broken trials before worker stops.
 
 
-.. _config_worker_reservation_timeout:
+.. _config_worker_idle_timeout:
 
-reservation_timeout
+idle_timeout
 ~~~~~~~~~~~~~~~~~~~
 
 :Type: int
 :Default: 60
-:Env var: ORION_RESERVATION_TIMEOUT
+:Env var: ORION_IDLE_TIMEOUT
 :Description:
     Maximum time the experiment can spend trying to reserve a new suggestion. Such timeout are
     generally caused by slow database, large number of concurrent workers leading to many race
@@ -487,13 +487,13 @@ max_idle_time
 .. warning::
 
    **DEPRECATED.** This argument will be removed in v0.3.
-   Use :ref:`config_worker_reservation_timeout` instead.
+   Use :ref:`config_worker_idle_timeout` instead.
 
 :Type: int
 :Default: 60
 :Env var: ORION_MAX_IDLE_TIME
 :Description:
-    (DEPRECATED) This argument will be removed in v0.3. Use :ref:`config_worker_reservation_timeout`
+    (DEPRECATED) This argument will be removed in v0.3. Use :ref:`config_worker_idle_timeout`
     instead.
 
 

--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -149,7 +149,7 @@ def build_experiment(
         for each trial. Defaults to a temporary directory that is deleted at end of execution.
     max_idle_time: int, optional
         Deprecated and will be removed in v0.3.0.
-        Use experiment.workon(reservation_timeout) instead.
+        Use experiment.workon(idle_timeout) instead.
     heartbeat: int, optional
         Frequency (seconds) at which the heartbeat of the trial is updated.
         If the heartbeat of a `reserved` trial is larger than twice the configured
@@ -210,7 +210,7 @@ def build_experiment(
     """
     if max_idle_time:
         log.warning(
-            "max_idle_time is deprecated. Use experiment.workon(reservation_timeout) instead."
+            "max_idle_time is deprecated. Use experiment.workon(idle_timeout) instead."
         )
 
     builder = experiment_builder.ExperimentBuilder(storage, debug=debug)

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -45,10 +45,16 @@ def reserve_trial(
     experiment: Experiment,
     producer: Producer,
     pool_size: int,
+    timeout: int | None = None,
 ) -> Trial:
     """Reserve a new trial, or produce and reserve a trial if none are available."""
     log.debug("Trying to reserve a new trial to evaluate.")
-
+    
+    if timeout is not None:
+        log.warning(
+            "Reservation_timeout is deprecated and will be removed in v0.4.0."
+            "Use idle_timeout instead."
+        )
     trial = None
     produced = 0
 

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -45,7 +45,6 @@ def reserve_trial(
     experiment: Experiment,
     producer: Producer,
     pool_size: int,
-    timeout: int | None = None,
 ) -> Trial:
     """Reserve a new trial, or produce and reserve a trial if none are available."""
     log.debug("Trying to reserve a new trial to evaluate.")

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -50,12 +50,6 @@ def reserve_trial(
     """Reserve a new trial, or produce and reserve a trial if none are available."""
     log.debug("Trying to reserve a new trial to evaluate.")
 
-    if timeout is not None:
-        log.warning(
-            "Reservation_timeout is deprecated and will be removed in v0.4.0."
-            "Use idle_timeout instead."
-        )
-
     trial = None
     produced = 0
 
@@ -674,7 +668,6 @@ class ExperimentClient:
         fct: Callable,
         n_workers: int | None = None,
         pool_size: int = 0,
-        reservation_timeout: int | None = None,
         max_trials: int | None = None,
         max_trials_per_worker: int | None = None,
         max_broken: int | None = None,
@@ -703,12 +696,6 @@ class ExperimentClient:
             config if defined.  Increase it to improve the sampling speed if workers spend too much
             time waiting for algorithms to sample points. An algorithm will try sampling
             `pool_size` trials but may return less.
-        reservation_timeout: int, optional
-            Maximum time allowed to try reserving a trial. ReservationTimeout will be raised if
-            timeout is reached.  Such timeout are generally caused by slow database, large number
-            of concurrent workers leading to many race conditions or small search spaces with
-            integer/categorical dimensions that may be fully explored.
-            Defaults to ``orion.core.config.worker.reservation_timeout``.
         max_trials: int, optional
             Maximum number of trials to execute within ``workon``. If the experiment or algorithm
             reach status is_done before, the execution of ``workon`` terminates.
@@ -785,9 +772,6 @@ class ExperimentClient:
             pool_size = orion.core.config.worker.pool_size
         if not pool_size:
             pool_size = n_workers
-
-        if not reservation_timeout:
-            reservation_timeout = orion.core.config.worker.reservation_timeout
 
         if not idle_timeout:
             idle_timeout = orion.core.config.worker.idle_timeout

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -49,7 +49,7 @@ def reserve_trial(
 ) -> Trial:
     """Reserve a new trial, or produce and reserve a trial if none are available."""
     log.debug("Trying to reserve a new trial to evaluate.")
-    
+
     if timeout is not None:
         log.warning(
             "Reservation_timeout is deprecated and will be removed in v0.4.0."

--- a/src/orion/client/experiment.py
+++ b/src/orion/client/experiment.py
@@ -571,9 +571,7 @@ class ExperimentClient:
             raise CompletedExperiment("Experiment is done, cannot sample more trials.")
 
         try:
-            trial = reserve_trial(
-                self._experiment, self._producer, pool_size, timeout=None
-            )
+            trial = reserve_trial(self._experiment, self._producer, pool_size)
 
         except (ReservationRaceCondition, WaitingForTrials) as e:
             if self.is_broken:

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -301,29 +301,11 @@ def define_worker_config(config):
         env_var="ORION_MAX_IDLE_TIME",
         deprecate=dict(
             version="v0.3",
-            alternative="worker.reservation_timeout",
+            alternative="worker.idle_timeout",
             name="worker.max_idle_time",
         ),
         help=(
-            "This argument will be removed in v0.3.0. Use reservation_timeout instead."
-        ),
-    )
-
-    worker_config.add_option(
-        "reservation_timeout",
-        option_type=int,
-        default=60,
-        env_var="ORION_RESERVATION_TIMEOUT",
-        deprecate=dict(
-            version="v0.4",
-            alternative="worker.idle_timeout",
-            name="worker.reservation_timeout",
-        ),
-        help=(
-            "Maximum time the experiment can spend trying to reserve a new suggestion."
-            "Such timeout are generally caused by slow database, large number of "
-            "concurrent workers leading to many race conditions or small search spaces "
-            "with integer/categorical dimensions that may be fully explored."
+            "This argument will be removed in v0.3.0. Use idle_timeout instead."
         ),
     )
 

--- a/src/orion/core/__init__.py
+++ b/src/orion/core/__init__.py
@@ -304,9 +304,7 @@ def define_worker_config(config):
             alternative="worker.idle_timeout",
             name="worker.max_idle_time",
         ),
-        help=(
-            "This argument will be removed in v0.3.0. Use idle_timeout instead."
-        ),
+        help=("This argument will be removed in v0.3.0. Use idle_timeout instead."),
     )
 
     worker_config.add_option(

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -128,7 +128,6 @@ def workon(
     max_trials=None,
     max_broken=None,
     max_idle_time=None,
-    reservation_timeout=None,
     heartbeat=None,
     user_script_config=None,
     interrupt_signal_code=None,
@@ -140,8 +139,8 @@ def workon(
     """Try to find solution to the search problem defined in `experiment`."""
 
     # NOTE: Remove in v0.3.0
-    if max_idle_time is not None and reservation_timeout is None:
-        reservation_timeout = max_idle_time
+    if max_idle_time is not None and idle_timeout is None:
+        idle_timeout = max_idle_time
 
     consumer = Consumer(
         experiment,
@@ -165,7 +164,6 @@ def workon(
                 consumer,
                 n_workers=n_workers,
                 pool_size=pool_size,
-                reservation_timeout=reservation_timeout,
                 max_trials_per_worker=max_trials,
                 max_broken=max_broken,
                 trial_arg="trial",

--- a/tests/functional/configuration/test_all_options.py
+++ b/tests/functional/configuration/test_all_options.py
@@ -615,7 +615,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "heartbeat": 30,
             "max_trials": 10,
             "max_broken": 5,
-            "reservation_timeout": 16,
             "idle_timeout": 17,
             "max_idle_time": 15,
             "interrupt_signal_code": 131,
@@ -630,7 +629,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
         "ORION_HEARTBEAT": 40,
         "ORION_WORKER_MAX_TRIALS": 20,
         "ORION_WORKER_MAX_BROKEN": 6,
-        "ORION_RESERVATION_TIMEOUT": 17,
         "ORION_IDLE_TIMEOUT": 18,
         "ORION_MAX_IDLE_TIME": 16,
         "ORION_INTERRUPT_CODE": 132,
@@ -646,7 +644,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "heartbeat": 50,
             "max_trials": 30,
             "max_broken": 7,
-            "reservation_timeout": 17,
             "idle_timeout": 18,
             "max_idle_time": 16,
             "interrupt_signal_code": 133,
@@ -741,9 +738,7 @@ class TestWorkerConfig(ConfigurationTestSuite):
             == config["executor_configuration"]
         )
         assert self.workon_kwargs["pool_size"] == config["pool_size"]
-        assert (
-            self.workon_kwargs["reservation_timeout"] == config["reservation_timeout"]
-        )
+
         assert self.workon_kwargs["idle_timeout"] == config["idle_timeout"]
         assert self.workon_kwargs["max_trials"] == config["max_trials"]
         assert self.workon_kwargs["max_broken"] == config["max_broken"]
@@ -769,7 +764,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "heartbeat": self.env_vars["ORION_HEARTBEAT"],
             "max_trials": self.env_vars["ORION_WORKER_MAX_TRIALS"],
             "max_broken": self.env_vars["ORION_WORKER_MAX_BROKEN"],
-            "reservation_timeout": self.env_vars["ORION_RESERVATION_TIMEOUT"],
             "idle_timeout": self.env_vars["ORION_IDLE_TIMEOUT"],
             "max_idle_time": self.env_vars["ORION_MAX_IDLE_TIME"],
             "interrupt_signal_code": self.env_vars["ORION_INTERRUPT_CODE"],
@@ -811,7 +805,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
             "executor": self.cmdargs["executor"],
             "executor_configuration": {"threads_per_worker": 2},
             "pool_size": self.cmdargs["pool-size"],
-            "reservation_timeout": self.cmdargs["reservation-timeout"],
             "idle_timeout": self.cmdargs["idle-timeout"],
             "heartbeat": self.cmdargs["heartbeat"],
             "max_trials": self.cmdargs["worker-max-trials"],

--- a/tests/functional/configuration/test_all_options.py
+++ b/tests/functional/configuration/test_all_options.py
@@ -658,7 +658,6 @@ class TestWorkerConfig(ConfigurationTestSuite):
         "heartbeat": 70,
         "worker-max-trials": 0,
         "worker-max-broken": 8,
-        "reservation-timeout": 18,
         "idle-timeout": 19,
         "max-idle-time": 17,
         "interrupt-signal-code": 134,

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -165,13 +165,11 @@ class TestReservationFct:
             client,
         ):
 
-            timeout = 3
-
             # Make sure first it produces properly
             n_trials_before_reserve = len(client.fetch_trials())
             assert not client.is_done
 
-            reserve_trial(experiment, client._producer, pool_size=1, timeout=timeout)
+            reserve_trial(experiment, client._producer, pool_size=1)
 
             assert not client.is_done
             assert len(client.fetch_trials()) == n_trials_before_reserve + 1
@@ -183,9 +181,7 @@ class TestReservationFct:
             monkeypatch.setattr(client._producer, "produce", cant_produce)
 
             with pytest.raises(RuntimeError, match="I should not be called"):
-                reserve_trial(
-                    experiment, client._producer, pool_size=1, timeout=timeout
-                )
+                reserve_trial(experiment, client._producer, pool_size=1)
 
             # Now make sure the producer is not called and no additional trials are generated
             def make_exp_is_done(reserve):
@@ -200,9 +196,7 @@ class TestReservationFct:
             assert not client.is_done
 
             with pytest.raises(CompletedExperiment):
-                reserve_trial(
-                    experiment, client._producer, pool_size=1, timeout=timeout
-                )
+                reserve_trial(experiment, client._producer, pool_size=1)
 
             assert client.is_done
             assert len(client.fetch_trials()) == n_trials_before_reserve

--- a/tests/unittests/client/test_experiment_client.py
+++ b/tests/unittests/client/test_experiment_client.py
@@ -663,7 +663,7 @@ class TestSuggest:
             """Never suggest a new trial"""
             return []
 
-        monkeypatch.setattr(orion.core.config.worker, "reservation_timeout", -1)
+        monkeypatch.setattr(orion.core.config.worker, "idle_timeout", -1)
 
         with create_experiment(config, base_trial, statuses=["completed"]) as (
             cfg,

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -273,10 +273,7 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
     assert worker_config.pop("max_trials") == orion.core.config.worker.max_trials
     assert worker_config.pop("max_broken") == orion.core.config.worker.max_broken
     assert worker_config.pop("max_idle_time") == orion.core.config.worker.max_idle_time
-    assert (
-        worker_config.pop("idle_timeout")
-        == orion.core.config.worker.idle_timeout
-    )
+    assert worker_config.pop("idle_timeout") == orion.core.config.worker.idle_timeout
     assert worker_config.pop("idle_timeout") == orion.core.config.worker.idle_timeout
     assert (
         worker_config.pop("interrupt_signal_code")

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -116,7 +116,7 @@ def test_fetch_config_from_cmdargs():
         "worker_max_trials": "worker_max_trials",
         "worker_max_broken": "worker_max_broken",
         "max_idle_time": "max_idle_time",
-        "reservation_timeout": "reservation_timeout",
+        "idle_timeout": "idle_timeout",
         "interrupt_signal_code": "interrupt_signal_code",
         "user_script_config": "user_script_config",
         "manual_resolution": "manual_resolution",
@@ -150,7 +150,7 @@ def test_fetch_config_from_cmdargs():
     assert worker_config.pop("max_trials") == "worker_max_trials"
     assert worker_config.pop("max_broken") == "worker_max_broken"
     assert worker_config.pop("max_idle_time") == "max_idle_time"
-    assert worker_config.pop("reservation_timeout") == "reservation_timeout"
+    assert worker_config.pop("idle_timeout") == "idle_timeout"
     assert worker_config.pop("interrupt_signal_code") == "interrupt_signal_code"
     assert worker_config.pop("user_script_config") == "user_script_config"
 
@@ -274,8 +274,8 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
     assert worker_config.pop("max_broken") == orion.core.config.worker.max_broken
     assert worker_config.pop("max_idle_time") == orion.core.config.worker.max_idle_time
     assert (
-        worker_config.pop("reservation_timeout")
-        == orion.core.config.worker.reservation_timeout
+        worker_config.pop("idle_timeout")
+        == orion.core.config.worker.idle_timeout
     )
     assert worker_config.pop("idle_timeout") == orion.core.config.worker.idle_timeout
     assert (

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -274,7 +274,6 @@ def test_fetch_config_global_local_coherence(monkeypatch, config_file):
     assert worker_config.pop("max_broken") == orion.core.config.worker.max_broken
     assert worker_config.pop("max_idle_time") == orion.core.config.worker.max_idle_time
     assert worker_config.pop("idle_timeout") == orion.core.config.worker.idle_timeout
-    assert worker_config.pop("idle_timeout") == orion.core.config.worker.idle_timeout
     assert (
         worker_config.pop("interrupt_signal_code")
         == orion.core.config.worker.interrupt_signal_code


### PR DESCRIPTION
# Description
Removing the deprecated reservation_timeout, using idle_timeout instead. Solving Github issue [reservation_timeout extra warning](https://github.com/Epistimio/orion/issues/1010)._

# Changes

Changing reservation_timeout to idle_timout, or removing it if idle_timeout was already there.

# Checklist
## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ x] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ x] I have updated the relevant documentation related to my changes

## Quality
- [x ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ x] My code follows the style guidelines (`$ tox -e lint`)
