### PR TITLE
Add matplotlib dependency to pb2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ extras_require = {
         "ConfigSpace",
         "sspace @ git+https://github.com/Epistimio/sample-space.git@master#egg=sspace",
     ],
-    "pb2": ["GPy"],
+    "pb2": ["GPy", "matplotlib"],
     "nevergrad": ["nevergrad>=0.4.3.post10", "fcmaes", "pymoo"],
     "hebo": [
         "numpy",


### PR DESCRIPTION
GPy imports it all the time but does not list it as a dependency

See https://github.com/Epistimio/hydra_orion_sweeper/actions/runs/3330026395/jobs/5507981924#step:5:248