### PR TITLE
Adding Ray Backend

### DIFF
--- a/src/orion/executor/ray_backend.py
+++ b/src/orion/executor/ray_backend.py
@@ -1,0 +1,109 @@
+import traceback
+
+from orion.executor.base import (
+    AsyncException,
+    AsyncResult,
+    BaseExecutor,
+    ExecutorClosed,
+    Future,
+)
+
+try:
+    import ray
+
+    HAS_RAY = True
+except ImportError:
+    HAS_RAY = False
+
+
+class _Future(Future):
+    def __init__(self, future):
+        self.future = future
+        self.exception = None
+
+    def get(self, timeout=None):
+        if self.exception:
+            raise self.exception
+        try:
+            return ray.get(self.future,timeout=timeout)
+        except ray.exceptions.GetTimeoutError as e:
+            print(e)
+
+    def wait(self, timeout=None):
+        try:
+            ray.get(self.future, timeout = timeout)
+        except ray.exceptions.GetTimeoutError:
+            pass
+        except Exception as e:
+            self.exception = e
+
+    def ready(self):
+        return self.future.future().done()
+
+    def successful(self):
+        # Python 3.6 raise assertion error
+        if not self.ready():
+            raise ValueError()
+
+        return self.future.successful()
+
+
+class Ray(BaseExecutor):
+    def __init__(self, n_workers=-1, **config):
+        super().__init__(n_workers=n_workers)
+        
+        if not HAS_RAY:
+            raise ImportError("Ray must be installed to use Ray executor.")
+        self.config = config
+        ray.init()
+        print("Ray was initiated")
+    
+    def __getstate__(self):
+        return super().__getstate__()
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+
+    def __del__(self):
+        ray.shutdown()
+
+    def __enter__(self):
+        return self
+
+    def submit(self, function, *args, **kwargs):
+        try:
+            remote_g = ray.remote(function)
+            return _Future(remote_g.remote(*args, **kwargs))
+        except Exception as e:
+            if str(e).startswith(
+                "Tried sending message after closing.  Status: closed"
+            ):
+                raise ExecutorClosed() from e
+
+            raise
+    def wait(self, futures):
+        return [future.get() for future in futures]
+
+    def async_get(self, futures, timeout=0.01):
+        results = []
+        tobe_deleted = []
+        for i, future in enumerate(futures):
+            if timeout and i == 0:
+                future.wait(timeout)
+
+            if future.ready():
+                try:
+                    results.append(AsyncResult(future, future.get()))
+                except Exception as err:
+                    results.append(AsyncException(future, err, traceback.format_exc()))
+
+                tobe_deleted.append(future)
+
+        for future in tobe_deleted:
+            futures.remove(future)
+
+        return results
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        ray.shutdown()
+        super().__exit__(exc_type, exc_value, traceback)

--- a/src/orion/executor/ray_backend.py
+++ b/src/orion/executor/ray_backend.py
@@ -1,5 +1,5 @@
 import traceback
-
+import os
 from orion.executor.base import (
     AsyncException,
     AsyncResult,
@@ -49,14 +49,17 @@ class _Future(Future):
 
 
 class Ray(BaseExecutor):
-    def __init__(self, n_workers=-1, **config):
+    def __init__(self, n_workers=-1, runtime_env=None, **config,):
         super().__init__(n_workers=n_workers)
-        
         if not HAS_RAY:
             raise ImportError("Ray must be installed to use Ray executor.")
         self.config = config
-        ray.init()
-        print("Ray was initiated")
+        if not ray.is_initialized():
+            if runtime_env is None:
+                ray.init()
+            else:
+                ray.init(runtime_env=runtime_env)
+            print("Ray was initiated")
     
     def __getstate__(self):
         return super().__getstate__()

--- a/tests/unittests/executor/test_executor.py
+++ b/tests/unittests/executor/test_executor.py
@@ -4,6 +4,7 @@ import pytest
 
 from orion.executor.base import AsyncException, ExecutorClosed, executor_factory
 from orion.executor.dask_backend import HAS_DASK, Dask
+from orion.executor.ray_backend import HAS_RAY, Ray
 from orion.executor.multiprocess_backend import PoolExecutor
 from orion.executor.single_backend import SingleExecutor
 
@@ -38,12 +39,34 @@ def xfail_dask_if_not_installed(
         ),
     )
 
+def skip_ray_if_not_installed(
+    value, reason="Ray dependency is required for these tests."
+):
+    return pytest.param(
+        value,
+        marks=pytest.mark.skipif(
+            not HAS_RAY,
+            reason=reason,
+        ),
+    )
+
+
+def xfail_ray_if_not_installed(
+    value, reason="Ray dependency is required for these tests."
+):
+    return pytest.param(
+        value,
+        marks=pytest.mark.xfail(
+            condition=not HAS_RAY, reason=reason, raises=ImportError
+        ),
+    )
 
 executors = [
     "joblib",
     "poolexecutor",
     "singleexecutor",
     skip_dask_if_not_installed("dask"),
+    skip_ray_if_not_installed("ray"),
 ]
 
 backends = [
@@ -51,6 +74,7 @@ backends = [
     multiprocess,
     SingleExecutor,
     skip_dask_if_not_installed(Dask),
+    skip_ray_if_not_installed(Ray),
 ]
 
 

--- a/tests/unittests/executor/test_executor.py
+++ b/tests/unittests/executor/test_executor.py
@@ -1,5 +1,5 @@
 import time
-
+import os
 import pytest
 
 from orion.executor.base import AsyncException, ExecutorClosed, executor_factory
@@ -16,6 +16,9 @@ def multiprocess(n):
 def thread(n):
     return PoolExecutor(n, "threading")
 
+def ray(n):
+    test_working_dir = os.path.dirname(os.path.abspath(__file__))
+    return Ray(n, runtime_env={"working_dir": test_working_dir})
 
 def skip_dask_if_not_installed(
     value, reason="Dask dependency is required for these tests."
@@ -74,7 +77,7 @@ backends = [
     multiprocess,
     SingleExecutor,
     skip_dask_if_not_installed(Dask),
-    skip_ray_if_not_installed(Ray),
+    skip_ray_if_not_installed(ray),
 ]
 
 
@@ -102,8 +105,8 @@ def test_execute_function(backend):
         assert executor.wait([future]) == [7]
 
     # Executor was closed at exit
-    with pytest.raises(ExecutorClosed):
-        executor.submit(function, 1, 2, c=3)
+    #with pytest.raises(ExecutorClosed):
+    #    executor.submit(function, 1, 2, c=3)
 
 
 @pytest.mark.parametrize("backend", backends)

--- a/tests/unittests/executor/test_executor.py
+++ b/tests/unittests/executor/test_executor.py
@@ -105,8 +105,8 @@ def test_execute_function(backend):
         assert executor.wait([future]) == [7]
 
     # Executor was closed at exit
-    #with pytest.raises(ExecutorClosed):
-    #    executor.submit(function, 1, 2, c=3)
+    with pytest.raises(ExecutorClosed):
+        executor.submit(function, 1, 2, c=3)
 
 
 @pytest.mark.parametrize("backend", backends)
@@ -176,7 +176,7 @@ def test_execute_async_all(backend):
         futures = [executor.submit(function, 1, 2, i) for i in range(10)]
 
         results = True
-        while results:
+        while results:  
             results = executor.async_get(futures, timeout=1)
             all_results_async.extend(results)
 


### PR DESCRIPTION
# Description
Adding a Ray backend for Orion ! Similar implementation of the Dask backend.

Solves github issue [ray_backend](https://github.com/Epistimio/orion/issues/1026)

# Changes
Adding a python file for the Ray class and its Future class. Modifying a little bit the executor test.

# Checklist


## Tests
- [x ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [x ] I have updated the relevant documentation related to my changes

## Quality
- [ x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ x] My code follows the style guidelines (`$ tox -e lint`)
