### PR TITLE
Fix algos for nested spaces

### DIFF
--- a/src/orion/algo/asha/asha.py
+++ b/src/orion/algo/asha/asha.py
@@ -18,6 +18,7 @@ from orion.algo.hyperband import (
     display_budgets,
 )
 from orion.algo.space import Space
+from orion.core.utils.flatten import flatten
 from orion.core.worker.trial import Trial
 
 logger = logging.getLogger(__name__)
@@ -303,7 +304,7 @@ class ASHABracket(HyperbandBracket[ASHA]):
                 # pylint: disable=logging-format-interpolation
                 logger.debug(
                     f"Promoting {candidate} from rung {rung_id} with fidelity "
-                    f"{candidate.params[self.owner.fidelity_index]} to "
+                    f"{flatten(candidate.params)[self.owner.fidelity_index]} to "
                     f"rung {rung_id + 1} with fidelity {self.rungs[rung_id + 1]['resources']}"
                 )
 

--- a/src/orion/algo/base/base.py
+++ b/src/orion/algo/base/base.py
@@ -23,6 +23,7 @@ from typing import Any
 from orion.algo.base.registry import Registry
 from orion.algo.space import Space
 from orion.core.utils import GenericFactory
+from orion.core.utils.flatten import flatten
 from orion.core.worker.trial import Trial
 
 log = logging.getLogger(__name__)
@@ -306,7 +307,7 @@ class BaseAlgorithm:
             fidelity_dim = self.space[fidelity_index]
             _, max_fidelity_value = fidelity_dim.interval()
             for trial in self.registry:
-                fidelity_value = trial.params[fidelity_index]
+                fidelity_value = flatten(trial.params)[fidelity_index]
                 if fidelity_value >= max_fidelity_value:
                     n_suggested_with_max_fidelity += 1
             return n_suggested_with_max_fidelity >= self.space.cardinality
@@ -332,7 +333,7 @@ class BaseAlgorithm:
                 return trial.status == "completed"
             return (
                 trial.status == "completed"
-                and trial.params[fidelity_index] >= max_fidelity_value
+                and flatten(trial.params)[fidelity_index] >= max_fidelity_value
             )
 
         return sum(map(_is_completed, self.registry)) >= self.max_trials

--- a/src/orion/algo/evolution_es/evolution_es.py
+++ b/src/orion/algo/evolution_es/evolution_es.py
@@ -17,6 +17,7 @@ import numpy as np
 from orion.algo.hyperband import BudgetTuple, Hyperband, HyperbandBracket
 from orion.algo.space import Space
 from orion.core.utils import format_trials
+from orion.core.utils.flatten import flatten
 from orion.core.worker.trial import Trial
 
 logger = logging.getLogger(__name__)
@@ -271,8 +272,9 @@ class BracketEVES(HyperbandBracket[EvolutionES]):
         for trial_index in range(population_range):
             objective, trial = rung_trials[trial_index]
             self.owner.performance[trial_index] = objective
+            trial_params = flatten(trial.params)
             for ith_dim in self.search_space_without_fidelity:
-                self.owner.population[ith_dim][trial_index] = trial.params[
+                self.owner.population[ith_dim][trial_index] = trial_params[
                     self.space[ith_dim].name
                 ]
 

--- a/src/orion/algo/pbt/pb2.py
+++ b/src/orion/algo/pbt/pb2.py
@@ -169,7 +169,7 @@ class PB2(PBT):
 
             # Set next level of fidelity
             new_params[self.fidelity_index] = self.fidelity_upgrades[
-                trial_to_branch.params[self.fidelity_index]
+                flatten(trial_to_branch.params)[self.fidelity_index]
             ]
 
             new_trial = trial_to_branch.branch(params=new_params)
@@ -199,6 +199,8 @@ class PB2(PBT):
         Derived from PB2 explore implementation in Ray (2022/02/18):
         https://github.com/ray-project/ray/blob/master/python/ray/tune/schedulers/pb2.py#L131
         """
+
+        base_params = flatten(base.params)
 
         data, current = self._get_data_and_current()
         bounds = {dim.name: dim.interval() for dim in space.values()}
@@ -245,15 +247,15 @@ class PB2(PBT):
                     num_f=len(t_r.columns),
                 )
 
-            new_config = base.params.copy()
+            new_config = base_params.copy()
             for i, col in enumerate(hparams.columns):
-                if isinstance(base.params[col], int):
+                if isinstance(base_params[col], int):
                     new_config[col] = int(new[i])
                 else:
                     new_config[col] = new[i]
 
         else:
-            new_config = base.params
+            new_config = base_params
 
         return new_config
 
@@ -272,12 +274,11 @@ class PB2(PBT):
                 current_trials.append(trial)
         data = self._trials_to_data(data_trials)
         if current_trials:
-            current = np.asarray(
-                [
-                    [trial.params[key] for key in self.space.keys()]
-                    for trial in current_trials
-                ]
-            )
+            current_array = []
+            for trial in current_trials:
+                trial_params = flatten(trial.params)
+                current_array.append([trial_params[key] for key in self.space.keys()])
+            current = np.asarray(current_array)
         else:
             current = None
         return data, current
@@ -287,9 +288,10 @@ class PB2(PBT):
         rows = []
         cols = ["Trial", "Budget"] + list(self.space.keys()) + ["Reward"]
         for trial in trials:
-            values = [trial.params[key] for key in self.space.keys()]
+            trial_params = flatten(trial.params)
+            values = [trial_params[key] for key in self.space.keys()]
             lst = (
-                [self.get_id(trial), trial.params[self.fidelity_index]]
+                [self.get_id(trial), trial_params[self.fidelity_index]]
                 + values
                 + [trial.objective.value]
             )

--- a/src/orion/algo/pbt/pbt.py
+++ b/src/orion/algo/pbt/pbt.py
@@ -452,7 +452,9 @@ class PBT(BaseAlgorithm):
                 logger.debug("Promoting trial %s, parameters stay the same.", trial)
             else:
                 new_params = flatten(
-                    self.explore_func(self.rng, self.space, trial_to_explore.params)
+                    self.explore_func(
+                        self.rng, self.space, flatten(trial_to_explore.params)
+                    )
                 )
                 trial_to_branch = trial_to_explore
                 logger.debug(
@@ -463,7 +465,7 @@ class PBT(BaseAlgorithm):
             assert trial_to_branch is not None  # note: implicitly assumed below.
             # Set next level of fidelity
             new_params[self.fidelity_index] = self.fidelity_upgrades[
-                trial_to_branch.params[self.fidelity_index]
+                flatten(trial_to_branch.params)[self.fidelity_index]
             ]
 
             new_trial = trial_to_branch.branch(params=new_params)
@@ -529,7 +531,7 @@ class PBT(BaseAlgorithm):
                     )
 
             elif trial.status == "completed":
-                if trial.params[self.fidelity_index] == self.fidelities[-1]:
+                if flatten(trial.params)[self.fidelity_index] == self.fidelities[-1]:
                     logger.debug(
                         "Trial %s is completed at full fidelity (%s). Not forking.",
                         trial,

--- a/src/orion/algo/tpe/tpe.py
+++ b/src/orion/algo/tpe/tpe.py
@@ -16,6 +16,7 @@ from orion.algo.base import BaseAlgorithm
 from orion.algo.base.parallel_strategy import ParallelStrategy, strategy_factory
 from orion.algo.space import Integer, Real, Space
 from orion.core.utils import format_trials
+from orion.core.utils.flatten import flatten
 from orion.core.worker.trial import Trial
 
 logger = logging.getLogger(__name__)
@@ -395,8 +396,12 @@ class TPE(BaseAlgorithm):
         below_trials, above_trials = self.split_trials()
 
         for dimension in self.space.values():
-            dim_below_trials = [trial.params[dimension.name] for trial in below_trials]
-            dim_above_trials = [trial.params[dimension.name] for trial in above_trials]
+            dim_below_trials = [
+                flatten(trial.params)[dimension.name] for trial in below_trials
+            ]
+            dim_above_trials = [
+                flatten(trial.params)[dimension.name] for trial in above_trials
+            ]
 
             if dimension.type == "real":
                 dim_samples = self._sample_real_dimension(
@@ -422,7 +427,7 @@ class TPE(BaseAlgorithm):
             elif dimension.type == "fidelity":
                 # fidelity dimension
                 trial = self.space.sample(1)[0]
-                dim_samples = trial.params[dimension.name]
+                dim_samples = flatten(trial.params)[dimension.name]
             else:
                 raise NotImplementedError()
 


### PR DESCRIPTION
Why:

There were no generic tests for nested spaces. Some of the base algo class methods were not handling nested spaces properly, in addition to 5 different algos.

How:

Add functional test with nested spaces, use flatten(trial.params) wherever it is used in algos as they all work on a flattened space.