### PR TITLE
[ci] Install Orion from local cloned repository

### DIFF
--- a/.github/workflows/dashboard-src.yml
+++ b/.github/workflows/dashboard-src.yml
@@ -38,13 +38,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: python -m pip install git+https://github.com/notoraptor/orion.git@feature/benchmark_webapi_rebased#egg=orion[profet]
-      - name: info about current directory
-        run: df .
-      - name: check filesystem type using df
-        run: df -Th
-      - name: check filesystem type using fstab
-        run: cat /etc/fstab
+      - name: Install Orion from local copy
+        run: |
+            cd ../../
+            python -m pip install .[profet]
+            cd dashboard/src/
 
       - name: Setup MongoDB
         uses: supercharge/mongodb-github-action@1.8.0
@@ -69,7 +67,7 @@ jobs:
       # check files formatting using Carbon's `ci-check` script
       - run: yarn ci-check
       # Run tests
-      # NB: Tests are running in parallel by default, this may cause backend to receive too many requests in small time
+      # NB: Tests are running in parallel by default, this may cause backend to receive too many requests in few time
       # Option --runInBand allows running tests sequentially: https://jestjs.io/docs/cli#--runinband
       - run: yarn test --all --verbose --runInBand
       # Upload orion backend log.

--- a/.github/workflows/dashboard-src.yml
+++ b/.github/workflows/dashboard-src.yml
@@ -39,10 +39,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Orion from local copy
-        run: |
-            cd ../../
-            python -m pip install .[profet]
-            cd dashboard/src/
+        run: python -m pip install ../../.[profet]
 
       - name: Setup MongoDB
         uses: supercharge/mongodb-github-action@1.8.0


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a small PR to make dashboard testing CI use local cloned repository instead of distant branch `git+https://github.com/notoraptor/orion.git@feature/benchmark_webapi_rebased#egg=orion[profet]` to run orion server. We should not need anymore to use a separate branch for server since benchmarks web API is now merged into `develop` branch.

# Changes

- In Github Actions `dashboard-src.yml`, directly use local cloned repository to install Orion with extra `profet`

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)