### PR TITLE
Fix detection of dashboard build files in installed packages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,6 +287,18 @@ jobs:
           if ( ls ${ORION_PREFIX}/orion-dashboard/build/static/js/main.*.js ); then true; else false; fi
           echo Check if frontend script can find dashboard build
           python -c "from orion.core.cli.frontend import get_dashboard_build_path; get_dashboard_build_path();"
+
+          echo Check if frontend script can find dashboard build on sys.prefix/local
+          mkdir -p ${ORION_PREFIX}/local/
+          mv ${ORION_PREFIX}/orion-dashboard ${ORION_PREFIX}/local/orion-dashboard
+          if ( [ -d "${ORION_PREFIX}/orion-dashboard" ] ); then false; else true; fi
+          if ( [ -d "${ORION_PREFIX}/local/orion-dashboard" ] ); then true; else false; fi
+          python -c "from orion.core.cli.frontend import get_dashboard_build_path; get_dashboard_build_path();"
+          echo Move build back to initial installation
+          mv ${ORION_PREFIX}/local/orion-dashboard ${ORION_PREFIX}/orion-dashboard
+          if ( [ -d "${ORION_PREFIX}/orion-dashboard" ] ); then true; else false; fi
+          if ( [ -d "${ORION_PREFIX}/local/orion-dashboard" ] ); then false; else true; fi
+
           echo Clean-up
           pip uninstall -y orion
           echo Check if dashboard build is correctly removed

--- a/conda/ci_build.sh
+++ b/conda/ci_build.sh
@@ -17,9 +17,9 @@ conda update -q conda
 conda info -a
 conda install conda-build anaconda-client
 
-conda build conda --python 3.7
-conda build conda --python 3.8
-conda build conda --python 3.9
+conda-build conda --python 3.7
+conda-build conda --python 3.8
+conda-build conda --python 3.9
 
 # Conda 3.10 does not work because of a bug inside conda itself
 # conda build conda --python 3.10

--- a/conda/ci_build.sh
+++ b/conda/ci_build.sh
@@ -11,6 +11,7 @@ conda config --set channel_priority strict
 
 pip uninstall -y setuptools
 conda install -c anaconda setuptools
+conda install conda-build
 
 conda update -q conda
 conda info -a

--- a/src/orion/core/cli/frontend.py
+++ b/src/orion/core/cli/frontend.py
@@ -32,7 +32,8 @@ def get_dashboard_build_path():
 
     NB (2023/02/20): It seems that, depending on installation, additional files may
     be installed in `<sys.prefix>/local` instead of just `<sys.prefix>`.
-    More info: https://stackoverflow.com/questions/14211575/any-python-function-to-get-data-files-root-directory#comment99087548_14211600
+    More info:
+    https://stackoverflow.com/questions/14211575/any-python-function-to-get-data-files-root-directory#comment99087548_14211600
     """
     current_file_path = __file__
     if current_file_path.startswith(sys.prefix):

--- a/src/orion/core/cli/frontend.py
+++ b/src/orion/core/cli/frontend.py
@@ -38,11 +38,15 @@ def get_dashboard_build_path():
     if current_file_path.startswith(sys.prefix):
         dashboard_build_path = os.path.join(sys.prefix, "orion-dashboard", "build")
         if not os.path.isdir(dashboard_build_path):
-            dashboard_build_path = os.path.join(sys.prefix, "local", "orion-dashboard", "build")
+            dashboard_build_path = os.path.join(
+                sys.prefix, "local", "orion-dashboard", "build"
+            )
     elif current_file_path.startswith(site.USER_BASE):
         dashboard_build_path = os.path.join(site.USER_BASE, "orion-dashboard", "build")
         if not os.path.isdir(dashboard_build_path):
-            dashboard_build_path = os.path.join(site.USER_BASE, "local", "orion-dashboard", "build")
+            dashboard_build_path = os.path.join(
+                site.USER_BASE, "local", "orion-dashboard", "build"
+            )
     else:
         dashboard_build_path = os.path.abspath(
             os.path.join(

--- a/src/orion/core/cli/frontend.py
+++ b/src/orion/core/cli/frontend.py
@@ -29,12 +29,20 @@ def get_dashboard_build_path():
     https://docs.python.org/3/distutils/setupscript.html#installing-additional-files
     Otherwise, dashboard build should be in dashboard folder near src
     in orion repository.
+
+    NB (2023/02/20): It seems that, depending on installation, additional files may
+    be installed in `<sys.prefix>/local` instead of just `<sys.prefix>`.
+    More info: https://stackoverflow.com/questions/14211575/any-python-function-to-get-data-files-root-directory#comment99087548_14211600
     """
     current_file_path = __file__
     if current_file_path.startswith(sys.prefix):
         dashboard_build_path = os.path.join(sys.prefix, "orion-dashboard", "build")
+        if not os.path.isdir(dashboard_build_path):
+            dashboard_build_path = os.path.join(sys.prefix, "local", "orion-dashboard", "build")
     elif current_file_path.startswith(site.USER_BASE):
         dashboard_build_path = os.path.join(site.USER_BASE, "orion-dashboard", "build")
+        if not os.path.isdir(dashboard_build_path):
+            dashboard_build_path = os.path.join(site.USER_BASE, "local", "orion-dashboard", "build")
     else:
         dashboard_build_path = os.path.abspath(
             os.path.join(


### PR DESCRIPTION
# Description

Hi @bouthilx ! This PR tries to fix #1083 . However, I don't know how to test it in CI. CI currently tests normal installation, but this issue seems related to a corner case, and I don't know how to reproduce it in CI.

# Changes

t seems that, depending on installation, additional files may be installed in `<sys.prefix>/local` instead of just `<sys.prefix>`. More info: https://stackoverflow.com/questions/14211575/any-python-function-to-get-data-files-root-directory#comment99087548_14211600

So, this PR just checks both `<sys.prefix>` then `<sys.prefix>/local` to find dashboard build parent folder (named `orion-dashboard`).

On regular installations (e.g. in CI tests), checking `<sys.prefix>` is enough. But it seems data are installed in `<sys.prefix>/local` on Jupyter installations. I don't know why there's this difference.

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)