### PR TITLE
Limit nevergrad version to fix long algo tests in CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ extras_require = {
         "sspace @ git+https://github.com/Epistimio/sample-space.git@master#egg=sspace",
     ],
     "pb2": ["GPy", "matplotlib"],
-    "nevergrad": ["nevergrad>=0.4.3.post10", "fcmaes", "pymoo"],
+    "nevergrad": ["nevergrad>=0.4.3.post10,<0.6", "fcmaes", "pymoo"],
     "hebo": [
         # Issue #1061 Pending update of hebo
         "numpy>=1.17,<1.24",


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a pull request to try to fix long algo failing tests.

It seems in nevergrad 0.6.0, we can't find `ng.optimizers.registry['NGOpt12']`. So I updated nevergrad version range.

# Changes

- Set nevergrad version to `"nevergrad>=0.4.3.post10,<0.6"`

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)
