### PR TITLE
Add web API entry to edit trial status

### DIFF
--- a/.github/workflows/dashboard-src-new-with-playwright.yml
+++ b/.github/workflows/dashboard-src-new-with-playwright.yml
@@ -31,7 +31,7 @@ jobs:
     # Launch Orion backend
 
     - name: Launch Orion server
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install Orion from local copy
@@ -48,12 +48,15 @@ jobs:
         python .github/workflows/orion/pickle_to_mongodb.py
         cd dashboard/src/
 
+    - name: check ulimit
+      run: ulimit -a
+
     - name: Start Orion backend
       run: |
         # Start Orion backend in repository root folder.
         cd ../../
         mkdir -p gunicorn_tmp_dir
-        orion -vv serve -c .github/workflows/orion/orion_config_mongodb.yaml 2> dashboard/src/orion-backend-${{ matrix.node-version }}.log &
+        orion -vv serve -c .github/workflows/orion/orion_config_mongodb.yaml > dashboard/src/orion-backend-${{ matrix.node-version }}.log 2>&1 &
         cd dashboard/src/
 
     - name: Install dependencies

--- a/dashboard/src/src/__tests__/ExperimentNavBar.test.js
+++ b/dashboard/src/src/__tests__/ExperimentNavBar.test.js
@@ -36,6 +36,9 @@ async function checkNormalBars(row, name, statusDescendingOrder) {
   const expectedNUllBars = [];
   for (let barStatus of PROGRESS_BAR_NAMES) {
     const subBar = await bar.locator(`.bg-${barStatus}`);
+    // Sub-war may have width 0, thus be considered as non-visible.
+    // So, we wait for element to be attached instead of visible.
+    await subBar.waitFor({ state: 'attached' });
     await expect(subBar).toHaveCount(1);
     // Collect bar width.
     barWidths[barStatus] = (await subBar.boundingBox()).width;

--- a/docs/src/user/web_api.rst
+++ b/docs/src/user/web_api.rst
@@ -216,7 +216,8 @@ Trials
 ------
 
 The trials resource permits the retrieval of your trials regardless of their status. You can
-retrieve individual trials as well as a list of all your trials per experiment.
+retrieve individual trials as well as a list of all your trials per experiment. You can
+also edit status for an individual trial.
 
 .. http:get:: /trials/:experiment
 
@@ -274,7 +275,8 @@ retrieve individual trials as well as a list of all your trials per experiment.
          "statistics": {
             "low": 1,
             "high": 42
-         }
+         },
+         "status": "completed"
       }
 
    :>json id: The ID of the trial.
@@ -286,10 +288,45 @@ retrieve individual trials as well as a list of all your trials per experiment.
    :>json objective: The objective found for this trial with the given hyper-parameters.
    :>json statistics: The dictionary of statistics recorded during the trial
       as ``"statistic-name":"statistic-value"``.
+   :>json status: The status of the trial.
 
    :statuscode 400: When an invalid query parameter is passed in the request.
    :statuscode 404: When the specified experiment doesn't exist in the database.
    :statuscode 404: When the specified trial doesn't exist for the specified experiment.
+
+.. http:get:: /trials/:experiment/:id/set-status/:status
+
+   Set status to value ``status`` for an existing trial with id ``id`` from the experiment ``experiment``.
+
+   Return the details of trial with updated status.
+   See the specification of :http:get:`/trials/:experiment/:id`
+   for a description of returned fields.
+
+   **Example response**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: text/javascript
+
+   .. code-block:: json
+
+      {
+         "id": "f70277",
+         "submitTime": "2020-01-22 14:19:42.02448"
+         "startTime": "2020-01-22 14:20:42.02448",
+         "endTime": "2020-01-22 14:20:42.0248",
+         "parameters": {
+            "epsilon": 1,
+            "lr": 0.1
+         },
+         "objective": -0.7865584361152724,
+         "statistics": {
+            "low": 1,
+            "high": 42
+         },
+         "status": "completed"
+      }
 
 Plots
 -----

--- a/src/orion/serving/webapi.py
+++ b/src/orion/serving/webapi.py
@@ -133,6 +133,11 @@ class WebApi(falcon.App):
             trials_resource,
             suffix="trial_in_experiment",
         )
+        self.add_route(
+            "/trials/{experiment_name}/{trial_id}/set-status/{status}",
+            trials_resource,
+            suffix="trial_set_status_in_experiment",
+        )
         self.add_route("/plots/lpi/{experiment_name}", plots_resource, suffix="lpi")
         self.add_route(
             "/plots/partial_dependencies/{experiment_name}",

--- a/tests/functional/serving/test_trials_resource.py
+++ b/tests/functional/serving/test_trials_resource.py
@@ -392,3 +392,37 @@ class TestTrialItem:
             "title": "Invalid parameter",
             "description": 'The "status" parameter is invalid. Invalid status',
         }
+
+    def test_set_trial_status_unknown_trial(self, client, ephemeral_storage):
+        """Tests that we cannot set status on unknown trial"""
+        storage = ephemeral_storage.storage
+
+        add_experiment(storage, name="a", version=1, _id=1)
+        add_trial(storage, experiment=1, id_override="00", status="completed", value=0)
+        add_trial(storage, experiment=1, id_override="01", status="completed", value=1)
+
+        response = client.simulate_get("/trials/a/unknown_trial/set-status/interrupted")
+        assert response.status == "404 Not Found"
+        assert response.json == {
+            "description": 'Trial "unknown_trial" does not exist',
+            "title": "Trial not found",
+        }
+
+    def test_set_trial_status_unknown_trial_and_experiment(
+        self, client, ephemeral_storage
+    ):
+        """Tests that we cannot set status on unknown trial and unknown experiment"""
+        storage = ephemeral_storage.storage
+
+        add_experiment(storage, name="a", version=1, _id=1)
+        add_trial(storage, experiment=1, id_override="00", status="completed", value=0)
+        add_trial(storage, experiment=1, id_override="01", status="completed", value=1)
+
+        response = client.simulate_get(
+            "/trials/unknown_experiment/unknown_trial/set-status/interrupted"
+        )
+        assert response.status == "404 Not Found"
+        assert response.json == {
+            "description": 'Experiment "unknown_experiment" does not exist',
+            "title": "Experiment not found",
+        }


### PR DESCRIPTION
# Description

Hi @bouthilx ! This is a PR to edit trial status from web API in backend. No yet changes in dashboard.

# Changes

- Add web API entry to edit trial status: `/trials/:experiment/:id/set-status/:status`
- Add doc for new web API entry
- Add unit tests

# Checklist

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
_Please include any additional information or comment that you feel will be helpful to the review of this pull request._
