### PR TITLE
Add appdirs to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,7 @@ setup_args = dict(
         ],
     },
     install_requires=[
+        "appdirs",
         "cloudpickle",
         "PyYAML",
         "pymongo>=3",


### PR DESCRIPTION
Build systems won't necessarily install things unless they are in install_requires.  Since orion depends on appdirs, it should be in install_requries.

## Quality
- [x] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [x] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [x] My code follows the style guidelines (`$ tox -e lint`)