### PR TITLE
Remove the profet import and warning

### DIFF
--- a/src/orion/benchmark/task/__init__.py
+++ b/src/orion/benchmark/task/__init__.py
@@ -10,13 +10,6 @@ from .eggholder import EggHolder
 from .forrester import Forrester
 from .rosenbrock import RosenBrock
 
-try:
-    from . import profet
-
-    # from .profet import ProfetSvmTask, ProfetFcNetTask, ProfetForresterTask, ProfetXgBoostTask
-except ImportError:
-    pass
-
 __all__ = [
     "BenchmarkTask",
     "RosenBrock",
@@ -24,10 +17,5 @@ __all__ = [
     "CarromTable",
     "EggHolder",
     "Forrester",
-    "profet",
-    # "ProfetSvmTask",
-    # "ProfetFcNetTask",
-    # "ProfetForresterTask",
-    # "ProfetXgBoostTask",
     "bench_task_factory",
 ]


### PR DESCRIPTION
# Description
Removes the warning about needing the profet extra to run profet tasks when importing Orion.
Also removes the `profet` module from the `__all__` of `orion.benchmark.task`, it will have to be imported directly instead.

# Changes
`from orion.benchmark.task import *` will no longer include `profet` when the dependencies are installed.

An alternative would be to remove the warning and keep the import. However needing to load PyTorch when importing Orion is not great. It's probably better for it to stay a lazy import. 
