### PR TITLE
Fix Kaleido version to work around release error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,8 @@ setup_args = dict(
         "tabulate",
         "AppDirs",
         "plotly",
-        "kaleido",
+        # Pin the version to work around https://github.com/plotly/Kaleido/issues/156.
+        "kaleido==0.2.1",
         "requests",
         "pandas",
         "gunicorn",


### PR DESCRIPTION
Due to https://github.com/plotly/Kaleido/issues/156, Kaleido doesn't work with package managers like Poetry.  It also hasn't seen a release in 2 years and the package manager seems to have forgotten about it.  Could we pin the version to solve this problem?