### PR TITLE
Make the logo show on Github. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Oríon
     :target: https://github.com/Epistimio/orion/actions?query=workflow:build+branch:master+event:schedule
     :alt: Github actions tests
 
-.. image:: docs/src/_static/logos/orion_logo_grid_150ppi.png
+.. image:: https://github.com/Epistimio/orion/blob/develop/docs/src/_static/logos/orion_logo_grid_150ppi.png
   :width: 400
   :alt: Oríon
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Oríon
     :target: https://github.com/Epistimio/orion/actions?query=workflow:build+branch:master+event:schedule
     :alt: Github actions tests
 
-.. image:: _static/logos/orion_logo_grid_150ppi.png
+.. image:: docs/src/_static/logos/orion_logo_grid_150ppi.png
   :width: 400
   :alt: Oríon
 


### PR DESCRIPTION
# Description

The logo currently doesn't show on Github but works on readthedocs. This PR fixes that and makes it show on both platforms by using an absolute URL.

# Changes

Changes a relative to an absolute reference to a PNG. This is a purely cosmetic change that allows one to see the Orion logo in its full glory on Github.

Before 😿 

<img width="926" alt="image" src="https://github.com/Epistimio/orion/assets/3516539/0273669d-fd5e-425c-8cd1-d7dc5c617ec6">

After 😸 

<img width="938" alt="image" src="https://github.com/Epistimio/orion/assets/3516539/4861618b-e00e-402b-a34e-6997503a6e5c">

