### PR TITLE
Pin pre-commit to py3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
       - run: pip install pre-commit
       - run: pre-commit --version
       - run: pre-commit install


### PR DESCRIPTION
Some dependencies (namely autoflake) are not compatible with py3.12 yet.

Pinning pre-commit to py3.11 until we can move to py3.12. There is no reason for having a pre-commit on a later version than what orion supports anyway.